### PR TITLE
 Add git version breadcrumb

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.id ident
+

--- a/.id
+++ b/.id
@@ -1,0 +1,1 @@
+$Id: please-fill-me-in, git$

--- a/.id
+++ b/.id
@@ -1,1 +1,1 @@
-$Id: please-fill-me-in, git$
+$Id$


### PR DESCRIPTION
Adds a file ".id" that shows the current git version/hash whenever the
tree is checked out. This is useful for determining the origin commit for release artifacts.