### PR TITLE
hssi: add multi-byte byte address support for I2C

### DIFF
--- a/tools/hssi/config_app.cpp
+++ b/tools/hssi/config_app.cpp
@@ -132,6 +132,7 @@ config_app::config_app()
 , hssi_cmd_count_(0)
 , ctrl_(static_cast<uint32_t>(fme_csr::hssi_ctrl))
 , stat_(static_cast<uint32_t>(fme_csr::hssi_stat))
+, byte_addr_size_(1)
 , header_stream_()
 , input_file_("")
 {
@@ -141,6 +142,7 @@ config_app::config_app()
     options_.add_option<uint8_t>("device",         'D', option::with_argument, "Device number of PCIe device");
     options_.add_option<uint8_t>("function",       'F', option::with_argument, "Function number of PCIe device");
     options_.add_option<bool>("c-header",          'C', option::no_argument,   "Generate a C header file to integrate into BIOS", false);
+    options_.add_option<uint32_t>("byte-address-size", option::with_argument,  "Byte address width (in bytes) of I2C devices", byte_addr_size_);
     options_.add_option<bool>("help",              'h', option::no_argument,   "Show help message", false);
 
     using std::placeholders::_1;
@@ -217,6 +219,7 @@ bool config_app::setup()
         std::string sysfs_path = sysfs_path_template;
         sysfs_path =  sysfs_path.replace(pos, 3, socket_str);
     }
+    options_.get_value<uint32_t>("byte-address-size", byte_addr_size_);
 
     if (options_["socket-id"] && options_["socket-id"]->is_set())
     {
@@ -252,7 +255,7 @@ bool config_app::setup()
         stat_ = it->offset() + 0x10;
     }
     przone_.reset(new hssi_przone(mmio_, ctrl_, stat_));
-    i2c_.reset(new i2c(std::dynamic_pointer_cast<przone_interface>(przone_)));
+    i2c_.reset(new i2c(std::dynamic_pointer_cast<przone_interface>(przone_), byte_addr_size_));
     mdio_.reset(new mdio(std::dynamic_pointer_cast<przone_interface>(przone_)));
     return true;
 

--- a/tools/hssi/config_app.h
+++ b/tools/hssi/config_app.h
@@ -112,6 +112,7 @@ private:
     uint32_t                  hssi_cmd_count_;
     uint32_t                  ctrl_;
     uint32_t                  stat_;
+    uint32_t                  byte_addr_size_;
     std::ostringstream        header_stream_;
     std::string               input_file_;
     intel::utils::logger      log_;

