### PR TITLE
ASE: Changed some global varialbles to local variables and some other…

### DIFF
--- a/ase/sw/app_backend.c
+++ b/ase/sw/app_backend.c
@@ -36,9 +36,6 @@
 
 #include "ase_common.h"
 
-// Log-level
-int glbl_loglevel = ASE_LOG_MESSAGE;
-
 // MMIO Mutex Lock, initilize it here
 pthread_mutex_t mmio_port_lock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -318,7 +315,7 @@ void session_init(void)
     if (session_exist_status != ESTABLISHED) {
 
 	// Set loglevel
-	glbl_loglevel = ase_calc_loglevel();
+	set_loglevel(ase_calc_loglevel());
 
 	setvbuf(stdout, NULL, (int) _IONBF, (size_t) 0);
 

--- a/ase/sw/ase_common.h
+++ b/ase/sw/ase_common.h
@@ -149,7 +149,10 @@ enum ase_loglevel {
 	ASE_LOG_DEBUG
 };
 
-extern int glbl_loglevel;
+int get_loglevel(void);
+void set_loglevel(int level);
+
+void calc_phys_memory_ranges(void); 
 
 int ase_calc_loglevel(void);
 void ase_print(int loglevel, char *fmt, ...);
@@ -761,14 +764,6 @@ extern char *ase_ready_filepath;
  */
 #define IPC_LOCAL_FILENAME ".ase_ipc_local"
 extern FILE *local_ipc_fp;
-
-/*
- * Physical Memory ranges for PrivMem & SysMem
- */
-// System Memory
-extern uint64_t sysmem_size;
-extern uint64_t sysmem_phys_lo;
-extern uint64_t sysmem_phys_hi;
 
 // ASE PID
 extern int ase_pid;

--- a/ase/sw/ase_common.h
+++ b/ase/sw/ase_common.h
@@ -152,7 +152,7 @@ enum ase_loglevel {
 int get_loglevel(void);
 void set_loglevel(int level);
 
-void calc_phys_memory_ranges(void); 
+void calc_phys_memory_ranges(void);
 
 int ase_calc_loglevel(void);
 void ase_print(int loglevel, char *fmt, ...);

--- a/ase/sw/ase_ops.c
+++ b/ase/sw/ase_ops.c
@@ -47,6 +47,22 @@ char *ase_ready_filepath;
 // ASE hostname
 static char *ase_hostname;
 
+// Log-level
+int glbl_loglevel = ASE_LOG_MESSAGE;
+
+inline int get_loglevel(void)
+{
+	return glbl_loglevel;
+}
+
+inline void set_loglevel(int level)
+{
+	if ( (level >= ASE_LOG_ERROR)
+		&&(level <= ASE_LOG_DEBUG))
+		glbl_loglevel = level;
+	else
+		ASE_MSG("%s: Illlegal loglevel value.\n", __func__);
+}
 
 /*
  * Generate unique socket server name

--- a/ase/sw/ase_ops.c
+++ b/ase/sw/ase_ops.c
@@ -57,8 +57,8 @@ inline int get_loglevel(void)
 
 inline void set_loglevel(int level)
 {
-	if ( (level >= ASE_LOG_ERROR)
-		&&(level <= ASE_LOG_DEBUG))
+	if ((level >= ASE_LOG_ERROR)
+		&& (level <= ASE_LOG_DEBUG))
 		glbl_loglevel = level;
 	else
 		ASE_MSG("%s: Illlegal loglevel value.\n", __func__);

--- a/ase/sw/mem_model.c
+++ b/ase/sw/mem_model.c
@@ -46,9 +46,9 @@ uint64_t *umsg_umas_vbase;
 static FILE *error_fp;
 
 // System Memory
-uint64_t sysmem_size = 0;
-uint64_t sysmem_phys_lo = 0;
-uint64_t sysmem_phys_hi = 0;
+uint64_t sysmem_size;
+uint64_t sysmem_phys_lo;
+uint64_t sysmem_phys_hi;
 
 /*
 * Calculate Sysmem & CAPCM ranges to be used by ASE

--- a/ase/sw/mem_model.c
+++ b/ase/sw/mem_model.c
@@ -45,6 +45,33 @@ uint64_t *umsg_umas_vbase;
 // ASE error file
 static FILE *error_fp;
 
+// System Memory
+uint64_t sysmem_size = 0;
+uint64_t sysmem_phys_lo = 0;
+uint64_t sysmem_phys_hi = 0;
+
+/*
+* Calculate Sysmem & CAPCM ranges to be used by ASE
+*/
+void calc_phys_memory_ranges(void)
+{
+	sysmem_size = cfg->phys_memory_available_gb * pow(1024, 3);
+	sysmem_phys_lo = 0;
+	sysmem_phys_hi = sysmem_size - 1;
+
+	// Calculate address mask
+	PHYS_ADDR_PREFIX_MASK =
+	    ((sysmem_phys_hi >> MEMBUF_2MB_ALIGN) << MEMBUF_2MB_ALIGN);
+#ifdef ASE_DEBUG
+	ASE_DBG("PHYS_ADDR_PREFIX_MASK = 0x%" PRIx64 "\n",
+		(uint64_t) PHYS_ADDR_PREFIX_MASK);
+#endif
+
+	ASE_MSG("        System memory range  => 0x%016" PRIx64 "-0x%016"
+		PRIx64 " | %" PRId64 "~%" PRId64 " GB \n", sysmem_phys_lo,
+		sysmem_phys_hi, sysmem_phys_lo / (uint64_t) pow(1024, 3),
+		(uint64_t) (sysmem_phys_hi + 1) / (uint64_t) pow(1024, 3));
+}
 
 // ---------------------------------------------------------------
 // ASE graceful shutdown - Called if: error() occurs


### PR DESCRIPTION
Purpose:  Improve code maintainability and readability.

Descriptions: 
This pull request is from external GitHub since internal GitHub cannot be modified because of the on-going beta release with some additional changes.

This is the start of a series of ASE code refactoring, changing several global variables to local variables. Also, changed glbl_loglevel variable into ase_ops.c module. 

Also, sysmem_size, sysmem_phys_lo and sysmem_phys_hi global variables were moved to mem_model.c from protocol_backend.c. Memory management related function calc_phys_memory_ranges(void) was moved to mem_model.c too.  In this way, these global variables are only used in mem_model.c. 

Please give your review feedback as soon as possible. I am planning to make code changes every day.

I did regression tests on Linux from my local Linux VM and hello_fpga test passed successfully.

Thanks for all your feedbacks. Will add loglevel checking in accessor functions and will change get_loglevel() to make BAT tests pass.
