### PR TITLE
fpgainfo: refactor sysfs properties

### DIFF
--- a/tools/fpgainfo/fpga_fmeinfo.py
+++ b/tools/fpgainfo/fpga_fmeinfo.py
@@ -36,7 +36,7 @@ class fme_command(fpga_common.fpga_command):
                   'socket_id',
                   'bitstream_id',
                   'bitstream_metadata',
-                  'pr_interface_id',
+                  'pr.interface_id',
                   'object_ID']
 
     def run(self, args):

--- a/tools/fpgainfo/fpgaerr.py
+++ b/tools/fpgainfo/fpgaerr.py
@@ -263,8 +263,8 @@ error_classes = {
 def set_error_parsers(err_feature, err_classes):
     for name, err_class in err_classes.iteritems():
         if hasattr(err_feature, name):
-            err_value = getattr(err_feature, name).fget(err_feature)
-            setattr(err_feature, name, err_class(err_value))
+            value = getattr(err_feature, name)
+            setattr(err_feature, name, value)
 
 
 class errors_command(fpga_command):
@@ -306,10 +306,10 @@ class errors_command(fpga_command):
         json_data = []
         for r in resources:
             if args.json:
-                json_data.append(r.to_dict())
+                json_data.append(r.to_dict(True))
             else:
                 r.print_info(
-                    "//****** {} ******//".format(r.name))
+                    "//****** {} ******//".format(r.name()))
 
         if args.json:
             print(json.dumps(json_data, indent=4, sort_keys=False))

--- a/tools/fpgainfo/fpgaerr.py
+++ b/tools/fpgainfo/fpgaerr.py
@@ -264,7 +264,7 @@ def set_error_parsers(err_feature, err_classes):
     for name, err_class in err_classes.iteritems():
         if hasattr(err_feature, name):
             value = getattr(err_feature, name)
-            setattr(err_feature, name, value)
+            setattr(err_feature, name, err_class(value.fget(err_feature)))
 
 
 class errors_command(fpga_command):

--- a/tools/fpgainfo/fpgatemp.py
+++ b/tools/fpgainfo/fpgatemp.py
@@ -37,11 +37,11 @@ class temp_command(cmd.fpga_command):
     name = "temp"
     thermal_props = [("temperature", print_celcius),
                      ("threshold1", print_celcius),
-                     ("threshold1_policy", repr),
+                     ("threshold1_policy", int),
                      ("threshold1_reached", bool),
                      ("threshold2", print_celcius),
                      ("threshold2_reached", bool),
-                     ("threshold2_policy", repr),
+                     ("threshold2_policy", int),
                      ("threshold_trip", print_celcius)]
 
     def run(self, args):

--- a/tools/fpgainfo/fpgatemp.py
+++ b/tools/fpgainfo/fpgatemp.py
@@ -41,7 +41,6 @@ class temp_command(cmd.fpga_command):
                      ("threshold1_reached", bool),
                      ("threshold2", print_celcius),
                      ("threshold2_reached", bool),
-                     ("threshold2_policy", int),
                      ("threshold_trip", print_celcius)]
 
     def run(self, args):

--- a/tools/fpgainfo/sysfs.py
+++ b/tools/fpgainfo/sysfs.py
@@ -68,6 +68,11 @@ class sysfs_filter(object):
         return True
 
 
+def add_static_property(sysfs_path):
+    return property(lambda s_: s_.parse_sysfs(sysfs_path),
+                    lambda s_, v_: s_.write_sysfs(v_, sysfs_path))
+
+
 class sysfs_resource(object):
     def __init__(self, path, instance_id, **kwargs):
         self._path = path
@@ -183,43 +188,22 @@ class pr_feature(sysfs_resource):
 
 
 class power_mgmt_feature(sysfs_resource):
-    @property
-    def consumed(self):
-        return self.parse_sysfs("consumed")
+    consumed = add_static_property("consumed")
 
 
 class thermal_feature(sysfs_resource):
