### PR TITLE
c++: Add implicit conversion operator

### DIFF
--- a/libopae++/include/opaec++/handle.h
+++ b/libopae++/include/opaec++/handle.h
@@ -46,7 +46,11 @@ public:
 
     ~handle();
 
-    fpga_handle get(){
+    fpga_handle get() const {
+        return handle_;
+    }
+
+    operator fpga_handle () const {
         return handle_;
     }
 

--- a/libopae++/include/opaec++/properties.h
+++ b/libopae++/include/opaec++/properties.h
@@ -51,6 +51,7 @@ public:
     ~properties();
 
     fpga_properties get() const { return props_; }
+    operator fpga_properties () const { return props_; }
 
     static properties::ptr_t read(std::shared_ptr<token> t);
     static properties::ptr_t read(fpga_token t);

--- a/libopae++/include/opaec++/token.h
+++ b/libopae++/include/opaec++/token.h
@@ -47,7 +47,10 @@ public:
 
     ~token();
 
-    fpga_token get(){
+    fpga_token get() const {
+        return token_;
+    }
+    operator fpga_token () const {
         return token_;
     }
 

--- a/libopae++/samples/simple_example.cpp
+++ b/libopae++/samples/simple_example.cpp
@@ -36,9 +36,9 @@ int main(int argc, char* argvp[])
 {
     const char* NLB0 = "D8424DC4-A4A3-C413-F89E-433683F9040B";
     const char* NLB3 = "F7DF405C-BD7A-CF72-22F1-44B0B93ACD18";
-   
+
     properties p;
-        
+
     p.socket_id = 1;
     p.type = FPGA_ACCELERATOR;
     uuid_t uuid;
@@ -49,35 +49,22 @@ int main(int argc, char* argvp[])
     auto tokens = token::enumerate({ p });
     if (tokens.size() > 0){
         auto tok = tokens[0];
-        auto props = properties::read(tok->get());
-        fpga_guid g;
-        auto r = props->guid.get_value(g);
-        if (r == FPGA_OK){
-            char guid_str[84];
-            uuid_unparse(g, guid_str);
-            std::cout << "guid prop read: " << guid_str << "\n";
-        }
+        auto props = properties::read(tok);
+        std::cout << "guid prop read: " << props->guid << "\n";
         fpga_token p;
-        r = props->parent.get_value(p);
-        if (r == FPGA_OK){
-            //char guid_str[84];
-            //uuid_unparse(g, guid_str);
-            //std::cout << "parent prop read: " << guid_str << "\n";
-        }
 
         std::cout << "bus: 0x" << std::hex << props->bus << "\n";
         handle::ptr_t h = handle::open(tok, FPGA_OPEN_SHARED);
         uint8_t *mmio_ptr = 0;
-        auto res = fpgaMapMMIO(h->get(), 0, reinterpret_cast<uint64_t**>(&mmio_ptr));
+        auto res = fpgaMapMMIO(*h, 0, reinterpret_cast<uint64_t**>(&mmio_ptr));
         if (res == FPGA_OK){
             uint64_t scratch = 0;
-            if (fpgaWriteMMIO64(h->get(), 0, 0x100, 0xdeadbeef) == FPGA_OK &&
-                fpgaReadMMIO64(h->get(), 0, 0x100, &scratch) == FPGA_OK){
+            if (fpgaWriteMMIO64(*h, 0, 0x100, 0xdeadbeef) == FPGA_OK &&
+                fpgaReadMMIO64(*h, 0, 0x100, &scratch) == FPGA_OK){
                 std::cout << "mmio @0x100: 0x" << std::hex << scratch << std::endl;
                 std::cout << "mmio @0x100: 0x" << std::hex << *reinterpret_cast<uint64_t*>(mmio_ptr+0x100) << std::endl;
-     
+
             }
-            
         }
     }
 


### PR DESCRIPTION
Add implicit conversion operator to the following classes:
* `properties`
  * convert to `fpga_properties`
* `token`
  * convert to `fpga_token`
* `handle`
  * convert to `fpga_handle`

Update simple_example to account for conversion operators. More
specifically:
* replace `p->get()` with `*p` when calling OPAE C API functions.
* use the `<<` operator on the `guid` property since it overloads it