### PR TITLE
mmlink: fix read_mmr optimization issue

### DIFF
--- a/tools/mmlink/mm_debug_link_linux.h
+++ b/tools/mmlink/mm_debug_link_linux.h
@@ -60,7 +60,13 @@ private:
 public:
 	mm_debug_link_linux();
 	int open(unsigned char* stpAddr);
-	void* read_mmr(uint32_t target, int access_type);
+
+	template <typename T, typename U>
+	T read_mmr(U offset)
+	{
+		return *reinterpret_cast<volatile T *>(map_base + offset);
+	}
+
 	void write_mmr(off_t target, int access_type, uint64_t write_val);
 	ssize_t read();
 	ssize_t write( const void *buf, size_t count);


### PR DESCRIPTION
The read_mmr() function is used to obtain a pointer to a
memory-mapped IO address (void *) given an offset from the MMIO base.

In the previous implementation, callers were forced to cast the obtained pointer to a volatile type,
or else the optimization phases of the compiler produced invalid
code. This was observed as a regression test failure when the default
build type was changed to -DCMAKE_BUILD_TYPE=RelWithDebInfo.

The change converts read_mmr to a template function so that
no casting to volatile is required at the call site.