### PR TITLE
Improve CCI-P clock crossing shim

### DIFF
--- a/platforms/platform_db/platform_defaults.json
+++ b/platforms/platform_db/platform_defaults.json
@@ -102,7 +102,8 @@
                      "name of another incoming clock.  Only CCI-P clocks may be",
                      "chosen. (E.g. pClkDiv2 or uClk_usr.)"
                   ],
-               "clock": "default"
+               "clock": "default",
+               "pclk-freq": 400
             },
 
          "local-memory":

--- a/platforms/platform_db/platform_defaults.json
+++ b/platforms/platform_db/platform_defaults.json
@@ -51,7 +51,7 @@
                "max-bw-active-lines-c0": "{ 512, 512, 256, 256 }",
                "max-bw-active-lines-c1": "{ 512, 256, 128, 128 }",
 
-               "max-outstanding-mmio-rd-reqs": 32,
+               "max-outstanding-mmio-rd-reqs": 64,
 
                "comment":
                   [

--- a/platforms/platform_if/par/platform_if_addenda.qsf
+++ b/platforms/platform_if/par/platform_if_addenda.qsf
@@ -25,40 +25,40 @@ set_global_assignment -name VERILOG_MACRO "PLATFORM_IF_AVAIL=1"
 ##
 
 # Search the current Verilog macro space, looking for "PLATFORM_NAME".
-set plat_name ""
+set platform_name ""
 set macros [get_all_global_assignments -name VERILOG_MACRO]
 foreach_in_collection m $macros {
     if {[info exists key]} { unset key }
     regexp {(.+)=(.+)} [lindex $m 2] full key val
     if {[info exists key]} {
         if {$key eq "PLATFORM_NAME"} {
-            set plat_name $val
-            puts "Platform macro is set: PLATFORM_NAME=${plat_name}"
+            set platform_name $val
+            puts "Platform macro is set: PLATFORM_NAME=${platform_name}"
             break
         }
     }
 }
 
 # If PLATFORM_NAME isn't defined try to figure it out.
-if {$plat_name eq ""} {
+if {$platform_name eq ""} {
     regexp {([0-9]+).([0-9]+).([0-9]+)} $quartus(version) version major minor build
     if {$major == 13} {
-        set plat_name "INTG_OME"
+        set platform_name "INTG_OME"
     } elseif {$major == 16} {
         if {$minor == 0 && $build == 0} {
-            set plat_name "INTG_BDX"
+            set platform_name "INTG_BDX"
         } else {
-            set plat_name "INTG_SKX"
+            set platform_name "INTG_SKX"
         }
     } elseif {$major == 17} {
-        set plat_name "DISCRETE_RC"
+        set platform_name "DISCRETE_RC"
     } else {
         error "PLATFORM_NAME should be defined in the base build configuration."
     }
 
-    puts "Inferred PLATFORM_NAME=\"${plat_name}\""
-    set_global_assignment -name VERILOG_MACRO PLATFORM_IS_${plat_name}=1
-    set_global_assignment -name VERILOG_MACRO PLATFORM_NAME="${plat_name}"
+    puts "Inferred PLATFORM_NAME=\"${platform_name}\""
+    set_global_assignment -name VERILOG_MACRO PLATFORM_IS_${platform_name}=1
+    set_global_assignment -name VERILOG_MACRO PLATFORM_NAME="${platform_name}"
 }
 
 

--- a/platforms/platform_if/par/platform_if_addenda.qsf
+++ b/platforms/platform_if/par/platform_if_addenda.qsf
@@ -79,18 +79,17 @@ set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shi
 set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/avalon_mem_if_async_shim.sv
 set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/avalon_mem_if_connect.sv
 set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/avalon_mem_if_reg.sv
+set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/platform_utils_ccip_activity_cnt.sv
+set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/platform_utils_ccip_async_shim.sv
 set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/platform_utils_ccip_reg.sv
 
-set_global_assignment -name VERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/BBB_ccip_async/platform_utils_ccip_afifo_channel.sv
-set_global_assignment -name VERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/BBB_ccip_async/platform_utils_ccip_async_activity_cnt.sv
-set_global_assignment -name VERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/BBB_ccip_async/platform_utils_ccip_async_shim.sv
-set_global_assignment -name SDC_FILE     $PLATFORM_IF_SRC/rtl/platform_shims/utils/BBB_ccip_async/platform_utils_ccip_async.sdc
+set_global_assignment -name VERILOG_FILE       $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_dc_fifo.v
+set_global_assignment -name VERILOG_FILE       $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_mm_clock_crossing_bridge.v
+set_global_assignment -name VERILOG_FILE       $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_mm_bridge.v
+set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_dc_fifo.sv
+set_global_assignment -name SDC_FILE           $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_dc_fifo.sdc
+set_global_assignment -name VERILOG_FILE       $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_dcfifo_synchronizer_bundle.v
+set_global_assignment -name VERILOG_FILE       $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_std_synchronizer_nocut.v
+set_global_assignment -name SDC_FILE           $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_dc_fifo.sdc
 
-set_global_assignment -name VERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_dc_fifo.v
-set_global_assignment -name VERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_mm_clock_crossing_bridge.v
-set_global_assignment -name VERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_mm_bridge.v
-set_global_assignment -name VERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_dcfifo_synchronizer_bundle.v
-set_global_assignment -name VERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_std_synchronizer_nocut.v
-set_global_assignment -name SDC_FILE     $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_dc_fifo.sdc
-
-set_global_assignment -name SDC_FILE     $PLATFORM_IF_SRC/par/platform_if.sdc
+set_global_assignment -name SDC_FILE           $PLATFORM_IF_SRC/par/platform_if.sdc

--- a/platforms/platform_if/rtl/device_cfg/ccip_cfg_pkg.sv
+++ b/platforms/platform_if/rtl/device_cfg/ccip_cfg_pkg.sv
@@ -105,6 +105,9 @@ package ccip_cfg_pkg;
     parameter int C0_MAX_BW_ACTIVE_LINES[4] = `PLATFORM_PARAM_CCI_P_MAX_BW_ACTIVE_LINES_C0;
     parameter int C1_MAX_BW_ACTIVE_LINES[4] = `PLATFORM_PARAM_CCI_P_MAX_BW_ACTIVE_LINES_C1;
 
+    // pClk frequency
+    parameter int PCLK_FREQ = `PLATFORM_PARAM_CCI_P_PCLK_FREQ;
+
 endpackage // ccip_cfg_pkg
 
 `endif // PLATFORM_PROVIDES_CCI_P

--- a/platforms/platform_if/rtl/platform_shims/utils/BBB_ccip_async/README
+++ b/platforms/platform_if/rtl/platform_shims/utils/BBB_ccip_async/README
@@ -1,6 +1,0 @@
-The CCI-P clock crossing shim here an updated copy of the BBB in
-https://github.com/OPAE/intel-fpga-bbb.  The module names have been changed to
-avoid clashes with AFUs that use the BBB.
-
-The SDC file is here instead of in a par directory to keep all the code
-together.

--- a/platforms/platform_if/rtl/platform_shims/utils/platform_utils_ccip_activity_cnt.sv
+++ b/platforms/platform_if/rtl/platform_shims/utils/platform_utils_ccip_activity_cnt.sv
@@ -35,7 +35,7 @@
 
 import ccip_if_pkg::*;
 
-module platform_utils_ccip_async_c0_active_cnt
+module platform_utils_ccip_c0_active_cnt
   #(
     parameter C0RX_DEPTH_RADIX = 10
     )
@@ -83,10 +83,10 @@ module platform_utils_ccip_async_c0_active_cnt
         end
     end
 
-endmodule // platform_utils_ccip_async_c0_active_cnt
+endmodule // platform_utils_ccip_c0_active_cnt
 
 
-module platform_utils_ccip_async_c1_active_cnt
+module platform_utils_ccip_c1_active_cnt
   #(
     parameter C1RX_DEPTH_RADIX = 10
     )
