### PR TITLE
cmake: Change CMAKE_SOURCE_DIR to OPAE_SDK_SOURCE

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -25,7 +25,7 @@
 ## POSSIBILITY OF SUCH DAMAGE.
 
 include_directories(${OPAE_INCLUDE_DIR}
-                    ${CMAKE_SOURCE_DIR}/libopae/src )
+                    ${OPAE_SDK_SOURCE}/libopae/src )
 
 set(CMAKE_C_FLAGS "-std=gnu99 ${CMAKE_C_FLAGS}")
 


### PR DESCRIPTION
Change samples/CMakeLists.txt to use ${OPAE_SDK_SOURCE} in its include
path instead of ${CMAKE_SOURCE_DIR}. This allows it to build when the
OPAE repo is a subdirectory of another CMake based build.