### PR TITLE
OPAE: Replace string functions with secure safe string

### DIFF
--- a/libopae/src/bitstream.c
+++ b/libopae/src/bitstream.c
@@ -143,7 +143,7 @@ fpga_result get_interface_id(fpga_handle handle, uint64_t *id_l, uint64_t *id_h)
 	}
 
 	// PR Interface id path
-	snprintf(file_path, sizeof(file_path), "%s/%s", _token->sysfspath,
+	snprintf_s_ss(file_path, sizeof(file_path), "%s/%s", _token->sysfspath,
 		 PR_INTERFACE_ID);
 
 	if ((stat(file_path, &astats)) != FPGA_OK) {

--- a/libopae/src/enum.c
+++ b/libopae/src/enum.c
@@ -108,7 +108,7 @@ matches_filter(const struct dev_list *attr, const fpga_properties filter)
 
 		device_id = (int) strtoul(p+1, NULL, 10);
 
-		snprintf(spath, SYSFS_PATH_MAX,
+		snprintf_s_ii(spath, SYSFS_PATH_MAX,
 				SYSFS_FPGA_CLASS_PATH
 				SYSFS_FME_PATH_FMT,
 				device_id, device_id);
@@ -364,7 +364,7 @@ enum_fme_afu(const char *sysfspath, const char *name, struct dev_list *parent)
 	if (strstr(name, FPGA_SYSFS_FME)) {
 		int socket_id = 0;
 
-		snprintf(dpath, sizeof(dpath), FPGA_DEV_PATH "/%s", name);
+		snprintf_s_s(dpath, sizeof(dpath), FPGA_DEV_PATH "/%s", name);
 
 		pdev = add_dev(sysfspath, dpath, parent);
 		if (!pdev) {
@@ -384,7 +384,7 @@ enum_fme_afu(const char *sysfspath, const char *name, struct dev_list *parent)
 		// populate from pr/interface_id
 
 		// Discover the FME GUID from sysfs (pr/interface_id)
-		snprintf(spath, sizeof(spath), "%s/"
+		snprintf_s_s(spath, sizeof(spath), "%s/"
 				FPGA_SYSFS_FME_INTERFACE_ID, sysfspath);
 
 		result = sysfs_read_guid(spath, pdev->guid);
@@ -392,20 +392,20 @@ enum_fme_afu(const char *sysfspath, const char *name, struct dev_list *parent)
 			return result;
 
 		// Discover the socket id from the FME's sysfs entry.
-		snprintf(spath, sizeof(spath), "%s/"
+		snprintf_s_s(spath, sizeof(spath), "%s/"
 				FPGA_SYSFS_SOCKET_ID, sysfspath);
 
 		result = sysfs_read_int(spath, &socket_id);
 		if (FPGA_OK != result)
 			return result;
 
-		snprintf(spath, sizeof(spath), "%s/"
+		snprintf_s_s(spath, sizeof(spath), "%s/"
 				FPGA_SYSFS_NUM_SLOTS, sysfspath);
 		result = sysfs_read_u32(spath, &pdev->fpga_num_slots);
 		if (FPGA_OK != result)
 			return result;
 
-		snprintf(spath, sizeof(spath), "%s/"
+		snprintf_s_s(spath, sizeof(spath), "%s/"
 				FPGA_SYSFS_BITSTREAM_ID, sysfspath);
 		result = sysfs_read_u64(spath, &pdev->fpga_bitstream_id);
 		if (FPGA_OK != result)
@@ -425,7 +425,7 @@ enum_fme_afu(const char *sysfspath, const char *name, struct dev_list *parent)
 	if (strstr(name, FPGA_SYSFS_AFU)) {
 		int res;
 
-		snprintf(dpath, sizeof(dpath), FPGA_DEV_PATH "/%s", name);
+		snprintf_s_s(dpath, sizeof(dpath), FPGA_DEV_PATH "/%s", name);
 
 		pdev = add_dev(sysfspath, dpath, parent);
 		if (!pdev) {
@@ -452,7 +452,7 @@ enum_fme_afu(const char *sysfspath, const char *name, struct dev_list *parent)
 		pdev->accelerator_num_irqs = 0;
 
 		// Discover the AFU GUID from sysfs.
-		snprintf(spath, sizeof(spath), "%s/" FPGA_SYSFS_AFU_GUID,
+		snprintf_s_s(spath, sizeof(spath), "%s/" FPGA_SYSFS_AFU_GUID,
 				sysfspath);
 
 		result = sysfs_read_guid(spath, pdev->guid);
@@ -560,7 +560,7 @@ enum_top_dev(const char *sysfspath, struct dev_list *list)
 		if (!strcmp(dirent->d_name, ".."))
 			continue;
 
-		snprintf(spath, sizeof(spath), "%s/%s", sysfspath,
+		snprintf_s_ss(spath, sizeof(spath), "%s/%s", sysfspath,
 				dirent->d_name);
 
 		result = enum_fme_afu(spath, dirent->d_name, pdev);
@@ -625,7 +625,7 @@ fpgaEnumerate(const fpga_properties *filters, uint32_t num_filters,
 		if (!strcmp(dirent->d_name, ".."))
 			continue;
 
-		snprintf(sysfspath, sizeof(sysfspath), "%s/%s",
+		snprintf_s_ss(sysfspath, sizeof(sysfspath), "%s/%s",
 				SYSFS_FPGA_CLASS_PATH,	dirent->d_name);
 
 		result = enum_top_dev(sysfspath, &head);
@@ -644,7 +644,7 @@ fpgaEnumerate(const fpga_properties *filters, uint32_t num_filters,
 	for (lptr = head.next ; NULL != lptr ; lptr = lptr->next) {
 		struct _fpga_token *_tok;
 
-		if (!strlen(lptr->devpath))
+		if (!strnlen_s(lptr->devpath,sizeof(lptr->devpath)))
 			continue;
 
 		// propagate the socket_id field.

--- a/libopae/src/enum.c
+++ b/libopae/src/enum.c
@@ -644,7 +644,7 @@ fpgaEnumerate(const fpga_properties *filters, uint32_t num_filters,
 	for (lptr = head.next ; NULL != lptr ; lptr = lptr->next) {
 		struct _fpga_token *_tok;
 
-		if (!strnlen_s(lptr->devpath,sizeof(lptr->devpath)))
+		if (!strnlen_s(lptr->devpath, sizeof(lptr->devpath)))
 			continue;
 
 		// propagate the socket_id field.

--- a/libopae/src/reconf.c
+++ b/libopae/src/reconf.c
@@ -148,7 +148,7 @@ static fpga_result clear_port_errors(fpga_handle handle)
 		return result;
 	}
 
-	snprintf(syfs_errpath, sizeof(syfs_errpath), "%s/%s", syfs_path, PORT_SYSFS_ERRORS);
+	snprintf_s_ss(syfs_errpath, sizeof(syfs_errpath), "%s/%s", syfs_path, PORT_SYSFS_ERRORS);
 	// Read port error.
 	result = sysfs_read_u64(syfs_errpath, &error);
 	if (result != FPGA_OK) {
@@ -156,7 +156,7 @@ static fpga_result clear_port_errors(fpga_handle handle)
 		return result;
 	}
 
-	snprintf(syfs_errpath, sizeof(syfs_errpath), "%s/%s", syfs_path, PORT_SYSFS_ERR_CLEAR);
+	snprintf_s_ss(syfs_errpath, sizeof(syfs_errpath), "%s/%s", syfs_path, PORT_SYSFS_ERR_CLEAR);
 	// Clear port error.
 	result = sysfs_write_u64(syfs_errpath, error);
 	if (result != FPGA_OK) {
@@ -243,7 +243,7 @@ fpga_result set_fpga_pwr_threshold(fpga_handle handle,
 	}
 
 	// set fpga threshold 1
-	snprintf(sysfs_path, sizeof(sysfs_path), "%s/%s",  _token->sysfspath, PWRMGMT_THRESHOLD1);
+	snprintf_s_ss(sysfs_path, sizeof(sysfs_path), "%s/%s",  _token->sysfspath, PWRMGMT_THRESHOLD1);
 	FPGA_DBG(" FPGA Threshold1             :%ld watts\n", fpga_power);
 
 	result = sysfs_write_u64(sysfs_path, fpga_power);

--- a/libopae/src/sysfs.c
+++ b/libopae/src/sysfs.c
@@ -37,6 +37,8 @@
 #include <errno.h>
 #include <opae/types.h>
 
+#include "safe_string/safe_string.h"
+
 #include "types_int.h"
 #include "sysfs_int.h"
 #include "log_int.h"
@@ -269,7 +271,7 @@ fpga_result __FIXME_MAKE_VISIBLE__ sysfs_write_u64(const char *path, uint64_t u)
 		goto out_close;
 	}
 
-	snprintf(buf, sizeof(buf), "0x%lx", u);
+	snprintf_s_l(buf, sizeof(buf), "0x%lx", u);
 
 	do {
 		res = write(fd, buf + b, sizeof(buf) -b);
@@ -364,7 +366,7 @@ fpga_result sysfs_get_socket_id(int dev, uint8_t *socket_id)
 	char spath[SYSFS_PATH_MAX];
 	int i;
 
-	snprintf(spath, SYSFS_PATH_MAX,
+	snprintf_s_ii(spath, SYSFS_PATH_MAX,
 		 SYSFS_FPGA_CLASS_PATH
 		 SYSFS_FME_PATH_FMT "/"
 		 FPGA_SYSFS_SOCKET_ID,
@@ -385,7 +387,7 @@ fpga_result sysfs_get_afu_id(int dev, fpga_guid guid)
 {
 	char spath[SYSFS_PATH_MAX];
 
-	snprintf(spath, SYSFS_PATH_MAX,
+	snprintf_s_ii(spath, SYSFS_PATH_MAX,
 		 SYSFS_FPGA_CLASS_PATH
 		 SYSFS_AFU_PATH_FMT "/"
 		 FPGA_SYSFS_AFU_GUID,
@@ -398,7 +400,7 @@ fpga_result sysfs_get_pr_id(int dev, fpga_guid guid)
 {
 	char spath[SYSFS_PATH_MAX];
 
-	snprintf(spath, SYSFS_PATH_MAX,
+	snprintf_s_ii(spath, SYSFS_PATH_MAX,
 		 SYSFS_FPGA_CLASS_PATH
 		 SYSFS_FME_PATH_FMT "/"
 		 FPGA_SYSFS_FME_INTERFACE_ID,
@@ -412,7 +414,7 @@ fpga_result sysfs_get_slots(int dev, uint32_t *slots)
 {
 	char spath[SYSFS_PATH_MAX];
 
-	snprintf(spath, SYSFS_PATH_MAX,
+	snprintf_s_ii(spath, SYSFS_PATH_MAX,
 		 SYSFS_FPGA_CLASS_PATH
 		 SYSFS_FME_PATH_FMT "/"
 		 FPGA_SYSFS_NUM_SLOTS,
@@ -426,7 +428,7 @@ fpga_result sysfs_get_bitstream_id(int dev, uint64_t *id)
 {
 	char spath[SYSFS_PATH_MAX];
 
-	snprintf(spath, SYSFS_PATH_MAX,
+	snprintf_s_ii(spath, SYSFS_PATH_MAX,
 		 SYSFS_FPGA_CLASS_PATH
 		 SYSFS_FME_PATH_FMT "/"
 		 FPGA_SYSFS_BITSTREAM_ID,
@@ -474,7 +476,7 @@ fpga_result get_port_sysfs(fpga_handle handle,
 
 	device_id = atoi(p + 1);
 
-	snprintf(sysfs_port, SYSFS_PATH_MAX,
+	snprintf_s_ii(sysfs_port, SYSFS_PATH_MAX,
 		SYSFS_FPGA_CLASS_PATH SYSFS_AFU_PATH_FMT,
 		device_id, device_id);
 

--- a/libopae/src/token_list.c
+++ b/libopae/src/token_list.c
@@ -147,7 +147,7 @@ struct _fpga_token *token_get_parent(struct _fpga_token *_t)
 
 	device_id = atoi(p+1);
 
-	snprintf(spath, sizeof(spath),
+	snprintf_s_ii(spath, sizeof(spath),
 			SYSFS_FPGA_CLASS_PATH SYSFS_FME_PATH_FMT,
 			device_id, device_id);
 

--- a/libopae/src/usrclk/user_clk_pgm_uclock.c
+++ b/libopae/src/usrclk/user_clk_pgm_uclock.c
@@ -41,9 +41,12 @@
 #include <stdarg.h>
 #include <time.h>
 
+#include "safe_string/safe_string.h"
+
 #include "user_clk_pgm_uclock.h"
 #include "user_clk_pgm_uclock_freq_template.h"
 #include "user_clk_pgm_uclock_eror_messages.h"
+
 
 // user clock sysfs
 #define  USER_CLOCK_CMD0       "userclk_freqcmd"
@@ -165,7 +168,7 @@ int fi_RunInitz(const char* sysfs_path)
 		printf(" Invalid input sysfs path \n");
 		return -1;
 	}
-	snprintf(gQUCPU_Uclock.sysfs_path, sizeof(gQUCPU_Uclock.sysfs_path), "%s", sysfs_path);
+	snprintf_s_s(gQUCPU_Uclock.sysfs_path, sizeof(gQUCPU_Uclock.sysfs_path), "%s", sysfs_path);
 
 	// Assume return error okay, for now
 	i_ReturnErr = 0;
@@ -194,7 +197,7 @@ int fi_RunInitz(const char* sysfs_path)
 	if (i_ReturnErr == 0) // This always true; added for future safety
 	{
 		// Verifying User Clock version number
-		snprintf(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_STS1);
+		snprintf_s_ss(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_STS1);
 		sysfs_read_u64(syfs_usrpath, &u64i_PrtData);
 		//printf(" fi_RunInitz u64i_PrtData %llx  \n", u64i_PrtData);
 
@@ -223,7 +226,7 @@ int fi_RunInitz(const char* sysfs_path)
 		gQUCPU_Uclock.u64i_cmd_reg_0 &= ~(QUCPU_UI64_CMD_0_MRN_b52);
 		u64i_PrtData = gQUCPU_Uclock.u64i_cmd_reg_0;
 
-		snprintf(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_CMD0);
+		snprintf_s_ss(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_CMD0);
 		sysfs_write_u64(syfs_usrpath, u64i_PrtData);
 
 		// Deasserting management & machine reset
@@ -320,13 +323,13 @@ int fi_AvmmRWcom(int i_CmdWrite,
 	// Write register 0 to kick it off
 
 	u64i_PrtData = gQUCPU_Uclock.u64i_cmd_reg_0;
-	snprintf(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_CMD0);
+	snprintf_s_ss(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_CMD0);
 	sysfs_write_u64(syfs_usrpath, u64i_PrtData);
 
 	li_sleep_nanoseconds = USRCLK_SLEEEP_1MS;
 	fv_SleepShort(li_sleep_nanoseconds);
 
-	snprintf(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_STS0);
+	snprintf_s_ss(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_STS0);
 
 	// Poll register 0 for completion.
 	// CCI is synchronous and needs only 1 read with matching sequence.
@@ -441,14 +444,14 @@ int fi_GetFreqs(QUCPU_tFreqs *ptFreqs_retFreqs)
 		gQUCPU_Uclock.u64i_cmd_reg_1 &= ~QUCPU_UI64_CMD_1_MEA_b32;
 
 		u64i_PrtData = gQUCPU_Uclock.u64i_cmd_reg_1;
-		snprintf(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_CMD1);
+		snprintf_s_ss(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_CMD1);
 		sysfs_write_u64(syfs_usrpath, u64i_PrtData);
 
 
 		li_sleep_nanoseconds = USRCLK_SLEEEP_10MS;            // 10 ms for frequency counter
 		fv_SleepShort(li_sleep_nanoseconds);
 
-		snprintf(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_STS1);
+		snprintf_s_ss(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_STS1);
 		sysfs_read_u64(syfs_usrpath,  &u64i_PrtData);
 
 
@@ -462,13 +465,13 @@ int fi_GetFreqs(QUCPU_tFreqs *ptFreqs_retFreqs)
 
 		u64i_PrtData = gQUCPU_Uclock.u64i_cmd_reg_1;
 
-		snprintf(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_CMD1);
+		snprintf_s_ss(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_CMD1);
 		sysfs_write_u64(syfs_usrpath,  u64i_PrtData);
 
 		li_sleep_nanoseconds = USRCLK_SLEEEP_10MS; // 10 ms for frequency counter
 		fv_SleepShort(li_sleep_nanoseconds);
 
-		snprintf(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_STS1);
+		snprintf_s_ss(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_STS1);
 		sysfs_read_u64(syfs_usrpath,  &u64i_PrtData);
 		ptFreqs_retFreqs->u64i_Frq_ClkUsr = (u64i_PrtData & QUCPU_UI64_STS_1_FRQ_b16t00) * 10000; // Hz
 		//printf(" ptFreqs_retFreqs->u64i_Frq_ClkUsr %llx \n", ptFreqs_retFreqs->u64i_Frq_ClkUsr);
@@ -551,7 +554,7 @@ int fi_SetFreqs(uint64_t u64i_Refclk,
 	if (i_ReturnErr == 0)
 	{ // Verifying fcr PLL not locking
 
-		snprintf(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_STS0);
+		snprintf_s_ss(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_STS0);
 		sysfs_read_u64(syfs_usrpath,  &u64i_PrtData);
 		//sysfs_read_uint64(gQUCPU_Uclock.sys_path, USER_CLOCK_STS0, &u64i_PrtData);
 
@@ -568,7 +571,7 @@ int fi_SetFreqs(uint64_t u64i_Refclk,
 		if (u64i_Refclk) gQUCPU_Uclock.u64i_cmd_reg_0 |= QUCPU_UI64_CMD_0_SR1_b58;
 		u64i_PrtData = gQUCPU_Uclock.u64i_cmd_reg_0;
 
-		snprintf(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_CMD0);
+		snprintf_s_ss(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_CMD0);
 		sysfs_write_u64(syfs_usrpath,  u64i_PrtData);
 
 		// Sleep 1 ms
@@ -646,7 +649,7 @@ int fi_SetFreqs(uint64_t u64i_Refclk,
 		for (u64i_I = 0; u64i_I<100; u64i_I++)
 		{ // Poll with 100 ms timeout
 
-			snprintf(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_STS0);
+			snprintf_s_ss(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_STS0);
 			sysfs_read_u64(syfs_usrpath,  &u64i_PrtData);
 
 			if ((u64i_PrtData & QUCPU_UI64_STS_0_LCK_b60) != 0) break;
@@ -769,7 +772,7 @@ int fi_WaitCalDone(void)
 	for (u64i_I = 0; u64i_I<1000; u64i_I++)
 	{ // Poll with 1000 ms timeout
 
-		snprintf(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_STS0);
+		snprintf_s_ss(syfs_usrpath, sizeof(syfs_usrpath), "%s/%s", gQUCPU_Uclock.sysfs_path, USER_CLOCK_STS0);
 		sysfs_read_u64(syfs_usrpath,  &u64i_PrtData);
 
 		if ((u64i_PrtData & QUCPU_UI64_STS_0_BSY_b61) == 0) break;


### PR DESCRIPTION
Changes:
   - Replace strlen() with strlen_s()
   - Replace snprintf () with snprintf_s_X ()