### PR TITLE
libopae: Generate config_int.h with version info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,23 @@ cmake_minimum_required(VERSION 2.8.11)
 project(opae)
 
 ############################################################################
+## Get git hash info, if available #########################################
+############################################################################
+find_program(GIT_EXECUTABLE git)
+if(EXISTS ${GIT_EXECUTABLE})
+  execute_process(COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_COMMIT_HASH
+    RESULT_VARIABLE GIT_LOG_RESULT
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT ${GIT_LOG_RESULT} EQUAL 0)
+      set(GIT_COMMIT_HASH unknown)
+    endif(NOT ${GIT_LOG_RESULT} EQUAL 0)
+else(EXISTS ${GIT_EXECUTABLE})
+  set(GIT_COMMIT_HASH unknown)
+endif(EXISTS ${GIT_EXECUTABLE})
+
+############################################################################
 ## Add 'versioning' library ################################################
 ############################################################################
 
@@ -35,6 +52,7 @@ set(INTEL_FPGA_API_VER_MAJOR 0  CACHE STRING "Intel FPGA API major version")
 set(INTEL_FPGA_API_VER_MINOR 12 CACHE STRING "Intel FPGA API minor version")
 set(INTEL_FPGA_API_VER_REV   0  CACHE STRING "Intel FPGA API revision version")
 set(INTEL_FPGA_API_VERSION   ${INTEL_FPGA_API_VER_MAJOR}.${INTEL_FPGA_API_VER_MINOR}.${INTEL_FPGA_API_VER_REV})
+set(INTEL_FPGA_API_HASH      ${GIT_COMMIT_HASH})
 
 ############################################################################
 ## Compilation configuration ###############################################
@@ -152,16 +170,6 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 option(HASH_ARCHIVES "Add git commit hash to archive names" OFF)
 mark_as_advanced(HASH_ARCHIVES)
-
-find_program(GIT_EXECUTABLE git)
-if(EXISTS ${GIT_EXECUTABLE})
-  execute_process(COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    OUTPUT_VARIABLE GIT_COMMIT_HASH
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-else(EXISTS ${GIT_EXECUTABLE})
-  set(GIT_COMMIT_HASH unknown)
-endif(EXISTS ${GIT_EXECUTABLE})
 
 include(packaging)
 set(CPACK_PACKAGE_NAME ${CMAKE_PROJECT_NAME})

--- a/cmake/config/config.h.in
+++ b/cmake/config/config.h.in
@@ -219,5 +219,9 @@
    pointer, if such a type exists, and if the system does not define it. */
 #cmakedefine uintptr_t
 
-#cmakedefine INTEL_FPGA_API_VERSION @INTEL_FPGA_API_VERSION@
-#cmakedefine INTEL_FPGA_API_HASH "@INTEL_FPGA_API_HASH@"
+#define INTEL_FPGA_API_VER_MAJOR @INTEL_FPGA_API_VER_MAJOR@
+#define INTEL_FPGA_API_VER_MINOR @INTEL_FPGA_API_VER_MINOR@
+#define INTEL_FPGA_API_VER_REV   @INTEL_FPGA_API_VER_REV@
+
+#cmakedefine INTEL_FPGA_API_VERSION "@INTEL_FPGA_API_VERSION@"
+#cmakedefine INTEL_FPGA_API_HASH    "@INTEL_FPGA_API_HASH@"

--- a/cmake/config/config.h.in
+++ b/cmake/config/config.h.in
@@ -218,3 +218,6 @@
 /* Define to the type of an unsigned integer type wide enough to hold a
    pointer, if such a type exists, and if the system does not define it. */
 #cmakedefine uintptr_t
+
+#cmakedefine INTEL_FPGA_API_VERSION @INTEL_FPGA_API_VERSION@
+#cmakedefine INTEL_FPGA_API_HASH "@INTEL_FPGA_API_HASH@"

--- a/libopae/CMakeLists.txt
+++ b/libopae/CMakeLists.txt
@@ -75,6 +75,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
 # paths. Keep current directory private.
 target_include_directories(opae-c PUBLIC
   $<BUILD_INTERFACE:${OPAE_INCLUDE_DIR}>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
   $<INSTALL_INTERFACE:include>
   PRIVATE src)
 
@@ -121,3 +122,10 @@ if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
     add_dependencies(coverage_opae-c gtapi)
   endif(BUILD_TESTS AND GTEST_FOUND)
 endif(CMAKE_BUILD_TYPE STREQUAL "Coverage")
+
+############################################################################
+## Create config_int.h #########################################################
+############################################################################
+
+configure_file ("${CMAKE_SOURCE_DIR}/cmake/config/config.h.in"
+                "${PROJECT_BINARY_DIR}/include/config_int.h" )


### PR DESCRIPTION
Creates a config_int.h containing CMake variables, including version
information and the current git hash.

This is in preparation for an API that allows software to query the
current OPAE API's release.