### PR TITLE
mb1: fix device status memory issue (#111)

### DIFF
--- a/tools/fpgadiag/mb1.cpp
+++ b/tools/fpgadiag/mb1.cpp
@@ -256,8 +256,8 @@ bool mb1::run()
 
     bool res = true;
 
-    dma_buffer::ptr_t dsm = accelerator_->allocate_buffer(dsm_size_);
-    if (!dsm) {
+    dsm_ = accelerator_->allocate_buffer(dsm_size_);
+    if (!dsm_) {
         log_.error("mb1") << "failed to allocate DSM workspace." << std::endl;
         return false;
     }


### PR DESCRIPTION
mb1 declares class member variable dsm_. The run() function was using
a local variable to allocate the buffer, but then attempting to use dsm_
to run the actual test. This resulted in a segfault. The fix is to both
allocate and use dsm_.