### PR TITLE
mmlink: fix instances of banned fn's

### DIFF
--- a/common/include/safe_string/safe_string.h
+++ b/common/include/safe_string/safe_string.h
@@ -696,16 +696,21 @@ extern "C" {
 #endif // __cplusplus
 
 int snprintf_s_i(char *dest, rsize_t dmax, const char *format, int a);
+int sscanf_s_i(const char *src, const char *format, int *a);
+int sscanf_s_u(const char *src, const char *format, unsigned *a);
 int snprintf_s_l(char *dest, rsize_t dmax, const char *format, long a);
 int snprintf_s_s(char *dest, rsize_t dmax, const char *format, const char *s);
 
 int snprintf_s_ss(char *dest, rsize_t dmax, const char *format, const char *s, const char *t);
 int snprintf_s_ii(char *dest, rsize_t dmax, const char *format, int a, int b);
+int sscanf_s_ii(const char *src, const char *format, int *a, int *b);
 int snprintf_s_si(char *dest, rsize_t dmax, const char *format, const char *s, int a);
 int snprintf_s_sl(char *dest, rsize_t dmax, const char *format, const char *s, long a);
 int snprintf_s_il(char *dest, rsize_t dmax, const char *format, int a, long b);
 
 int snprintf_s_iis(char *dest, rsize_t dmax, const char *format, int a, int b, const char *s);
+
+int snprintf_s_iiii(char *dest, rsize_t dmax, const char *format, int a, int b, int c, int d);
 
 #if defined(__cplusplus)
 }

--- a/safe_string/snprintf_support.c
+++ b/safe_string/snprintf_support.c
@@ -242,6 +242,53 @@ inline int snprintf_s_i(char *dest, rsize_t dmax, const char *format, int a)
 
 
 
+
+inline int sscanf_s_i(const char *src, const char *format, int *a)
+{
+	char pformatList[MAX_FORMAT_ELEMENTS];
+	unsigned int index = 0;
+
+	// Determine the number of format options in the format string
+	unsigned int  nfo = parse_format(format, &pformatList[0], MAX_FORMAT_ELEMENTS);
+
+	// Check that there are not too many format options
+	if ( nfo != 1 ) {
+		return SNPRFNEGATE(ESBADFMT);
+	}
+	// Check that the format is for an integer type
+	if ( check_integer_format(pformatList[index]) == 0) {
+		return SNPRFNEGATE(ESFMTTYP);
+	}
+
+	return sscanf(src, format, a);
+}
+
+
+
+
+inline int sscanf_s_u(const char *src, const char *format, unsigned *a)
+{
+	char pformatList[MAX_FORMAT_ELEMENTS];
+	unsigned int index = 0;
+
+	// Determine the number of format options in the format string
+	unsigned int  nfo = parse_format(format, &pformatList[0], MAX_FORMAT_ELEMENTS);
+
+	// Check that there are not too many format options
+	if ( nfo != 1 ) {
+		return SNPRFNEGATE(ESBADFMT);
+	}
+	// Check that the format is for an integer type
+	if ( check_integer_format(pformatList[index]) == 0) {
+		return SNPRFNEGATE(ESFMTTYP);
+	}
+
+	return sscanf(src, format, a);
+}
+
+
+
+
 inline int snprintf_s_l(char *dest, rsize_t dmax, const char *format, long a)
 {
 	char pformatList[MAX_FORMAT_ELEMENTS];
@@ -350,6 +397,35 @@ inline int snprintf_s_ii(char *dest, rsize_t dmax, const char *format, int a, in
 	}
 
 	return snprintf(dest, dmax, format, a, b);
+}
+
+
+
+
+inline int sscanf_s_ii(const char *src, const char *format, int *a, int *b)
+{
+	char pformatList[MAX_FORMAT_ELEMENTS];
+	unsigned int index = 0;
+
+	// Determine the number of format options in the format string
+	unsigned int  nfo = parse_format(format, &pformatList[0], MAX_FORMAT_ELEMENTS);
+
+	// Check that there are not too many format options
+	if ( nfo != 2 ) {
+		return SNPRFNEGATE(ESBADFMT);
+	}
+	// Check that the format is for an integer type
+	if ( check_integer_format(pformatList[index]) == 0) {
+		return SNPRFNEGATE(ESFMTTYP);
+	}
+	index++;
+
+	// Check that the format is for an integer type
+	if ( check_integer_format(pformatList[index]) == 0) {
+		return SNPRFNEGATE(ESFMTTYP);
+	}
+
+	return sscanf(src, format, a, b);
 }
 
 
@@ -487,3 +563,49 @@ inline int snprintf_s_iis(char *dest, rsize_t dmax, const char *format, int a, i
 	return snprintf(dest, dmax, format, a, b, s);
 }
 
+
+
+
+inline int snprintf_s_iiii(char *dest, rsize_t dmax, const char *format, int a, int b, int c, int d)
+{
+	char pformatList[MAX_FORMAT_ELEMENTS];
+	unsigned int index = 0;
+
+	// Determine the number of format options in the format string
+	unsigned int  nfo = parse_format(format, &pformatList[0], MAX_FORMAT_ELEMENTS);
+
+	// Check that there are not too many format options
+	if ( nfo != 4 ) {
+		dest[0] = '\0';
+		return SNPRFNEGATE(ESBADFMT);
+	}
+
+	// Check that the format is for an integer type
+	if ( check_integer_format(pformatList[index]) == 0) {
+		dest[0] = '\0';
+		return SNPRFNEGATE(ESFMTTYP);
+	}
+	index++;
+
+	// Check that the format is for an integer type
+	if ( check_integer_format(pformatList[index]) == 0) {
+		dest[0] = '\0';
+		return SNPRFNEGATE(ESFMTTYP);
+	}
+	index++;
+
+	// Check that the format is for an integer type
+	if ( check_integer_format(pformatList[index]) == 0) {
+		dest[0] = '\0';
+		return SNPRFNEGATE(ESFMTTYP);
+	}
+	index++;
+
+	// Check that the format is for an integer type
+	if ( check_integer_format(pformatList[index]) == 0) {
+		dest[0] = '\0';
+		return SNPRFNEGATE(ESFMTTYP);
+	}
+
+	return snprintf(dest, dmax, format, a, b, c, d);
+}