@@ -141,4 +141,4 @@ module platform_utils_ccip_async_c1_active_cnt
         end
     end
 
-endmodule // platform_utils_ccip_async_c1_active_cnt
+endmodule // platform_utils_ccip_c1_active_cnt

--- a/platforms/platform_if/rtl/platform_shims/utils/platform_utils_ccip_activity_cnt.sv
+++ b/platforms/platform_if/rtl/platform_shims/utils/platform_utils_ccip_activity_cnt.sv
@@ -71,6 +71,13 @@ module platform_utils_ccip_c0_active_cnt
         active_decr = c0Rx.rspValid && (c0Rx.hdr.resp_type == eRSP_RDLINE);
     end
 
+    // Two stage counter improves timing but delays updates for a cycle.
+    logic [3:0] active_delta;
+    always_ff @(posedge clk)
+    begin
+        active_delta <= 4'(active_incr) - 4'(active_decr);
+    end
+
     always_ff @(posedge clk)
     begin
         if (reset)
@@ -79,7 +86,7 @@ module platform_utils_ccip_c0_active_cnt
         end
         else
         begin
-            cnt <= cnt + t_active_cnt'(active_incr) - t_active_cnt'(active_decr);
+            cnt <= cnt + t_active_cnt'(signed'(active_delta));
         end
     end
 
