### PR TITLE
c++: Add C++ logger class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,26 @@
 language: c
+cache:
+  - ccache
+  - pip
 compiler: gcc
 install:
   - pip install --user pylint
   - pip install --user pycodestyle
+  - pip install --user jsonschema
 
-script:
-    - scripts/test-codingstyle.sh
-    - scripts/test-codingstyle-py.sh
-    - scripts/test-build.sh
-    - scripts/test-gtapi-mock-drv.sh
+jobs:
+  include:
+    - stage: BAT
+      script: scripts/test-codingstyle.sh
+    - # BAT
+      script: scripts/test-codingstyle-py.sh
+    - # BAT
+      script: scripts/test-build.sh
+    - # BAT
+      script: scripts/test-gtapi-mock-drv.sh
 addons:
   apt:
     packages:
       - libboost-all-dev
       - libjson-c-dev
       - uuid-dev
-      - libjsoncpp-dev

--- a/libopae++/CMakeLists.txt
+++ b/libopae++/CMakeLists.txt
@@ -55,7 +55,8 @@ set(OPAECXX_SRC src/properties.cpp
                 src/token.cpp
                 src/handle.cpp
                 src/dma_buffer.cpp
-                src/except.cpp)
+                src/except.cpp
+                src/log.cpp)
 
 add_library(opae-cxx-core SHARED ${OPAECXX_SRC})
 target_link_libraries(opae-cxx-core opae-c)

