### PR TITLE
opaec++: fix guid_t streamer issue

### DIFF
--- a/common/include/opae/cxx/pvalue.h
+++ b/common/include/opae/cxx/pvalue.h
@@ -97,7 +97,7 @@ struct guid_t {
     fpga_result res;
     if ((res = fpgaPropertiesGetGUID(props, &guid_value)) == FPGA_OK) {
       char guid_str[84];
-      uuid_unparse(g.data_.data(), guid_str);
+      uuid_unparse(guid_value, guid_str);
       ostr << guid_str;
     } else if (FPGA_NOT_FOUND == res) {
       g.log_.debug() << "fpgaPropertiesGetGUID() returned (" << res


### PR DESCRIPTION
The guid_t ostream streamer was retrieving the current guid value from
the underlying properties object, but was streaming the cached local
copy of the guid. Ideally, we want to update the cached local copy of
the guid, then stream it; however, the guid_t in question is passed by
const &.