### PR TITLE
Install safe string library with opae-devel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,9 @@ install(DIRECTORY common/include/opae
   DESTINATION include
   COMPONENT libopaeheaders)
 
+install(DIRECTORY common/include/safe_string
+  DESTINATION include
+  COMPONENT safestrheaders)
 ############################################################################
 ## Add 'documentation' target ##############################################
 ############################################################################
@@ -189,6 +192,8 @@ define_pkg(devel
   docxml
   platform
   samplesrc
+  safestrlib
+  safestrheaders
   GROUP "devel"
   DISPLAY_NAME "opae-devel"
   DESCRIPTION "OPAE headers, sample source, and documentation"

--- a/safe_string/CMakeLists.txt
+++ b/safe_string/CMakeLists.txt
@@ -111,3 +111,7 @@ add_library(safestr STATIC ${SRC})
 set_property(TARGET safestr PROPERTY C_STANDARD 99)
 set_property(TARGET safestr PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(safestr PRIVATE PIC=1)
+
+install(TARGETS safestr
+        ARCHIVE DESTINATION lib
+        COMPONENT safestrlib)

--- a/safe_string/CMakeLists.txt
+++ b/safe_string/CMakeLists.txt
@@ -111,6 +111,7 @@ add_library(safestr STATIC ${SRC})
 set_property(TARGET safestr PROPERTY C_STANDARD 99)
 set_property(TARGET safestr PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(safestr PRIVATE PIC=1)
+target_compile_options(safestr PRIVATE -O3)
 
 install(TARGETS safestr
         ARCHIVE DESTINATION lib


### PR DESCRIPTION
Safe string library is built and used with OPAE.  It is also needed for some AFUs now and probably more in the future.  This PR causes the safe string library to be installed with OPAE.