### PR TITLE
Add scripts for Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: c
+compiler: gcc
+script: mkdir mybuild && cd mybuild && cmake .. -DBUILD_ASE=1 && make
+addons:
+  apt:
+    packages:
+      - libboost-all-dev
+      - libjson-c-dev
+      - uuid-dev
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: c
 compiler: gcc
-script: mkdir mybuild && cd mybuild && cmake .. -DBUILD_ASE=1 && make
+script:
+  - scripts/test-build.sh
+  - scripts/test-codingstyle.sh
 addons:
   apt:
     packages:

--- a/scripts/test-build.sh
+++ b/scripts/test-build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+mkdir mybuild
+pushd mybuild
+
+trap "popd" EXIT
+
+cmake .. -DBUILD_ASE=1
+make -j
+
+echo "test-build PASSED"

--- a/scripts/test-codingstyle.sh
+++ b/scripts/test-codingstyle.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+pushd $(dirname $0)
+
+CHECKPATCH=checkpatch.pl
+FILES=$(find ../libopae ../common/include/opae ../ase/api/src ../ase/sw ../tools/fpgaconf ../tools/fpgad ../samples \( -iname "*.c" -or -iname "*.h" \) -and \( ! -name "srv.c" \) -and \( ! -path "../libopae/src/usrclk/*" \) )
+
+if [ ! -f $CHECKPATCH ]; then
+	wget --no-check-certificate https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl
+	if [ ! -f $CHECKPATCH ]; then
+		echo "Couldn't download checkpatch.pl - please put a copy into the same"
+		echo "directory as this script."
+		popd
+		exit 1
+	fi
+fi
+
+perl ./$CHECKPATCH --no-tree --no-signoff --terse -f $FILES | grep -v "need consistent spacing" | grep ERROR
+
+if [ $? -eq 0 ]; then
+	echo "test-codingstyle FAILED"
+	popd
+	exit 1
+else
+	echo "test-codingstyle PASSED"
+	popd
+	exit 0
+fi
+


### PR DESCRIPTION
This set of patches adds continuous build and code-style tests to be run on new commits and pull requests. It utilizes Travis CI for open-source projects (https://travis-ci.org/), which runs the specified tests on an Ubuntu 14.04 VM.