### PR TITLE
Remove '-j' switch on Travis make

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,8 @@ script:
   - scripts/test-codingstyle.sh
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
-      - g++-5
       - libboost-all-dev
       - libjson-c-dev
       - uuid-dev
-before_install:
-  - export CC="gcc-5" CXX="g++-5"
 

--- a/scripts/test-build.sh
+++ b/scripts/test-build.sh
@@ -6,6 +6,6 @@ pushd mybuild
 trap "popd" EXIT
 
 cmake .. -DBUILD_ASE=1
-make -j
+make
 
 echo "test-build PASSED"


### PR DESCRIPTION
GCC seems to require too much memory on Travis (see #16, which didn't
really fix things). This reverts the switch to GCC 5, but forces Travis
to build things sequentially to reduce memory consumption.