### PR TITLE
opaec++: add class except for runtime exceptions

### DIFF
--- a/libopae++/CMakeLists.txt
+++ b/libopae++/CMakeLists.txt
@@ -54,7 +54,9 @@ include_directories(
 set(OPAECXX_SRC src/properties.cpp
                 src/token.cpp
                 src/handle.cpp
-                src/dma_buffer.cpp)
+                src/dma_buffer.cpp
+                src/except.cpp)
+
 add_library(opae-cxx-core SHARED ${OPAECXX_SRC})
 target_link_libraries(opae-cxx-core opae-c)
 add_executable(simple_example samples/simple_example.cpp)

--- a/libopae++/include/opaec++/except.h
+++ b/libopae++/include/opaec++/except.h
@@ -1,0 +1,109 @@
+// Copyright(c) 2017, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+#include <exception>
+#include <cstdint>
+
+#include <opae/types_enum.h>
+
+namespace opae
+{
+namespace fpga
+{
+namespace types
+{
+
+/// Identify a particular line in a source file.
+class src_location
+{
+public:
+    /** src_location constructor
+     * @param[in] file The source file name, typically __FILE__.
+     * @param[in] fn The current function, typically __func__.
+     * @param[in] line The current line number, typically __LINE__.
+     */
+    src_location(const char *file,
+                 const char *fn,
+                 int line) noexcept;
+
+    /** Retrieve the file name component of the location.
+     */
+    const char *file() const noexcept;
+
+    /** Retrieve the function name component of the location.
+     */
+    const char *fn() const noexcept { return fn_; }
+
+    /** Retrieve the line number component of the location.
+     */
+     int line() const noexcept { return line_; }
+
+private:
+    const char *file_;
+    const char *fn_;
+    int line_;
+};
+
+/// Construct a src_location object for the current source line.
+#define OPAECXX_HERE opae::fpga::types::src_location(__FILE__, __func__, __LINE__)
+
+class except : public std::exception
+{
+public:
+    static const std::size_t MAX_EXCEPT = 100;
+
+    /** except constructor
+     * The fpga_result value is FPGA_EXCEPTION.
+     *
+     * @param[in] loc Location where the exception was constructed.
+     */
+    except(src_location loc) noexcept;
+
+    /** except constructor
+     *
+     * @param[in] res The fpga_result value associated with this exception.
+     * @param[in] loc Location where the exception was constructed.
+     */
+    except(fpga_result res, src_location loc) noexcept;
+
+    /** Convert this except to an informative string.
+     */
+    virtual const char * what() const noexcept override;
+
+    /** Convert this except to its fpga_result.
+     */
+    operator fpga_result() const noexcept { return res_; }
+
+protected:
+    fpga_result res_;
+    src_location loc_;
+    mutable char buf_[MAX_EXCEPT];
+};
+
+} // end of namespace types
+} // end of namespace fpga
+} // end of namespace opae
+

--- a/libopae++/include/opaec++/except.h
+++ b/libopae++/include/opaec++/except.h
@@ -24,86 +24,79 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
-#include <exception>
 #include <cstdint>
+#include <exception>
 
 #include <opae/types_enum.h>
 
