### PR TITLE
Change events log level

### DIFF
--- a/libopae/src/event.c
+++ b/libopae/src/event.c
@@ -588,10 +588,11 @@ fpga_result __FPGA_API__ fpgaDestroyEventHandle(fpga_event_handle *event_handle)
 	int err = 0;
 
 	//sanity check
-	if (!event_handle)
-		return FPGA_INVALID_PARAM;
+	if (!event_handle) {
+      return FPGA_INVALID_PARAM;
+   }
 
-	_eh = (struct _fpga_event_handle *) *event_handle;
+   _eh = (struct _fpga_event_handle *) *event_handle;
 
 	result = event_handle_check_and_lock(_eh);
 	if (result)

--- a/libopae/src/event.c
+++ b/libopae/src/event.c
@@ -291,7 +291,7 @@ static fpga_result check_interrupts_supported(fpga_handle handle)
 		if (fme_info.capability & FPGA_FME_CAP_ERR_IRQ) {
 			res = FPGA_OK;
 		} else {
-			FPGA_ERR("Interrupts not supported in hw");
+			FPGA_MSG("Interrupts not supported in hw");
 			res = FPGA_NOT_SUPPORTED;
 		}
 	} else if (objtype == FPGA_ACCELERATOR) {
@@ -304,7 +304,7 @@ static fpga_result check_interrupts_supported(fpga_handle handle)
 		if (port_info.capability & FPGA_PORT_CAP_ERR_IRQ) {
 			res = FPGA_OK;
 		} else {
-			FPGA_ERR("Interrupts not supported in hw");
+			FPGA_MSG("Interrupts not supported in hw");
 			res = FPGA_NOT_SUPPORTED;
 		}
 	}
@@ -329,7 +329,7 @@ static fpga_result driver_register_event(fpga_handle handle,
 
 	res = check_interrupts_supported(handle);
 	if (res != FPGA_OK) {
-		FPGA_ERR("Could not determine whether interrupts are supported");
+		FPGA_MSG("Could not determine whether interrupts are supported");
 		return FPGA_NOT_SUPPORTED;
 	}
 
@@ -376,7 +376,7 @@ static fpga_result driver_unregister_event(fpga_handle handle,
 
 	res = check_interrupts_supported(handle);
 	if (res != FPGA_OK) {
-		FPGA_ERR("Could not determine whether interrupts are supported");
+		FPGA_MSG("Could not determine whether interrupts are supported");
 		return FPGA_NOT_SUPPORTED;
 	}
 
@@ -588,9 +588,8 @@ fpga_result __FPGA_API__ fpgaDestroyEventHandle(fpga_event_handle *event_handle)
 	int err = 0;
 
 	//sanity check
-	if (!event_handle) {
+	if (!event_handle)
 		return FPGA_INVALID_PARAM;
-	}
 
 	_eh = (struct _fpga_event_handle *) *event_handle;
 


### PR DESCRIPTION
   - Use log level FPGA_MSG() when trying to detect whether
   interrupts are supported in hardware. MCP does not support
   interrupts, and an error message could be unnecessary noise
   for the user.