### PR TITLE
[ASE] Transaction ordering config change for integrated and discrete

### DIFF
--- a/ase/rtl/ase_pkg.sv
+++ b/ase/rtl/ase_pkg.sv
@@ -278,8 +278,6 @@ package ase_pkg;
     */
    // Number of transactions in latency scoreboard
    parameter LATBUF_NUM_TRANSACTIONS = 32;
-   // Radix of latency scoreboard radix
-   parameter LATBUF_COUNT_WIDTH      = $clog2(LATBUF_NUM_TRANSACTIONS) + 1;
    // ASE_fifo full threshold inside latency scoreboard
    parameter LATBUF_FULL_THRESHOLD   = LATBUF_NUM_TRANSACTIONS - 5;
    // Radix of ASE_fifo (subcomponent in latency scoreboard)

--- a/ase/rtl/ccip_emulator.sv
+++ b/ase/rtl/ccip_emulator.sv
@@ -1732,9 +1732,8 @@ module ccip_emulator
        .DEBUG_LOGNAME       ("latbuf_ch0.log"),
        .NUM_WAIT_STATIONS   (LATBUF_NUM_TRANSACTIONS),
        .NUM_STATIONS_FULL_THRESH (LATBUF_FULL_THRESHOLD),
-       .COUNT_WIDTH         (LATBUF_COUNT_WIDTH),
-       .VISIBLE_DEPTH_BASE2 (8),
-       .VISIBLE_FULL_THRESH (220),
+       .VISIBLE_DEPTH       (`ASE_CHANNEL_0_DEPTH),
+       .VISIBLE_FULL_THRESH (`ASE_CHANNEL_0_FULLTHRESH),
        .LATBUF_MAX_TXN      (1),
        .WRITE_CHANNEL       (0)
        )
@@ -1812,9 +1811,8 @@ module ccip_emulator
        .DEBUG_LOGNAME       ("latbuf_ch1.log"),
        .NUM_WAIT_STATIONS   (LATBUF_NUM_TRANSACTIONS),
        .NUM_STATIONS_FULL_THRESH (LATBUF_FULL_THRESHOLD),
-       .COUNT_WIDTH         (LATBUF_COUNT_WIDTH),
-       .VISIBLE_DEPTH_BASE2 (8),
-       .VISIBLE_FULL_THRESH (220),
+       .VISIBLE_DEPTH       (`ASE_CHANNEL_1_DEPTH),
+       .VISIBLE_FULL_THRESH (`ASE_CHANNEL_1_FULLTHRESH),
        .LATBUF_MAX_TXN      (4),
        .WRITE_CHANNEL       (1)
        )

--- a/ase/rtl/inorder_wrf_channel.sv
+++ b/ase/rtl/inorder_wrf_channel.sv
@@ -65,8 +65,7 @@ module inorder_wrf_channel
     parameter string DEBUG_LOGNAME = "channel.log",
     parameter int    NUM_WAIT_STATIONS = 8,
     parameter int    NUM_STATIONS_FULL_THRESH = 3,
-    parameter int    COUNT_WIDTH = 8,
-    parameter int    VISIBLE_DEPTH_BASE2 = 8,
+    parameter int    VISIBLE_DEPTH = 256,
     parameter int    VISIBLE_FULL_THRESH = 220,
     parameter int    LATBUF_MAX_TXN = 4,
     parameter int    WRITE_CHANNEL = 0
@@ -104,10 +103,6 @@ module inorder_wrf_channel
       $fwrite(log_fd, "Logger for %m transactions\n");
    end
 `endif
-
-
-   // Visible depth
-   localparam VISIBLE_DEPTH = 2**VISIBLE_DEPTH_BASE2;
 
    // Internal signals
    logic [LATBUF_TID_WIDTH-1:0] 	  tid_in;

--- a/ase/rtl/outoforder_wrf_channel.sv
+++ b/ase/rtl/outoforder_wrf_channel.sv
@@ -95,8 +95,7 @@ module outoforder_wrf_channel
     parameter string DEBUG_LOGNAME = "channel.log",
     parameter int    NUM_WAIT_STATIONS = 8,
     parameter int    NUM_STATIONS_FULL_THRESH = 3,
-    parameter int    COUNT_WIDTH = 8,
-    parameter int    VISIBLE_DEPTH_BASE2 = 8,
+    parameter int    VISIBLE_DEPTH = 256,
     parameter int    VISIBLE_FULL_THRESH = 220,
     parameter int    LATBUF_MAX_TXN = 4,
     parameter int    WRITE_CHANNEL = 0
@@ -184,9 +183,6 @@ module outoforder_wrf_channel
    localparam OUTFIFO_WIDTH       = LATBUF_TID_WIDTH + CCIP_RX_HDR_WIDTH + CCIP_TX_HDR_WIDTH + CCIP_DATA_WIDTH;
 
    localparam LATBUF_SLOT_INVALID = 255;
-
-   // Visible depth
-   localparam VISIBLE_DEPTH = 2**VISIBLE_DEPTH_BASE2;
 
    // Internal FIFOs are invisible FIFOs inside channel
    localparam INTERNAL_FIFO_DEPTH_RADIX    = 6;

--- a/ase/rtl/platform.vh
+++ b/ase/rtl/platform.vh
@@ -130,9 +130,8 @@
 
 
 /*
- * Disable Transaction shuffling
- * - In integrated mode, OutOfOrder channel control is used
- * - In discrete mode, InOrder channel control is used
+ * By default ASE will cause transactions to be returned out of order.
+ * This reflects that there is no ordering guarantee when using CCI-P.
  *
  * Infinite bandwidth test mode (independent of platform selection)
  * `define INFINITE_BANDWIDTH_MODE
@@ -141,17 +140,31 @@
  * selected based on platform type
  */
 // ------------------------------------------------------ //
-`ifdef FPGA_PLATFORM_INTG_XEON
+
+// Set forwarding channel type
  `ifdef INFINITE_BANDWIDTH_MODE
   `define FORWARDING_CHANNEL            inorder_wrf_channel
  `else
   `define FORWARDING_CHANNEL            outoforder_wrf_channel
  `endif
+
+/*
+ * Forwarding channel configuration and message types
+ */
+// ------------------------------------------------------ //
+`ifdef FPGA_PLATFORM_INTG_XEON
+ `define ASE_CHANNEL_0_DEPTH            256
+ `define ASE_CHANNEL_0_FULLTHRESH       220
+ `define ASE_CHANNEL_1_DEPTH            256
+ `define ASE_CHANNEL_1_FULLTHRESH       220
  `define ASE_ENABLE_UMSG_FEATURE
  `undef  ASE_ENABLE_INTR_FEATURE
 // ------------------------------------------------------ //
 `elsif FPGA_PLATFORM_DISCRETE
- `define FORWARDING_CHANNEL             inorder_wrf_channel
+ `define ASE_CHANNEL_0_DEPTH            64
+ `define ASE_CHANNEL_0_FULLTHRESH       48
+ `define ASE_CHANNEL_1_DEPTH            64
+ `define ASE_CHANNEL_1_FULLTHRESH       48
  `undef  ASE_ENABLE_UMSG_FEATURE
  `define ASE_ENABLE_INTR_FEATURE
 // ------------------------------------------------------ //


### PR DESCRIPTION
This change modifies the way in which transaction order control is selected. CCI-P specification does not imply ordering of responses in any platform. ASE mimics that behavior.
An infinite bandwidth mode is set to override the out-of-order behavior for high-throughput AFU tuning.

Signed-off-by: Rahul R Sharma <rahul.r.sharma@email.com>
