### PR TITLE
tools: Replace string functions with secure safe string

### DIFF
--- a/tools/fpgaconf/fpgaconf.c
+++ b/tools/fpgaconf/fpgaconf.c
@@ -273,7 +273,7 @@ int parse_args(int argc, char *argv[])
 				break;
 			endptr = NULL;
 			config.target.bus = (int) strtoul(tmp_optarg, &endptr, 0);
-			if (endptr != tmp_optarg + strlen(tmp_optarg)) {
+			if (endptr != tmp_optarg + strnlen_s(tmp_optarg, sizeof(tmp_optarg))) {
 				fprintf(stderr, "invalid bus: %s\n", tmp_optarg);
 				return -1;
 			}
@@ -284,7 +284,7 @@ int parse_args(int argc, char *argv[])
 				break;
 			endptr = NULL;
 			config.target.device = (int) strtoul(tmp_optarg, &endptr, 0);
-			if (endptr != tmp_optarg + strlen(tmp_optarg)) {
+			if (endptr != tmp_optarg + strnlen_s(tmp_optarg, sizeof(tmp_optarg))) {
 				fprintf(stderr, "invalid device: %s\n", tmp_optarg);
 				return -1;
 			}
@@ -295,7 +295,7 @@ int parse_args(int argc, char *argv[])
 				break;
 			endptr = NULL;
 			config.target.function = (int) strtoul(tmp_optarg, &endptr, 0);
-			if (endptr != tmp_optarg + strlen(tmp_optarg)) {
+			if (endptr != tmp_optarg + strnlen_s(tmp_optarg, sizeof(tmp_optarg))) {
 				fprintf(stderr, "invalid function: %s\n", tmp_optarg);
 				return -1;
 			}
@@ -306,7 +306,7 @@ int parse_args(int argc, char *argv[])
 				break;
 			endptr = NULL;
 			config.target.socket = (int) strtoul(tmp_optarg, &endptr, 0);
-			if (endptr != tmp_optarg + strlen(tmp_optarg)) {
+			if (endptr != tmp_optarg + strnlen_s(tmp_optarg, sizeof(tmp_optarg))) {
 				fprintf(stderr, "invalid socket: %s\n", tmp_optarg);
 				return -1;
 			}

--- a/tools/fpgaconf/fpgaconf.c
+++ b/tools/fpgaconf/fpgaconf.c
@@ -273,7 +273,7 @@ int parse_args(int argc, char *argv[])
 				break;
 			endptr = NULL;
 			config.target.bus = (int) strtoul(tmp_optarg, &endptr, 0);
-			if (endptr != tmp_optarg + strnlen_s(tmp_optarg, sizeof(tmp_optarg))) {
+			if (*tmp_optarg == '\0' || *endptr != '\0') {
 				fprintf(stderr, "invalid bus: %s\n", tmp_optarg);
 				return -1;
 			}
@@ -284,7 +284,7 @@ int parse_args(int argc, char *argv[])
 				break;
 			endptr = NULL;
 			config.target.device = (int) strtoul(tmp_optarg, &endptr, 0);
-			if (endptr != tmp_optarg + strnlen_s(tmp_optarg, sizeof(tmp_optarg))) {
+			if (*tmp_optarg == '\0' || *endptr != '\0') {
 				fprintf(stderr, "invalid device: %s\n", tmp_optarg);
 				return -1;
 			}
@@ -295,7 +295,7 @@ int parse_args(int argc, char *argv[])
 				break;
 			endptr = NULL;
 			config.target.function = (int) strtoul(tmp_optarg, &endptr, 0);
-			if (endptr != tmp_optarg + strnlen_s(tmp_optarg, sizeof(tmp_optarg))) {
+			if (*tmp_optarg == '\0' || *endptr != '\0') {
 				fprintf(stderr, "invalid function: %s\n", tmp_optarg);
 				return -1;
 			}
@@ -306,7 +306,7 @@ int parse_args(int argc, char *argv[])
 				break;
 			endptr = NULL;
 			config.target.socket = (int) strtoul(tmp_optarg, &endptr, 0);
-			if (endptr != tmp_optarg + strnlen_s(tmp_optarg, sizeof(tmp_optarg))) {
+			if (*tmp_optarg == '\0' || *endptr != '\0') {
 				fprintf(stderr, "invalid socket: %s\n", tmp_optarg);
 				return -1;
 			}

--- a/tools/ras/main.c
+++ b/tools/ras/main.c
@@ -1067,7 +1067,7 @@ fpga_result mmio_error(struct RASCommandLine *rasCmdLine)
 	if ( rasCmdLine->function >0 )
 		function = rasCmdLine->bus;
 
-	snprintf(sysfs_path, sizeof(sysfs_path),
+	snprintf_s_iiii(sysfs_path, sizeof(sysfs_path),
 			DEVICEID_PATH,0,bus,device,function);
 
 	result = sysfs_read_u64(sysfs_path, &value);
@@ -1081,7 +1081,7 @@ fpga_result mmio_error(struct RASCommandLine *rasCmdLine)
 		return FPGA_NOT_SUPPORTED;
 	}
 
-	snprintf(sysfs_path, sizeof(sysfs_path),
+	snprintf_s_iiii(sysfs_path, sizeof(sysfs_path),
 			FPGA_PORT_RES_PATH,0,bus,device,function);
 
 	fd = open(sysfs_path, O_RDWR);


### PR DESCRIPTION
Changes:
   - Replace strlen() with strlen_s()
   - Replace snprintf () with snprintf_s_X ()