--- a/libopae++/include/opaec++/log.h
+++ b/libopae++/include/opaec++/log.h
@@ -1,0 +1,215 @@
+// Copyright(c) 2017, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+#include <memory>
+#include <sstream>
+
+namespace opae {
+namespace fpga {
+namespace internal {
+
+/**
+ * @brief wrapped_stream wraps the logging functionality in libopae-c.
+ * It is what is returned from a logger object when it
+ * begins a stream sequence. Its destructor is called when the sequence ends.
+ */
+class wrapped_stream
+{
+ public:
+
+ /**
+  * @brief create a wrapped_stream object with a given level
+  *
+  * @param level The log level expected by the logger in libopae-c
+  * @param new_line Used to determine whether or not a newline is
+  *                 automatically appended to the stream
+  */
+  wrapped_stream(int level, bool new_line = false);
+
+  /**
+   * @brief copy constructor of wrapped_stream that copies internal
+   *        stream data structures
+   *
+   * @param other The other wrapped_stream object to copy from
+   */
+  wrapped_stream(const wrapped_stream & other);
+
+  /**
+   * @brief assignment operator of a wrapped_stream that copies internal
+   *        stream data structures
+   *
+   * @param other The other wrapped_stream object to copy from
+   *
+   * @return A reference to `this` after copying internal data
+   */
+  wrapped_stream & operator=(const wrapped_stream & other);
+
+  /**
+   * @brief wrapped_stream destructor which indicates the end of the stream
+   * sequence
+   */
+  ~wrapped_stream();
+
+  /**
+   * @brief Templated stream operator
+   *
+   * @tparam T The type of the variable being streamed
+   * @param v The variable to stream
+   *
+   * @return A reference to `this`
+   */
+  template<typename T>
+  wrapped_stream& operator<<(const T& v)
+  {
+      sstream_ << v;
+      return *this;
+  }
+
+  /**
+   * @brief Overload of the stream operator used for stream manipulators
+   *
+   * @param manip The stream manipulator
+   *
+   * @return A reference to `this`
+   */
+  wrapped_stream& operator<<(std::ostream& (*manip)(std::ostream&));
+ private:
+  std::stringstream sstream_;
+  int level_;
+  char fmt_[4];
+};
+
+/**
+ * @brief Named logger object used to format log messages with the process
+ * id, the logger name, and the level of the log message
+ */
+class logger {
+ public:
+  /**
+   * @brief log level enumeration that roughly maps to the log levels in
+   * libopae-c
+   */
+  enum class level : int
+  {
+      none        = -1,
+      error       = 0,
+      exception   = 10,
+      fatal       = 15,
+      warn        = 20,
+      info        = 25,
+      debug       = 40
+  };
+
+  /**
+   * @brief named logger constructor
+   *
+   * @param name The name of the logger to include in log messages
+   */
+  logger(const std::string & name);
+
+  /**
+   * @brief Generic log method that uses loglevel parameter
+   *
+   * @param l The level of the log message
+   * @param str An optional string that may include more contextual
+   *            information
+   *
+   * @return A wrapped_stream object to begin the stream sequence
+   */
+  wrapped_stream log(level l, std::string str = "");
+
+  /**
+   * @brief Log method for debug messages
+   *
+   * @param str An optional string that may include more contextual
+   *            information
+   *
+   * @return A wrapped_stream object to begin the stream sequence
+   */
+  wrapped_stream debug(std::string str = "");
+
+  /**
+   * @brief Log method for info messages
+   *
+   * @param str An optional string that may include more contextual
+   *            information
+   *
+   * @return A wrapped_stream object to begin the stream sequence
+   */
+  wrapped_stream info(std::string str = "");
+
+  /**
+   * @brief Log method for warning messages
+   *
+   * @param str An optional string that may include more contextual
+   *            information
+   *
+   * @return A wrapped_stream object to begin the stream sequence
+   */
+  wrapped_stream warn(std::string str = "");
+
+  /**
+   * @brief Log method for error messages
+   *
+   * @param str An optional string that may include more contextual
+   *            information
+   *
+   * @return A wrapped_stream object to begin the stream sequence
+   */
+  wrapped_stream error(std::string str= "");
+
+  /**
+   * @brief Log method for exception messages
+   *
+   * @param str An optional string that may include more contextual
+   *            information
+   *
+   * @return A wrapped_stream object to begin the stream sequence
+   */
+  wrapped_stream exception(std::string str = "");
+
+  /**
+   * @brief Log method for fatal error messages
+   *        Meant to be called when detecting a condition that will
+   *        terminate program execution
+   *
+   * @param str An optional string that may include more contextual
+   *            information
+   *
+   * @return A wrapped_stream object to begin the stream sequence
+   */
+  wrapped_stream fatal(std::string str = "");
+
+
+ private:
+  std::string name_;
+  int pid_;
+};
+
+
+}  // end of namespace internal
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/libopae++/include/opaec++/log.h
+++ b/libopae++/include/opaec++/log.h
@@ -115,9 +115,9 @@ class logger {
   enum class level : int
   {
       none        = -1,
-      error       = 0,
+      fatal       = 0,
       exception   = 10,
-      fatal       = 15,
+      error       = 15,
       warn        = 20,
       info        = 25,
       debug       = 40

--- a/libopae++/src/log.cpp
+++ b/libopae++/src/log.cpp
@@ -96,8 +96,7 @@ wrapped_stream logger::log(logger::level l, std::string str)
   wrapped_stream stream(lvl);
   stream << std::dec << "[" << s_pid << "][" << s_level_map[l] << "]";
   if (name_ != "") stream << "[" << name_ << "]";
-  if (str != "")
-  {
+  if (str != ""){
       stream << "[" << str << "]";
   }
   stream << std::boolalpha << " ";

--- a/libopae++/src/log.cpp
+++ b/libopae++/src/log.cpp
@@ -1,0 +1,140 @@
+// Copyright(c) 2017, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include <safe_string/safe_string.h>
+
+#include <unistd.h>
+#include <map>
+
+#include "opaec++/log.h"
+
+extern "C" {
+  void fpga_print(int, char*, ...);
+}
+
+namespace opae {
+namespace fpga {
+namespace internal {
+
+static int s_pid = ::getpid();
+
+static std::map<logger::level, std::string> s_level_map =
+{
+    {logger::level::none,       "NONE"},
+    {logger::level::debug,      "DEBUG"},
+    {logger::level::info,       "INFO"},
+    {logger::level::warn,       "WARN"},
+    {logger::level::error,      "ERROR"},
+    {logger::level::exception,  "EXCEPTION"},
+    {logger::level::fatal,      "FATAL"}
+};
+
+wrapped_stream::wrapped_stream(int level, bool new_line)
+    : sstream_()
+    , level_(level)
+    , fmt_{"%s\n"}
+{
+  if (!new_line){
+    fmt_[2] = 0;
+  }
+}
+
+wrapped_stream::wrapped_stream(const wrapped_stream & other)
+    : sstream_(other.sstream_.str())
+{
+}
+
+wrapped_stream & wrapped_stream::operator=(const wrapped_stream & other) {
+  if (this != &other) {
+      sstream_.str(other.sstream_.str());
+  }
+  return *this;
+}
+
+wrapped_stream::~wrapped_stream() {
+  fpga_print(level_, fmt_, sstream_.str().c_str());
+  sstream_.str(std::string());
+}
+
+
+wrapped_stream& wrapped_stream::operator<<(std::ostream& (*manip)(std::ostream&)) {
+  sstream_ << manip;
+  return *this;
+}
+
+logger::logger(const std::string & name)
+  : name_(name)
+{
+}
+
+wrapped_stream logger::log(logger::level l, std::string str)
+{
+  // convert C++ log levels to C log
+  int lvl = static_cast<int>(l)/20;
+  wrapped_stream stream(lvl);
+  stream << std::dec << "[" << s_pid << "][" << s_level_map[l] << "]";
+  if (name_ != "") stream << "[" << name_ << "]";
+  if (str != "")
+  {
+      stream << "[" << str << "]";
+  }
+  stream << std::boolalpha << " ";
+
+  return stream;
+}
+
+wrapped_stream logger::debug(std::string str)
+{
+  return log(level::debug, str);
+}
+
+wrapped_stream logger::info(std::string str)
+{
+  return log(level::info, str);
+}
+
+wrapped_stream logger::warn(std::string str)
+{
+  return log(level::warn, str);
+}
+
+wrapped_stream logger::error(std::string str)
+{
+  return log(level::error, str);
+}
+
+wrapped_stream logger::exception(std::string str)
+{
+  return log(level::exception, str);
+}
+
+wrapped_stream logger::fatal(std::string str)
+{
+  return log(level::fatal, str);
+}
+
+}  // end of namespace internal
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,7 +104,8 @@ set(SRC gtmain.cpp
   unit/gtCxxEnumerate.cpp
   unit/gtCxxOpenClose.cpp
   unit/gtCxxProperties.cpp
-  unit/gtCxxExcept.cpp)
+  unit/gtCxxExcept.cpp
+  unit/gtCxxLog.cpp)
 
 add_executable(gtapi ${SRC})
 target_include_directories(gtapi PUBLIC
@@ -170,6 +171,7 @@ add_gtfilter(CxxEnum "CxxEnum*" True)
 add_gtfilter(CxxOpenClose "CxxOpen*" True)
 add_gtfilter(CxxBuffer "CxxEnum*" True)
 add_gtfilter(CxxExcept "CxxExcept*" False)
+add_gtfilter(CxxLog "CxxLog*" False)
 ############################################################################
 ## Add 'coverage' ##########################################################
 ############################################################################

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -169,7 +169,7 @@ set_tests_properties(
 add_gtfilter(CxxProperties "CxxProperties*" False)
 add_gtfilter(CxxEnum "CxxEnum*" True)
 add_gtfilter(CxxOpenClose "CxxOpen*" True)
-add_gtfilter(CxxBuffer "CxxEnum*" True)
+add_gtfilter(CxxBuffer "CxxBuffer*" True)
 add_gtfilter(CxxExcept "CxxExcept*" False)
 add_gtfilter(CxxLog "CxxLog*" False)
 ############################################################################

--- a/tests/unit/gtCxxLog.cpp
+++ b/tests/unit/gtCxxLog.cpp
@@ -1,0 +1,21 @@
+#include "gtest/gtest.h"
+
+#include "opaec++/log.h"
+
+using namespace opae::fpga::internal;
+
+
+/**
+ * @test log_error
+ * Given a logger object with a given name
+ * When I log an error message
+ * Then a formatted log messages is printed to stderr
+ */
+TEST(CxxLog, log_error) {
+  logger log("the_name");
+  testing::internal::CaptureStderr();
+  log.error() << "ThIs IS aN erroR StrIng";
+  std::string msg = testing::internal::GetCapturedStderr();
+  EXPECT_NE(msg.find("[ERROR][the_name] ThIs IS aN erroR StrIng"), std::string::npos);
+}
+


### PR DESCRIPTION
* Add a named logger class that is used to start a logging stream
sequence with an indicated log level. This returns a `wrapped_logger`
object which is used to stream the log message and eventually emit it to
its destination by calling the log methat in libopae-c

* Add a unit test to verify the error messages are sent to stderr in the
expected format