### PR TITLE
c++: Enhance `guid_t` and add ctor to `properties`

### DIFF
--- a/libopae++/include/opaec++/properties.h
+++ b/libopae++/include/opaec++/properties.h
@@ -44,6 +44,9 @@ class properties {
   const static std::vector<properties> none;
 
   properties();
+
+  properties(fpga_guid guid_in);
+
   properties(fpga_objtype objtype);
 
   ~properties();

--- a/libopae++/include/opaec++/pvalue.h
+++ b/libopae++/include/opaec++/pvalue.h
@@ -43,6 +43,7 @@ struct guid_t {
             *props_, reinterpret_cast<fpga_guid *>(data_.data())) == FPGA_OK) {
       return data_.data();
     }
+    return nullptr;
   }
 
   const uint8_t* get() const {

--- a/libopae++/include/opaec++/pvalue.h
+++ b/libopae++/include/opaec++/pvalue.h
@@ -43,7 +43,10 @@ struct guid_t {
             *props_, reinterpret_cast<fpga_guid *>(data_.data())) == FPGA_OK) {
       return data_.data();
     }
-    return nullptr;
+  }
+
+  const uint8_t* get() const {
+      return data_.data();
   }
 
   guid_t &operator=(fpga_guid g) {

--- a/libopae++/src/properties.cpp
+++ b/libopae++/src/properties.cpp
@@ -64,6 +64,8 @@ properties::properties()
   }
 }
 
+properties::properties(fpga_guid guid_in) : properties(){ guid = guid_in; }
+
 properties::properties(fpga_objtype objtype) : properties() { type = objtype; }
 
 properties::~properties() {

--- a/libopae++/tests/unit/gtCxxProperties.cpp
+++ b/libopae++/tests/unit/gtCxxProperties.cpp
@@ -77,12 +77,28 @@ TEST(CxxProperties, get_guid) {
  * When I set compare its guid with the known guid
  * Then the result is true
  */
-TEST(CxxProperties, compare_guid) {
+TEST(CxxProperties, compare_guid){
   fpga_guid guid_in;
   properties p;
   uuid_parse(TEST_GUID_STR, guid_in);
   EXPECT_FALSE(p.guid == guid_in);
   p.guid = guid_in;
+  ASSERT_EQ(memcmp(p.guid.get(), guid_in, sizeof(fpga_guid)), 0);
+  EXPECT_TRUE(p.guid == guid_in);
+}
+
+/**
+ * @test props_ctor_01
+ * Given a new properties object with a known guid
+ * passed in the constructor
+ * When I set compare its guid with the known guid
+ * Then the result is true
+ */
+TEST(CxxProperties, props_ctor_01){
+  fpga_guid guid_in;
+  uuid_parse(TEST_GUID_STR, guid_in);
+  properties p(guid_in);
+  ASSERT_EQ(memcmp(p.guid.get(), guid_in, sizeof(fpga_guid)), 0);
   EXPECT_TRUE(p.guid == guid_in);
 }
 


### PR DESCRIPTION
* Add a constructor to `properties` class with only one parameter of type
`fpga_guid`.
This contructor is to allow implicit conversion of an fpga_guid object
to a properties object.
* Add `get` method to `guid_t` class that returns a pointer to the guid
data.
* Add unit test for this too and fix other unit test to have a more
explicit comparison (`memcmpof`)  guid objects.