### PR TITLE
opaec++: add DMA buffer support

### DIFF
--- a/libopae++/CMakeLists.txt
+++ b/libopae++/CMakeLists.txt
@@ -53,7 +53,8 @@ include_directories(
 
 set(OPAECXX_SRC src/properties.cpp
                 src/token.cpp
-                src/handle.cpp)
+                src/handle.cpp
+                src/dma_buffer.cpp)
 add_library(opae-cxx-core SHARED ${OPAECXX_SRC})
 target_link_libraries(opae-cxx-core opae-c)
 add_executable(simple_example samples/simple_example.cpp)

--- a/libopae++/include/opaec++/dma_buffer.h
+++ b/libopae++/include/opaec++/dma_buffer.h
@@ -59,6 +59,19 @@ public:
      */
     static dma_buffer::ptr_t allocate(handle::ptr_t handle, size_t len);
 
+    /** Attach a pre-allocated buffer to a dma_buffer object.
+     *
+     * @param[in] handle The handle used to attach the buffer.
+     * @param[in] base The base of the pre-allocated memory.
+     * @param[in] len The size of the pre-allocated memory,
+     * which must be a multiple of the page size.
+     * @return A valid dma_buffer smart pointer on success, or an
+     * empty smart pointer on failure.
+     */
+    static dma_buffer::ptr_t attach(handle::ptr_t handle,
+                                    uint8_t *base,
+                                    size_t len);
+
     /** Retrieve the virtual address of the buffer base.
      */
     volatile uint8_t * get() const { return virt_; }