--- a/tools/hssi/i2c.cpp
+++ b/tools/hssi/i2c.cpp
@@ -46,7 +46,7 @@ i2c::i2c(przone_interface::ptr_t przone, size_t byte_addr_size)
 
 bool i2c::send_byte_address(uint32_t instance, uint32_t byte_addr)
 {
-    uint32_t ctrl = i2c_ctrl_trigger  | i2c_ctrl_transmit | i2c_ctrl_send_start;
+    uint32_t ctrl = i2c_ctrl_trigger | i2c_ctrl_transmit | i2c_ctrl_send_start;
     // support multi-byte byte addresses in big endian format
     uint8_t *base_ptr = reinterpret_cast<uint8_t*>(&byte_addr);
     // start with the upper byte (base address of the byte_addr + byte address size)

--- a/tools/hssi/i2c.cpp
+++ b/tools/hssi/i2c.cpp
@@ -38,9 +38,26 @@ namespace hssi
 using namespace std;
 using namespace std::chrono;
 
-i2c::i2c(przone_interface::ptr_t przone)
+i2c::i2c(przone_interface::ptr_t przone, size_t byte_addr_size)
 : przone_(przone)
+, byte_addr_size_(byte_addr_size)
 {
+}
+
+bool i2c::send_byte_address(uint32_t instance, uint32_t byte_addr)
+{
+    uint32_t ctrl = i2c_ctrl_trigger  | i2c_ctrl_transmit | i2c_ctrl_send_start;
+    // support multi-byte byte addresses in big endian format
+    uint8_t *base_ptr = reinterpret_cast<uint8_t*>(&byte_addr);
+    // start with the upper byte (base address of the byte_addr + byte address size)
+    uint8_t* ptr = base_ptr + byte_addr_size_;
+    // make sure we decrement the ptr before we start using it to dereference the byte
+    while (ptr-- > base_ptr){
+        ctrl = i2c_ctrl_trigger | i2c_ctrl_transmit;
+        przone_->write(i2c_reg_ctrl_wrdata, (instance << i2c_ctrl_instance) | ctrl | *ptr);
+        wait_for_i2c_tx();
+    }
+    return true;
 }
 
 bool i2c::read(uint32_t instance, uint32_t device_addr, uint32_t byte_addr, uint8_t bytes[], size_t read_bytes)
@@ -49,17 +66,9 @@ bool i2c::read(uint32_t instance, uint32_t device_addr, uint32_t byte_addr, uint
     uint32_t ctrl = i2c_ctrl_trigger  | i2c_ctrl_transmit | i2c_ctrl_send_start;
     przone_->write(i2c_reg_ctrl_wrdata, (instance << i2c_ctrl_instance) | ctrl | device_addr);
     wait_for_i2c_tx();
-    if (byte_addr > 0xFF) //TODO:Nasty hack for EEPROM address 
-    {
-    // 2a. Set the Byte Address (00) and the control bits (03) into I2C_CTRL_WDATA
-    ctrl = i2c_ctrl_trigger | i2c_ctrl_transmit;
-    przone_->write(i2c_reg_ctrl_wrdata, (instance << i2c_ctrl_instance) | ctrl | ((byte_addr & 0xFF00) >> 8));
-    wait_for_i2c_tx();
-    }
+
     // 2. Set the byte address and control bits (03) into I2C_CTRL_WDATA
-    ctrl = i2c_ctrl_trigger | i2c_ctrl_transmit;
-    przone_->write(i2c_reg_ctrl_wrdata, (instance << i2c_ctrl_instance) | ctrl | (byte_addr & 0xFF));
-    wait_for_i2c_tx();
+    send_byte_address(instance, byte_addr);
 
     // 3. Set the device address (as read) and control bits (07) into I2C_CTRL_WDATA
     ctrl = i2c_ctrl_trigger | i2c_ctrl_transmit | i2c_ctrl_send_start;
@@ -100,17 +109,10 @@ bool i2c::write(uint32_t instance, uint32_t device_addr, uint32_t byte_addr, uin
     // 1. Set the Device Address (30) and the control bits (07) into I2C_CTRL_WDATA
     przone_->write(i2c_reg_ctrl_wrdata, (instance << i2c_ctrl_instance) | ctrl | device_addr);
     wait_for_i2c_tx();
-    if (byte_addr > 0xFF) //TODO:Nasty hack for EEPROM address 
-    {
-    // 2a. Set the Byte Address (00) and the control bits (03) into I2C_CTRL_WDATA
-    ctrl = i2c_ctrl_trigger | i2c_ctrl_transmit;
-    przone_->write(i2c_reg_ctrl_wrdata, (instance << i2c_ctrl_instance) | ctrl | ((byte_addr & 0xFF00) >> 8));
-    wait_for_i2c_tx();
-    }
-    // 2. Set the Byte Address (00) and the control bits (03) into I2C_CTRL_WDATA
-    ctrl = i2c_ctrl_trigger | i2c_ctrl_transmit;
-    przone_->write(i2c_reg_ctrl_wrdata, (instance << i2c_ctrl_instance) | ctrl | (byte_addr & 0xFF));
-    wait_for_i2c_tx();
+
+    // 2. Set the byte address and control bits (03) into I2C_CTRL_WDATA
+    send_byte_address(instance, byte_addr);
+
     // 3. Set the Byte0 Value (bb) and the control bits (13) into I2C_CTRL_WDATA
     ctrl = i2c_ctrl_trigger | i2c_ctrl_transmit;
     for (size_t i = 0; i < write_bytes; ++i)

--- a/tools/hssi/i2c.h
+++ b/tools/hssi/i2c.h
@@ -78,7 +78,7 @@ class i2c
 {
 public:
     typedef std::shared_ptr<i2c> ptr_t;
-    i2c(przone_interface::ptr_t przone);
+    i2c(przone_interface::ptr_t przone, size_t byte_addr_size = 1);
     ~i2c(){}
     bool read(uint32_t instance, uint32_t device_addr, uint32_t byte_addr, uint8_t bytes[], std::size_t read_bytes);
     bool write(uint32_t instance, uint32_t device_addr, uint32_t byte_addr, uint8_t bytes[], std::size_t read_bytes);
@@ -86,6 +86,9 @@ public:
 private:
     przone_interface::ptr_t przone_;
     intel::utils::logger log_;
+    size_t byte_addr_size_;
+
+    bool send_byte_address(uint32_t instance, uint32_t byte_addr);
 };
 
 } // end of namespace hssi


### PR DESCRIPTION
Change i2c class:
* Change constructor to take in device address width
  * This is in bytes with a default value of 1
* Add i2c::send_byte_address function that sends the byte
  address over i2c and uses the byte_address_size_ member var
  Note: The byte address is in big-endian format so we start
  with the upper bytes of the byte address
* Change i2c::read and i2c::write to use i2c::send_byte_address

Change config_app:
* Add a --byte-address-size command line argument
  and default it to 1 byte
* Instantiate an i2c device with the byte address size