### PR TITLE
ASE: MMIO Read Response Timeout value changed to 65536 pClks

### DIFF
--- a/ase/rtl/platform.vh
+++ b/ase/rtl/platform.vh
@@ -94,7 +94,7 @@
 /*
  * MMIO Specifications
  */
-`define MMIO_RESPONSE_TIMEOUT        512
+`define MMIO_RESPONSE_TIMEOUT        65536
 `define MMIO_RESPONSE_TIMEOUT_RADIX  $clog2(`MMIO_RESPONSE_TIMEOUT) + 1
 `define MMIO_MAX_OUTSTANDING         64
 


### PR DESCRIPTION
- AFU MMIO timeout has been reported to be restrictive . The MMIO timeout
has been extended from 1.28us to 163.84us. For ASE, MMIO_RDRSP_TIMEOUT has
to be changed from 512 to 512*128=65536 pClk.