--- a/libopae++/include/opaec++/dma_buffer.h
+++ b/libopae++/include/opaec++/dma_buffer.h
@@ -1,0 +1,248 @@
+// Copyright(c) 2017, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+#include <memory>
+#include <cstdint>
+#include <vector>
+#include <initializer_list>
+#include <chrono>
+#include <thread>
+
+#include <opae/buffer.h>
+#include <opaec++/handle.h>
+
+namespace opae
+{
+namespace fpga
+{
+namespace types
+{
+
+class dma_buffer : public std::enable_shared_from_this<dma_buffer>
+{
+public:
+    typedef std::size_t size_t;
+    typedef std::shared_ptr<dma_buffer> ptr_t;
+
+    /** dma_buffer destructor.
+     */
+    virtual ~dma_buffer();
+
+    /** dma_buffer factory method - allocate a dma_buffer.
+     * @param[in] handle The handle used to allocate the buffer.
+     * @param[in] len    The length in bytes of the requested buffer.
+     * @return A valid dma_buffer smart pointer on success, or an
+     * empty smart pointer on failure.
+     */
+    static dma_buffer::ptr_t allocate(handle::ptr_t handle, size_t len);
+
+    /** Retrieve the virtual address of the buffer base.
+     */
+    volatile uint8_t * get() const { return virt_; }
+
+    /** Retrieve the handle smart pointer associated with
+     * this buffer.
+     */
+    handle::ptr_t get_owner() const { return handle_; }
+
+    /** Retrieve the length of the buffer in bytes.
+     */
+    size_t get_size() const { return len_; }
+
+    /** Retrieve the address of the buffer suitable for
+     * programming into the accelerator device.
+     */
+    uint64_t get_iova() const { return iova_; }
+
+    /** Divide a buffer into a series of smaller buffers.
+     *
+     * For each item sz found in sizes, create a new dma_buffer
+     * smart pointer whose size is sz and append the new smart
+     * pointer to the end of the returned vector. The sub-buffers
+     * are created in increasing order from the beginning of
+     * this dma_buffer. The parent buffer (this) of each sub-buffer
+     * is tracked so that it cannot be freed prior to a sub-buffer
+     * free.
+     *
+     * @param[in] sizes An initializer list of sizes for the sub-buffers.
+     * @return A std::vector of the sub-buffer pointers.
+     */
+    template <typename T>
+    std::vector<ptr_t> split(std::initializer_list<T> sizes)
+    {
+        std::vector<ptr_t> v;
+        size_t offset = 0;
+
+        v.reserve(sizes.size());
+
+        for (const auto &sz : sizes) {
+            ptr_t p;
+            p.reset(new dma_buffer(handle_,
+                                   sz,
+                                   virt_ + offset,
+                                   wsid_,
+                                   iova_ + offset,
+                                   shared_from_this()));
+            v.push_back(p);
+            offset += sz;
+        }
+
+        return v;
+    }
+
+    /** Write c to each byte location in the buffer.
+     */
+    void fill(int c);
+
+    /** Compare this dma_buffer (the first len bytes)
+     * to that held in other, using memcmp().
+     */
+    int compare(ptr_t other, size_t len) const;
+
+    /** Read a T-sized block of memory at the given location.
+     * @param[in] offset The byte offset from the start of the buffer.
+     * @return A T from buffer base + offset.
+     */
+    template <typename T>
+    T read(size_t offset) const
+    {
+        if ((offset < len_) && (virt_ != nullptr)) {
+            return *reinterpret_cast<T *>(virt_ + offset);
+        }
+        // TODO log/throw error
+
+        return T();
+    }
+
+    /** Write a T-sized block of memory to the given location.
+     * @param[in] value The value to write.
+     * @param[in] offset The byte offset from the start of the buffer.
+     */
+    template <typename T>
+    void write(const T &value, size_t offset)
+    {
+        if ((offset < len_) && (virt_ != nullptr)) {
+            *reinterpret_cast<T *>(virt_ + offset) = value;
+        }
+        // TODO log/throw error
+    }
+
+    using microseconds_t = std::chrono::microseconds;
+    using time_point_t = std::chrono::high_resolution_clock::time_point;
+    using duration_t = std::chrono::duration<double>;
+
+    /** Poll for a specific value to appear at a given buffer location.
+     *
+     * Loops on a memory location without explicitly yielding the processor.
+     * This API should be used only for time-critical scenarios, eg waiting
+     * on a DMA address to be updated by hardware.
+     *
+     * @param[in] offset The byte offset from the start of the buffer.
+     * @param[in] timeout The maximum time to wait in microseconds.
+     * @param[in] mask A bit mask to apply to the value read from the buffer.
+     * @param[in] value The expected value after applying the mask.
+     * @retval true If the expected value was observed.
+     * @retval false If the timeout expired before seeing the expected value.
+     */
+    template <typename T>
+    bool poll(size_t offset, microseconds_t timeout, T mask, T value) const
+    {
+        time_point_t start = std::chrono::high_resolution_clock::now();
+        microseconds_t elapsed;
+
+        do
+        {
+            if ((read<T>(offset) & mask) == value)
+                return true;
+
+            elapsed = std::chrono::duration_cast<microseconds_t>(
+                        std::chrono::high_resolution_clock::now() - start);
+
+        }while(elapsed < timeout);
+
+        return false;
+    }
+
+    /** Wait for a specific value to appear at a given buffer location.
+     *
+     * Loops on a memory location, yielding the processor after each iteration.
+     * This API should not be used for time-critical scenarios. See poll instead.
+     *
+     * @param[in] offset The byte offset from the start of the buffer.
+     * @param[in] each The number of microseconds to sleep each loop iteration.
+     * @param[in] timeout The maximum time to wait in microseconds.
+     * @param[in] mask A bit mask to apply to the value read from the buffer.
+     * @param[in] value The expected value after applying the mask.
+     * @retval true If the expected value was observed.
+     * @retval false If the timeout expired before seeing the expected value.
+     */
+    template <typename T>
+    bool wait(size_t offset, microseconds_t each, microseconds_t timeout, T mask, T value) const
+    {
+        time_point_t start = std::chrono::high_resolution_clock::now();
+        microseconds_t elapsed;
+
+        do
+        {
+            if ((read<T>(offset) & mask) == value)
+                return true;
+
+            std::this_thread::sleep_for(each);
+
+            elapsed = std::chrono::duration_cast<microseconds_t>(
+                        std::chrono::high_resolution_clock::now() - start);
+
+        }while(elapsed < timeout);
+
+        return false;
+    }
+
+protected:
+    handle::ptr_t handle_;
+    size_t len_;
+    uint8_t *virt_;
+    uint64_t wsid_;
+    uint64_t iova_;
+    ptr_t parent_; // for split buffers
+
+private:
+    dma_buffer(handle::ptr_t handle,
+               size_t len,
+               uint8_t *virt,
+               uint64_t wsid,
+               uint64_t iova);
+
+    dma_buffer(handle::ptr_t handle,
+               size_t len,
+               uint8_t *virt,
+               uint64_t wsid,
+               uint64_t iova,
+               ptr_t parent);
+};
+
+} // end of namespace types
+} // end of namespace fpga
+} // end of namespace opae