-namespace opae
-{
-namespace fpga
-{
-namespace types
-{
+namespace opae {
+namespace fpga {
+namespace types {
 
 /// Identify a particular line in a source file.
-class src_location
-{
-public:
-    /** src_location constructor
-     * @param[in] file The source file name, typically __FILE__.
-     * @param[in] fn The current function, typically __func__.
-     * @param[in] line The current line number, typically __LINE__.
-     */
-    src_location(const char *file,
-                 const char *fn,
-                 int line) noexcept;
+class src_location {
+ public:
+  /** src_location constructor
+   * @param[in] file The source file name, typically __FILE__.
+   * @param[in] fn The current function, typically __func__.
+   * @param[in] line The current line number, typically __LINE__.
+   */
+  src_location(const char *file, const char *fn, int line) noexcept;
 
-    /** Retrieve the file name component of the location.
-     */
-    const char *file() const noexcept;
+  /** Retrieve the file name component of the location.
+   */
+  const char *file() const noexcept;
 
-    /** Retrieve the function name component of the location.
-     */
-    const char *fn() const noexcept { return fn_; }
+  /** Retrieve the function name component of the location.
+   */
+  const char *fn() const noexcept { return fn_; }
 
-    /** Retrieve the line number component of the location.
-     */
-     int line() const noexcept { return line_; }
+  /** Retrieve the line number component of the location.
+   */
+  int line() const noexcept { return line_; }
 
-private:
-    const char *file_;
-    const char *fn_;
-    int line_;
+ private:
+  const char *file_;
+  const char *fn_;
+  int line_;
 };
 
 /// Construct a src_location object for the current source line.
-#define OPAECXX_HERE opae::fpga::types::src_location(__FILE__, __func__, __LINE__)
+#define OPAECXX_HERE \
+  opae::fpga::types::src_location(__FILE__, __func__, __LINE__)
 
-class except : public std::exception
-{
-public:
-    static const std::size_t MAX_EXCEPT = 100;
+class except : public std::exception {
+ public:
+  static const std::size_t MAX_EXCEPT = 100;
 
-    /** except constructor
-     * The fpga_result value is FPGA_EXCEPTION.
-     *
-     * @param[in] loc Location where the exception was constructed.
-     */
-    except(src_location loc) noexcept;
+  /** except constructor
+   * The fpga_result value is FPGA_EXCEPTION.
+   *
+   * @param[in] loc Location where the exception was constructed.
+   */
+  except(src_location loc) noexcept;
 
-    /** except constructor
-     *
-     * @param[in] res The fpga_result value associated with this exception.
-     * @param[in] loc Location where the exception was constructed.
-     */
-    except(fpga_result res, src_location loc) noexcept;
+  /** except constructor
+   *
+   * @param[in] res The fpga_result value associated with this exception.
+   * @param[in] loc Location where the exception was constructed.
+   */
+  except(fpga_result res, src_location loc) noexcept;
 
-    /** Convert this except to an informative string.
-     */
-    virtual const char * what() const noexcept override;
+  /** Convert this except to an informative string.
+   */
+  virtual const char *what() const noexcept override;
 
-    /** Convert this except to its fpga_result.
-     */
-    operator fpga_result() const noexcept { return res_; }
+  /** Convert this except to its fpga_result.
+   */
+  operator fpga_result() const noexcept { return res_; }
 
-protected:
-    fpga_result res_;
-    src_location loc_;
-    mutable char buf_[MAX_EXCEPT];
+ protected:
+  fpga_result res_;
+  src_location loc_;
+  mutable char buf_[MAX_EXCEPT];
 };
 
-} // end of namespace types
-} // end of namespace fpga
-} // end of namespace opae
-
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/libopae++/src/except.cpp
+++ b/libopae++/src/except.cpp
@@ -1,0 +1,100 @@
+// Copyright(c) 2017, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include <cerrno>
+#include <cstring>
+
+#include <safe_string/safe_string.h>
+#include <opae/utils.h>
+
+#include "opaec++/except.h"
+
+namespace opae
+{
+namespace fpga
+{
+namespace types
+{
+
+src_location::src_location(const char *file,
+                           const char *fn,
+                           int line) noexcept
+: file_(file)
+, fn_(fn)
+, line_(line)
+{}
+
+const char * src_location::file() const noexcept
+{
+    // return a pointer to the file name component.
+    const char *p = file_;
+
+    while (*p++) {}
+    while ((p > file_) &&
+           (*p != '\\') &&
+           (*p != '/'))
+        --p;
+    if (('\\' == *p) ||
+        ('/' == *p))
+        ++p;
+
+    return p;
+}
+
+except::except(src_location loc) noexcept
+: res_(FPGA_EXCEPTION)
+, loc_(loc)
+{}
+
+except::except(fpga_result res, src_location loc) noexcept
+: res_(res)
+, loc_(loc)
+{}
+
+const char * except::what() const noexcept
+{
+    errno_t err;
+
+    err = strncpy_s(buf_, 32, loc_.file(), 32);
+
+    err = strcat_s(buf_, 34, ":");
+
+    err = strcat_s(buf_, 50, loc_.fn());
+
+    err = strcat_s(buf_, 53, "():");
+
+    err = snprintf_s_i(buf_+strlen(buf_), 64, "%d:", loc_.line());
+
+    err = strcat_s(buf_, sizeof(buf_), fpgaErrStr(res_));
+
+// TODO log err
+
+    return const_cast<const char *>(buf_);
+}
+
+} // end of namespace types
+} // end of namespace fpga
+} // end of namespace opae
+

--- a/libopae++/src/except.cpp
+++ b/libopae++/src/except.cpp
@@ -26,75 +26,55 @@
 #include <cerrno>
 #include <cstring>
 
-#include <safe_string/safe_string.h>
 #include <opae/utils.h>
+#include <safe_string/safe_string.h>
 
 #include "opaec++/except.h"
 
-namespace opae
-{
-namespace fpga
-{
-namespace types
-{
+namespace opae {
+namespace fpga {
+namespace types {
 
-src_location::src_location(const char *file,
-                           const char *fn,
-                           int line) noexcept
-: file_(file)
-, fn_(fn)
-, line_(line)
-{}
+src_location::src_location(const char *file, const char *fn, int line) noexcept
+    : file_(file), fn_(fn), line_(line) {}
 
-const char * src_location::file() const noexcept
-{
-    // return a pointer to the file name component.
-    const char *p = file_;
+const char *src_location::file() const noexcept {
+  // return a pointer to the file name component.
+  const char *p = file_;
 
-    while (*p++) {}
-    while ((p > file_) &&
-           (*p != '\\') &&
-           (*p != '/'))
-        --p;
-    if (('\\' == *p) ||
-        ('/' == *p))
-        ++p;
+  while (*p++) {
+  }
+  while ((p > file_) && (*p != '\\') && (*p != '/')) --p;
+  if (('\\' == *p) || ('/' == *p)) ++p;
 
-    return p;
+  return p;
 }
 
-except::except(src_location loc) noexcept
-: res_(FPGA_EXCEPTION)
-, loc_(loc)
-{}
+except::except(src_location loc) noexcept : res_(FPGA_EXCEPTION), loc_(loc) {}
 
 except::except(fpga_result res, src_location loc) noexcept
-: res_(res)
-, loc_(loc)
-{}
+    : res_(res), loc_(loc) {}
 
-const char * except::what() const noexcept
-{
-    errno_t err;
+const char *except::what() const noexcept {
+  errno_t err;
 
-    err = strncpy_s(buf_, 32, loc_.file(), 32);
+  err = strncpy_s(buf_, 32, loc_.file(), 32);
 
-    err = strcat_s(buf_, 34, ":");
+  err = strcat_s(buf_, 34, ":");
 
-    err = strcat_s(buf_, 50, loc_.fn());
+  err = strcat_s(buf_, 50, loc_.fn());
 
-    err = strcat_s(buf_, 53, "():");
+  err = strcat_s(buf_, 53, "():");
 
-    err = snprintf_s_i(buf_+strlen(buf_), 64, "%d:", loc_.line());
+  err = snprintf_s_i(buf_ + strlen(buf_), 64, "%d:", loc_.line());
 
-    err = strcat_s(buf_, sizeof(buf_), fpgaErrStr(res_));
+  err = strcat_s(buf_, sizeof(buf_), fpgaErrStr(res_));
 
-// TODO log err
+  // TODO log err
 
-    return const_cast<const char *>(buf_);
+  return const_cast<const char *>(buf_);
 }
 
-} // end of namespace types
-} // end of namespace fpga
-} // end of namespace opae
-
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/libopae++/tests/CMakeLists.txt
+++ b/libopae++/tests/CMakeLists.txt
@@ -33,7 +33,9 @@ set(SRC gtmain.cpp
     unit/gtEnumerate.cpp
     unit/gtOpenClose.cpp
     unit/gtCxxProperties.cpp
-    unit/gtBuffer.cpp)
+    unit/gtBuffer.cpp
+    unit/gtExcept.cpp)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include ${GTEST_INCLUDE_DIRS})
 add_executable(gtcxx ${SRC})
 target_link_libraries(gtcxx  opae-c opae-cxx-core uuid ${GTEST_BOTH_LIBRARIES})

--- a/libopae++/tests/unit/gtBuffer.cpp
+++ b/libopae++/tests/unit/gtBuffer.cpp
@@ -10,8 +10,8 @@ extern "C" {
 
 #include "gtest/gtest.h"
 
-#include "opaec++/handle.h"
 #include "opaec++/dma_buffer.h"
+#include "opaec++/handle.h"
 
 using namespace opae::fpga::types;
 
@@ -73,10 +73,8 @@ TEST_F(CxxBuffer_f1, alloc_07) {
 
   buf_ = dma_buffer::attach(accel_, buf, pg_size);
   ASSERT_NE(nullptr, buf_.get());
-
   EXPECT_EQ(static_cast<dma_buffer::size_t>(pg_size), buf_->size());
   EXPECT_NE(0, buf_->iova());
-
   free(buf);
 }
 

--- a/libopae++/tests/unit/gtExcept.cpp
+++ b/libopae++/tests/unit/gtExcept.cpp
@@ -11,19 +11,18 @@ extern "C" {
 
 using namespace opae::fpga::types;
 
-
 /**
  * @test except_01
  * Given a src_location object<br>
  * When the object is constructed with OPAECXX_HERE<br>
  * Then it represents the current location in the source file.<br>
  */
-TEST(CxxExcept, except_01){
-    src_location loc(OPAECXX_HERE);
+TEST(CxxExcept, except_01) {
+  src_location loc(OPAECXX_HERE);
 
-    EXPECT_STREQ("gtExcept.cpp", loc.file());
-    EXPECT_STREQ("TestBody", loc.fn());
-    EXPECT_EQ(22, loc.line());
+  EXPECT_STREQ("gtExcept.cpp", loc.file());
+  EXPECT_STREQ("TestBody", loc.fn());
+  EXPECT_EQ(21, loc.line());
 }
 
 /**
@@ -32,25 +31,24 @@ TEST(CxxExcept, except_01){
  * When the object is constructed with a src_location only<br>
  * Then then the fpga_result value is FPGA_EXCEPTION.<br>
  */
-TEST(CxxExcept, except_02){
-    except e(OPAECXX_HERE);
+TEST(CxxExcept, except_02) {
+  except e(OPAECXX_HERE);
 
-    EXPECT_EQ(FPGA_EXCEPTION, e);
+  EXPECT_EQ(FPGA_EXCEPTION, e);
 }
 
 /**
  * @test except_03
  * Given an except object<br>
  * When the object is constructed with an fpga_result and src_location<br>
- * Then then the fpga_result value matches the value passed to the constructor<br>
- * And the string returned by what() represents the fpga_result and src_location.<br>
+ * Then then the fpga_result value matches the value passed to the
+ * constructor<br> And the string returned by what() represents the fpga_result
+ * and src_location.<br>
  */
-TEST(CxxExcept, except_03){
-    except e(FPGA_INVALID_PARAM, OPAECXX_HERE);
+TEST(CxxExcept, except_03) {
+  except e(FPGA_INVALID_PARAM, OPAECXX_HERE);
 
-    EXPECT_EQ(FPGA_INVALID_PARAM, e);
+  EXPECT_EQ(FPGA_INVALID_PARAM, e);
 
-    EXPECT_STREQ("gtExcept.cpp:TestBody():49:invalid parameter", e.what());
+  EXPECT_STREQ("gtExcept.cpp:TestBody():49:invalid parameter", e.what());
 }
-
-

--- a/libopae++/tests/unit/gtExcept.cpp
+++ b/libopae++/tests/unit/gtExcept.cpp
@@ -1,0 +1,56 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "gtest/gtest.h"
+#include "opaec++/except.h"
+
+using namespace opae::fpga::types;
+
+
+/**
+ * @test except_01
+ * Given a src_location object<br>
+ * When the object is constructed with OPAECXX_HERE<br>
+ * Then it represents the current location in the source file.<br>
+ */
+TEST(CxxExcept, except_01){
+    src_location loc(OPAECXX_HERE);
+
+    EXPECT_STREQ("gtExcept.cpp", loc.file());
+    EXPECT_STREQ("TestBody", loc.fn());
+    EXPECT_EQ(22, loc.line());
+}
+
+/**
+ * @test except_02
+ * Given an except object<br>
+ * When the object is constructed with a src_location only<br>
+ * Then then the fpga_result value is FPGA_EXCEPTION.<br>
+ */
+TEST(CxxExcept, except_02){
+    except e(OPAECXX_HERE);
+
+    EXPECT_EQ(FPGA_EXCEPTION, e);
+}
+
+/**
+ * @test except_03
+ * Given an except object<br>
+ * When the object is constructed with an fpga_result and src_location<br>
+ * Then then the fpga_result value matches the value passed to the constructor<br>
+ * And the string returned by what() represents the fpga_result and src_location.<br>
+ */
+TEST(CxxExcept, except_03){
+    except e(FPGA_INVALID_PARAM, OPAECXX_HERE);
+
+    EXPECT_EQ(FPGA_INVALID_PARAM, e);
+
+    EXPECT_STREQ("gtExcept.cpp:TestBody():49:invalid parameter", e.what());
+}
+
+


### PR DESCRIPTION
except encapsulates a location in the source code along with an
fpga_result flag. except overrides std::exception::what() to provide an
informative message about the exception.