### PR TITLE
c++: Add static variable, properties::none

### DIFF
--- a/libopae++/include/opaec++/properties.h
+++ b/libopae++/include/opaec++/properties.h
@@ -45,7 +45,7 @@ class properties
 public:
     typedef std::shared_ptr<properties> ptr_t;
 
-    static std::vector<properties> none;
+    const static std::vector<properties> none;
 
     properties();
     properties(fpga_objtype objtype);

--- a/libopae++/include/opaec++/properties.h
+++ b/libopae++/include/opaec++/properties.h
@@ -45,6 +45,8 @@ class properties
 public:
     typedef std::shared_ptr<properties> ptr_t;
 
+    static std::vector<properties> none;
+
     properties();
     properties(fpga_objtype objtype);
 

--- a/libopae++/include/opaec++/token.h
+++ b/libopae++/include/opaec++/token.h
@@ -43,6 +43,9 @@ class token
 {
 public:
     typedef std::shared_ptr<token> ptr_t;
+
+    static std::vector<token::ptr_t> enumerate();
+
     static std::vector<token::ptr_t> enumerate(const std::vector<properties> & props);
 
     ~token();

--- a/libopae++/include/opaec++/token.h
+++ b/libopae++/include/opaec++/token.h
@@ -44,8 +44,6 @@ class token
 public:
     typedef std::shared_ptr<token> ptr_t;
 
-    static std::vector<token::ptr_t> enumerate();
-
     static std::vector<token::ptr_t> enumerate(const std::vector<properties> & props);
 
     ~token();

--- a/libopae++/src/properties.cpp
+++ b/libopae++/src/properties.cpp
@@ -33,7 +33,7 @@ namespace fpga
 namespace types
 {
 
-std::vector<properties> properties::none = {};
+const std::vector<properties> properties::none = {};
 
 properties::properties()
 : props_(nullptr)

--- a/libopae++/src/properties.cpp
+++ b/libopae++/src/properties.cpp
@@ -33,6 +33,8 @@ namespace fpga
 namespace types
 {
 
+std::vector<properties> properties::none = {};
+
 properties::properties()
 : props_(nullptr)
 , type(&props_, fpgaPropertiesGetObjectType, fpgaPropertiesSetObjectType)

--- a/libopae++/src/token.cpp
+++ b/libopae++/src/token.cpp
@@ -34,6 +34,10 @@ namespace types
 {
 
 
+std::vector<token::ptr_t> token::enumerate(){
+    return token::enumerate({});
+}
+
 std::vector<token::ptr_t> token::enumerate(const std::vector<properties> & props){
     std::vector<token::ptr_t> tokens;
     std::vector<fpga_properties> c_props(props.size());

--- a/libopae++/src/token.cpp
+++ b/libopae++/src/token.cpp
@@ -33,11 +33,6 @@ namespace fpga
 namespace types
 {
 
-
-std::vector<token::ptr_t> token::enumerate(){
-    return token::enumerate({});
-}
-
 std::vector<token::ptr_t> token::enumerate(const std::vector<properties> & props){
     std::vector<token::ptr_t> tokens;
     std::vector<fpga_properties> c_props(props.size());


### PR DESCRIPTION
Add a static variable, `properties::none` that is initialized to an empty vector of `properties`