--- a/libopae++/src/dma_buffer.cpp
+++ b/libopae++/src/dma_buffer.cpp
@@ -81,6 +81,40 @@ dma_buffer::ptr_t dma_buffer::allocate(handle::ptr_t handle, size_t len)
     return p;
 }
 
+dma_buffer::ptr_t dma_buffer::attach(handle::ptr_t handle,
+                                     uint8_t *base,
+                                     size_t len)
+{
+    ptr_t p;
+
+    uint8_t *virt = base;
+    uint64_t iova = 0;
+    uint64_t wsid = 0;
+
+    fpga_result res = fpgaPrepareBuffer(handle->get(),
+                                        len,
+                                        reinterpret_cast<void **>(&virt),
+                                        &wsid,
+                                        FPGA_BUF_PREALLOCATED);
+ 
+    if (res == FPGA_OK) {
+
+        res = fpgaGetIOAddress(handle->get(), wsid, &iova);
+        if (res == FPGA_OK) {
+
+            p.reset(new dma_buffer(handle, len, virt, wsid, iova));
+
+        } else {
+            // TODO: log/throw error
+        }
+
+    } else {
+        // TODO: log/throw error
+    }
+
+    return p;
+}
+
 void dma_buffer::fill(int c)
 {
     ::memset(virt_, c, len_);

--- a/libopae++/src/dma_buffer.cpp
+++ b/libopae++/src/dma_buffer.cpp
@@ -1,0 +1,123 @@
+// Copyright(c) 2017, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include <cstring>
+
+#include "opaec++/dma_buffer.h"
+
+namespace opae
+{
+namespace fpga
+{
+namespace types
+{
+
+dma_buffer::~dma_buffer()
+{
+    // If this owns the buffer allocation and
+    // that allocation was successful.
+    if (!parent_ && virt_) {
+        fpga_result res = fpgaReleaseBuffer(handle_->get(), wsid_);
+
+        if (res != FPGA_OK) {
+            // TODO log/throw error
+        }
+    }
+}
+
+dma_buffer::ptr_t dma_buffer::allocate(handle::ptr_t handle, size_t len)
+{
+    ptr_t p;
+
+    if (!len)
+        return p;
+
+    uint8_t *virt = nullptr;
+    uint64_t iova = 0;
+    uint64_t wsid = 0;
+
+    fpga_result res = fpgaPrepareBuffer(handle->get(),
+                                        len,
+                                        reinterpret_cast<void **>(&virt),
+                                        &wsid,
+                                        0);
+    if (res == FPGA_OK) {
+
+        res = fpgaGetIOAddress(handle->get(), wsid, &iova);
+        if (res == FPGA_OK) {
+
+            p.reset(new dma_buffer(handle, len, virt, wsid, iova));
+
+        } else {
+            // TODO: log/throw error
+        }
+
+    } else {
+        // TODO: log/throw error
+    }
+
+    return p;
+}
+
+void dma_buffer::fill(int c)
+{
+    ::memset(virt_, c, len_);
+}
+
+int dma_buffer::compare(dma_buffer::ptr_t other, size_t len) const
+{
+    return ::memcmp(virt_, other->virt_, len);
+}
+
+dma_buffer::dma_buffer(handle::ptr_t handle,
+                       size_t len,
+                       uint8_t *virt,
+                       uint64_t wsid,
+                       uint64_t iova)
+: handle_(handle)
+, len_(len)
+, virt_(virt)
+, wsid_(wsid)
+, iova_(iova)
+{}
+
+dma_buffer::dma_buffer(handle::ptr_t handle,
+                       size_t len,
+                       uint8_t *virt,
+                       uint64_t wsid,
+                       uint64_t iova,
+                       dma_buffer::ptr_t parent)
+: handle_(handle)
+, len_(len)
+, virt_(virt)
+, wsid_(wsid)
+, iova_(iova)
+, parent_(parent)
+{}
+
+} // end of namespace types
+} // end of namespace fpga
+} // end of namespace opae
+

--- a/libopae++/tests/CMakeLists.txt
+++ b/libopae++/tests/CMakeLists.txt
@@ -32,8 +32,8 @@ find_package(GTest)
 set(SRC gtmain.cpp
     unit/gtEnumerate.cpp
     unit/gtOpenClose.cpp
-    unit/gtCxxProperties.cpp)
-
+    unit/gtCxxProperties.cpp
+    unit/gtBuffer.cpp)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include ${GTEST_INCLUDE_DIRS})
 add_executable(gtcxx ${SRC})
 target_link_libraries(gtcxx  opae-c opae-cxx-core uuid ${GTEST_BOTH_LIBRARIES})

