### PR TITLE
Update ccip_if_pkg to latest version

### DIFF
--- a/platforms/platform_if/rtl/device_if/ccip_if_pkg.sv
+++ b/platforms/platform_if/rtl/device_if/ccip_if_pkg.sv
@@ -1,30 +1,32 @@
-/* ****************************************************************************
- * Copyright(c) 2011-2016, Intel Corporation
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- * * Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- * * Neither the name of Intel Corporation nor the names of its contributors
- * may be used to endorse or promote products derived from this software
- * without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+// ***************************************************************************
+// Copyright (c) 2016, Intel Corporation
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+// * Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software
+// without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// ***************************************************************************
+
 // Date: 02/2/2016
 // Compliant with CCI-P spec v0.7
 package ccip_if_pkg;
@@ -41,7 +43,6 @@ parameter CCIP_MMIODATA_WIDTH    = 64;
 parameter CCIP_TID_WIDTH         = 9;
 
 parameter CCIP_MDATA_WIDTH       = 16;
-
 
 // Number of requests that can be accepted after almost full is asserted.
 parameter CCIP_TX_ALMOST_FULL_THRESHOLD = 8;
@@ -62,6 +63,7 @@ typedef logic [CCIP_TID_WIDTH-1:0]      t_ccip_tid;
 
 
 typedef logic [CCIP_MDATA_WIDTH-1:0]    t_ccip_mdata;
+
 typedef logic [1:0]                     t_ccip_clNum;
 typedef logic [2:0]                     t_ccip_qwIdx;
 
@@ -122,79 +124,82 @@ typedef enum logic [1:0] {
 // Structures for Request and Response headers
 //----------------------------------------------------------------------
 typedef struct packed {
-    t_ccip_vc       vc_sel;
-    logic [1:0]     rsvd1;     // reserved, drive 0
-    t_ccip_clLen    cl_len;
-    t_ccip_c0_req   req_type;
-    logic [5:0]     rsvd0;     // reserved, drive 0
-    t_ccip_clAddr   address;
-    t_ccip_mdata    mdata;
+    t_ccip_vc       vc_sel;    // [73:72]
+    logic [1:0]     rsvd1;     // [71:70]   reserved, drive 0
+    t_ccip_clLen    cl_len;    // [69:68]
+    t_ccip_c0_req   req_type;  // [67:64]
+    logic [5:0]     rsvd0;     // [63:58]   reserved, drive 0
+    t_ccip_clAddr   address;   // [57:16]
+    t_ccip_mdata    mdata;     // [15:0]
 } t_ccip_c0_ReqMemHdr;
 parameter CCIP_C0TX_HDR_WIDTH = $bits(t_ccip_c0_ReqMemHdr);
 
 typedef struct packed {
-    logic [5:0]     rsvd2;
-    t_ccip_vc       vc_sel;
-    logic           sop;
-    logic           rsvd1;     // reserved, drive 0
-    t_ccip_clLen    cl_len;
-    t_ccip_c1_req   req_type;
-    logic [5:0]     rsvd0;     // reserved, drive 0
-    t_ccip_clAddr   address;
-    t_ccip_mdata    mdata;
+    logic [5:0]     rsvd2;      // [79:74]  reserved, drive 0
+    t_ccip_vc       vc_sel;     // [73:72]
+    logic           sop;        // [71]
+    logic           rsvd1;      // [70]     reserved, drive 0
+    t_ccip_clLen    cl_len;     // [69:68]
+    t_ccip_c1_req   req_type;   // [67:64]
+    logic [5:0]     rsvd0;      // [63:58]  reserved, drive 0
+    t_ccip_clAddr   address;    // [57:16]
+    t_ccip_mdata    mdata;      // [15:0]
 } t_ccip_c1_ReqMemHdr;
 parameter CCIP_C1TX_HDR_WIDTH = $bits(t_ccip_c1_ReqMemHdr);
 
 typedef struct packed {
-    logic [5:0]     rsvd2;          // reserved, drive 0
-    t_ccip_vc       vc_sel;
-    logic [3:0]     rsvd1;          // reserved, drive 0
-    t_ccip_c1_req   req_type;
-    logic [47:0]    rsvd0;          // reserved, drive 0
-    t_ccip_mdata    mdata;
+    logic [5:0]     rsvd2;      // [79:74]  reserved, drive 0
+    t_ccip_vc       vc_sel;     // [73:72]
+    logic [3:0]     rsvd1;      // [71:68]  reserved, drive 0
+    t_ccip_c1_req   req_type;   // [67:64]
+    logic [47:0]    rsvd0;      // [63:16]  reserved, drive 0
+    t_ccip_mdata    mdata;      // [15:0]
 }t_ccip_c1_ReqFenceHdr;
 
 typedef struct packed {
-    logic [11:0]    rsvd1;          // reserved, drive 0
-    t_ccip_c1_req   req_type;
-    logic [60:0]    rsvd0;          // reserved, drive 0
-    logic [2:0]     id;
+    logic [5:0]     rsvd2;      // [79:74]  reserved, drive 0
+    t_ccip_vc       vc_sel;     // [73:72]
+    logic [9:0]     rsvd1;      // [71:68]  reserved, drive 0
+    t_ccip_c1_req   req_type;   // [67:64]
+    logic [61:0]    rsvd0;      // [63:2]   reserved, drive 0
+    logic [1:0]     id;         // [1:0]
 }t_ccip_c1_ReqIntrHdr;
 
 typedef struct packed {
-    t_ccip_vc       vc_used;
-    logic           rsvd1;          // reserved, don't care
-    logic           hit_miss;
-    logic [1:0]     rsvd0;          // reserved, don't care
-    t_ccip_clNum    cl_num;
-    t_ccip_c0_rsp   resp_type;
-    t_ccip_mdata    mdata;
+    t_ccip_vc       vc_used;    // [27:26]
+    logic           rsvd1;      // [25]     reserved, don't care
+    logic           hit_miss;   // [24]
+    logic [1:0]     rsvd0;      // [23:22]  reserved, don't care
+    t_ccip_clNum    cl_num;     // [21:20]
+    t_ccip_c0_rsp   resp_type;  // [19:16]
+    t_ccip_mdata    mdata;      // [15:0]
 } t_ccip_c0_RspMemHdr;
 parameter CCIP_C0RX_HDR_WIDTH = $bits(t_ccip_c0_RspMemHdr);
 
 typedef struct packed {
-    t_ccip_vc       vc_used;
-    logic           rsvd1;          // reserved, don't care
-    logic           hit_miss;
-    logic           format;
-    logic           rsvd0;          // reserved, don't care
-    t_ccip_clNum    cl_num;
-    t_ccip_c1_rsp   resp_type;
-    t_ccip_mdata    mdata;
+    t_ccip_vc       vc_used;   // [27:26]
+    logic           rsvd1;     // [25]      reserved, don't care
+    logic           hit_miss;  // [24]
+    logic           format;    // [23]
+    logic           rsvd0;     // [22]      reserved, don't care
+    t_ccip_clNum    cl_num;    // [21:20]
+    t_ccip_c1_rsp   resp_type; // [19:16]
+    t_ccip_mdata    mdata;     // [15:0]
 } t_ccip_c1_RspMemHdr;
 parameter CCIP_C1RX_HDR_WIDTH = $bits(t_ccip_c1_RspMemHdr);
 
 typedef struct packed {
-    logic [7:0]     rsvd0;          // reserved, don't care
-    t_ccip_c1_rsp   resp_type;
-    t_ccip_mdata    mdata;
+    logic [7:0]     rsvd0;     // [27:20]   reserved, don't care
+    t_ccip_c1_rsp   resp_type; // [19:16]
+    t_ccip_mdata    mdata;     // [15:0]
 } t_ccip_c1_RspFenceHdr;
 
 typedef struct packed {
-    logic [7:0]     rsvd1;          // reserved, don't care
-    t_ccip_c1_rsp   resp_type;
-    logic [12:0]    rsvd0;          // reserved, don't care
-    logic [2:0]     id;
+    t_ccip_vc       vc_used;   // [27:26]
+    logic [5:0]     rsvd1;     // [25:20]   reserved, don't care
+    t_ccip_c1_rsp   resp_type; // [19:16]
+    logic [13:0]    rsvd0;     // [15:2]    reserved, don't care
+    logic [1:0]     id;        // [1:0]
 } t_ccip_c1_RspIntrHdr;
 
 
@@ -204,15 +209,15 @@ typedef struct packed {
 //  the message is an MMIO request and should be processed by casting
 //  t_if_ccip_c0_Rx.hdr to t_ccip_c0_ReqMmioHdr.
 typedef struct packed {
-    t_ccip_mmioAddr address;    // 4B aligned Mmio address
-    logic [1:0]     length;     // 2'b00- 4B, 2'b01- 8B, 2'b10- 64B
-    logic           rsvd;       // reserved, don't care
-    t_ccip_tid      tid;
+    t_ccip_mmioAddr address;    // [27:12]  4B aligned Mmio address
+    logic [1:0]     length;     // [11:10]  2'b00- 4B, 2'b01- 8B, 2'b10- 64B
+    logic           rsvd;       // [9]      reserved, don't care
+    t_ccip_tid      tid;        // [8:0]
 } t_ccip_c0_ReqMmioHdr;
 parameter CCIP_C0RX_MMIOHDR_WIDTH = $bits(t_ccip_c0_ReqMmioHdr);
 
 typedef struct packed {
-    t_ccip_tid     tid;         // Returned back from ReqMmioHdr
+    t_ccip_tid     tid;         // [8:0]    returned back from ReqMmioHdr
 } t_ccip_c2_RspMmioHdr;
 parameter CCIP_C2TX_HDR_WIDTH = $bits(t_ccip_c2_RspMmioHdr);
 

--- a/platforms/scripts/afu_platform_config
+++ b/platforms/scripts/afu_platform_config
@@ -162,7 +162,7 @@ def emitConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
         # Does either the AFU or platform request some preprocessor
         # definitions?
         for d in (afu_arg['define'] + plat_arg['define']):
-            f.write("`undef {0}\n`define {0} 1\n".format(d))
+            f.write("`define {0} 1\n".format(d))
 
         # Gather the parameters required by this class.  Start with
         # the defaults and then merge in any specified by the platform.


### PR DESCRIPTION
Updated to the latest fields widths for interrupts.

Most of the changes are just comments (field sizes). Tested on a variety of Xeon+FPGA platforms before commit.
