### PR TITLE
Fix pthreads compilation problem and compiler flags

### DIFF
--- a/cmake/modules/compiler_config.cmake
+++ b/cmake/modules/compiler_config.cmake
@@ -103,8 +103,8 @@ if (C_SUPPORTS_NO_FORMAT_TRUNCATION)
 endif()
 
 check_c_compiler_flag("-Wno-unused-parameter"
-  C_SUPPORTS_NO_FORMAT_TRUNCATION)
-if (C_SUPPORTS_NO_FORMAT_TRUNCATION)
+  C_SUPPORTS_NO_UNUSED_PARAMETER)
+if (C_SUPPORTS_NO_UNUSED_PARAMETER)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-parameter")
 endif()
 
@@ -133,8 +133,8 @@ if (CXX_SUPPORTS_NO_UNKNOWN_PRAGMAS)
 endif()
 
 check_cxx_compiler_flag("-Wno-unused-local-typedefs"
-  CXX_SUPPORTS_NO_UNKNOWN_PRAGMAS)
-if (CXX_SUPPORTS_NO_UNKNOWN_PRAGMAS)
+  CXX_SUPPORTS_NO_LOCAL_TYPEDEFS)
+if (CXX_SUPPORTS_NO_LOCAL_TYPEDEFS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
 endif()
 

--- a/cmake/modules/compiler_config.cmake
+++ b/cmake/modules/compiler_config.cmake
@@ -102,6 +102,12 @@ if (C_SUPPORTS_NO_FORMAT_TRUNCATION)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-truncation")
 endif()
 
+check_c_compiler_flag("-Wno-unused-parameter"
+  C_SUPPORTS_NO_FORMAT_TRUNCATION)
+if (C_SUPPORTS_NO_FORMAT_TRUNCATION)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-parameter")
+endif()
+
 check_cxx_compiler_flag("-Wno-format"
   CXX_SUPPORTS_NO_FORMAT)
 if (CXX_SUPPORTS_NO_FORMAT)
@@ -124,6 +130,12 @@ check_cxx_compiler_flag("-Wno-unknown-pragmas"
   CXX_SUPPORTS_NO_UNKNOWN_PRAGMAS)
 if (CXX_SUPPORTS_NO_UNKNOWN_PRAGMAS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+endif()
+
+check_cxx_compiler_flag("-Wno-unused-local-typedefs"
+  CXX_SUPPORTS_NO_UNKNOWN_PRAGMAS)
+if (CXX_SUPPORTS_NO_UNKNOWN_PRAGMAS)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
 endif()
 
 check_cxx_compiler_flag("-Wno-strict-aliasing"

--- a/libopae/src/event.c
+++ b/libopae/src/event.c
@@ -28,6 +28,8 @@
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
+#include "common_int.h"
+
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/eventfd.h>
@@ -38,7 +40,6 @@
 #include "opae/access.h"
 #include "opae/properties.h"
 #include "types_int.h"
-#include "common_int.h"
 #include "intel-fpga.h"
 
 #define EVENT_SOCKET_NAME     "/tmp/fpga_event_socket"


### PR DESCRIPTION
Changing the order of include files in event.c causes pthreads.h to be
included with _GNU_SOURCE set (libopae/src/common_int.h), which adds
the definition of PTHREAD_MUTEX_RECURSIVE.

Drop some compiler warnings that were generating lots of errors in
system includes.