### PR TITLE
Improve support for platform database in AFU JSON

### DIFF
--- a/tools/packager/schema/afu_schema_v01.json
+++ b/tools/packager/schema/afu_schema_v01.json
@@ -8,6 +8,13 @@
             "properties" : {
                 "magic-no" : {"type" : "number"},
                 "interface-uuid" : {"type" : "string"},
+                "afu-top-interface": {
+                    "type" : "object",
+                    "properties" : {
+                        "name" : {"type" : "string"}
+                    },
+                    "required" : ["name"]
+                },
                 "clock-frequency-low" : {"type" : "number"},
                 "clock-frequency-high" : {"type" : "number"},
                 "power": {"type" : "number"},
@@ -24,7 +31,7 @@
                     }
                 }
             },
-            "required" : ["interface-uuid", "accelerator-clusters", "power"]
+            "required" : ["accelerator-clusters", "power"]
         }
     },
     "required": ["afu-image","version"]


### PR DESCRIPTION
This change is backward compatible with existing JSON and platform build scripts.

AFUs may be configured to run on multiple platforms. It makes little sense to
specify the platform's interface-uuid in a static AFU JSON file.  The schema no
longer requires "interface-uuid", making it possible to write an abstract AFU
JSON file and fill in the UUID at packaging time.

Typically, a packaging script for a particular platform sets interface-uuid.
The afu.py script is updated to provide syntax for specifying a key's full path,
making it possible to set afu-image/interface-uuid. The script is also updated
for legacy support: when just "interface-uuid" is specified it is assumed to be
"afu-image/interface-uuid".

Added "afu-image/afu-top-interface" to the schema for specifying the top-level
interface class.

afu-image/magic-no is now set automatically if not already present and is no
longer required to be set in every AFU's JSON file.