### PR TITLE
ASE: Code refactoring --changing global variables to local variables to static local variables

### DIFF
--- a/ase/sw/ase_common.h
+++ b/ase/sw/ase_common.h
@@ -259,11 +259,6 @@ extern char *ase_workdir_path;
 
 // Timestamp IPC file
 #define TSTAMP_FILENAME ".ase_timestamp"
-extern char tstamp_filepath[ASE_FILEPATH_LEN];
-extern char *glbl_session_id;
-
-// CCIP Warnings and Error stat location
-extern char ccip_sniffer_file_statpath[ASE_FILEPATH_LEN];
 
 // READY file name
 #define ASE_READY_FILENAME ".ase_ready.pid"
@@ -670,7 +665,6 @@ struct ase_cfg_t {
 	int usr_tps;
 	int phys_memory_available_gb;
 };
-struct ase_cfg_t *cfg;
 
 // ASE config file
 // #define ASE_CONFIG_FILE "ase.cfg"

--- a/ase/sw/ase_common.h
+++ b/ase/sw/ase_common.h
@@ -259,6 +259,7 @@ extern char *ase_workdir_path;
 
 // Timestamp IPC file
 #define TSTAMP_FILENAME ".ase_timestamp"
+extern char tstamp_filepath[ASE_FILEPATH_LEN];
 
 // READY file name
 #define ASE_READY_FILENAME ".ase_ready.pid"
@@ -665,6 +666,7 @@ struct ase_cfg_t {
 	int usr_tps;
 	int phys_memory_available_gb;
 };
+extern struct ase_cfg_t *cfg;
 
 // ASE config file
 // #define ASE_CONFIG_FILE "ase.cfg"

--- a/ase/sw/mem_model.c
+++ b/ase/sw/mem_model.c
@@ -38,8 +38,6 @@
 
 #include "ase_common.h"
 
-extern struct ase_cfg_t *cfg;
-
 // Base addresses of required regions
 uint64_t *mmio_afu_vbase;
 uint64_t *umsg_umas_vbase;

--- a/ase/sw/mem_model.c
+++ b/ase/sw/mem_model.c
@@ -38,6 +38,8 @@
 
 #include "ase_common.h"
 
+extern struct ase_cfg_t *cfg;
+
 // Base addresses of required regions
 uint64_t *mmio_afu_vbase;
 uint64_t *umsg_umas_vbase;

--- a/ase/sw/protocol_backend.c
+++ b/ase/sw/protocol_backend.c
@@ -38,16 +38,9 @@
  */
 #include "ase_common.h"
 
-// Global test complete counter
-// Keeps tabs of how many session_deinits were received
-int glbl_test_cmplt_cnt;
+struct ase_cfg_t *cfg;
 
-// Global umsg mode, lookup before issuing UMSG
-int glbl_umsgmode;
-char umsg_mode_msg[ASE_LOGGER_LEN];
-
-// Session status
-int session_empty;
+int glbl_test_cmplt_cnt;   // Keeps the number of session_deinits received
 
 volatile int sockserver_kill;
 pthread_t socket_srv_tid;
@@ -55,20 +48,13 @@ pthread_t socket_srv_tid;
 // MMIO Respons lock
 // pthread_mutex_t mmio_resp_lock;
 
-// User clock frequency
-float f_usrclk;
-
 // Variable declarations
 char tstamp_filepath[ASE_FILEPATH_LEN];
-char *glbl_session_id;
 char ccip_sniffer_file_statpath[ASE_FILEPATH_LEN];
 
 // CONFIG,SCRIPT parameter paths received from SV (initial)
 char sv2c_config_filepath[ASE_FILEPATH_LEN];
 char sv2c_script_filepath[ASE_FILEPATH_LEN];
-
-// ASE-APP run command
-char *app_run_cmd;
 
 // ASE seed
 uint64_t ase_seed;
@@ -614,6 +600,14 @@ int ase_listener(void)
 	char portctrl_msgstr[ASE_MQ_MSGSIZE];
 	char logger_str[ASE_LOGGER_LEN];
 	char umsg_mapstr[ASE_MQ_MSGSIZE];
+
+	// Session status
+	static int   session_empty;
+	static char *glbl_session_id;
+
+	//umsg, lookup before issuing UMSG
+	static int   glbl_umsgmode;
+	char umsg_mode_msg[ASE_LOGGER_LEN];	
 
 	//   FUNC_CALL_ENTRY;
 
@@ -1166,8 +1160,8 @@ int ase_ready(void)
 {
 	FUNC_CALL_ENTRY;
 
-	// App run command
-	app_run_cmd = ase_malloc(ASE_FILEPATH_LEN);
+	// ASE-APP run command
+	char app_run_cmd[ASE_FILEPATH_LEN];
 
 	// Set test_cnt to 0
 	glbl_test_cmplt_cnt = 0;
@@ -1347,6 +1341,9 @@ void ase_config_parse(char *filename)
 	int value;
 	char *pch;
 	char *saveptr;
+	// User clock frequency
+	float f_usrclk;
+
 
 	// Allocate space to store ASE config
 	cfg = (struct ase_cfg_t *) ase_malloc(sizeof(struct ase_cfg_t));

--- a/ase/sw/protocol_backend.c
+++ b/ase/sw/protocol_backend.c
@@ -607,7 +607,7 @@ int ase_listener(void)
 
 	//umsg, lookup before issuing UMSG
 	static int   glbl_umsgmode;
-	char umsg_mode_msg[ASE_LOGGER_LEN];	
+	char umsg_mode_msg[ASE_LOGGER_LEN];
 
 	//   FUNC_CALL_ENTRY;
 

--- a/ase/sw/tstamp_ops.c
+++ b/ase/sw/tstamp_ops.c
@@ -34,7 +34,6 @@
 
 #include "ase_common.h"
 
-extern char tstamp_filepath[ASE_FILEPATH_LEN];
 
 // -----------------------------------------------------------------------
 // Timestamp based isolation

--- a/ase/sw/tstamp_ops.c
+++ b/ase/sw/tstamp_ops.c
@@ -34,6 +34,7 @@
 
 #include "ase_common.h"
 
+extern char tstamp_filepath[ASE_FILEPATH_LEN];
 
 // -----------------------------------------------------------------------
 // Timestamp based isolation
@@ -67,10 +68,8 @@ void put_timestamp(void)
 	FUNC_CALL_ENTRY;
 
 	FILE *fp = (FILE *) NULL;
-	char *tstamp_path;
+	char tstamp_path[ASE_FILEPATH_LEN];
 	unsigned long long rdtsc_out;
-
-	tstamp_path = (char *) ase_malloc(ASE_FILEPATH_LEN);
 
 	snprintf(tstamp_path, ASE_FILEPATH_LEN, "%s/%s", ase_workdir_path,
 		 TSTAMP_FILENAME);
@@ -95,8 +94,6 @@ void put_timestamp(void)
 		// Close file
 		fclose(fp);
 	}
-
-	free(tstamp_path);
 
 	FUNC_CALL_EXIT;
 }


### PR DESCRIPTION
- Changed global variables in protocol_backend.c such as session_empty, glbl_session_id, f_usrclk, glbl_umsgmode, umsg_mode_msg and app_run_cmd to be local varialble or static local variables; 
- Moved global variable cfg declaration from ase_common.h to protocol_backend.c;
- Fixed a memory leak issue in variable app_run_cmd


Passed regression test on Linux VM locally
