### PR TITLE
Update Travis CI config to use gcc 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,13 @@ script:
   - scripts/test-codingstyle.sh
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
+      - g++-5
       - libboost-all-dev
       - libjson-c-dev
       - uuid-dev
+before_install:
+  - export CC="gcc-5" CXX="g++-5"
 


### PR DESCRIPTION
Travis builds seem to fail when compiling some of the tools on
gcc 4.8.

This installs gcc and g++ 5 on Travis and sets up CC and CXX
environment variables. Done according to
https://docs.travis-ci.com/user/languages/c/#GCC-on-Linux