-    @property
-    def temperature(self):
-        return self.parse_sysfs("temperature")
-
-    @property
-    def threshold1(self):
-        return self.parse_sysfs("threshold1")
-
-    @property
-    def threshold1_policy(self):
-        return self.parse_sysfs("threshold1_policy")
-
-    @property
-    def threshold1_reached(self):
-        return self.parse_sysfs("threshold1_reached")
-
-    @property
-    def threshold2(self):
-        return self.parse_sysfs("threshold2")
-
-    @property
-    def threshold2_reached(self):
-        return self.parse_sysfs("threshold2_reached")
-
-    @property
-    def threshold_trip(self):
-        return self.parse_sysfs("threshold_trip")
+    temperature = add_static_property("temperature")
+    threshold1 = add_static_property("threshold1")
+    threshold1_policy = add_static_property("threshold1_policy")
+    threshold1_reached = add_static_property("threshold1_reached")
+    threshold2 = add_static_property("threshold2")
+    threshold2_reached = add_static_property("threshold2_reached")
+    threshold_trip = add_static_property("threshold_trip")
 
 
 class errors_feature(sysfs_resource):
     error_files = {}
+    revision = add_static_property("revision")
 
     def __init__(self, path, instance_id, **kwargs):
         super(errors_feature, self).__init__(path, instance_id, **kwargs)
@@ -248,10 +232,6 @@ class errors_feature(sysfs_resource):
                 setattr(self,
                         os.path.basename(err_file),
                         property(lambda self_: self_.parse_sysfs(err_file)))
-
-    @property
-    def revision(self):
-        return self.parse_sysfs("revision")
 
     def clear(self):
         value = self.parse_sysfs(self.errors_file)

--- a/tools/fpgainfo/sysfs.py
+++ b/tools/fpgainfo/sysfs.py
@@ -73,6 +73,20 @@ def add_static_property(sysfs_path):
                     lambda s_, v_: s_.write_sysfs(v_, sysfs_path))
 
 
+def add_dynamic_property(obj, property_name, sysfs_path=None):
+    sysfs_path = sysfs_path or property_name
+
+    def getter(self_):
+        return self_.parse_sysfs(sysfs_path)
+
+    def setter(self_, v_):
+        self_.write_sysfs(v_, sysfs_path)
+
+    if obj.sysfs_path_exists(sysfs_path):
+        setattr(obj, property_name,
+                property(getter, setter))
+
+
 class sysfs_resource(object):
     def __init__(self, path, instance_id, **kwargs):
         self._path = path
@@ -269,6 +283,15 @@ class fme_errors(errors_feature):
         self.name = "fme errors"
         self.errors_file = "fme-errors/errors"
         self.clear_file = "fme-errors/clear"
+        add_dynamic_property(self, "errors", "fme-errors/errors")
+        add_dynamic_property(self, "first_error", "fme-errors/first_error")
+        add_dynamic_property(self, "next_error", "fme-errors/next_error")
+        add_dynamic_property(self, "bbs_errors")
+        add_dynamic_property(self, "gbs_errors")
+        add_dynamic_property(self, "pcie0_errors")
+        add_dynamic_property(self, "pcie1_errors")
+        add_dynamic_property(self, "catfatal_errors")
+        add_dynamic_property(self, "nonfatal_errors")
 
 
 class port_errors(errors_feature):
@@ -283,6 +306,8 @@ class port_errors(errors_feature):
         self.name = "port errors"
         self.errors_file = "errors"
         self.clear_file = "clear"
+        add_dynamic_property(self, "errors")
+        add_dynamic_property(self, "first_error")
 
 
 class fme_info(sysfs_resource):

--- a/tools/fpgainfo/sysfs.py
+++ b/tools/fpgainfo/sysfs.py
@@ -111,7 +111,7 @@ class sysfs_resource(object):
             k_, v_ = k, v
             if isinstance(v, property):
                 k_, v_ = k, v.fget(self)
