### PR TITLE
check for negative return value from `read`

### DIFF
--- a/samples/hello_events.c
+++ b/samples/hello_events.c
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
 			 bytes_read = read(pfd.fd, &count, sizeof(count));
 			 if (bytes_read <= 0)
 				 printf("WARNING: error reading from poll fd: %s\n",
-				        bytes_read < 0 ? strerror(errno) : "zero bytes read");
+						 bytes_read < 0 ? strerror(errno) : "zero bytes read");
 		}
 
 		res = fpgaUnregisterEvent(fpga_device_handle, FPGA_EVENT_ERROR, eh);

--- a/samples/hello_events.c
+++ b/samples/hello_events.c
@@ -176,8 +176,9 @@ int main(int argc, char *argv[])
 		} else {
 			 printf("FME Interrupt occured\n");
 			 bytes_read = read(pfd.fd, &count, sizeof(count));
-			 if (bytes_read == 0)
-				 printf("WARNING: read zero bytes from poll fd\n");
+			 if (bytes_read <= 0)
+				 printf("WARNING: error reading from poll fd: %s\n",
+				        bytes_read < 0 ? strerror(errno) : "zero bytes read");
 		}
 
 		res = fpgaUnregisterEvent(fpga_device_handle, FPGA_EVENT_ERROR, eh);


### PR DESCRIPTION
In hello_events.c, check `bytes_read` from calling `read` to be <= 0
and if less than zero, print out the string error of errno.
Otherwise, print out "zero bytes read"