--- a/libopae++/tests/unit/gtBuffer.cpp
+++ b/libopae++/tests/unit/gtBuffer.cpp
@@ -1,0 +1,161 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "gtest/gtest.h"
+
+#include "opaec++/handle.h"
+#include "opaec++/dma_buffer.h"
+
+using namespace opae::fpga::types;
+
+
+class CxxBuffer_f1 : public ::testing::Test
+{
+protected:
+    CxxBuffer_f1() {}
+
+    virtual void SetUp() override
+    {
+        tokens_ = token::enumerate({FPGA_ACCELERATOR});
+        ASSERT_GT(tokens_.size(), 0);
+        accel_ = handle::open(tokens_[0], 0);
+        ASSERT_NE(nullptr, accel_.get());
+    }
+
+    virtual void TearDown() override
+    {
+        accel_.reset();
+        ASSERT_NO_THROW(tokens_.clear());
+    }
+
+    std::vector<token::ptr_t> tokens_;
+    handle::ptr_t accel_;
+    dma_buffer::ptr_t buf_;
+};
+
+/**
+ * @test alloc_01
+ * Given an open accelerator handle object<br>
+ * When I call dma_buffer::allocate() with a length of 0<br>
+ * Then I get an empty dma_buffer pointer.<br>
+ */
+TEST_F(CxxBuffer_f1, alloc_01){
+    buf_ = dma_buffer::allocate(accel_, 0);
+    ASSERT_EQ(nullptr, buf_.get());
+}
+
+/**
+ * @test alloc_02
+ * Given an open accelerator handle object<br>
+ * When I call dma_buffer::allocate() with a length greater than 0<br>
+ * Then I get a valid dma_buffer pointer.<br>
+ */
+TEST_F(CxxBuffer_f1, alloc_02){
+    buf_ = dma_buffer::allocate(accel_, 64);
+    ASSERT_NE(nullptr, buf_.get());
+
+    EXPECT_EQ(64, buf_->get_size());
+    EXPECT_NE(0, buf_->get_iova());
+}
+
+/**
+ * @test split_03
+ * Given a valid dma_buffer smart pointer<br>
+ * When I call dma_buffer::split(),<br>
+ * The sub-buffers are created according to the initialier_list.<br>
+ */
+TEST_F(CxxBuffer_f1, split_03){
+    buf_ = dma_buffer::allocate(accel_, 64);
+    ASSERT_NE(nullptr, buf_.get());
+
+    std::vector<dma_buffer::ptr_t> v = buf_->split({16, 16, 16, 16});
+
+    EXPECT_EQ(buf_->get(), v[0]->get());
+    EXPECT_EQ(buf_->get_iova(), v[0]->get_iova());
+    EXPECT_EQ(16, v[0]->get_size());
+
+    EXPECT_EQ(buf_->get()+16, v[1]->get());
+    EXPECT_EQ(buf_->get_iova()+16, v[1]->get_iova());
+    EXPECT_EQ(16, v[1]->get_size());
+
+    EXPECT_EQ(buf_->get()+32, v[2]->get());
+    EXPECT_EQ(buf_->get_iova()+32, v[2]->get_iova());
+    EXPECT_EQ(16, v[2]->get_size());
+
+    EXPECT_EQ(buf_->get()+48, v[3]->get());
+    EXPECT_EQ(buf_->get_iova()+48, v[3]->get_iova());
+    EXPECT_EQ(16, v[3]->get_size());
+}
+
+/**
+ * @test fill_compare_04
+ * Given a valid dma_buffer smart pointer<br>
+ * When I call dma_buffer::fill(),<br>
+ * Each byte of the buffer is set to the input value.<br>
+ * When I call dma_buffer::compare(),<br>
+ * Then a byte-wise comparison is performed.<br>
+ */
+TEST_F(CxxBuffer_f1, fill_compare_04){
+    buf_ = dma_buffer::allocate(accel_, 4);
+    ASSERT_NE(nullptr, buf_.get());
+
+    dma_buffer::ptr_t buf2 = dma_buffer::allocate(accel_, 4);
+    ASSERT_NE(nullptr, buf2.get());
+
+    buf_->fill(1);
+    buf2->fill(1);
+    EXPECT_EQ(0, buf_->compare(buf2, buf_->get_size()));
+}
+
+/**
+ * @test read_write_05
+ * Given a valid dma_buffer smart pointer<br>
+ * When I call dma_buffer::write(),<br>
+ * Then the requested memory block is updated.<br>
+ * When I call dma_buffer::read(),<br>
+ * Then the requested memory block is returned.<br>
+ */
+TEST_F(CxxBuffer_f1, read_write_05){
+    buf_ = dma_buffer::allocate(accel_, 4);
+    ASSERT_NE(nullptr, buf_.get());
+
+    buf_->write<uint32_t>(0xdecafbad, 0);
+    EXPECT_EQ(0xdecafbad, buf_->read<uint32_t>(0));
+}
+
+/**
+ * @test poll_wait_06
+ * Given a valid dma_buffer smart pointer<br>
+ * When I call dma_buffer::poll(),<br>
+ * Then the return value is false when the given mask/value are not observed .<br>
+ * When I call dma_buffer::poll(),<br>
+ * Then the return value is true when the given mask/value are observed .<br>
+ * When I call dma_buffer::wait(),<br>
+ * Then the return value is false when the given mask/value are not observed .<br>
+ * When I call dma_buffer::wait(),<br>
+ * Then the return value is true when the given mask/value are observed .<br>
+ */
+TEST_F(CxxBuffer_f1, poll_wait_06){
+    buf_ = dma_buffer::allocate(accel_, 4);
+    ASSERT_NE(nullptr, buf_.get());
+
+    dma_buffer::size_t offset = 0;
+    dma_buffer::microseconds_t micros(1000);
+    dma_buffer::microseconds_t each(100);
+    uint32_t mask = 0xffffffff;
+    uint32_t value = 0xdecafbad;
+    uint32_t wrong_value = 0xdeadbeef;
+
+    buf_->write<uint32_t>(value, offset);
+    EXPECT_FALSE(buf_->poll(offset, micros, mask, wrong_value));
+    EXPECT_TRUE(buf_->poll(offset, micros, mask, value));
+
+    EXPECT_FALSE(buf_->wait(offset, each, micros, mask, wrong_value));
+    EXPECT_TRUE(buf_->wait(offset, each, micros, mask, value));
+}
+

