### PR TITLE
Fix compile warning in hello_events

### DIFF
--- a/samples/hello_events.c
+++ b/samples/hello_events.c
@@ -113,6 +113,7 @@ int main(int argc, char *argv[])
 	struct pollfd pfd;
 	int timeout = 10000;
 	int poll_ret = 0;
+	ssize_t bytes_read = 0;
 
 	UNUSED_PARAM(argc);
 	UNUSED_PARAM(argv);
@@ -174,7 +175,9 @@ int main(int argc, char *argv[])
 			 goto out_destroy_eh;
 		} else {
 			 printf("FME Interrupt occured\n");
-			 read(pfd.fd, &count, sizeof(count));
+			 bytes_read = read(pfd.fd, &count, sizeof(count));
+			 if (bytes_read == 0)
+				 printf("WARNING: read zero bytes from poll fd\n");
 		}
 
 		res = fpgaUnregisterEvent(fpga_device_handle, FPGA_EVENT_ERROR, eh);


### PR DESCRIPTION
Compiler was warning about ignoring the return value of `read`
This assigns the return value to `bytes_read` and acts on it if zero