-            elif hasattr(v, 'to_dict') and k != '__class__':
+            elif not as_string and hasattr(v, 'to_dict') and k != '__class__':
                 k_, v_ = k, v.to_dict()
             if as_string:
                 yield k_, unicode(v_)

--- a/tools/fpgainfo/sysfs.py
+++ b/tools/fpgainfo/sysfs.py
@@ -179,10 +179,11 @@ class sysfs_resource(object):
         print('{:22} : 0x{:02X}'.format('Device', self.device))
         print('{:22} : 0x{:02X}'.format('Function', self.function))
 
-        if not props:
-            props = [(k, v) for k, v in self.enum_props(as_string=True)]
+        prop_values = [(k, v) for k, v in self.enum_props(as_string=True)]
+        if props:
+            prop_values = filter(lambda (k, v): k in props, prop_values)
 
-        for k, v in props:
+        for k, v in prop_values:
             value = kwargs.get(k)(v) if k in kwargs else v
             label = ' '.join([_.capitalize() for _ in k.split('_')])
             print(u'{:22} : {}'.format(label, value))

--- a/tools/fpgainfo/sysfs.py
+++ b/tools/fpgainfo/sysfs.py
@@ -181,12 +181,24 @@ class sysfs_resource(object):
 
         prop_values = [(k, v) for k, v in self.enum_props(as_string=True)]
         if props:
-            prop_values = filter(lambda (k, v): k in props, prop_values)
+            def get_value(key):
+                namespaces = key.split('.')
+                obj = self
+                try:
+                    while len(namespaces) > 1:
+                        obj = getattr(obj, namespaces.pop(0))
+                    return getattr(obj, namespaces[0])
+                except AttributeError:
+                    pass
+
+            prop_values = [(k, get_value(k)) for k in props]
 
         for k, v in prop_values:
-            value = kwargs.get(k)(v) if k in kwargs else v
-            label = ' '.join([_.capitalize() for _ in k.split('_')])
-            print(u'{:22} : {}'.format(label, value))
+            if v is not None:
+                value = kwargs.get(k)(v) if k in kwargs else v
+                subbed = re.sub('[_\.]', ' ', k)
+                label = ' '.join([_.capitalize() for _ in subbed.split()])
+                print(u'{:22} : {}'.format(label, value))
 
         print('\n')
 


### PR DESCRIPTION
Refactor classes/functions is sysfs.py for better property enumeration and better
handling of dynamic properties. 
These changes also fixes an issue with errors not being accurately reflected from sysfs nodes.

# Refactor static properties
Add a function called `add_static_property` that adds a class property
and uses the passed in path to
* Read and parse the sysfs file when getting
* Write to the sysfs file when setting

# Refactor dynamic properties
Add function `add_dynamic_property` that is used to add properties to
objects (rather that classes) depending on whether the relative sysfs
path exists. This should be used in the __init__ method of
sysfs_resource subclasses to add properties only if the relative path
exists.

This also changes `fme_errors` and `port_errors` to use this method.

# Refactor to_dict and print_info
Add new method, `enum_props` that enumerates object/class properties
using the `inspect.getmembers` from the `inspect` Python module.
`enum_props` will also filter out any members that
* are a member of the base class, `sysfs_resource` as these are handled
  separately
* are methods
* begin with underscore character (`_`).

Finally, refactord `errors_feature` and subclasses to use underscore
character for "private" member variables so that they won't be included
in the `enum_props` method. Added a `name()` method to get the name of
the feature.

# Change formatting func. for some props
Change formatting function from `repr` to  `int` for:
* threshold1_policy

This will allow these properties to be printed as integers.

# Update fpgaerr for refactored sysfs
Update calls in fpgaerr.py into objects from sysfs.py to accomodate
changes in sysfs.py