### PR TITLE
Use absolute paths in DUT_INCDIR to keep QuestaSim happy (#261) (#264)

### DIFF
--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -342,7 +342,11 @@ def auto_find_sources(fd):
     # Recursively find and add directory locations for VH
     print("")
     print("Finding include directories ... ")
-    str = commands_getoutput("find -L " + str_dirlist + " -type d")
+
+    # use absolute path names in DUT_INCDIR to keep Questa happy
+    pathname = os.path.abspath(str_dirlist)
+    str = commands_getoutput("find -L " + pathname + " -type d")
+
     str = str.replace("\n", "+")
     if len(str) != 0:
         print("DUT_INCDIR = " + str)


### PR DESCRIPTION
ASE searches for verilog/SV include files in DUT_INCDIR
using relative paths (sim_afu). QuestaSim
needs absolute path for include files.

(cherry picked from commit 14ba1121473181a06e8979ade3466273127430dd)