@@ -129,6 +136,13 @@ module platform_utils_ccip_c1_active_cnt
         end
     end
 
+    // Two stage counter improves timing but delays updates for a cycle.
+    logic [3:0] active_delta;
+    always_ff @(posedge clk)
+    begin
+        active_delta <= 4'(active_incr) - 4'(active_decr);
+    end
+
     always_ff @(posedge clk)
     begin
         if (reset)
@@ -137,7 +151,7 @@ module platform_utils_ccip_c1_active_cnt
         end
         else
         begin
-            cnt <= cnt + t_active_cnt'(active_incr) - t_active_cnt'(active_decr);
+            cnt <= cnt + t_active_cnt'(signed'(active_delta));
         end
     end
 

--- a/platforms/platform_if/rtl/platform_shims/utils/platform_utils_ccip_async_shim.sv
+++ b/platforms/platform_if/rtl/platform_shims/utils/platform_utils_ccip_async_shim.sv
@@ -151,7 +151,7 @@ module platform_utils_ccip_async_shim
     logic                        c0tx_rdempty;
     logic                        c0tx_fifo_wrfull;
 
-    platform_utils_ccip_afifo_channel
+    platform_utils_dc_fifo
       #(
         .DATA_WIDTH(C0TX_TOTAL_WIDTH),
         .DEPTH_RADIX(C0TX_DEPTH_RADIX)
@@ -189,7 +189,7 @@ module platform_utils_ccip_async_shim
     // Track round-trip request -> response credits to avoid filling the
     // response pipeline.
     logic [C0RX_DEPTH_RADIX-1:0] c0req_cnt;
-    platform_utils_ccip_async_c0_active_cnt
+    platform_utils_ccip_c0_active_cnt
       #(
         .C0RX_DEPTH_RADIX (C0RX_DEPTH_RADIX)
         )
@@ -240,7 +240,7 @@ module platform_utils_ccip_async_shim
     logic                        c1tx_rdempty;
     logic                        c1tx_fifo_wrfull;
 
-    platform_utils_ccip_afifo_channel
+    platform_utils_dc_fifo
       #(
         .DATA_WIDTH(C1TX_TOTAL_WIDTH),
         .DEPTH_RADIX(C1TX_DEPTH_RADIX)
@@ -279,7 +279,7 @@ module platform_utils_ccip_async_shim
     // Track round-trip request -> response credits to avoid filling the
     // response pipeline.
     logic [C1RX_DEPTH_RADIX-1:0] c1req_cnt;
