### PR TITLE
c++: Add event class and tests

### DIFF
--- a/libopae++/CMakeLists.txt
+++ b/libopae++/CMakeLists.txt
@@ -55,6 +55,7 @@ set(OPAECXX_SRC src/properties.cpp
                 src/token.cpp
                 src/handle.cpp
                 src/dma_buffer.cpp
+                src/events.cpp
                 src/except.cpp
                 src/log.cpp)
 

--- a/libopae++/include/opaec++/events.h
+++ b/libopae++/include/opaec++/events.h
@@ -1,0 +1,94 @@
+// Copyright(c) 2017, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <memory>
+
+#include <opae/types_enum.h>
+
+#include <opaec++/handle.h>
+#include <opaec++/log.h>
+
+namespace opae {
+namespace fpga {
+namespace types {
+
+/**
+ * @brief Wraps fpga event routines in OPAE C
+ */
+class event {
+ public:
+  typedef std::shared_ptr<event> ptr_t;
+
+  /**
+   * @brief Destroy event and associated resources
+   */
+  virtual ~event();
+
+  /**
+   * @brief C++ struct that is interchangeable with fpga_event_type enum
+   */
+  struct type_t
+  {
+    type_t(fpga_event_type c_type)
+    : type_(c_type){}
+
+    operator fpga_event_type()
+    {
+      return type_;
+    }
+
+    static constexpr fpga_event_type interrupt =  FPGA_EVENT_INTERRUPT;
+    static constexpr fpga_event_type error =  FPGA_EVENT_ERROR;
+    static constexpr fpga_event_type power_thermal =  FPGA_EVENT_POWER_THERMAL;
+
+   private:
+    fpga_event_type type_;
+
+  };
+
+  /**
+   * @brief Factory function to create event objects
+   *
+   * @param h A shared ptr of a resource handle
+   * @param t The resource type
+   * @param flags Event registration flags passed on to fpgaRegisterEvent
+   *
+   * @return A shared ptr to an event object
+   */
+  static event::ptr_t register_event(handle::ptr_t h, event::type_t t, int flags = 0);
+
+ private:
+  event(handle::ptr_t h, event::type_t t, fpga_event_handle event_h);
+  handle::ptr_t handle_;
+  event::type_t type_;
+  fpga_event_handle event_handle_;
+  opae::fpga::internal::logger log_;
+};
+
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/libopae++/include/opaec++/events.h
+++ b/libopae++/include/opaec++/events.h
@@ -71,6 +71,13 @@ class event {
   };
 
   /**
+   * @brief Coversion operator for converting to fpga_event_handle objects
+   *
+   * @return The fpga_event_handle contained in this object
+   */
+  operator fpga_event_handle();
+
+  /**
    * @brief Factory function to create event objects
    *
    * @param h A shared ptr of a resource handle

--- a/libopae++/include/opaec++/events.h
+++ b/libopae++/include/opaec++/events.h
@@ -71,6 +71,13 @@ class event {
   };
 
   /**
+   * @brief Get the fpga_event_handle contained in this object
+   *
+   * @return The fpga_event_handle contained in this object
+   */
+  fpga_event_handle get() { return event_handle_; }
+
+  /**
    * @brief Coversion operator for converting to fpga_event_handle objects
    *
    * @return The fpga_event_handle contained in this object

--- a/libopae++/src/events.cpp
+++ b/libopae++/src/events.cpp
@@ -44,6 +44,11 @@ event::~event()
   }
 }
 
+event::operator fpga_event_handle()
+{
+  return event_handle_;
+}
+
 event::ptr_t event::register_event(handle::ptr_t h, event::type_t t, int flags)
 {
   event::ptr_t evptr;

--- a/libopae++/src/events.cpp
+++ b/libopae++/src/events.cpp
@@ -1,0 +1,68 @@
+// Copyright(c) 2017, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <opae/event.h>
+
+#include "opaec++/events.h"
+#include "opaec++/except.h"
+
+namespace opae {
+namespace fpga {
+namespace types {
+
+event::~event()
+{
+  auto res = fpgaUnregisterEvent(*handle_, type_, event_handle_);
+  if (res){
+    log_.warn("~event()") << "fpgaUnregisterEvent returned " << fpgaErrStr(res);
+  }else{
+    res = fpgaDestroyEventHandle(&event_handle_);
+    log_.warn_if(res, "~event()") << "fpgaDestroyEventHandle returned " << fpgaErrStr(res);
+  }
+}
+
+event::ptr_t event::register_event(handle::ptr_t h, event::type_t t, int flags)
+{
+  event::ptr_t evptr;
+  fpga_event_handle eh;
+  auto res = fpgaCreateEventHandle(&eh);
+  if (res) throw except(res, OPAECXX_HERE);
+  res = fpgaRegisterEvent(*h, t, eh, flags);
+  if (res) throw except(res, OPAECXX_HERE);
+  evptr.reset(new event(h, t, eh));
+
+  return evptr;
+}
+
+event::event(handle::ptr_t h, event::type_t t, fpga_event_handle eh)
+    : handle_(h)
+    , type_(t)
+    , event_handle_(eh)
+    , log_("event"){}
+
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/scripts/test-gtapi-mock-drv.sh
+++ b/scripts/test-gtapi-mock-drv.sh
@@ -4,8 +4,10 @@ mkdir mybuild_gtapi_mock_drv
 pushd mybuild_gtapi_mock_drv
 
 trap "popd" EXIT
+trap "killall fpgad" EXIT
 
 cmake .. -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
-make
+make gtapi mock fpgad
+./bin/fpgad -d
 CTEST_OUTPUT_ON_FAILURE=1 make test
 echo "test-gtapi-mock-drv build PASSED"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,6 +102,7 @@ set(SRC gtmain.cpp
   jsonParser.cpp
   unit/gtOpenClose_base.cpp
   unit/gtCxxEnumerate.cpp
+  unit/gtCxxEvents.cpp
   unit/gtCxxOpenClose.cpp
   unit/gtCxxProperties.cpp
   unit/gtCxxExcept.cpp
@@ -173,6 +174,7 @@ add_gtfilter(CxxOpenClose "CxxOpen*" True)
 add_gtfilter(CxxBuffer "CxxBuffer*" True)
 add_gtfilter(CxxExcept "CxxExcept*" False)
 add_gtfilter(CxxLog "CxxLog*" False)
+add_gtfilter(CxxEvent "CxxEvent*" True)
 ############################################################################
 ## Add 'coverage' ##########################################################
 ############################################################################
@@ -186,3 +188,9 @@ if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
     add_dependencies(coverage_opae-c gtapi)
   endif(BUILD_TESTS AND GTEST_FOUND)
 endif(CMAKE_BUILD_TYPE STREQUAL "Coverage")
+
+
+############################################################################
+## Add 'valgrind' ##########################################################
+############################################################################
+set(MEMORYCHECK_COMMAND FILEPATH /usr/bin/valgrind)

--- a/tests/unit/gtCxxEvents.cpp
+++ b/tests/unit/gtCxxEvents.cpp
@@ -1,0 +1,58 @@
+#include "gtest/gtest.h"
+
+#include "opaec++/events.h"
+
+using namespace opae::fpga::types;
+
+class CxxEvent_f1 : public ::testing::Test {
+ protected:
+  CxxEvent_f1() {}
+
+  virtual void SetUp() override {
+    tokens_ = token::enumerate({FPGA_ACCELERATOR});
+    ASSERT_GT(tokens_.size(), 0);
+    accel_ = handle::open(tokens_[0], 0);
+    ASSERT_NE(nullptr, accel_.get());
+  }
+
+  virtual void TearDown() override {
+    accel_.reset();
+    ASSERT_NO_THROW(tokens_.clear());
+  }
+
+  std::vector<token::ptr_t> tokens_;
+  handle::ptr_t accel_;
+};
+
+
+/**
+ * @test register_event_01
+ * Given an open accelerator handle object<br>
+ * When I call event::register_event() with that handle<br>
+ * And event type of event::type_t::error
+ * Then no exception is thrown<br>
+ * And I get a non-null event shared pointer<br>
+ */
+TEST_F(CxxEvent_f1, register_event_01){
+  event::ptr_t ev;
+  ASSERT_NO_THROW(
+      ev = event::register_event(accel_, event::type_t::error)
+      );
+  ASSERT_NE(nullptr, ev.get());
+}
+
+/**
+ * @test register_event_02
+ * Given an open accelerator handle object<br>
+ * When I call event::register_event() with that handle<br>
+ * And event type of FPGA_EVENT_ERROR
+ * Then no exception is thrown<br>
+ * And I get a non-null event shared pointer<br>
+ */
+TEST_F(CxxEvent_f1, register_event_02){
+  event::ptr_t ev;
+  ASSERT_NO_THROW(
+      ev = event::register_event(accel_, FPGA_EVENT_ERROR);
+      );
+  ASSERT_NE(nullptr, ev.get());
+}


### PR DESCRIPTION
Add file `opae::fpga::types::event` class that wraps basic event
functions in OPAE C API.

Add two unit tests to test basic functionality

Add starting/stopping of `fpgad` in test script