### PR TITLE
add logger `warn_if` and `error_if` functions

### DIFF
--- a/libopae++/include/opaec++/log.h
+++ b/libopae++/include/opaec++/log.h
@@ -39,6 +39,11 @@ namespace internal {
 class wrapped_stream
 {
  public:
+ /**
+  * @brief create an empty wrapped_stream
+  *
+  */
+  wrapped_stream();
 
  /**
   * @brief create a wrapped_stream object with a given level
@@ -84,7 +89,9 @@ class wrapped_stream
   template<typename T>
   wrapped_stream& operator<<(const T& v)
   {
-      sstream_ << v;
+      if (sstream_ != nullptr){
+        *sstream_ << v;
+      }
       return *this;
   }
 
@@ -98,7 +105,7 @@ class wrapped_stream
   wrapped_stream& operator<<(std::ostream& (*manip)(std::ostream&));
 
  protected:
-  std::stringstream sstream_;
+  std::ostringstream* sstream_;
 
  private:
   int level_;

--- a/libopae++/include/opaec++/log.h
+++ b/libopae++/include/opaec++/log.h
@@ -71,7 +71,7 @@ class wrapped_stream
    * @brief wrapped_stream destructor which indicates the end of the stream
    * sequence
    */
-  ~wrapped_stream();
+  virtual ~wrapped_stream();
 
   /**
    * @brief Templated stream operator
@@ -96,8 +96,11 @@ class wrapped_stream
    * @return A reference to `this`
    */
   wrapped_stream& operator<<(std::ostream& (*manip)(std::ostream&));
- private:
+
+ protected:
   std::stringstream sstream_;
+
+ private:
   int level_;
   char fmt_[4];
 };
@@ -139,7 +142,7 @@ class logger {
    *
    * @return A wrapped_stream object to begin the stream sequence
    */
-  wrapped_stream log(level l, std::string str = "");
+  wrapped_stream log(level l, std::string str = "") const;
 
   /**
    * @brief Log method for debug messages
@@ -149,7 +152,7 @@ class logger {
    *
    * @return A wrapped_stream object to begin the stream sequence
    */
-  wrapped_stream debug(std::string str = "");
+  wrapped_stream debug(std::string str = "") const;
 
   /**
    * @brief Log method for info messages
@@ -159,7 +162,7 @@ class logger {
    *
    * @return A wrapped_stream object to begin the stream sequence
    */
-  wrapped_stream info(std::string str = "");
+  wrapped_stream info(std::string str = "") const;
 
   /**
    * @brief Log method for warning messages
@@ -169,7 +172,18 @@ class logger {
    *
    * @return A wrapped_stream object to begin the stream sequence
    */
-  wrapped_stream warn(std::string str = "");
+  wrapped_stream warn(std::string str = "") const;
+
+  /**
+   * @brief Log method for warning messages if condition is true
+   *
+   * @param cond boolean flag that determines if message is logged
+   * @param str An optional string that may include more contextual
+   *            information
+   *
+   * @return A wrapped_stream object to begin the stream sequence
+   */
+  wrapped_stream warn_if(bool cond, std::string str = "") const;
 
   /**
    * @brief Log method for error messages
@@ -179,7 +193,18 @@ class logger {
    *
    * @return A wrapped_stream object to begin the stream sequence
    */
-  wrapped_stream error(std::string str= "");
+  wrapped_stream error(std::string str= "") const;
+
+  /**
+   * @brief Log method for error messages if condition is true
+   *
+   * @param cond boolean flag that determines if message is logged
+   * @param str An optional string that may include more contextual
+   *            information
+   *
+   * @return A wrapped_stream object to begin the stream sequence
+   */
+  wrapped_stream error_if(bool cond, std::string str = "") const;
 
   /**
    * @brief Log method for exception messages
@@ -189,7 +214,7 @@ class logger {
    *
    * @return A wrapped_stream object to begin the stream sequence
    */
-  wrapped_stream exception(std::string str = "");
+  wrapped_stream exception(std::string str = "") const;
 
   /**
    * @brief Log method for fatal error messages
@@ -201,7 +226,7 @@ class logger {
    *
    * @return A wrapped_stream object to begin the stream sequence
    */
-  wrapped_stream fatal(std::string str = "");
+  wrapped_stream fatal(std::string str = "") const;
 
 
  private:

--- a/libopae++/src/log.cpp
+++ b/libopae++/src/log.cpp
@@ -76,7 +76,7 @@ wrapped_stream::wrapped_stream(const wrapped_stream & other)
 }
 
 wrapped_stream & wrapped_stream::operator=(const wrapped_stream & other) {
-  if (this != &other) {
+  if (this != &other && other.sstream_ != nullptr) {
       sstream_->str(other.sstream_->str());
   }
   return *this;

--- a/libopae++/src/log.cpp
+++ b/libopae++/src/log.cpp
@@ -104,7 +104,7 @@ class null_stream : public wrapped_stream {
  public:
   null_stream() : wrapped_stream() {}
 
-  virtual ~null_stream(){
+  ~null_stream(){
   }
 
 };

--- a/tests/unit/gtCxxLog.cpp
+++ b/tests/unit/gtCxxLog.cpp
@@ -19,3 +19,31 @@ TEST(CxxLog, log_error) {
   EXPECT_NE(msg.find("[ERROR][the_name] ThIs IS aN erroR StrIng"), std::string::npos);
 }
 
+/**
+ * @test error_if_true
+ * Given a logger object with a given name
+ * When I call error_if with a true condition
+ * Then a formatted log messages is printed to stderr
+ */
+TEST(CxxLog, error_if_true) {
+  logger log("the_name");
+  testing::internal::CaptureStderr();
+  log.error_if(true) << "ThIs IS aN erroR StrIng";
+  std::string msg = testing::internal::GetCapturedStderr();
+  EXPECT_NE(msg.find("[ERROR][the_name] ThIs IS aN erroR StrIng"), std::string::npos);
+}
+
+/**
+ * @test error_if_false
+ * Given a logger object with a given name
+ * When I call error_if with a false condition
+ * And I read from stderr
+ * Then stderr is empty
+ */
+TEST(CxxLog, warn_if_false) {
+  logger log("the_name");
+  testing::internal::CaptureStderr();
+  log.error_if(false) << "ThIs IS aN erroR StrIng";
+  std::string msg = testing::internal::GetCapturedStderr();
+  EXPECT_TRUE(msg.empty());
+}


### PR DESCRIPTION
* Create a null_stream object that derives from wrapped_stream but does
  nothing at the end of the stream
* Change `logger` methods to `const`
* Change `wrapped_stream::sstream_` member variable to
  * protected
  * a pointer
* Check if `wrapped_stream::sstream_` member is null in the `<<` operator overaloads
* Add `warn_if` and `error_if` functions return `null_stream` instance
  when the condition argument is null