-    platform_utils_ccip_async_c1_active_cnt
+    platform_utils_ccip_c1_active_cnt
       #(
         .C1RX_DEPTH_RADIX(C1RX_DEPTH_RADIX)
         )
@@ -326,7 +326,7 @@ module platform_utils_ccip_async_shim
     logic                        c2tx_rdempty;
     logic                        c2tx_fifo_wrfull;
 
-    platform_utils_ccip_afifo_channel
+    platform_utils_dc_fifo
       #(
         .DATA_WIDTH  (C2TX_TOTAL_WIDTH),
         .DEPTH_RADIX (C2TX_DEPTH_RADIX)
@@ -369,7 +369,7 @@ module platform_utils_ccip_async_shim
     logic                        c0rx_rdempty;
     logic                        c0rx_fifo_wrfull;
 
-    platform_utils_ccip_afifo_channel
+    platform_utils_dc_fifo
       #(
         .DATA_WIDTH(C0RX_TOTAL_WIDTH),
         .DEPTH_RADIX(C0RX_DEPTH_RADIX)
@@ -420,7 +420,7 @@ module platform_utils_ccip_async_shim
     logic               c1rx_rdempty;
     logic               c1rx_fifo_wrfull;
 
-    platform_utils_ccip_afifo_channel
+    platform_utils_dc_fifo
       #(
         .DATA_WIDTH(C1RX_TOTAL_WIDTH),
         .DEPTH_RADIX(C1RX_DEPTH_RADIX)

--- a/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_dc_fifo.sdc
+++ b/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_dc_fifo.sdc
@@ -95,4 +95,4 @@ foreach each_inst $inst_list {
 ##
 ###########################################################################
 
-apply_sdc_pre_dcfifo "platform_utils_ccip_afifo_channel"
+apply_sdc_pre_dcfifo "platform_utils_dc_fifo"

--- a/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_dc_fifo.sv
+++ b/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_dc_fifo.sv
@@ -20,7 +20,7 @@
 `timescale 1 ps / 1 ps
 // synopsys translate_on
 
-module platform_utils_ccip_afifo_channel
+module platform_utils_dc_fifo
   #(
     parameter DATA_WIDTH = 32,
     parameter DEPTH_RADIX = 9

--- a/platforms/platform_if/sim/platform_if_addenda.txt
+++ b/platforms/platform_if/sim/platform_if_addenda.txt
@@ -23,14 +23,13 @@
 ../rtl/platform_shims/utils/avalon_mem_if_async_shim.sv
 ../rtl/platform_shims/utils/avalon_mem_if_connect.sv
 ../rtl/platform_shims/utils/avalon_mem_if_reg.sv
+../rtl/platform_shims/utils/platform_utils_ccip_activity_cnt.sv
+../rtl/platform_shims/utils/platform_utils_ccip_async_shim.sv
 ../rtl/platform_shims/utils/platform_utils_ccip_reg.sv
-
-../rtl/platform_shims/utils/BBB_ccip_async/platform_utils_ccip_afifo_channel.sv
-../rtl/platform_shims/utils/BBB_ccip_async/platform_utils_ccip_async_activity_cnt.sv
-../rtl/platform_shims/utils/BBB_ccip_async/platform_utils_ccip_async_shim.sv
 
 ../rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_dc_fifo.v
 ../rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_mm_clock_crossing_bridge.v
 ../rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_mm_bridge.v
+../rtl/platform_shims/utils/quartus_ip/platform_utils_dc_fifo.sv
 ../rtl/platform_shims/utils/quartus_ip/platform_utils_dcfifo_synchronizer_bundle.v
 ../rtl/platform_shims/utils/quartus_ip/platform_utils_std_synchronizer_nocut.v


### PR DESCRIPTION
- Better timing, tested to 500 MHz
- Simplify DC FIFO control logic and reduce pipeline stages
- Bug fixes for almost full overrun due to long pipelines
- Restructure for better separation of Quartus IP from platform logic
