### PR TITLE
opaec++: make dma_buffer and handle uncopyable

### DIFF
--- a/common/include/opae/cxx/buffers.h
+++ b/common/include/opae/cxx/buffers.h
@@ -105,7 +105,10 @@ class buffer_slice : public opae::fpga::types::dma_buffer,
   dma_buffer::ptr_t parent_;  // for split buffers
 
  private:
-  buffer_slice(dma_buffer::ptr_t buffer) : dma_buffer(*buffer), parent_(buffer){}
+  buffer_slice(dma_buffer::ptr_t buffer)
+    : dma_buffer(buffer->owner(), buffer->size(), const_cast<uint8_t *>(buffer->get()),
+        buffer->wsid(), buffer->iova()),
+      parent_(buffer){}    
 
   buffer_slice(handle::ptr_t handle, size_t len, uint8_t *virt, uint64_t wsid,
                uint64_t iova, dma_buffer::ptr_t parent)

--- a/common/include/opae/cxx/dma_buffer.h
+++ b/common/include/opae/cxx/dma_buffer.h
@@ -45,6 +45,9 @@ class dma_buffer {
   typedef std::size_t size_t;
   typedef std::shared_ptr<dma_buffer> ptr_t;
 
+  dma_buffer(const dma_buffer & ) = delete;
+  dma_buffer & operator =(const dma_buffer & ) = delete;
+
   /** dma_buffer destructor.
    */
   virtual ~dma_buffer();
@@ -81,6 +84,10 @@ class dma_buffer {
   /** Retrieve the length of the buffer in bytes.
    */
   size_t size() const { return len_; }
+
+  /** Retrieve the underlying buffer's workspace id.
+   */
+  uint64_t wsid() const { return wsid_; }
 
   /** Retrieve the address of the buffer suitable for
    * programming into the accelerator device.
@@ -138,7 +145,6 @@ class dma_buffer {
   dma_buffer(handle::ptr_t handle, size_t len, uint8_t *virt, uint64_t wsid,
              uint64_t iova);
 
-  dma_buffer(const dma_buffer & other);
 
   handle::ptr_t handle_;
   size_t len_;

--- a/common/include/opae/cxx/handle.h
+++ b/common/include/opae/cxx/handle.h
@@ -40,6 +40,9 @@ class handle {
  public:
   typedef std::shared_ptr<handle> ptr_t;
 
+  handle(const handle & ) = delete;
+  handle & operator =(const handle & ) = delete;
+
   ~handle();
 
   fpga_handle get() const { return handle_; }

--- a/libopae++/src/dma_buffer.cpp
+++ b/libopae++/src/dma_buffer.cpp
@@ -31,14 +31,6 @@ namespace opae {
 namespace fpga {
 namespace types {
 
-dma_buffer::dma_buffer(const dma_buffer & other)
-    : handle_(other.handle_)
-    , len_(other.len_)
-    , virt_(other.virt_)
-    , wsid_(other.wsid_)
-    , iova_(other.iova_)
-    , log_("dma_buffer"){}
-
 dma_buffer::~dma_buffer() {
   // If the allocation was successful.
   if (virt_) {


### PR DESCRIPTION
Creating shallow copies of these objects must be avoided, so we prohibit
it explicitly.