### PR TITLE
Creating dir "rtl" when creating ASE build dir

### DIFF
--- a/ase/Makefile
+++ b/ase/Makefile
@@ -44,6 +44,8 @@
 
 include ase_sources.mk
 
+ASE_OOD = 0
+
 ###############################################################
 ##                                                           ##
 ##         ASE Platform value (selection method)             ##
@@ -141,7 +143,13 @@ WORK = work
 
 # ASE Source directory
 ASE_SRCDIR = $(shell pwd)
+ifeq ($(ASE_OOD),0) 
 OPAE_BASEDIR ?= $(ASE_SRCDIR)/../
+OPAE_INCDIR = $(OPAE_BASEDIR)/common/include
+else
+OPAE_BASEDIR ?= $(ASE_SRCDIR)/../../../
+OPAE_INCDIR = $(OPAE_BASEDIR)/include
+endif
 ASE_WORKDIR = $(PWD)/$(WORK)
 
 # Configuration & regression file inputs
@@ -162,10 +170,10 @@ endif
 TIMESCALE = 1ps/1ps
 
 ## ASE HW file setup
-ASEHW_FILE_LIST = -F $(ASE_SRCDIR)/rtl/sources.txt
+ASEHW_FILE_LIST = -F $(PWD)/rtl/sources.txt
 
 ## ASE platform-specific HW
-ASE_PLATFORM_INC = -F $(ASE_SRCDIR)/rtl/includes.txt
+ASE_PLATFORM_INC = -F $(PWD)/rtl/includes.txt
 ASE_PLATFORM_FILE_LIST ?=
 ifeq ($(ASE_PLATFORM), FPGA_PLATFORM_DISCRETE)
   ASE_PLATFORM_FILE_LIST += -F $(ASE_MEM_SRC)/sources.txt
@@ -218,7 +226,7 @@ endif
 
 ## C Compiler options
 CC_OPT?=
-CC_OPT+= -g $(CC_INT_SIZE) -fPIC -D SIM_SIDE=1 -I $(ASE_SRCDIR)/sw/ -I $(OPAE_BASEDIR)/common/include/
+CC_OPT+= -g $(CC_INT_SIZE) -fPIC -D SIM_SIDE=1 -I $(ASE_SRCDIR)/sw/ -I $(OPAE_INCDIR)
 CC_OPT+= -D SIMULATOR=$(SIMULATOR) -D $(ASE_PLATFORM)
 CC_OPT+= -Wall -Wformat -Wformat-security
 CC_OPT+= -O2 -D_FORTIFY_SOURCE=2
@@ -242,7 +250,11 @@ endif
 
 ## ASE Link options
 ASE_LD_SWITCHES?=
+ifeq ($(ASE_OOD),0) 
 ASE_LD_SWITCHES+= -lrt -lpthread
+else
+ASE_LD_SWITCHES+= -L$(OPAE_BASEDIR)/lib -lrt -lpthread -lsafestr
+endif
 
 ## Library names
 ASE_SHOBJ_NAME = ase_libs
@@ -455,7 +467,9 @@ help: header
 sw_build:
 	make header
 	mkdir -p $(WORK)
+ifeq ($(ASE_OOD),0)
 	cd $(WORK) ; $(CC) $(CC_OPT) -c $(SAFESTR_SRC_LIST) || exit 1 ; cd -
+endif
 	cd $(WORK) ; $(CC) $(CC_OPT) -c $(ASESW_FILE_LIST) || exit 1 ; cd -
 	cd $(WORK) ; $(CC) $(CC_INT_SIZE) -g -shared -o $(ASE_SHOBJ_SO) `ls *.o` $(ASE_LD_SWITCHES) ; cd -
 	nm $(WORK)/$(ASE_SHOBJ_SO) > $(WORK)/$(ASE_SHOBJ_NAME).nm

--- a/ase/scripts/create_ase_simbuild_env.sh
+++ b/ase/scripts/create_ase_simbuild_env.sh
@@ -101,7 +101,7 @@ mkdir ase
 cp $ase_srcdir/Makefile ./ase/
 cp $ase_srcdir/ase.cfg ./ase/
 cp $ase_srcdir/ase_regress.sh ./ase/
-mkdir ase/rtl
+cp -r $ase_srcdir/rtl ./ase
 
 ## Change permission of 'ase' directory
 chmod 644 ase/Makefile ase/ase.cfg
@@ -110,6 +110,9 @@ chmod 744 ase/ase_regress.sh
 ## Modify ASE_SRCDIR location
 ## grep/sed and replace only the first instance of ASE_SRCDIR
 sed -i 's#^ASE_SRCDIR.*#ASE_SRCDIR = '$ase_srcdir'#g' ase/Makefile
+## Change Switch to out of dir ASE
+sed -i 's#^ASE_OOD.*#ASE_OOD = 1#g' ase/Makefile
+
 
 ## Print information about ase_sources.mk
 echo ""

--- a/ase/scripts/create_ase_simbuild_env.sh
+++ b/ase/scripts/create_ase_simbuild_env.sh
@@ -51,6 +51,7 @@ set -e
 ##           * Create 'ase' directory
 ##           * Copy ase/Makefile script, then ase_regress.sh, and ase.cfg
 ##           * grep/sed ASE_SRCDIR to point to retrieved source directory
+##           * Create dir rtl
 ##         * FALSE
 ##           * Error exit here
 ##     * Copy 'ase' directory from
@@ -100,6 +101,7 @@ mkdir ase
 cp $ase_srcdir/Makefile ./ase/
 cp $ase_srcdir/ase.cfg ./ase/
 cp $ase_srcdir/ase_regress.sh ./ase/
+mkdir ase/rtl
 
 ## Change permission of 'ase' directory
 chmod 644 ase/Makefile ase/ase.cfg


### PR DESCRIPTION
When the ase build dir is generated through the provided scripts, the rtl
directory was not created. This very minor change creates the dir when calling the scripts, which prevents the python scripts used to configure the environment from complaining. 