--- a/tools/mmlink/mmlink_connection.cpp
+++ b/tools/mmlink/mmlink_connection.cpp
@@ -198,7 +198,7 @@ int mmlink_connection::handle_unbound_command(char *cmd)
 				" setting to bound state\n";
 
 		bind();
-		send(OK, strlen(OK));
+		send(OK, strnlen_s(OK, sizeof(OK)));
 	}
 	else
 	{
@@ -230,7 +230,7 @@ int mmlink_connection::handle_bound_command(char *cmd)
 	int arg1, arg2;
 	bool unknown = true;
 
-	if (1 == sscanf(cmd, "IDENT %X", &u))
+	if (1 == sscanf_s_u(cmd, "IDENT %X", &u))
 	{
 		arg1 = (int)u;
 		if (arg1 >= 0 && arg1 <= 0xF) {
@@ -241,39 +241,39 @@ int mmlink_connection::handle_bound_command(char *cmd)
 			// Write the nibble value
 			driver()->write_ident(arg1);
 			driver()->ident(ident);
-			snprintf(msg, msg_len, "%08X%08X%08X%08X\n",
+			snprintf_s_iiii(msg, msg_len, "%08X%08X%08X%08X\n",
 				 ident[3], ident[2], ident[1], ident[0]);
 
-			send(msg, strlen(msg));
+			send(msg, strnlen_s(msg, sizeof(msg)));
 			unknown = false;
 		}
 	}
-	else if (1 == sscanf(cmd, "RESET %d", &arg1))
+	else if (1 == sscanf_s_i(cmd, "RESET %d", &arg1))
 	{
 		if (arg1 == 0 || arg1 == 1)
 		{
 			driver()->reset(arg1);
-			send(OK, strlen(OK));
+			send(OK, strnlen_s(OK, sizeof(OK)));
 			unknown = false;
 		}
 	}
-	else if (2 == sscanf(cmd, "ENABLE %d %d", &arg1, &arg2))
+	else if (2 == sscanf_s_ii(cmd, "ENABLE %d %d", &arg1, &arg2))
 	{
 		if (arg1 >= 0 && (arg2 == 0 || arg2 == 1))
 		{
 			driver()->enable(arg1, arg2);
-			send(OK, strlen(OK));
+			send(OK, strnlen_s(OK, sizeof(OK)));
 			unknown = false;
 		}
 	}
 	else if (0 == strncmp(cmd, "NOOP", 4))
 	{
-		send(OK, strlen(OK));
+		send(OK, strnlen_s(OK, sizeof(OK)));
 		unknown = false;
 	}
 
 	if (unknown)
-		send(UNKNOWN, strlen(UNKNOWN));
+		send(UNKNOWN, strnlen_s(UNKNOWN, sizeof(UNKNOWN)));
 
 	return 0;
 }

--- a/tools/mmlink/mmlink_server.cpp
+++ b/tools/mmlink/mmlink_server.cpp
@@ -49,6 +49,8 @@
 #include "mmlink_connection.h"
 #include "mmlink_server.h"
 
+#include "safe_string/safe_string.h"
+
 using namespace std;
 
 mmlink_server::mmlink_server(struct sockaddr_in *sock, mm_debug_link_interface *driver)
@@ -219,7 +221,7 @@ int mmlink_server::run(unsigned char* stpAddr)
 
 				get_welcome_message(msg, sizeof(msg) / sizeof(*msg));
 				// to do:spin until all bytes sent.
-				pc->send(msg, strlen(msg));
+				pc->send(msg, strnlen_s(msg, sizeof(msg)));
 			}
 		}
 
@@ -367,11 +369,13 @@ void mmlink_server::get_welcome_message(char *msg, size_t msg_len)
 		//snprintf(msg, msg_len, "SystemConsole CONFIGROM IDENT=%08X%08X%08X%08X HANDLE=%08X\r\n",
 		//         ident[3], ident[2], ident[1], ident[0], m_server_id);
 
-		snprintf(msg, msg_len, "SystemConsole CONFIGROM IDENT=0001000000007BF899BB8B9AA2D864C3 HANDLE=%08X\r\n", m_server_id);
+		snprintf_s_i(msg, msg_len, "SystemConsole CONFIGROM IDENT=0001000000007BF899BB8B9AA2D864C3 HANDLE=%08X\r\n", m_server_id);
 	}
 	else
 	{
-		snprintf(msg, msg_len, "SystemConsole CONFIGROM IDENT=0001000000007BF899BB8B9AA2D864C3 HANDLE\r\n");
+		strncpy_s(msg, msg_len, "SystemConsole CONFIGROM IDENT=0001000000007BF899BB8B9AA2D864C3 HANDLE\r\n", 73);
+
+		//snprintf(msg, msg_len, "SystemConsole CONFIGROM IDENT=0001000000007BF899BB8B9AA2D864C3 HANDLE\r\n");
 		//snprintf(msg, msg_len, "SystemConsole CONFIGROM IDENT=%08X%08X%08X%08X HANDLE\r\n",
 		//         ident[3], ident[2], ident[1], ident[0]);
 	}


### PR DESCRIPTION
These instances were identified by the new safe string checkers.