### PR TITLE
Don't warn on C++ unused local typedefs because of Boost warnings

### DIFF
--- a/cmake/modules/compiler_config.cmake
+++ b/cmake/modules/compiler_config.cmake
@@ -78,6 +78,13 @@ elseif(COMPILER_SUPPORTS_CXX0X)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 endif()
 
+# Disable some warnings that fire in system libraries
+check_cxx_compiler_flag("-Wno-unused-local-typedefs"
+  CXX_SUPPORTS_NO_LOCAL_TYPEDEFS)
+if (CXX_SUPPORTS_NO_LOCAL_TYPEDEFS)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
+endif()
+
 # If building on a 32-bit system, make sure off_t can store offsets > 2GB
 if(CMAKE_COMPILER_IS_GNUCC)
   if(CMAKE_SIZEOF_VOID_P EQUAL 4)


### PR DESCRIPTION
Can we please exclude this one warning that is fired over and over by Boost code that isn't in our control? When it's on you can't see the warnings that are under our control.

It's also not the sort of syntax that is a major problem and looks bad to customers.