--- a/libopae++/tests/unit/gtBuffer.cpp
+++ b/libopae++/tests/unit/gtBuffer.cpp
@@ -59,8 +59,8 @@ TEST_F(CxxBuffer_f1, alloc_02){
     buf_ = dma_buffer::allocate(accel_, 64);
     ASSERT_NE(nullptr, buf_.get());
 
-    EXPECT_EQ(64, buf_->get_size());
-    EXPECT_NE(0, buf_->get_iova());
+    EXPECT_EQ(64, buf_->size());
+    EXPECT_NE(0, buf_->iova());
 }
 
 /**
@@ -76,20 +76,20 @@ TEST_F(CxxBuffer_f1, split_03){
     std::vector<dma_buffer::ptr_t> v = buf_->split({16, 16, 16, 16});
 
     EXPECT_EQ(buf_->get(), v[0]->get());
-    EXPECT_EQ(buf_->get_iova(), v[0]->get_iova());
-    EXPECT_EQ(16, v[0]->get_size());
+    EXPECT_EQ(buf_->iova(), v[0]->iova());
+    EXPECT_EQ(16, v[0]->size());
 
     EXPECT_EQ(buf_->get()+16, v[1]->get());
-    EXPECT_EQ(buf_->get_iova()+16, v[1]->get_iova());
-    EXPECT_EQ(16, v[1]->get_size());
+    EXPECT_EQ(buf_->iova()+16, v[1]->iova());
+    EXPECT_EQ(16, v[1]->size());
 
     EXPECT_EQ(buf_->get()+32, v[2]->get());
-    EXPECT_EQ(buf_->get_iova()+32, v[2]->get_iova());
-    EXPECT_EQ(16, v[2]->get_size());
+    EXPECT_EQ(buf_->iova()+32, v[2]->iova());
+    EXPECT_EQ(16, v[2]->size());
 
     EXPECT_EQ(buf_->get()+48, v[3]->get());
-    EXPECT_EQ(buf_->get_iova()+48, v[3]->get_iova());
-    EXPECT_EQ(16, v[3]->get_size());
+    EXPECT_EQ(buf_->iova()+48, v[3]->iova());
+    EXPECT_EQ(16, v[3]->size());
 }
 
 /**
@@ -109,7 +109,7 @@ TEST_F(CxxBuffer_f1, fill_compare_04){
 
     buf_->fill(1);
     buf2->fill(1);
-    EXPECT_EQ(0, buf_->compare(buf2, buf_->get_size()));
+    EXPECT_EQ(0, buf_->compare(buf2, buf_->size()));
 }
 
 /**
@@ -131,13 +131,13 @@ TEST_F(CxxBuffer_f1, read_write_05){
 /**
  * @test poll_wait_06
  * Given a valid dma_buffer smart pointer<br>
- * When I call dma_buffer::poll(),<br>
+ * When I call poll(),<br>
  * Then the return value is false when the given mask/value are not observed .<br>
- * When I call dma_buffer::poll(),<br>
+ * When I call poll(),<br>
  * Then the return value is true when the given mask/value are observed .<br>
- * When I call dma_buffer::wait(),<br>
+ * When I call wait(),<br>
  * Then the return value is false when the given mask/value are not observed .<br>
- * When I call dma_buffer::wait(),<br>
+ * When I call wait(),<br>
  * Then the return value is true when the given mask/value are observed .<br>
  */
 TEST_F(CxxBuffer_f1, poll_wait_06){
@@ -145,17 +145,17 @@ TEST_F(CxxBuffer_f1, poll_wait_06){
     ASSERT_NE(nullptr, buf_.get());
 
     dma_buffer::size_t offset = 0;
-    dma_buffer::microseconds_t micros(1000);
-    dma_buffer::microseconds_t each(100);
+    std::chrono::microseconds micros(1000);
+    std::chrono::microseconds each(100);
     uint32_t mask = 0xffffffff;
     uint32_t value = 0xdecafbad;
     uint32_t wrong_value = 0xdeadbeef;
 
     buf_->write<uint32_t>(value, offset);
-    EXPECT_FALSE(buf_->poll(offset, micros, mask, wrong_value));
-    EXPECT_TRUE(buf_->poll(offset, micros, mask, value));
+    EXPECT_FALSE(poll(buf_, offset, micros, mask, wrong_value));
+    EXPECT_TRUE(poll(buf_, offset, micros, mask, value));
 
-    EXPECT_FALSE(buf_->wait(offset, each, micros, mask, wrong_value));
-    EXPECT_TRUE(buf_->wait(offset, each, micros, mask, value));
+    EXPECT_FALSE(wait(buf_, offset, each, micros, mask, wrong_value));
+    EXPECT_TRUE(wait(buf_, offset, each, micros, mask, value));
 }
 

--- a/libopae++/tests/unit/gtBuffer.cpp
+++ b/libopae++/tests/unit/gtBuffer.cpp
@@ -6,6 +6,8 @@ extern "C" {
 }
 #endif
 
+#include <unistd.h>
+
 #include "gtest/gtest.h"
 
 #include "opaec++/handle.h"
@@ -61,6 +63,26 @@ TEST_F(CxxBuffer_f1, alloc_02){
 
     EXPECT_EQ(64, buf_->size());
     EXPECT_NE(0, buf_->iova());
+}
+
+/**
+ * @test alloc_07
+ * Given an open accelerator handle object and a pre-allocated buffer<br>
+ * When I call dma_buffer::attach() with a length that is a multiple of the page size<br>
+ * Then I get a valid dma_buffer pointer.<br>
+ */
+TEST_F(CxxBuffer_f1, alloc_07){
+
+    uint64_t pg_size = (uint64_t) sysconf(_SC_PAGE_SIZE);
+    uint8_t *buf = (uint8_t *) malloc(pg_size);
+
+    buf_ = dma_buffer::attach(accel_, buf, pg_size);
+    ASSERT_NE(nullptr, buf_.get());
+
+    EXPECT_EQ(static_cast<dma_buffer::size_t>(pg_size), buf_->size());
+    EXPECT_NE(0, buf_->iova());
+
+    free(buf);
 }
 
 /**


### PR DESCRIPTION
Provides methods for fill, compare, read, write, poll, wait, and split.
Tracks the buffer owner (handle) so that it is not released before the
buffer.