### PR TITLE
opae-c: link libopae-c with pthreads

### DIFF
--- a/libopae/CMakeLists.txt
+++ b/libopae/CMakeLists.txt
@@ -65,7 +65,8 @@ target_link_libraries(opae-c
   m
   safestr
   ${libjson-c_LIBRARIES}
-  ${libuuid_LIBRARIES})
+  ${libuuid_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT})
 
 # Define headers for this library. PUBLIC headers are used for
 # compiling the library, and will be added to consumers' build

--- a/libopae/CMakeLists.txt
+++ b/libopae/CMakeLists.txt
@@ -68,6 +68,8 @@ target_link_libraries(opae-c
   ${libuuid_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT})
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
+
 # Define headers for this library. PUBLIC headers are used for
 # compiling the library, and will be added to consumers' build
 # paths. Keep current directory private.


### PR DESCRIPTION
Not linking opae-c with pthreads placed the burden on applications to
link with the library. This change adds -lpthread to the opae-c link
line where it rightly belongs.