### PR TITLE
Update minimum Cmake version to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.12)
 project(opae)
 
 ############################################################################

--- a/ase/api/CMakeLists.txt
+++ b/ase/api/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.12)
 
 project("opae-c-ase")
 find_package(Threads  REQUIRED)

--- a/doc/src/install_guide/installation_guide.md
+++ b/doc/src/install_guide/installation_guide.md
@@ -182,7 +182,7 @@ $ make package
 This will generate the following rpm packages. The names of the packages may be
 different, depending on the cmake version used.
 
-* If cmake version is between 2.8.11 and 3.0.0:
+* If cmake version is between 2.8.12 and 3.0.0:
 ```console
 opae-<release>-1.x86_64-libs.rpm    (libopae-c and samples)
 opae-<release>-1.x86_64-tools.rpm   (tools)
@@ -201,7 +201,7 @@ opae-ase-<release>-1.x86_64.rpm     (libopae-c-ase)
 ## OPAE SDK installation with rpm packages ##
 The rpm packages generated in the previous step can be installed
 using these commands (This example assumes the cmake version used to generate
-these packages was 2.8.11):
+these packages was 2.8.12):
 
 ```console
 $ sudo yum install opae-<release>-1.x86_64-libs.rpm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.12)
 project(opae-tests)
 
 # Bootstrap gtest

--- a/tools/packager/CMakeLists.txt
+++ b/tools/packager/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.12)
 include(packaging)
 
 ################# generate executable python zip files ########################


### PR DESCRIPTION
   target_compile_options() needs the cmake version to be 2.8.12
   or higher