### PR TITLE
fpgad: correct instances of snprintf and strlen

### DIFF
--- a/common/include/safe_string/safe_string.h
+++ b/common/include/safe_string/safe_string.h
@@ -696,10 +696,11 @@ extern "C" {
 #endif // __cplusplus
 
 int snprintf_s_i(char *dest, rsize_t dmax, const char *format, int a);
-int snprintf_s_si(char *dest, rsize_t dmax, const char *format, char *s, int a);
 int snprintf_s_l(char *dest, rsize_t dmax, const char *format, long a);
-int snprintf_s_sl(char *dest, rsize_t dmax, const char *format, char *s, long a);
+int snprintf_s_s(char *dest, rsize_t dmax, const char *format, const char *s);
 
+int snprintf_s_si(char *dest, rsize_t dmax, const char *format, const char *s, int a);
+int snprintf_s_sl(char *dest, rsize_t dmax, const char *format, const char *s, long a);
 int snprintf_s_il(char *dest, rsize_t dmax, const char *format, int a, long b);
 
 #if defined(__cplusplus)

--- a/safe_string/snprintf_support.c
+++ b/safe_string/snprintf_support.c
@@ -268,6 +268,31 @@ inline int snprintf_s_l(char *dest, rsize_t dmax, const char *format, long a)
 
 
 
+inline int snprintf_s_s(char *dest, rsize_t dmax, const char *format, const char *s)
+{
+	char pformatList[MAX_FORMAT_ELEMENTS];
+	unsigned int index = 0;
+
+	// Determine the number of format options in the format string
+	unsigned int  nfo = parse_format(format, &pformatList[0], MAX_FORMAT_ELEMENTS);
+
+	// Check that there are not too many format options
+	if ( nfo != 1 ) {
+		dest[0] = '\0';
+		return SNPRFNEGATE(ESBADFMT);
+	}
+	// Check first format is of string type
+	if ( CHK_FORMAT(FMT_STRING, pformatList[index]) == 0) {
+		dest[0] = '\0';
+		return SNPRFNEGATE(ESFMTTYP);
+	}
+	index++;
+
+	return snprintf(dest, dmax, format, s);
+}
+
+
+
 inline int snprintf_s_il(char *dest, rsize_t dmax, const char *format, int a, long b)
 {
 	char pformatList[MAX_FORMAT_ELEMENTS];
@@ -302,7 +327,7 @@ inline int snprintf_s_il(char *dest, rsize_t dmax, const char *format, int a, lo
 
 
 
-inline int snprintf_s_si(char *dest, rsize_t dmax, const char *format, char *s, int a)
+inline int snprintf_s_si(char *dest, rsize_t dmax, const char *format, const char *s, int a)
 {
 	char pformatList[MAX_FORMAT_ELEMENTS];
 	unsigned int index = 0;
@@ -333,7 +358,7 @@ inline int snprintf_s_si(char *dest, rsize_t dmax, const char *format, char *s, 
 }
 
 
-inline int snprintf_s_sl(char *dest, rsize_t dmax, const char *format, char *s, long a)
+inline int snprintf_s_sl(char *dest, rsize_t dmax, const char *format, const char *s, long a)
 {
 	char pformatList[MAX_FORMAT_ELEMENTS];
 	unsigned int index = 0;

--- a/tools/fpgad/ap_event.c
+++ b/tools/fpgad/ap_event.c
@@ -33,6 +33,8 @@
 #include "log.h"
 #include "config_int.h"
 
+#include "safe_string/safe_string.h"
+
 enum fpga_power_state {
 	NORAML_PWR = 0,
 	AP1_STATE,
@@ -76,7 +78,7 @@ static int poll_ap_event(struct fpga_ap_event *event)
 	}
 
 	// Read AP1 Event
-	snprintf(sysfspath, sizeof(sysfspath),
+	snprintf_s_s(sysfspath, sizeof(sysfspath),
 		"%s/ap1_event", event->sysfsfile);
 
 	if (read_event(sysfspath, &ap1_event) != 0) {
@@ -88,7 +90,7 @@ static int poll_ap_event(struct fpga_ap_event *event)
 	}
 
 	// Read AP2 Event
-	snprintf(sysfspath, sizeof(sysfspath),
+	snprintf_s_s(sysfspath, sizeof(sysfspath),
 		"%s/ap2_event", event->sysfsfile);
 
 	if (read_event(sysfspath, &ap2_event) != 0) {
@@ -100,7 +102,7 @@ static int poll_ap_event(struct fpga_ap_event *event)
 	}
 
 	// Read FPGA power state
-	snprintf(sysfspath, sizeof(sysfspath),
+	snprintf_s_s(sysfspath, sizeof(sysfspath),
 		"%s/power_state", event->sysfsfile);
 
 	if (read_event(sysfspath, &pwr_state) != 0) {

--- a/tools/fpgad/errtable.c
+++ b/tools/fpgad/errtable.c
@@ -33,6 +33,8 @@
 #include "log.h"
 #include "config_int.h"
 
+#include "safe_string/safe_string.h"
+
 //#define  ACCELERATOR_IRQ(fil, field, l, hi)
 #define PORT_ERR(sock, fil, field, lo, hi)        { sock, fil, field, lo, hi, false, evt_notify_error        }
 #define  FME_ERR(sock, fil, field, lo, hi)        { sock, fil, field, lo, hi, false, evt_notify_error        }
@@ -609,7 +611,7 @@ void *logger_thread(void *thread_context)
 	 * Check the errors/revision sysfs file to determine
 	 * which table to use.
 	 */
-	snprintf(sysfspath, sizeof(sysfspath),
+	snprintf_s_s(sysfspath, sizeof(sysfspath),
 			"%s/errors/revision", SYSFS_PORT0);
 
 	if (!stat(sysfspath, &stats)) {
@@ -640,7 +642,7 @@ void *logger_thread(void *thread_context)
 	 * Check the errors/revision sysfs file to determine
 	 * which table to use.
 	 */
-	snprintf(sysfspath, sizeof(sysfspath),
+	snprintf_s_s(sysfspath, sizeof(sysfspath),
 			"%s/errors/revision", SYSFS_FME0);
 
 	if (!stat(sysfspath, &stats)) {

--- a/tools/fpgad/evt.c
+++ b/tools/fpgad/evt.c
@@ -29,11 +29,13 @@
 #include "log.h"
 #include "ap6.h"
 
+#include "safe_string/safe_string.h"
+
 static void evt_notify_accelerator_interrupt_callback(struct client_event_registry *r,
 		const struct fpga_err *e)
 {
 	if ((FPGA_EVENT_INTERRUPT == r->event) &&
-		!strncmp(e->sysfsfile, r->device, strlen(r->device))) {
+		!strncmp(e->sysfsfile, r->device, strnlen_s(r->device, sizeof(r->device)))) {
 		dlog("event: FPGA_EVENT_INTERRUPT\n");
 		if (write(r->fd, &r->data, sizeof(r->data)) < 0)
 			dlog("write: %s\n", strerror(errno));
@@ -50,7 +52,7 @@ static void evt_notify_error_callback(struct client_event_registry *r,
 			const struct fpga_err *e)
 {
 	if ((FPGA_EVENT_ERROR == r->event) &&
-		!strncmp(e->sysfsfile, r->device, strlen(r->device))) {
+		!strncmp(e->sysfsfile, r->device, strnlen_s(r->device, sizeof(r->device)))) {
 		dlog("event: FPGA_EVENT_ERROR\n");
 		if (write(r->fd, &r->data, sizeof(r->data)) < 0)
 			dlog("write: %s\n", strerror(errno));
@@ -67,7 +69,7 @@ static void evt_notify_ap6_callback(struct client_event_registry *r,
 			const struct fpga_err *e)
 {
 	if ((FPGA_EVENT_POWER_THERMAL == r->event) &&
-		!strncmp(e->sysfsfile, r->device, strlen(r->device))) {
+		!strncmp(e->sysfsfile, r->device, strnlen_s(r->device, sizeof(r->device)))) {
 		dlog("event: FPGA_EVENT_POWER_THERMAL\n");
 		if (write(r->fd, &r->data, sizeof(r->data)) < 0)
 			dlog("write: %s\n", strerror(errno));


### PR DESCRIPTION
In preparation for enabling the additional safe string checkers, this
change replaces instances of snprintf and strlen with the safe string
equivalents. It also illustrates adding snprintf_s_X support for new
format strings.