### PR TITLE
c++: apply coding style

### DIFF
--- a/libopae++/include/opaec++/handle.h
+++ b/libopae++/include/opaec++/handle.h
@@ -31,78 +31,71 @@
 #include <opae/enum.h>
 #include <opaec++/token.h>
 
-namespace opae
-{
-namespace fpga
-{
-namespace types
-{
+namespace opae {
+namespace fpga {
+namespace types {
 
+class handle {
+ public:
+  typedef std::shared_ptr<handle> ptr_t;
 
-class handle
-{
-public:
-    typedef std::shared_ptr<handle> ptr_t;
+  ~handle();
 
-    ~handle();
+  fpga_handle get() const { return handle_; }
 
-    fpga_handle get() const {
-        return handle_;
-    }
+  operator fpga_handle() const { return handle_; }
 
-    operator fpga_handle () const {
-        return handle_;
-    }
+  /** Write 32-bit value to MMIO.
+   * @param[in] offset The byte offset from MMIO base to write.
+   * @param[in] value  The value to be written.
+   * @return Whether the write was successful.
+   */
+  virtual bool write(uint64_t offset, uint32_t value);
 
-    /** Write 32-bit value to MMIO.
-     * @param[in] offset The byte offset from MMIO base to write.
-     * @param[in] value  The value to be written.
-     * @return Whether the write was successful.
-     */
-    virtual bool write(uint64_t offset, uint32_t value);
+  /** Write 64-bit value to MMIO.
+   * @param[in] offset The byte offset from MMIO base to write.
+   * @param[in] value  The value to be written.
+   * @return Whether the write was successful.
+   */
+  virtual bool write(uint64_t offset, uint64_t value);
 
-    /** Write 64-bit value to MMIO.
-     * @param[in] offset The byte offset from MMIO base to write.
-     * @param[in] value  The value to be written.
-     * @return Whether the write was successful.
-     */
-    virtual bool write(uint64_t offset, uint64_t value);
+  /** Read 32-bit value from MMIO.
+   * @param[in]  offset The byte offset from MMIO base to read.
+   * @param[out] value  Receives the value read.
+   * @return Whether the read was successful.
+   */
+  virtual bool read(uint64_t offset, uint32_t &value) const;
 
-    /** Read 32-bit value from MMIO.
-     * @param[in]  offset The byte offset from MMIO base to read.
-     * @param[out] value  Receives the value read.
-     * @return Whether the read was successful.
-     */
-    virtual bool read(uint64_t offset, uint32_t &value) const;
+  /** Read 64-bit value from MMIO.
+   * @param[in]  offset The byte offset from MMIO base to read.
+   * @param[out] value  Receives the value read.
+   * @return Whether the read was successful.
+   */
+  virtual bool read(uint64_t offset, uint64_t &value) const;
 
-    /** Read 64-bit value from MMIO.
-     * @param[in]  offset The byte offset from MMIO base to read.
-     * @param[out] value  Receives the value read.
-     * @return Whether the read was successful.
-     */
-    virtual bool read(uint64_t offset, uint64_t &value) const;
+  /** Retrieve a pointer to the MMIO region.
+   * @param[in] offset The byte offset to add to MMIO base.
+   * @return MMIO base + offset
+   */
+  uint8_t *mmio_ptr(uint64_t offset) const { return mmio_base_ + offset; }
 
-    /** Retrieve a pointer to the MMIO region.
-     * @param[in] offset The byte offset to add to MMIO base.
-     * @return MMIO base + offset
-     */
-    uint8_t * mmio_ptr(uint64_t offset) const { return mmio_base_ + offset; }
+  static handle::ptr_t open(fpga_token token, int flags,
+                            uint32_t mmio_region = 0);
 
-    static handle::ptr_t open(fpga_token token, int flags, uint32_t mmio_region=0);
+  static handle::ptr_t open(token::ptr_t token, int flags,
+                            uint32_t mmio_region = 0);
 
-    static handle::ptr_t open(token::ptr_t token, int flags, uint32_t mmio_region=0);
+ protected:
+  fpga_result close();
 
-protected:
-    fpga_result close();
+ private:
+  handle(fpga_handle h, uint32_t mmio_region, uint8_t *mmio_base);
 
-private:
-    handle(fpga_handle h, uint32_t mmio_region, uint8_t *mmio_base);
-
-    fpga_handle handle_;
-    uint32_t mmio_region_;
-    uint8_t *mmio_base_;
+  fpga_handle handle_;
+  uint32_t mmio_region_;
+  uint8_t *mmio_base_;
 };
 
-} // end of namespace types
-} // end of namespace fpga
-} // end of namespace opae
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/libopae++/include/opaec++/properties.h
+++ b/libopae++/include/opaec++/properties.h
@@ -31,56 +31,52 @@
 #include <opae/properties.h>
 #include <opaec++/pvalue.h>
 
-namespace opae
-{
-namespace fpga
-{
-namespace types
-{
+namespace opae {
+namespace fpga {
+namespace types {
 
 class token;
 
-class properties
-{
-public:
-    typedef std::shared_ptr<properties> ptr_t;
+class properties {
+ public:
+  typedef std::shared_ptr<properties> ptr_t;
 
-    const static std::vector<properties> none;
+  const static std::vector<properties> none;
 
-    properties();
-    properties(fpga_objtype objtype);
+  properties();
+  properties(fpga_objtype objtype);
 
-    ~properties();
+  ~properties();
 
-    fpga_properties get() const { return props_; }
-    operator fpga_properties () const { return props_; }
+  fpga_properties get() const { return props_; }
+  operator fpga_properties() const { return props_; }
 
-    static properties::ptr_t read(std::shared_ptr<token> t);
-    static properties::ptr_t read(fpga_token t);
+  static properties::ptr_t read(std::shared_ptr<token> t);
+  static properties::ptr_t read(fpga_token t);
 
-    pvalue<fpga_objtype>           type;
-    pvalue<uint8_t>                bus;
-    pvalue<uint8_t>                device;
-    pvalue<uint8_t>                function;
-    pvalue<uint8_t>                socket_id;
-    pvalue<uint32_t>               num_slots;
-    pvalue<uint64_t>               bbs_id;
-    pvalue<fpga_version>           bbs_version;
-    pvalue<uint16_t>               vendor_id;
-    pvalue<char*>                  model;
-    pvalue<uint64_t>               local_memory_size;
-    pvalue<uint64_t>               capabilities;
-    pvalue<uint32_t>               num_mmio;
-    pvalue<uint32_t>               num_interrupts;
-    pvalue<fpga_accelerator_state> accelerator_state;
-    pvalue<uint64_t>               object_id;
-    pvalue<fpga_token>             parent;
-    guid_t                         guid;
+  pvalue<fpga_objtype> type;
+  pvalue<uint8_t> bus;
+  pvalue<uint8_t> device;
+  pvalue<uint8_t> function;
+  pvalue<uint8_t> socket_id;
+  pvalue<uint32_t> num_slots;
+  pvalue<uint64_t> bbs_id;
+  pvalue<fpga_version> bbs_version;
+  pvalue<uint16_t> vendor_id;
+  pvalue<char*> model;
+  pvalue<uint64_t> local_memory_size;
+  pvalue<uint64_t> capabilities;
+  pvalue<uint32_t> num_mmio;
+  pvalue<uint32_t> num_interrupts;
+  pvalue<fpga_accelerator_state> accelerator_state;
+  pvalue<uint64_t> object_id;
+  pvalue<fpga_token> parent;
+  guid_t guid;
 
-private:
-    fpga_properties props_;
+ private:
+  fpga_properties props_;
 };
 
-} // end of namespace types
-} // end of namespace fpga
-} // end of namespace opae
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/libopae++/include/opaec++/pvalue.h
+++ b/libopae++/include/opaec++/pvalue.h
@@ -31,131 +31,111 @@
 #include <uuid/uuid.h>
 #include <opae/properties.h>
 
-namespace opae
-{
-namespace fpga
-{
-namespace types
-{
+namespace opae {
+namespace fpga {
+namespace types {
 
-struct guid_t
-{
-    guid_t(fpga_properties * p)
-    : props_(p)
-    {
+struct guid_t {
+  guid_t(fpga_properties *p) : props_(p) {}
+
+  operator uint8_t *() {
+    if (fpgaPropertiesGetGUID(
+            *props_, reinterpret_cast<fpga_guid *>(data_.data())) == FPGA_OK) {
+      return data_.data();
     }
+    return nullptr;
+  }
 
-    operator uint8_t* (){
-        if (fpgaPropertiesGetGUID(*props_, reinterpret_cast<fpga_guid*>(data_.data())) == FPGA_OK){
-            return data_.data();
-        }
-        return nullptr;
+  guid_t &operator=(fpga_guid g) {
+    if (fpgaPropertiesSetGUID(*props_, g) == FPGA_OK) {
+      uint8_t *begin = &g[0];
+      uint8_t *end = begin + sizeof(fpga_guid);
+      std::copy(begin, end, data_.begin());
+    } else {
+      // throw exception
     }
+    return *this;
+  }
 
-    guid_t & operator=(fpga_guid g){
-        if (fpgaPropertiesSetGUID(*props_, g) == FPGA_OK){
-            uint8_t *begin = &g[0];
-            uint8_t *end = begin+sizeof(fpga_guid);
-            std::copy(begin, end, data_.begin());
-        }else{
-            // throw exception
-        }
-        return *this;
+  bool operator==(const fpga_guid &g) {
+    return 0 == std::memcmp(data_.data(), g, sizeof(fpga_guid));
+  }
+
+  void parse(const char *str) {
+    if (0 != uuid_parse(str, data_.data())) {
+      // throw error
     }
-
-    bool operator==(const fpga_guid & g){
-        return 0 == std::memcmp(data_.data(), g, sizeof(fpga_guid));
+    if (FPGA_OK != fpgaPropertiesSetGUID(*props_, data_.data())) {
+      // throw error
     }
+  }
 
-    void parse(const char* str){
-        if (0 != uuid_parse(str, data_.data())){
-            //throw error
-        }
-        if (FPGA_OK != fpgaPropertiesSetGUID(*props_, data_.data())){
-            // throw error
-        }
+  friend std::ostream &operator<<(std::ostream &ostr, const guid_t &g) {
+    fpga_properties props = *g.props_;
+    fpga_guid guid_value;
+    if (fpgaPropertiesGetGUID(props, &guid_value) == FPGA_OK) {
+      char guid_str[84];
+      uuid_unparse(g.data_.data(), guid_str);
+      ostr << guid_str;
+    } else {
+      // TODO: Log or throw
     }
+    return ostr;
+  }
 
-    friend std::ostream & operator<<(std::ostream & ostr, const guid_t & g){
-        fpga_properties props = *g.props_;
-        fpga_guid guid_value;
-        if (fpgaPropertiesGetGUID(props, &guid_value) == FPGA_OK){
-            char guid_str[84];
-            uuid_unparse(g.data_.data(), guid_str);
-            ostr << guid_str;
-        }else{
-            // TODO: Log or throw
-        }
-        return ostr;
-    }
-
-private:
-    fpga_properties *props_;
-    std::array<uint8_t, 16> data_;
-
+ private:
+  fpga_properties *props_;
+  std::array<uint8_t, 16> data_;
 };
 
-template<typename T>
-struct pvalue
-{
-    typedef typename std::conditional<std::is_same<T, char*>::value,
-                                      fpga_result(*)(fpga_properties, T),
-                                      fpga_result(*)(fpga_properties, T*)>::type getter_t;
-    typedef fpga_result (*setter_t)(fpga_properties, T);
-    pvalue()
-    : props_(0)
-    {
-    }
+template <typename T>
+struct pvalue {
+  typedef typename std::conditional<
+      std::is_same<T, char *>::value, fpga_result (*)(fpga_properties, T),
+      fpga_result (*)(fpga_properties, T *)>::type getter_t;
+  typedef fpga_result (*setter_t)(fpga_properties, T);
+  pvalue() : props_(0) {}
 
-    pvalue(fpga_properties *p, getter_t g, setter_t s)
-    : props_(p)
-    , get_(g)
-    , set_(s)
-    {
-    }
+  pvalue(fpga_properties *p, getter_t g, setter_t s)
+      : props_(p), get_(g), set_(s) {}
 
-    pvalue<T>& operator=(const T& v){
-        auto res = set_(*props_, v);
-        if (res == FPGA_OK){
-            copy_ = v;
-        }
+  pvalue<T> &operator=(const T &v) {
+    auto res = set_(*props_, v);
+    if (res == FPGA_OK) {
+      copy_ = v;
     }
+  }
 
-    bool operator==(const T & other){
-        return copy_ == other;
+  bool operator==(const T &other) { return copy_ == other; }
+
+  operator T() {
+    if (get_(*props_, &copy_) == FPGA_OK) {
+      return copy_;
     }
+    return T();
+  }
 
-    operator T () {
-        if (get_(*props_, &copy_) == FPGA_OK){
-            return copy_;
-        }
-        return T();
+  // TODO: Remove this once all properties are tested
+  fpga_result get_value(T &value) const { return get_(*props_, &value); }
+
+  friend std::ostream &operator<<(std::ostream &ostr, const pvalue<T> &p) {
+    T value;
+    fpga_properties props = *p.props_;
+    if (p.get_(props, &value) == FPGA_OK) {
+      ostr << +(value);
+    } else {
+      // TODO: Log or throw
     }
+    return ostr;
+  }
 
-    // TODO: Remove this once all properties are tested
-    fpga_result get_value(T & value) const {
-        return get_(*props_, &value);
-    }
-
-    friend std::ostream & operator<<(std::ostream & ostr, const pvalue<T> & p){
-        T value;
-        fpga_properties props = *p.props_;
-        if (p.get_(props, &value) == FPGA_OK){
-            ostr << +(value);
-        }else{
-            // TODO: Log or throw
-        }
-        return ostr;
-    }
-
-private:
-    fpga_properties *props_;
-    T copy_;
-    getter_t get_;
-    setter_t set_;
+ private:
+  fpga_properties *props_;
+  T copy_;
+  getter_t get_;
+  setter_t set_;
 };
 
-
-} // end of namespace types
-} // end of namespace fpga
-} // end of namespace opae
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/libopae++/include/opaec++/token.h
+++ b/libopae++/include/opaec++/token.h
@@ -32,35 +32,27 @@
 #include <opae/enum.h>
 #include <opaec++/properties.h>
 
-namespace opae
-{
-namespace fpga
-{
-namespace types
-{
+namespace opae {
+namespace fpga {
+namespace types {
 
-class token
-{
-public:
-    typedef std::shared_ptr<token> ptr_t;
+class token {
+ public:
+  typedef std::shared_ptr<token> ptr_t;
 
-    static std::vector<token::ptr_t> enumerate(const std::vector<properties> & props);
+  static std::vector<token::ptr_t> enumerate(
+      const std::vector<properties>& props);
 
-    ~token();
+  ~token();
 
-    fpga_token get() const {
-        return token_;
-    }
-    operator fpga_token () const {
-        return token_;
-    }
+  fpga_token get() const { return token_; }
+  operator fpga_token() const { return token_; }
 
-private:
-    fpga_token token_;
-    token(fpga_token tok);
+ private:
+  fpga_token token_;
+  token(fpga_token tok);
 };
 
-} // end of namespace types
-} // end of namespace fpga
-} // end of namespace opae
-
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/libopae++/samples/simple_example.cpp
+++ b/libopae++/samples/simple_example.cpp
@@ -32,34 +32,34 @@
 
 using namespace opae::fpga::types;
 
-int main(int argc, char* argvp[])
-{
-    const char* NLB0 = "D8424DC4-A4A3-C413-F89E-433683F9040B";
-    const char* NLB3 = "F7DF405C-BD7A-CF72-22F1-44B0B93ACD18";
+int main(int argc, char* argvp[]) {
+  const char* NLB0 = "D8424DC4-A4A3-C413-F89E-433683F9040B";
+  const char* NLB3 = "F7DF405C-BD7A-CF72-22F1-44B0B93ACD18";
 
-    properties props_filter;
+  properties props_filter;
 
-    props_filter.socket_id = 1;
-    props_filter.type = FPGA_ACCELERATOR;
-    uuid_t uuid;
-    if (uuid_parse(NLB0, uuid) == 0){
-        props_filter.guid = uuid;
-    }
-    props_filter.bbs_id = 0; // This is invalid - libopae-c prints out a warning
-    auto tokens = token::enumerate({props_filter});
-    if (tokens.size() > 0){
-        auto tok = tokens[0];
-        auto props = properties::read(tok);
-        std::cout << "guid prop read: " << props->guid << "\n";
+  props_filter.socket_id = 1;
+  props_filter.type = FPGA_ACCELERATOR;
+  uuid_t uuid;
+  if (uuid_parse(NLB0, uuid) == 0) {
+    props_filter.guid = uuid;
+  }
+  props_filter.bbs_id = 0;  // This is invalid - libopae-c prints out a warning
+  auto tokens = token::enumerate({props_filter});
+  if (tokens.size() > 0) {
+    auto tok = tokens[0];
+    auto props = properties::read(tok);
+    std::cout << "guid prop read: " << props->guid << "\n";
 
-        std::cout << "bus: 0x" << std::hex << props->bus << "\n";
-        handle::ptr_t h = handle::open(tok, FPGA_OPEN_SHARED);
-        uint64_t value1 = 0xdeadbeef, value2 = 0;
-        h->write(0x100, value1);
-        h->read(0x100, value2);
-        std::cout << "mmio @0x100: 0x" << std::hex << value2 << "\n";
-        std::cout << "mmio @0x100: 0x" << std::hex << *reinterpret_cast<uint64_t*>(h->mmio_ptr(0x100)) << "\n";
-    }
+    std::cout << "bus: 0x" << std::hex << props->bus << "\n";
+    handle::ptr_t h = handle::open(tok, FPGA_OPEN_SHARED);
+    uint64_t value1 = 0xdeadbeef, value2 = 0;
+    h->write(0x100, value1);
+    h->read(0x100, value2);
+    std::cout << "mmio @0x100: 0x" << std::hex << value2 << "\n";
+    std::cout << "mmio @0x100: 0x" << std::hex
+              << *reinterpret_cast<uint64_t*>(h->mmio_ptr(0x100)) << "\n";
+  }
 
-    return  0;
+  return 0;
 }

--- a/libopae++/src/properties.cpp
+++ b/libopae++/src/properties.cpp
@@ -26,72 +26,69 @@
 #include "opaec++/properties.h"
 #include "opaec++/token.h"
 
-namespace opae
-{
-namespace fpga
-{
-namespace types
-{
+namespace opae {
+namespace fpga {
+namespace types {
 
 const std::vector<properties> properties::none = {};
 
 properties::properties()
-: props_(nullptr)
-, type(&props_, fpgaPropertiesGetObjectType, fpgaPropertiesSetObjectType)
-, bus(&props_, fpgaPropertiesGetBus, fpgaPropertiesSetBus)
-, device(&props_, fpgaPropertiesGetDevice, fpgaPropertiesSetDevice)
-, function(&props_, fpgaPropertiesGetFunction, fpgaPropertiesSetFunction)
-, socket_id(&props_, fpgaPropertiesGetSocketID, fpgaPropertiesSetSocketID)
-, num_slots(&props_, fpgaPropertiesGetNumSlots, fpgaPropertiesSetNumSlots)
-, bbs_id(&props_, fpgaPropertiesGetBBSID, fpgaPropertiesSetBBSID)
-, bbs_version(&props_, fpgaPropertiesGetBBSVersion, fpgaPropertiesSetBBSVersion)
-, vendor_id(&props_, fpgaPropertiesGetVendorID, fpgaPropertiesSetVendorID)
-, model(&props_, fpgaPropertiesGetModel, fpgaPropertiesSetModel)
-, local_memory_size(&props_, fpgaPropertiesGetLocalMemorySize, fpgaPropertiesSetLocalMemorySize)
-, capabilities(&props_, fpgaPropertiesGetCapabilities, fpgaPropertiesSetCapabilities)
-, num_mmio(&props_, fpgaPropertiesGetNumMMIO, fpgaPropertiesSetNumMMIO)
-, num_interrupts(&props_, fpgaPropertiesGetNumInterrupts, fpgaPropertiesSetNumInterrupts)
-, accelerator_state(&props_, fpgaPropertiesGetAcceleratorState, fpgaPropertiesSetAcceleratorState)
-, object_id(&props_, fpgaPropertiesGetObjectID, fpgaPropertiesSetObjectID)
-, parent(&props_, fpgaPropertiesGetParent, fpgaPropertiesSetParent)
-, guid(&props_)
-{
-    auto res = fpgaGetProperties(nullptr, &props_);
-    if (res != FPGA_OK){
-        props_ = nullptr;
-        // TODO: Throw fpga_error
+    : props_(nullptr),
+      type(&props_, fpgaPropertiesGetObjectType, fpgaPropertiesSetObjectType),
+      bus(&props_, fpgaPropertiesGetBus, fpgaPropertiesSetBus),
+      device(&props_, fpgaPropertiesGetDevice, fpgaPropertiesSetDevice),
+      function(&props_, fpgaPropertiesGetFunction, fpgaPropertiesSetFunction),
+      socket_id(&props_, fpgaPropertiesGetSocketID, fpgaPropertiesSetSocketID),
+      num_slots(&props_, fpgaPropertiesGetNumSlots, fpgaPropertiesSetNumSlots),
+      bbs_id(&props_, fpgaPropertiesGetBBSID, fpgaPropertiesSetBBSID),
+      bbs_version(&props_, fpgaPropertiesGetBBSVersion,
+                  fpgaPropertiesSetBBSVersion),
+      vendor_id(&props_, fpgaPropertiesGetVendorID, fpgaPropertiesSetVendorID),
+      model(&props_, fpgaPropertiesGetModel, fpgaPropertiesSetModel),
+      local_memory_size(&props_, fpgaPropertiesGetLocalMemorySize,
+                        fpgaPropertiesSetLocalMemorySize),
+      capabilities(&props_, fpgaPropertiesGetCapabilities,
+                   fpgaPropertiesSetCapabilities),
+      num_mmio(&props_, fpgaPropertiesGetNumMMIO, fpgaPropertiesSetNumMMIO),
+      num_interrupts(&props_, fpgaPropertiesGetNumInterrupts,
+                     fpgaPropertiesSetNumInterrupts),
+      accelerator_state(&props_, fpgaPropertiesGetAcceleratorState,
+                        fpgaPropertiesSetAcceleratorState),
+      object_id(&props_, fpgaPropertiesGetObjectID, fpgaPropertiesSetObjectID),
+      parent(&props_, fpgaPropertiesGetParent, fpgaPropertiesSetParent),
+      guid(&props_) {
+  auto res = fpgaGetProperties(nullptr, &props_);
+  if (res != FPGA_OK) {
+    props_ = nullptr;
+    // TODO: Throw fpga_error
+  }
+}
+
+properties::properties(fpga_objtype objtype) : properties() { type = objtype; }
+
+properties::~properties() {
+  if (props_ != nullptr) {
+    auto res = fpgaDestroyProperties(&props_);
+    if (res != FPGA_OK) {
+      // TODO: Throw fpga_error
     }
+  }
 }
 
-properties::properties(fpga_objtype objtype)
-: properties(){
-    type = objtype;
+properties::ptr_t properties::read(fpga_token tok) {
+  ptr_t p(new properties());
+  auto res = fpgaGetProperties(tok, &p->props_);
+  if (res != FPGA_OK) {
+    // TODO: Throw fpga_error
+    p.reset();
+  }
+  return p;
 }
 
-properties::~properties(){
-    if (props_ != nullptr){
-        auto res = fpgaDestroyProperties(&props_);
-        if (res != FPGA_OK){
-            // TODO: Throw fpga_error
-        }
-    }
-
+properties::ptr_t properties::read(token::ptr_t tok) {
+  return read(tok->get());
 }
 
-properties::ptr_t properties::read(fpga_token tok){
-    ptr_t p(new properties());
-    auto res = fpgaGetProperties(tok, &p->props_);
-    if (res != FPGA_OK){
-        // TODO: Throw fpga_error
-        p.reset();
-    }
-    return p;
-}
-
-properties::ptr_t properties::read(token::ptr_t tok){
-    return read(tok->get());
-}
-
-} // end of namespace types
-} // end of namespace fpga
-} // end of namespace opae
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/libopae++/src/token.cpp
+++ b/libopae++/src/token.cpp
@@ -26,60 +26,43 @@
 #include <algorithm>
 #include "opaec++/token.h"
 
-namespace opae
-{
-namespace fpga
-{
-namespace types
-{
+namespace opae {
+namespace fpga {
+namespace types {
 
-std::vector<token::ptr_t> token::enumerate(const std::vector<properties> & props){
-    std::vector<token::ptr_t> tokens;
-    std::vector<fpga_properties> c_props(props.size());
-    std::transform(props.begin(), props.end(), c_props.begin(),
-                   [](const properties & p){
-                       return p.get();
-                   });
-    uint32_t matches = 0;
-    auto res = fpgaEnumerate(c_props.data(),
-                             c_props.size(),
-                             nullptr,
-                             0,
-                             &matches);
-    if (res == FPGA_OK && matches > 0){
-        std::vector<fpga_token> c_tokens(matches);
-        tokens.resize(matches);
-        res = fpgaEnumerate(c_props.data(),
-                            c_props.size(),
-                            c_tokens.data(),
-                            c_tokens.size(),
-                            &matches);
+std::vector<token::ptr_t> token::enumerate(
+    const std::vector<properties>& props) {
+  std::vector<token::ptr_t> tokens;
+  std::vector<fpga_properties> c_props(props.size());
+  std::transform(props.begin(), props.end(), c_props.begin(),
+                 [](const properties& p) { return p.get(); });
+  uint32_t matches = 0;
+  auto res =
+      fpgaEnumerate(c_props.data(), c_props.size(), nullptr, 0, &matches);
+  if (res == FPGA_OK && matches > 0) {
+    std::vector<fpga_token> c_tokens(matches);
+    tokens.resize(matches);
+    res = fpgaEnumerate(c_props.data(), c_props.size(), c_tokens.data(),
+                        c_tokens.size(), &matches);
 
-        // create a new c++ token object for each c token struct
-        std::transform(c_tokens.begin(), c_tokens.end(), tokens.begin(),
-                       [](fpga_token t){
-                           return token::ptr_t(new token(t));
-                       });
+    // create a new c++ token object for each c token struct
+    std::transform(c_tokens.begin(), c_tokens.end(), tokens.begin(),
+                   [](fpga_token t) { return token::ptr_t(new token(t)); });
 
-        // discard our c struct token objects
-        std::for_each(c_tokens.begin(), c_tokens.end(),
-                      [](fpga_token t){
-                          auto res = fpgaDestroyToken(&t);
-                      });
-    }
-    return tokens;
+    // discard our c struct token objects
+    std::for_each(c_tokens.begin(), c_tokens.end(),
+                  [](fpga_token t) { auto res = fpgaDestroyToken(&t); });
+  }
+  return tokens;
 }
 
-token::~token(){
-    auto res = fpgaDestroyToken(&token_);
+token::~token() { auto res = fpgaDestroyToken(&token_); }
+
+token::token(fpga_token tok) {
+  auto res = fpgaCloneToken(tok, &token_);
+  // TODO: Throw exception on failure
 }
 
-token::token(fpga_token tok){
-    auto res = fpgaCloneToken(tok, &token_);
-    // TODO: Throw exception on failure
-}
-
-} // end of namespace types
-} // end of namespace fpga
-} // end of namespace opae
-
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/libopae++/tests/gtmain.cpp
+++ b/libopae++/tests/gtmain.cpp
@@ -9,13 +9,8 @@ using ::testing::UnitTest;
 
 using namespace std;
 
-
 int main(int argc, char** argv) {
-
   ::testing::InitGoogleTest(&argc, argv);
 
-  return  RUN_ALL_TESTS();
+  return RUN_ALL_TESTS();
 }
-
-
-

--- a/libopae++/tests/unit/gtBuffer.cpp
+++ b/libopae++/tests/unit/gtBuffer.cpp
@@ -15,29 +15,25 @@ extern "C" {
 
 using namespace opae::fpga::types;
 
+class CxxBuffer_f1 : public ::testing::Test {
+ protected:
+  CxxBuffer_f1() {}
 
-class CxxBuffer_f1 : public ::testing::Test
-{
-protected:
-    CxxBuffer_f1() {}
+  virtual void SetUp() override {
+    tokens_ = token::enumerate({FPGA_ACCELERATOR});
+    ASSERT_GT(tokens_.size(), 0);
+    accel_ = handle::open(tokens_[0], 0);
+    ASSERT_NE(nullptr, accel_.get());
+  }
 
-    virtual void SetUp() override
-    {
-        tokens_ = token::enumerate({FPGA_ACCELERATOR});
-        ASSERT_GT(tokens_.size(), 0);
-        accel_ = handle::open(tokens_[0], 0);
-        ASSERT_NE(nullptr, accel_.get());
-    }
+  virtual void TearDown() override {
+    accel_.reset();
+    ASSERT_NO_THROW(tokens_.clear());
+  }
 
-    virtual void TearDown() override
-    {
-        accel_.reset();
-        ASSERT_NO_THROW(tokens_.clear());
-    }
-
-    std::vector<token::ptr_t> tokens_;
-    handle::ptr_t accel_;
-    dma_buffer::ptr_t buf_;
+  std::vector<token::ptr_t> tokens_;
+  handle::ptr_t accel_;
+  dma_buffer::ptr_t buf_;
 };
 
 /**
@@ -46,9 +42,9 @@ protected:
  * When I call dma_buffer::allocate() with a length of 0<br>
  * Then I get an empty dma_buffer pointer.<br>
  */
-TEST_F(CxxBuffer_f1, alloc_01){
-    buf_ = dma_buffer::allocate(accel_, 0);
-    ASSERT_EQ(nullptr, buf_.get());
+TEST_F(CxxBuffer_f1, alloc_01) {
+  buf_ = dma_buffer::allocate(accel_, 0);
+  ASSERT_EQ(nullptr, buf_.get());
 }
 
 /**
@@ -57,32 +53,31 @@ TEST_F(CxxBuffer_f1, alloc_01){
  * When I call dma_buffer::allocate() with a length greater than 0<br>
  * Then I get a valid dma_buffer pointer.<br>
  */
-TEST_F(CxxBuffer_f1, alloc_02){
-    buf_ = dma_buffer::allocate(accel_, 64);
-    ASSERT_NE(nullptr, buf_.get());
+TEST_F(CxxBuffer_f1, alloc_02) {
+  buf_ = dma_buffer::allocate(accel_, 64);
+  ASSERT_NE(nullptr, buf_.get());
 
-    EXPECT_EQ(64, buf_->size());
-    EXPECT_NE(0, buf_->iova());
+  EXPECT_EQ(64, buf_->size());
+  EXPECT_NE(0, buf_->iova());
 }
 
 /**
  * @test alloc_07
  * Given an open accelerator handle object and a pre-allocated buffer<br>
- * When I call dma_buffer::attach() with a length that is a multiple of the page size<br>
- * Then I get a valid dma_buffer pointer.<br>
+ * When I call dma_buffer::attach() with a length that is a multiple of the page
+ * size<br> Then I get a valid dma_buffer pointer.<br>
  */
-TEST_F(CxxBuffer_f1, alloc_07){
+TEST_F(CxxBuffer_f1, alloc_07) {
+  uint64_t pg_size = (uint64_t)sysconf(_SC_PAGE_SIZE);
+  uint8_t *buf = (uint8_t *)malloc(pg_size);
 
-    uint64_t pg_size = (uint64_t) sysconf(_SC_PAGE_SIZE);
-    uint8_t *buf = (uint8_t *) malloc(pg_size);
+  buf_ = dma_buffer::attach(accel_, buf, pg_size);
+  ASSERT_NE(nullptr, buf_.get());
 
-    buf_ = dma_buffer::attach(accel_, buf, pg_size);
-    ASSERT_NE(nullptr, buf_.get());
+  EXPECT_EQ(static_cast<dma_buffer::size_t>(pg_size), buf_->size());
+  EXPECT_NE(0, buf_->iova());
 
-    EXPECT_EQ(static_cast<dma_buffer::size_t>(pg_size), buf_->size());
-    EXPECT_NE(0, buf_->iova());
-
-    free(buf);
+  free(buf);
 }
 
 /**
@@ -91,27 +86,27 @@ TEST_F(CxxBuffer_f1, alloc_07){
  * When I call dma_buffer::split(),<br>
  * The sub-buffers are created according to the initialier_list.<br>
  */
-TEST_F(CxxBuffer_f1, split_03){
-    buf_ = dma_buffer::allocate(accel_, 64);
-    ASSERT_NE(nullptr, buf_.get());
+TEST_F(CxxBuffer_f1, split_03) {
+  buf_ = dma_buffer::allocate(accel_, 64);
+  ASSERT_NE(nullptr, buf_.get());
 
-    std::vector<dma_buffer::ptr_t> v = buf_->split({16, 16, 16, 16});
+  std::vector<dma_buffer::ptr_t> v = buf_->split({16, 16, 16, 16});
 
-    EXPECT_EQ(buf_->get(), v[0]->get());
-    EXPECT_EQ(buf_->iova(), v[0]->iova());
-    EXPECT_EQ(16, v[0]->size());
+  EXPECT_EQ(buf_->get(), v[0]->get());
+  EXPECT_EQ(buf_->iova(), v[0]->iova());
+  EXPECT_EQ(16, v[0]->size());
 
-    EXPECT_EQ(buf_->get()+16, v[1]->get());
-    EXPECT_EQ(buf_->iova()+16, v[1]->iova());
-    EXPECT_EQ(16, v[1]->size());
+  EXPECT_EQ(buf_->get() + 16, v[1]->get());
+  EXPECT_EQ(buf_->iova() + 16, v[1]->iova());
+  EXPECT_EQ(16, v[1]->size());
 
-    EXPECT_EQ(buf_->get()+32, v[2]->get());
-    EXPECT_EQ(buf_->iova()+32, v[2]->iova());
-    EXPECT_EQ(16, v[2]->size());
+  EXPECT_EQ(buf_->get() + 32, v[2]->get());
+  EXPECT_EQ(buf_->iova() + 32, v[2]->iova());
+  EXPECT_EQ(16, v[2]->size());
 
-    EXPECT_EQ(buf_->get()+48, v[3]->get());
-    EXPECT_EQ(buf_->iova()+48, v[3]->iova());
-    EXPECT_EQ(16, v[3]->size());
+  EXPECT_EQ(buf_->get() + 48, v[3]->get());
+  EXPECT_EQ(buf_->iova() + 48, v[3]->iova());
+  EXPECT_EQ(16, v[3]->size());
 }
 
 /**
@@ -122,16 +117,16 @@ TEST_F(CxxBuffer_f1, split_03){
  * When I call dma_buffer::compare(),<br>
  * Then a byte-wise comparison is performed.<br>
  */
-TEST_F(CxxBuffer_f1, fill_compare_04){
-    buf_ = dma_buffer::allocate(accel_, 4);
-    ASSERT_NE(nullptr, buf_.get());
+TEST_F(CxxBuffer_f1, fill_compare_04) {
+  buf_ = dma_buffer::allocate(accel_, 4);
+  ASSERT_NE(nullptr, buf_.get());
 
-    dma_buffer::ptr_t buf2 = dma_buffer::allocate(accel_, 4);
-    ASSERT_NE(nullptr, buf2.get());
+  dma_buffer::ptr_t buf2 = dma_buffer::allocate(accel_, 4);
+  ASSERT_NE(nullptr, buf2.get());
 
-    buf_->fill(1);
-    buf2->fill(1);
-    EXPECT_EQ(0, buf_->compare(buf2, buf_->size()));
+  buf_->fill(1);
+  buf2->fill(1);
+  EXPECT_EQ(0, buf_->compare(buf2, buf_->size()));
 }
 
 /**
@@ -142,42 +137,40 @@ TEST_F(CxxBuffer_f1, fill_compare_04){
  * When I call dma_buffer::read(),<br>
  * Then the requested memory block is returned.<br>
  */
-TEST_F(CxxBuffer_f1, read_write_05){
-    buf_ = dma_buffer::allocate(accel_, 4);
-    ASSERT_NE(nullptr, buf_.get());
+TEST_F(CxxBuffer_f1, read_write_05) {
+  buf_ = dma_buffer::allocate(accel_, 4);
+  ASSERT_NE(nullptr, buf_.get());
 
-    buf_->write<uint32_t>(0xdecafbad, 0);
-    EXPECT_EQ(0xdecafbad, buf_->read<uint32_t>(0));
+  buf_->write<uint32_t>(0xdecafbad, 0);
+  EXPECT_EQ(0xdecafbad, buf_->read<uint32_t>(0));
 }
 
 /**
  * @test poll_wait_06
  * Given a valid dma_buffer smart pointer<br>
  * When I call poll(),<br>
- * Then the return value is false when the given mask/value are not observed .<br>
- * When I call poll(),<br>
- * Then the return value is true when the given mask/value are observed .<br>
- * When I call wait(),<br>
- * Then the return value is false when the given mask/value are not observed .<br>
- * When I call wait(),<br>
- * Then the return value is true when the given mask/value are observed .<br>
+ * Then the return value is false when the given mask/value are not observed
+ * .<br> When I call poll(),<br> Then the return value is true when the given
+ * mask/value are observed .<br> When I call wait(),<br> Then the return value
+ * is false when the given mask/value are not observed .<br> When I call
+ * wait(),<br> Then the return value is true when the given mask/value are
+ * observed .<br>
  */
-TEST_F(CxxBuffer_f1, poll_wait_06){
-    buf_ = dma_buffer::allocate(accel_, 4);
-    ASSERT_NE(nullptr, buf_.get());
+TEST_F(CxxBuffer_f1, poll_wait_06) {
+  buf_ = dma_buffer::allocate(accel_, 4);
+  ASSERT_NE(nullptr, buf_.get());
 
-    dma_buffer::size_t offset = 0;
-    std::chrono::microseconds micros(1000);
-    std::chrono::microseconds each(100);
-    uint32_t mask = 0xffffffff;
-    uint32_t value = 0xdecafbad;
-    uint32_t wrong_value = 0xdeadbeef;
+  dma_buffer::size_t offset = 0;
+  std::chrono::microseconds micros(1000);
+  std::chrono::microseconds each(100);
+  uint32_t mask = 0xffffffff;
+  uint32_t value = 0xdecafbad;
+  uint32_t wrong_value = 0xdeadbeef;
 
-    buf_->write<uint32_t>(value, offset);
-    EXPECT_FALSE(poll(buf_, offset, micros, mask, wrong_value));
-    EXPECT_TRUE(poll(buf_, offset, micros, mask, value));
+  buf_->write<uint32_t>(value, offset);
+  EXPECT_FALSE(poll(buf_, offset, micros, mask, wrong_value));
+  EXPECT_TRUE(poll(buf_, offset, micros, mask, value));
 
-    EXPECT_FALSE(wait(buf_, offset, each, micros, mask, wrong_value));
-    EXPECT_TRUE(wait(buf_, offset, each, micros, mask, value));
+  EXPECT_FALSE(wait(buf_, offset, each, micros, mask, wrong_value));
+  EXPECT_TRUE(wait(buf_, offset, each, micros, mask, value));
 }
-

--- a/libopae++/tests/unit/gtCxxProperties.cpp
+++ b/libopae++/tests/unit/gtCxxProperties.cpp
@@ -13,7 +13,6 @@ extern "C" {
 using namespace opae::fpga::types;
 const char* TEST_GUID_STR = "ae2878a7-926f-4332-aba1-2b952ad6df8e";
 
-
 /**
  * @test set_guid
  * Given a new properties object and a valid fpga_guid object
@@ -21,16 +20,16 @@ const char* TEST_GUID_STR = "ae2878a7-926f-4332-aba1-2b952ad6df8e";
  * And I retrieve the same property using fpgaGetPropertiesGUID
  * Then the known guid matches the one retrieved
  */
-TEST(CxxProperties, set_guid){
-    fpga_guid guid_in, guid_out;
-    properties p;
-    // set the guid to an fpga_guid
-    uuid_parse(TEST_GUID_STR, guid_in);
-    p.guid = guid_in;
+TEST(CxxProperties, set_guid) {
+  fpga_guid guid_in, guid_out;
+  properties p;
+  // set the guid to an fpga_guid
+  uuid_parse(TEST_GUID_STR, guid_in);
+  p.guid = guid_in;
 
-    // now check we set the guid using C APIs
-    ASSERT_EQ(fpgaPropertiesGetGUID(p.get(), &guid_out), FPGA_OK);
-    EXPECT_EQ(memcmp(guid_in, guid_out, sizeof(fpga_guid)), 0);
+  // now check we set the guid using C APIs
+  ASSERT_EQ(fpgaPropertiesGetGUID(p.get(), &guid_out), FPGA_OK);
+  EXPECT_EQ(memcmp(guid_in, guid_out, sizeof(fpga_guid)), 0);
 }
 
 /**
@@ -40,17 +39,17 @@ TEST(CxxProperties, set_guid){
  * And I retrieve the same property using fpgaGetPropertiesGUID
  * Then the known guid string parsed matches the one retrieved
  */
-TEST(CxxProperties, parse_guid){
-    fpga_guid guid_out;
-    properties p;
-    // set the guid to an fpga_guid
-    p.guid.parse(TEST_GUID_STR);
+TEST(CxxProperties, parse_guid) {
+  fpga_guid guid_out;
+  properties p;
+  // set the guid to an fpga_guid
+  p.guid.parse(TEST_GUID_STR);
 
-    // now check we set the guid using C APIs
-    ASSERT_EQ(fpgaPropertiesGetGUID(p.get(), &guid_out), FPGA_OK);
-    char guid_str[84];
-    uuid_unparse(guid_out, guid_str);
-    EXPECT_STREQ(TEST_GUID_STR, guid_str);
+  // now check we set the guid using C APIs
+  ASSERT_EQ(fpgaPropertiesGetGUID(p.get(), &guid_out), FPGA_OK);
+  char guid_str[84];
+  uuid_unparse(guid_out, guid_str);
+  EXPECT_STREQ(TEST_GUID_STR, guid_str);
 }
 
 /**
@@ -60,16 +59,16 @@ TEST(CxxProperties, parse_guid){
  * And I get a pointer to the guid member variable of the property object
  * Then the known guid matches the one retrieved
  */
-TEST(CxxProperties, get_guid){
-    fpga_guid guid_in, guid_out;
-    properties p;
-    // set the guid using fpgaPropertiesSetGUID
-    uuid_parse(TEST_GUID_STR, guid_in);
-    fpgaPropertiesSetGUID(p.get(), guid_in);
+TEST(CxxProperties, get_guid) {
+  fpga_guid guid_in, guid_out;
+  properties p;
+  // set the guid using fpgaPropertiesSetGUID
+  uuid_parse(TEST_GUID_STR, guid_in);
+  fpgaPropertiesSetGUID(p.get(), guid_in);
 
-    uint8_t* guid_ptr = p.guid;
-    ASSERT_NE(nullptr, guid_ptr);
-    EXPECT_EQ(memcmp(guid_in, guid_ptr, sizeof(fpga_guid)), 0);
+  uint8_t* guid_ptr = p.guid;
+  ASSERT_NE(nullptr, guid_ptr);
+  EXPECT_EQ(memcmp(guid_in, guid_ptr, sizeof(fpga_guid)), 0);
 }
 
 /**
@@ -78,13 +77,13 @@ TEST(CxxProperties, get_guid){
  * When I set compare its guid with the known guid
  * Then the result is true
  */
-TEST(CxxProperties, compare_guid){
-    fpga_guid guid_in;
-    properties p;
-    uuid_parse(TEST_GUID_STR, guid_in);
-    EXPECT_FALSE(p.guid == guid_in);
-    p.guid = guid_in;
-    EXPECT_TRUE(p.guid == guid_in);
+TEST(CxxProperties, compare_guid) {
+  fpga_guid guid_in;
+  properties p;
+  uuid_parse(TEST_GUID_STR, guid_in);
+  EXPECT_FALSE(p.guid == guid_in);
+  p.guid = guid_in;
+  EXPECT_TRUE(p.guid == guid_in);
 }
 
 /**
@@ -93,10 +92,11 @@ TEST(CxxProperties, compare_guid){
  * When I set the object type to a known value
  * Then the property is set
  */
-TEST(CxxProperties, set_objtype){
-    properties p;
-    fpga_objtype t = p.type;
-    fpga_objtype other_t = (t == FPGA_ACCELERATOR) ? FPGA_DEVICE : FPGA_ACCELERATOR;
-    p.type = other_t;
-    EXPECT_TRUE(p.type == other_t);
+TEST(CxxProperties, set_objtype) {
+  properties p;
+  fpga_objtype t = p.type;
+  fpga_objtype other_t =
+      (t == FPGA_ACCELERATOR) ? FPGA_DEVICE : FPGA_ACCELERATOR;
+  p.type = other_t;
+  EXPECT_TRUE(p.type == other_t);
 }

--- a/libopae++/tests/unit/gtEnumerate.cpp
+++ b/libopae++/tests/unit/gtEnumerate.cpp
@@ -10,7 +10,6 @@ extern "C" {
 #include "gtest/gtest.h"
 using namespace opae::fpga::types;
 
-
 /**
  * @test cxx_enum_01
  * Given an environment with at least one accelerator<br>
@@ -18,8 +17,8 @@ using namespace opae::fpga::types;
  * Then I get at least one accelerator object in the return list<br>
  * And no exceptions are thrown
  */
-TEST(CxxEnum, enum_01){
-    auto tokens = token::enumerate({});
-    EXPECT_TRUE(tokens.size() > 0);
-    ASSERT_NO_THROW(tokens.clear());
+TEST(CxxEnum, enum_01) {
+  auto tokens = token::enumerate({});
+  EXPECT_TRUE(tokens.size() > 0);
+  ASSERT_NO_THROW(tokens.clear());
 }

--- a/libopae++/tests/unit/gtOpenClose.cpp
+++ b/libopae++/tests/unit/gtOpenClose.cpp
@@ -13,7 +13,6 @@ extern "C" {
 
 using namespace opae::fpga::types;
 
-
 /**
  * @test cxx_enum_01
  * Given an environment with at least one accelerator<br>
@@ -22,11 +21,11 @@ using namespace opae::fpga::types;
  * Then I get a non-null handle<br>
  * And no exceptions are thrown
  */
-TEST(CxxOpen, open_01){
-    auto tokens = token::enumerate({ FPGA_ACCELERATOR });
-    EXPECT_TRUE(tokens.size() > 0);
-    handle::ptr_t h = handle::open(tokens[0], FPGA_OPEN_SHARED);
-    ASSERT_NE(nullptr, h.get());
-    h.reset();
-    ASSERT_NO_THROW(tokens.clear());
+TEST(CxxOpen, open_01) {
+  auto tokens = token::enumerate({FPGA_ACCELERATOR});
+  EXPECT_TRUE(tokens.size() > 0);
+  handle::ptr_t h = handle::open(tokens[0], FPGA_OPEN_SHARED);
+  ASSERT_NE(nullptr, h.get());
+  h.reset();
+  ASSERT_NO_THROW(tokens.clear());
 }


### PR DESCRIPTION
I used clang-format to modify all .h|.cpp files in the libopae++
codebase to apply google's coding style for C++.

_NOTE:_ Because this coding style uses two-space indentation instead of
the four that had been used before, this change will touch most code.