### PR TITLE
Fix string variable line split issue for CMake 2.X

### DIFF
--- a/tools/packager/CMakeLists.txt
+++ b/tools/packager/CMakeLists.txt
@@ -29,9 +29,7 @@ include(packaging)
 
 ################# generate executable python zip file ########################
 set(PYTHONE_FILES
-     "afu.py gbs.py __main__.py packager.py utils.py \
-     metadata/constants.py metadata/__init__.py metadata/metadata.py \
-     schema/afu_schema_v01.json README" )  
+    "afu.py gbs.py __main__.py packager.py utils.py metadata/constants.py metadata/__init__.py metadata/metadata.py schema/afu_schema_v01.json README" )  
 
 set(PY_EXE_NAME "packager")
 CREATE_PYTHONE_EXE(${PY_EXE_NAME} "${PYTHONE_FILES}")


### PR DESCRIPTION
CMake 2.X doesn't support "\" to split a long string to multiple lines in a variable. Fix packager/CMakeLists.txt file to work with minimum CMake version.