### PR TITLE
opaec++: include cleanup

### DIFF
--- a/libopae++/include/opaec++/handle.h
+++ b/libopae++/include/opaec++/handle.h
@@ -24,12 +24,12 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
-#include <opae/types.h>
-#include <opae/enum.h>
-
 #include <vector>
 #include <memory>
-#include "token.h"
+
+#include <opae/types.h>
+#include <opae/enum.h>
+#include <opaec++/token.h>
 
 namespace opae
 {

--- a/libopae++/include/opaec++/properties.h
+++ b/libopae++/include/opaec++/properties.h
@@ -27,8 +27,9 @@
 #include <map>
 #include <memory>
 #include <iostream>
-#include "pvalue.h"
+
 #include <opae/properties.h>
+#include <opaec++/pvalue.h>
 
 namespace opae
 {

--- a/libopae++/include/opaec++/pvalue.h
+++ b/libopae++/include/opaec++/pvalue.h
@@ -24,9 +24,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
-#include <opae/properties.h>
 #include <type_traits>
 #include <iostream>
+
+#include <opae/properties.h>
 
 namespace opae
 {

--- a/libopae++/include/opaec++/token.h
+++ b/libopae++/include/opaec++/token.h
@@ -24,13 +24,13 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
+#include <vector>
+#include <memory>
+
 #include <opae/types.h>
 #include <opae/access.h>
 #include <opae/enum.h>
-
-#include <vector>
-#include <memory>
-#include "opaec++/properties.h"
+#include <opaec++/properties.h>
 
 namespace opae
 {

--- a/libopae++/src/token.cpp
+++ b/libopae++/src/token.cpp
@@ -23,8 +23,8 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#include "opaec++/token.h"
 #include <algorithm>
+#include "opaec++/token.h"
 
 namespace opae
 {


### PR DESCRIPTION
Follow the convention that system headers be included first.
Use opaec++/header.h when refering to opaec++ headers.