### PR TITLE
c++: Migrate dma_buffer functions to separate file

### DIFF
--- a/libopae++/include/opaec++/buffers.h
+++ b/libopae++/include/opaec++/buffers.h
@@ -1,0 +1,185 @@
+// Copyright(c) 2017, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+#include <memory>
+#include <cstdint>
+#include <vector>
+#include <initializer_list>
+#include <chrono>
+#include <thread>
+
+#include <opaec++/dma_buffer.h>
+#include <opaec++/handle.h>
+#include <opaec++/log.h>
+#include <opaec++/except.h>
+
+using opae::fpga::types::handle;
+using opae::fpga::types::dma_buffer;
+
+namespace opae {
+namespace fpga {
+namespace memory {
+
+
+class buffer_chunk : public opae::fpga::types::dma_buffer,
+                     public std::enable_shared_from_this<buffer_chunk> {
+ public:
+  typedef std::shared_ptr<buffer_chunk> ptr_t;
+
+
+  /**
+   * @brief Factor function to create buffer_chunk objects from existing
+   *        dma_buffer objects
+   *
+   * @param buffer A shared pointer to a dma_buffer object
+   *
+   * @return A shared pointer to a buffer_chunk object
+   */
+  static buffer_chunk::ptr_t convert(dma_buffer::ptr_t buffer)
+  {
+    return buffer_chunk::ptr_t(new buffer_chunk(buffer));
+  }
+  /**
+   * @brief buffer_chunk destructor
+   *        Invalidates its virt_ member variable so dma_buffer destructor
+   *        won't try to release the buffer
+   */
+  ~buffer_chunk() { virt_ = 0; }
+
+
+  /** Divide a buffer into a series of smaller buffers.
+   *
+   * For each item sz found in sizes, create a new dma_buffer
+   * smart pointer whose size is sz and append the new smart
+   * pointer to the end of the returned vector. The sub-buffers
+   * are created in increasing order from the beginning of
+   * this dma_buffer. The parent buffer (this) of each sub-buffer
+   * is tracked so that it cannot be freed prior to a sub-buffer
+   * free.
+   *
+   * @param[in] sizes An initializer list of sizes for the sub-buffers.
+   * @return A std::vector of the sub-buffer pointers.
+   */
+  template <typename T>
+  std::vector<dma_buffer::ptr_t> split(std::initializer_list<T> sizes) {
+    std::vector<dma_buffer::ptr_t> v;
+    size_t offset = 0;
+
+    v.reserve(sizes.size());
+
+    for (const auto &sz : sizes) {
+      ptr_t p;
+      p.reset(new buffer_chunk(handle_, sz, virt_ + offset, wsid_, iova_ + offset,
+                               shared_from_this()));
+      v.push_back(p);
+      offset += sz;
+    }
+
+    return v;
+  }
+
+ protected:
+  dma_buffer::ptr_t parent_;  // for split buffers
+
+ private:
+  buffer_chunk(dma_buffer::ptr_t buffer) : dma_buffer(*buffer), parent_(buffer){}
+
+  buffer_chunk(handle::ptr_t handle, size_t len, uint8_t *virt, uint64_t wsid,
+               uint64_t iova, dma_buffer::ptr_t parent)
+    : dma_buffer(handle, len, virt, wsid, iova)
+    , parent_(parent){}
+};
+
+/** Poll for a specific value to appear at a given buffer location.
+ *
+ * Loops on a memory location without explicitly yielding the processor.
+ * This API should be used only for time-critical scenarios, eg waiting
+ * on a DMA address to be updated by hardware.
+ *
+ * @param[in] buf The buffer containing the memory location.
+ * @param[in] offset The byte offset from the start of the buffer.
+ * @param[in] timeout The maximum time to wait in microseconds.
+ * @param[in] mask A bit mask to apply to the value read from the buffer.
+ * @param[in] value The expected value after applying the mask.
+ * @retval true If the expected value was observed.
+ * @retval false If the timeout expired before seeing the expected value.
+ */
+template <typename T>
+bool poll(dma_buffer::ptr_t buf, size_t offset,
+          std::chrono::microseconds timeout, T mask, T value) {
+  std::chrono::high_resolution_clock::time_point start =
+      std::chrono::high_resolution_clock::now();
+
+  std::chrono::microseconds elapsed;
+
+  do {
+    if ((buf->read<T>(offset) & mask) == value) return true;
+
+    elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::high_resolution_clock::now() - start);
+
+  } while (elapsed < timeout);
+
+  return false;
+}
+
+/** Wait for a specific value to appear at a given buffer location.
+ *
+ * Loops on a memory location, yielding the processor after each iteration.
+ * This API should not be used for time-critical scenarios. See poll instead.
+ *
+ * @param[in] buf The buffer containing the memory location.
+ * @param[in] offset The byte offset from the start of the buffer.
+ * @param[in] each The number of microseconds to sleep each loop iteration.
+ * @param[in] timeout The maximum time to wait in microseconds.
+ * @param[in] mask A bit mask to apply to the value read from the buffer.
+ * @param[in] value The expected value after applying the mask.
+ * @retval true If the expected value was observed.
+ * @retval false If the timeout expired before seeing the expected value.
+ */
+template <typename T>
+bool wait(dma_buffer::ptr_t buf, size_t offset, std::chrono::microseconds each,
+          std::chrono::microseconds timeout, T mask, T value) {
+  std::chrono::high_resolution_clock::time_point start =
+      std::chrono::high_resolution_clock::now();
+  std::chrono::microseconds elapsed;
+
+  do {
+    if ((buf->read<T>(offset) & mask) == value) return true;
+
+    std::this_thread::sleep_for(each);
+
+    elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::high_resolution_clock::now() - start);
+
+  } while (elapsed < timeout);
+
+  return false;
+}
+
+}  // end of namespace memory
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/libopae++/include/opaec++/buffers.h
+++ b/libopae++/include/opaec++/buffers.h
@@ -44,30 +44,30 @@ namespace fpga {
 namespace memory {
 
 
-class buffer_chunk : public opae::fpga::types::dma_buffer,
-                     public std::enable_shared_from_this<buffer_chunk> {
+class buffer_slice : public opae::fpga::types::dma_buffer,
+                     public std::enable_shared_from_this<buffer_slice> {
  public:
-  typedef std::shared_ptr<buffer_chunk> ptr_t;
+  typedef std::shared_ptr<buffer_slice> ptr_t;
 
 
   /**
-   * @brief Factor function to create buffer_chunk objects from existing
+   * @brief Factor function to create buffer_slice objects from existing
    *        dma_buffer objects
    *
    * @param buffer A shared pointer to a dma_buffer object
    *
-   * @return A shared pointer to a buffer_chunk object
+   * @return A shared pointer to a buffer_slice object
    */
-  static buffer_chunk::ptr_t convert(dma_buffer::ptr_t buffer)
+  static buffer_slice::ptr_t convert(dma_buffer::ptr_t buffer)
   {
-    return buffer_chunk::ptr_t(new buffer_chunk(buffer));
+    return buffer_slice::ptr_t(new buffer_slice(buffer));
   }
   /**
-   * @brief buffer_chunk destructor
+   * @brief buffer_slice destructor
    *        Invalidates its virt_ member variable so dma_buffer destructor
    *        won't try to release the buffer
    */
-  ~buffer_chunk() { virt_ = 0; }
+  ~buffer_slice() { virt_ = 0; }
 
 
   /** Divide a buffer into a series of smaller buffers.
@@ -92,7 +92,7 @@ class buffer_chunk : public opae::fpga::types::dma_buffer,
 
     for (const auto &sz : sizes) {
       ptr_t p;
-      p.reset(new buffer_chunk(handle_, sz, virt_ + offset, wsid_, iova_ + offset,
+      p.reset(new buffer_slice(handle_, sz, virt_ + offset, wsid_, iova_ + offset,
                                shared_from_this()));
       v.push_back(p);
       offset += sz;
@@ -105,9 +105,9 @@ class buffer_chunk : public opae::fpga::types::dma_buffer,
   dma_buffer::ptr_t parent_;  // for split buffers
 
  private:
-  buffer_chunk(dma_buffer::ptr_t buffer) : dma_buffer(*buffer), parent_(buffer){}
+  buffer_slice(dma_buffer::ptr_t buffer) : dma_buffer(*buffer), parent_(buffer){}
 
-  buffer_chunk(handle::ptr_t handle, size_t len, uint8_t *virt, uint64_t wsid,
+  buffer_slice(handle::ptr_t handle, size_t len, uint8_t *virt, uint64_t wsid,
                uint64_t iova, dma_buffer::ptr_t parent)
     : dma_buffer(handle, len, virt, wsid, iova)
     , parent_(parent){}

--- a/libopae++/include/opaec++/dma_buffer.h
+++ b/libopae++/include/opaec++/dma_buffer.h
@@ -45,13 +45,6 @@ class dma_buffer {
   typedef std::size_t size_t;
   typedef std::shared_ptr<dma_buffer> ptr_t;
 
-  /**
-   * @brief dma_buffer copy constructor
-   *
-   * @param other buffer to copy from
-   */
-  dma_buffer(const dma_buffer & other);
-
   /** dma_buffer destructor.
    */
   virtual ~dma_buffer();
@@ -144,6 +137,8 @@ class dma_buffer {
  protected:
   dma_buffer(handle::ptr_t handle, size_t len, uint8_t *virt, uint64_t wsid,
              uint64_t iova);
+
+  dma_buffer(const dma_buffer & other);
 
   handle::ptr_t handle_;
   size_t len_;

--- a/libopae++/src/dma_buffer.cpp
+++ b/libopae++/src/dma_buffer.cpp
@@ -31,10 +31,17 @@ namespace opae {
 namespace fpga {
 namespace types {
 
+dma_buffer::dma_buffer(const dma_buffer & other)
+    : handle_(other.handle_)
+    , len_(other.len_)
+    , virt_(other.virt_)
+    , wsid_(other.wsid_)
+    , iova_(other.iova_)
+    , log_("dma_buffer"){}
+
 dma_buffer::~dma_buffer() {
-  // If this owns the buffer allocation and
-  // that allocation was successful.
-  if (!parent_ && virt_) {
+  // If the allocation was successful.
+  if (virt_) {
     fpga_result res = fpgaReleaseBuffer(handle_->get(), wsid_);
 
     if (res != FPGA_OK) {
@@ -119,16 +126,6 @@ int dma_buffer::compare(dma_buffer::ptr_t other, size_t len) const {
 dma_buffer::dma_buffer(handle::ptr_t handle, size_t len, uint8_t *virt,
                        uint64_t wsid, uint64_t iova)
     : handle_(handle), len_(len), virt_(virt), wsid_(wsid), iova_(iova), log_("dma_buffer") {}
-
-dma_buffer::dma_buffer(handle::ptr_t handle, size_t len, uint8_t *virt,
-                       uint64_t wsid, uint64_t iova, dma_buffer::ptr_t parent)
-    : handle_(handle),
-      len_(len),
-      virt_(virt),
-      wsid_(wsid),
-      iova_(iova),
-      log_("dma_buffer"),
-      parent_(parent) {}
 
 }  // end of namespace types
 }  // end of namespace fpga

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -105,6 +105,7 @@ set(SRC gtmain.cpp
   unit/gtCxxOpenClose.cpp
   unit/gtCxxProperties.cpp
   unit/gtCxxExcept.cpp
+  unit/gtCxxBuffer.cpp
   unit/gtCxxLog.cpp)
 
 add_executable(gtapi ${SRC})

--- a/tests/unit/gtCxxBuffer.cpp
+++ b/tests/unit/gtCxxBuffer.cpp
@@ -5,15 +5,18 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
+#include <memory>
 #include <unistd.h>
 
 #include "gtest/gtest.h"
 
 #include "opaec++/dma_buffer.h"
+#include "opaec++/buffers.h"
 #include "opaec++/handle.h"
+#include "opaec++/except.h"
 
 using namespace opae::fpga::types;
+using namespace opae::fpga::memory;
 
 class CxxBuffer_f1 : public ::testing::Test {
  protected:
@@ -43,8 +46,7 @@ class CxxBuffer_f1 : public ::testing::Test {
  * Then I get an empty dma_buffer pointer.<br>
  */
 TEST_F(CxxBuffer_f1, alloc_01) {
-  buf_ = dma_buffer::allocate(accel_, 0);
-  ASSERT_EQ(nullptr, buf_.get());
+  ASSERT_THROW(buf_ = dma_buffer::allocate(accel_, 0), except);
 }
 
 /**
@@ -81,29 +83,30 @@ TEST_F(CxxBuffer_f1, alloc_07) {
 /**
  * @test split_03
  * Given a valid dma_buffer smart pointer<br>
- * When I call dma_buffer::split(),<br>
+ * When I convert it to a buffer_chunk <br>
+ * And I call buffer_chunk::split()<br>
  * The sub-buffers are created according to the initialier_list.<br>
  */
 TEST_F(CxxBuffer_f1, split_03) {
   buf_ = dma_buffer::allocate(accel_, 64);
   ASSERT_NE(nullptr, buf_.get());
+  auto chunk = buffer_chunk::convert(buf_);
+  std::vector<dma_buffer::ptr_t> v = chunk->split({16, 16, 16, 16});
 
-  std::vector<dma_buffer::ptr_t> v = buf_->split({16, 16, 16, 16});
-
-  EXPECT_EQ(buf_->get(), v[0]->get());
-  EXPECT_EQ(buf_->iova(), v[0]->iova());
+  EXPECT_EQ(chunk->get(), v[0]->get());
+  EXPECT_EQ(chunk->iova(), v[0]->iova());
   EXPECT_EQ(16, v[0]->size());
 
-  EXPECT_EQ(buf_->get() + 16, v[1]->get());
-  EXPECT_EQ(buf_->iova() + 16, v[1]->iova());
+  EXPECT_EQ(chunk->get() + 16, v[1]->get());
+  EXPECT_EQ(chunk->iova() + 16, v[1]->iova());
   EXPECT_EQ(16, v[1]->size());
 
-  EXPECT_EQ(buf_->get() + 32, v[2]->get());
-  EXPECT_EQ(buf_->iova() + 32, v[2]->iova());
+  EXPECT_EQ(chunk->get() + 32, v[2]->get());
+  EXPECT_EQ(chunk->iova() + 32, v[2]->iova());
   EXPECT_EQ(16, v[2]->size());
 
-  EXPECT_EQ(buf_->get() + 48, v[3]->get());
-  EXPECT_EQ(buf_->iova() + 48, v[3]->iova());
+  EXPECT_EQ(chunk->get() + 48, v[3]->get());
+  EXPECT_EQ(chunk->iova() + 48, v[3]->iova());
   EXPECT_EQ(16, v[3]->size());
 }
 

--- a/tests/unit/gtCxxBuffer.cpp
+++ b/tests/unit/gtCxxBuffer.cpp
@@ -43,7 +43,7 @@ class CxxBuffer_f1 : public ::testing::Test {
  * @test alloc_01
  * Given an open accelerator handle object<br>
  * When I call dma_buffer::allocate() with a length of 0<br>
- * Then I get an empty dma_buffer pointer.<br>
+ * Then an exception is throw of type opae::fpga::types::except
  */
 TEST_F(CxxBuffer_f1, alloc_01) {
   ASSERT_THROW(buf_ = dma_buffer::allocate(accel_, 0), except);
@@ -83,14 +83,14 @@ TEST_F(CxxBuffer_f1, alloc_07) {
 /**
  * @test split_03
  * Given a valid dma_buffer smart pointer<br>
- * When I convert it to a buffer_chunk <br>
- * And I call buffer_chunk::split()<br>
+ * When I convert it to a buffer_slice <br>
+ * And I call buffer_slice::split()<br>
  * The sub-buffers are created according to the initialier_list.<br>
  */
 TEST_F(CxxBuffer_f1, split_03) {
   buf_ = dma_buffer::allocate(accel_, 64);
   ASSERT_NE(nullptr, buf_.get());
-  auto chunk = buffer_chunk::convert(buf_);
+  auto chunk = buffer_slice::convert(buf_);
   std::vector<dma_buffer::ptr_t> v = chunk->split({16, 16, 16, 16});
 
   EXPECT_EQ(chunk->get(), v[0]->get());


### PR DESCRIPTION
This migrates functionality that is not intended to go into the core c++
library

* Move `poll` and `wait` template functions into new file `buffers.h`
* Create a `buffer_chunk` class that can be used to split buffers
* Add gtCxxBuffers to tests