### PR TITLE
BDF to accept hexadecimal values. (#288)

### DIFF
--- a/tools/fpgabist/bist_common.py
+++ b/tools/fpgabist/bist_common.py
@@ -57,11 +57,11 @@ def get_bdf_from_args(args):
     bdf_pattern = re.compile(pattern)
     bdf_list = []
     param = ':{}:{}.{}'.format(
-            vars(args)['bus']
+            hex(int(vars(args)['bus'], 16))
             if vars(args)['bus'] else '',
-            vars(args)['device']
+            hex(int(vars(args)['device'], 16))
             if vars(args)['device'] else '',
-            vars(args)['function']
+            hex(int(vars(args)['function'], 16))
             if vars(args)['function'] else '')
     host = subprocess.check_output(['/usr/sbin/lspci', '-s', param])
     matches = re.findall(bdf_pattern, host)


### PR DESCRIPTION
Cherry pick internal:
Rework the way B,D, or F input handles hex values.
Print the information in more human readable format
using hex() function. Also handle invalid inputs better.