### PR TITLE
opaec++: add MMIO support to handle class

### DIFF
--- a/libopae++/include/opaec++/handle.h
+++ b/libopae++/include/opaec++/handle.h
@@ -50,18 +50,53 @@ public:
         return handle_;
     }
 
+    /** Write 32-bit value to MMIO.
+     * @param[in] offset The byte offset from MMIO base to write.
+     * @param[in] value  The value to be written.
+     * @return Whether the write was successful.
+     */
+    virtual bool write(uint64_t offset, uint32_t value);
 
-    static handle::ptr_t open(fpga_token token, int flags);
+    /** Write 64-bit value to MMIO.
+     * @param[in] offset The byte offset from MMIO base to write.
+     * @param[in] value  The value to be written.
+     * @return Whether the write was successful.
+     */
+    virtual bool write(uint64_t offset, uint64_t value);
 
-    static handle::ptr_t open(token::ptr_t token, int flags);
+    /** Read 32-bit value from MMIO.
+     * @param[in]  offset The byte offset from MMIO base to read.
+     * @param[out] value  Receives the value read.
+     * @return Whether the read was successful.
+     */
+    virtual bool read(uint64_t offset, uint32_t &value) const;
+
+    /** Read 64-bit value from MMIO.
+     * @param[in]  offset The byte offset from MMIO base to read.
+     * @param[out] value  Receives the value read.
+     * @return Whether the read was successful.
+     */
+    virtual bool read(uint64_t offset, uint64_t &value) const;
+
+    /** Retrieve a pointer to the MMIO region.
+     * @param[in] offset The byte offset to add to MMIO base.
+     * @return MMIO base + offset
+     */
+    uint8_t * mmio_ptr(uint64_t offset) const { return mmio_base_ + offset; }
+
+    static handle::ptr_t open(fpga_token token, int flags, uint32_t mmio_region=0);
+
+    static handle::ptr_t open(token::ptr_t token, int flags, uint32_t mmio_region=0);
 
 protected:
     fpga_result close();
 
 private:
-    handle(fpga_handle h);
+    handle(fpga_handle h, uint32_t mmio_region, uint8_t *mmio_base);
 
     fpga_handle handle_;
+    uint32_t mmio_region_;
+    uint8_t *mmio_base_;
 };
 
 } // end of namespace types


### PR DESCRIPTION
Parameterize the open call and the handle constructor so that the
desired MMIO region can be specified.
Map the MMIO region during object creation and unmap it during
destruction.
Provide 32- and 64-bit read and write methods.
Provide MMIO base pointer query method.