### PR TITLE
c++: add pvalue<char*> specialization plus docs

### DIFF
--- a/tests/unit/gtCxxProperties.cpp
+++ b/tests/unit/gtCxxProperties.cpp
@@ -116,3 +116,15 @@ TEST(CxxProperties, set_objtype) {
   p.type = other_t;
   EXPECT_TRUE(p.type == other_t);
 }
+
+/**
+ * @test get_model
+ * Given a properties object
+ * When I get the model property
+ * Then I get an empty string
+ */
+TEST(CxxProperties, get_model) {
+  properties p;
+  std::string model = p.model;
+  EXPECT_TRUE(model.empty());
+}


### PR DESCRIPTION
* Define `copy_t` as either `T` or `std::string` for `char*`
* Specialize pvalue<char*>::operator copy_t()
  * To call the getter function with a char[] declared on the stack
  * Assign the value of the char[] if the getter succeeds
* Add doxygen documentation to pvalue
* Add unit test for getting model