### PR TITLE
c++: Fix pvalue stream operator to call fpga get

### DIFF
--- a/libopae++/include/opaec++/pvalue.h
+++ b/libopae++/include/opaec++/pvalue.h
@@ -77,9 +77,15 @@ struct guid_t
     }
 
     friend std::ostream & operator<<(std::ostream & ostr, const guid_t & g){
-        char guid_str[84];
-        uuid_unparse(g.data_.data(), guid_str);
-        ostr << guid_str;
+        fpga_properties props = *g.props_;
+        fpga_guid guid_value;
+        if (fpgaPropertiesGetGUID(props, &guid_value) == FPGA_OK){
+            char guid_str[84];
+            uuid_unparse(g.data_.data(), guid_str);
+            ostr << guid_str;
+        }else{
+            // TODO: Log or throw
+        }
         return ostr;
     }
 
@@ -132,7 +138,13 @@ struct pvalue
     }
 
     friend std::ostream & operator<<(std::ostream & ostr, const pvalue<T> & p){
-        ostr << +(p.copy_);
+        T value;
+        fpga_properties props = *p.props_;
+        if (p.get_(props, &value) == FPGA_OK){
+            ostr << +(value);
+        }else{
+            // TODO: Log or throw
+        }
         return ostr;
     }
 


### PR DESCRIPTION
When the stream operator is called on a pvalue struct or a guid_t
struct, its copied value may not be an accurate reflection of the
property stored in its `fpga_properties*` member variable `props_`

This updates the `<<` operator to use the approprate getter function
(`get_` for `pvalue` or `fpgaPropertiesGetGUID` for `guid_t`) to get
the value from its `fpga_properties*` member, `props_`.