### PR TITLE
tools: MMlink set default IP address to zero (#180)

### DIFF
--- a/tools/mmlink/main.cpp
+++ b/tools/mmlink/main.cpp
@@ -143,7 +143,7 @@ int main( int argc, char** argv )
 
 	if ('\0' == mmlinkCmdLine.ip[0]) {
 		strncpy_s(mmlinkCmdLine.ip, sizeof(mmlinkCmdLine.ip),
-			"127.0.0.1", 9);
+			"0.0.0.0", 9);
 	}
 
 	printf(" ------- Command line Input START ---- \n \n");


### PR DESCRIPTION
Changes:
 - Set socket default IP address to 0.0.0.0 instead of loop back IP address 127.0.0.1