### PR TITLE
 Add an even more descriptive warning about setting PATH

### DIFF
--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -139,7 +139,9 @@ def commands_list_getoutput(cmd):
             str_out = byte_out.decode("utf-8")
         except OSError as e:
             if e.errno == os.errno.ENOENT:
-                errorExit(cmd[0] + " not found on PATH")
+                msg = cmd[0] + " not found on PATH!\n"
+                msg += "The installed OPAE SDK bin directory must be on the PATH environment variable."
+                errorExit(msg)
             else:
                 raise
 

--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -140,7 +140,8 @@ def commands_list_getoutput(cmd):
         except OSError as e:
             if e.errno == os.errno.ENOENT:
                 msg = cmd[0] + " not found on PATH!\n"
-                msg += "The installed OPAE SDK bin directory must be on the PATH environment variable."
+                msg += "The installed OPAE SDK bin directory must be on " + \
+                       "the PATH environment variable."
                 errorExit(msg)
             else:
                 raise


### PR DESCRIPTION
When an invoked command fails, explicitly warn that OPAE SDK's installed bin directory must be on PATH.
