### PR TITLE
c++: Update API and example to use new APIs

### DIFF
--- a/libopae++/samples/simple_example.cpp
+++ b/libopae++/samples/simple_example.cpp
@@ -46,7 +46,7 @@ int main(int argc, char* argvp[])
         p.guid = uuid;
     }
     p.bbs_id = 0;
-    auto tokens = token::enumerate({ p });
+    auto tokens = token::enumerate({p});
     if (tokens.size() > 0){
         auto tok = tokens[0];
         auto props = properties::read(tok);
@@ -54,17 +54,11 @@ int main(int argc, char* argvp[])
 
         std::cout << "bus: 0x" << std::hex << props->bus << "\n";
         handle::ptr_t h = handle::open(tok, FPGA_OPEN_SHARED);
-        uint8_t *mmio_ptr = 0;
-        auto res = fpgaMapMMIO(*h, 0, reinterpret_cast<uint64_t**>(&mmio_ptr));
-        if (res == FPGA_OK){
-            uint64_t scratch = 0;
-            if (fpgaWriteMMIO64(*h, 0, 0x100, 0xdeadbeef) == FPGA_OK &&
-                fpgaReadMMIO64(*h, 0, 0x100, &scratch) == FPGA_OK){
-                std::cout << "mmio @0x100: 0x" << std::hex << scratch << std::endl;
-                std::cout << "mmio @0x100: 0x" << std::hex << *reinterpret_cast<uint64_t*>(mmio_ptr+0x100) << std::endl;
-
-            }
-        }
+        uint64_t value1 = 0xdeadbeef, value2 = 0;
+        h->write(0x100, value1);
+        h->read(0x100, value2);
+        std::cout << "mmio @0x100: 0x" << std::hex << value2 << "\n";
+        std::cout << "mmio @0x100: 0x" << std::hex << *reinterpret_cast<uint64_t*>(h->mmio_ptr(0x100)) << "\n";
     }
 
     return  0;

--- a/libopae++/samples/simple_example.cpp
+++ b/libopae++/samples/simple_example.cpp
@@ -37,16 +37,16 @@ int main(int argc, char* argvp[])
     const char* NLB0 = "D8424DC4-A4A3-C413-F89E-433683F9040B";
     const char* NLB3 = "F7DF405C-BD7A-CF72-22F1-44B0B93ACD18";
 
-    properties p;
+    properties props_filter;
 
-    p.socket_id = 1;
-    p.type = FPGA_ACCELERATOR;
+    props_filter.socket_id = 1;
+    props_filter.type = FPGA_ACCELERATOR;
     uuid_t uuid;
     if (uuid_parse(NLB0, uuid) == 0){
-        p.guid = uuid;
+        props_filter.guid = uuid;
     }
-    p.bbs_id = 0;
-    auto tokens = token::enumerate({p});
+    props_filter.bbs_id = 0; // This is invalid - libopae-c prints out a warning
+    auto tokens = token::enumerate({props_filter});
     if (tokens.size() > 0){
         auto tok = tokens[0];
         auto props = properties::read(tok);

--- a/libopae++/src/handle.cpp
+++ b/libopae++/src/handle.cpp
@@ -75,9 +75,8 @@ handle::ptr_t handle::open(fpga_token token, int flags, uint32_t mmio_region){
         fpga_objtype ty = FPGA_DEVICE;
 
         properties::ptr_t props = properties::read(token);
-        props->type.get_value(ty);
 
-        if (FPGA_ACCELERATOR == ty) {
+        if (FPGA_ACCELERATOR == props->type) {
 
             res = fpgaMapMMIO(c_handle, mmio_region, reinterpret_cast<uint64_t **>(&mmio_base));
 
@@ -93,8 +92,8 @@ handle::ptr_t handle::open(fpga_token token, int flags, uint32_t mmio_region){
     return p;
 }
 
-handle::ptr_t handle::open(token::ptr_t token, int flags, uint32_t mmio_region){
-    return handle::open(token->get(), flags, mmio_region);
+handle::ptr_t handle::open(token::ptr_t tok, int flags, uint32_t mmio_region){
+    return handle::open(*tok, flags, mmio_region);
 }
 
 fpga_result handle::close(){


### PR DESCRIPTION
Update handle class to use implicit conversion operator for handle and
for properties::type.

Update simple_example to use handle::read and handle::write and
handle::mmio_ptr.