### PR TITLE
fpgamux: Change `muxfile` to `config`

### DIFF
--- a/tools/fpgadiag/mux.cpp
+++ b/tools/fpgadiag/mux.cpp
@@ -176,7 +176,7 @@ int main(int argc, char* argv[])
         return EXIT_SUCCESS;
     }
 
-    auto muxopt = opts.find("muxfile");
+    auto muxopt = opts.find("config");
     if (!muxopt || !muxopt->is_set() || !path_exists(muxopt->value<std::string>()))
     {
         log.error("main") << "Invalid or no muxfile specified" << std::endl;


### PR DESCRIPTION
The command line option for specifying the mux configuration had
been previously changed to `config` from `muxfile`. This updates mux.cpp
to use the `config` key instead of `muxfile`.