### PR TITLE
c++: Change guid_t uint8_t* conversion operator

### DIFF
--- a/libopae++/include/opaec++/pvalue.h
+++ b/libopae++/include/opaec++/pvalue.h
@@ -46,7 +46,7 @@ struct guid_t
     }
 
     operator uint8_t* (){
-        if (fpgaPropertiesGetGUID(*props_, reinterpret_cast<fpga_guid*>(&data_)) == FPGA_OK){
+        if (fpgaPropertiesGetGUID(*props_, reinterpret_cast<fpga_guid*>(data_.data())) == FPGA_OK){
             return data_.data();
         }
         return nullptr;


### PR DESCRIPTION
Change call to `fpgaPropertiesGetGUID` to use `data_.data()` instead of
`&data_`