### PR TITLE
Add support to AFU JSON files to request automatic frequency setting of uClk

### DIFF
--- a/platforms/platform_if/par/afu_json.tcl
+++ b/platforms/platform_if/par/afu_json.tcl
@@ -1,0 +1,81 @@
+##
+## Extract information from an AFU's JSON file.
+##
+
+package require json
+
+##
+## Find the JSON file in the project.  The file must have been added with
+## set_global_assignment in the MISC_FILE namespace.
+##
+## The function returns the first JSON file found.
+##
+proc get_afu_json_file {} {
+    set misc_file_col [get_all_global_assignments -name MISC_FILE]
+    foreach_in_collection misc_file $misc_file_col {
+        set fn [lindex $misc_file 2]
+        if {[string match -nocase *.json $fn]} {
+            return $fn
+        }
+    }
+    return ""
+}
+
+##
+## Given the path of an AFU JSON file return a Tcl dictionary with the contents.
+##
+proc afu_json_file_to_dict {json_path} {
+    set d [dict create]
+    if {$json_path != ""} {
+        set f [open $json_path]
+        set d [::json::json2dict [read $f]]
+    }
+    return $d
+}
+
+##
+## Given a Tcl dictionary loaded from JSON, return the user clock low
+## frequency (MHz).
+##
+## Returns 0 if no frequency is set.
+##
+proc afu_get_clock_frequency_low {json_dict} {
+    if ([dict exists $json_dict afu-image clock-frequency-low]) {
+        return [dict get $json_dict afu-image clock-frequency-low]
+    }
+
+    return 0
+}
+
+##
+## Given a Tcl dictionary loaded from JSON, return the user clock high
+## frequency (MHz).
+##
+## Returns 0 if no frequency is set.
+##
+proc afu_get_clock_frequency_high {json_dict} {
+    if ([dict exists $json_dict afu-image clock-frequency-high]) {
+        return [dict get $json_dict afu-image clock-frequency-high]
+    }
+
+    return 0
+}
+
+##
+## Return a list of user clock frequencies requested in the AFU's JSON file.
+## Index 0 is the low frequency, index 1 is the high frequency.  If no
+## JSON file is set in the project (as a MISC_FILE) or the frequency is not
+## specified in the JSON, 0 is returned for a missing entry.  (The
+## returned list is always length 2.)
+##
+proc get_afu_json_user_clock_frequencies {} {
+    # Path of the JSON file (or empty string if not defined)
+    set jf [get_afu_json_file]
+    # JSON as a Tcl dictionary.  (Empty if no JSON file is in the project.)
+    set jd [afu_json_file_to_dict $jf]
+
+    set freqs {}
+    lappend freqs [afu_get_clock_frequency_low $jd]
+    lappend freqs [afu_get_clock_frequency_high $jd]
+    return $freqs
+}

--- a/platforms/platform_if/par/afu_json.tcl
+++ b/platforms/platform_if/par/afu_json.tcl
@@ -39,7 +39,7 @@ proc afu_json_file_to_dict {json_path} {
 ##
 ## Returns 0 if no frequency is set.
 ##
-proc afu_get_clock_frequency_low {json_dict} {
+proc afu_get_clock_freq_low {json_dict} {
     if ([dict exists $json_dict afu-image clock-frequency-low]) {
         return [dict get $json_dict afu-image clock-frequency-low]
     }
@@ -53,7 +53,7 @@ proc afu_get_clock_frequency_low {json_dict} {
 ##
 ## Returns 0 if no frequency is set.
 ##
-proc afu_get_clock_frequency_high {json_dict} {
+proc afu_get_clock_freq_high {json_dict} {
     if ([dict exists $json_dict afu-image clock-frequency-high]) {
         return [dict get $json_dict afu-image clock-frequency-high]
     }
@@ -65,17 +65,24 @@ proc afu_get_clock_frequency_high {json_dict} {
 ## Return a list of user clock frequencies requested in the AFU's JSON file.
 ## Index 0 is the low frequency, index 1 is the high frequency.  If no
 ## JSON file is set in the project (as a MISC_FILE) or the frequency is not
-## specified in the JSON, 0 is returned for a missing entry.  (The
-## returned list is always length 2.)
+## specified in the JSON, 0 is returned for a missing entry.
 ##
-proc get_afu_json_user_clock_frequencies {} {
+## If no user clock frequencies are specified in the JSON file then
+## an empty list is returned.
+##
+proc get_afu_json_user_clock_freqs {} {
     # Path of the JSON file (or empty string if not defined)
     set jf [get_afu_json_file]
     # JSON as a Tcl dictionary.  (Empty if no JSON file is in the project.)
     set jd [afu_json_file_to_dict $jf]
 
-    set freqs {}
-    lappend freqs [afu_get_clock_frequency_low $jd]
-    lappend freqs [afu_get_clock_frequency_high $jd]
-    return $freqs
+    set uclk_freq_low [afu_get_clock_freq_low $jd]
+    set uclk_freq_high [afu_get_clock_freq_high $jd]
+
+    if {$uclk_freq_low > 0 || $uclk_freq_high > 0} {
+        return [list $uclk_freq_low $uclk_freq_high]
+    } else {
+        # Return an empty list if no user clocks are set in the JSON
+        return [list]
+    }
 }

--- a/platforms/platform_if/par/platform_if_addenda.qsf
+++ b/platforms/platform_if/par/platform_if_addenda.qsf
@@ -93,3 +93,5 @@ set_global_assignment -name VERILOG_FILE       $PLATFORM_IF_SRC/rtl/platform_shi
 set_global_assignment -name SDC_FILE           $PLATFORM_IF_SRC/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_dc_fifo.sdc
 
 set_global_assignment -name SDC_FILE           $PLATFORM_IF_SRC/par/platform_if.sdc
+set_global_assignment -name SOURCE_TCL_SCRIPT_FILE $PLATFORM_IF_SRC/par/afu_json.tcl
+set_global_assignment -name SOURCE_TCL_SCRIPT_FILE $PLATFORM_IF_SRC/par/user_clock_config.tcl

--- a/platforms/platform_if/par/user_clock_config.tcl
+++ b/platforms/platform_if/par/user_clock_config.tcl
@@ -1,0 +1,256 @@
+##
+## User clock frequency configuration support.
+##
+
+##
+## Input: a pair of user clock frequency requests from the AFU's JSON file,
+## passed as an array, and the maximum permitted frequency.
+##
+## Output: target frequencies for the user clocks.
+##
+## The AFU JSON may say "auto" or "auto-<target freq>" as a user clock frequency.
+## In that case, the clock will be constrained in the fitter either to
+## "target freq" or to freq_max.  The actual frequencies will be set based on
+## the timing results.
+##
+## For systems where there are two aligned user clocks: one primary and one running
+## at half the speed of the primary.
+##
+proc get_aligned_user_clock_targets {afu_json_uclk_freqs freq_max} {
+    set uclk_freq_low [lindex $afu_json_uclk_freqs 0]
+    set uclk_freq_high [lindex $afu_json_uclk_freqs 1]
+
+    # First, check whether the user clock frequencies have already been
+    # computed following place & route.
+    set computed_uclk [load_computed_user_clocks $freq_max]
+    if {[llength $computed_uclk]} {
+        post_message [concat "Target user clock high: computed " [lindex $computed_uclk 1]]
+        post_message [concat "Target user clock low: computed " [lindex $computed_uclk 0]]
+
+        return $computed_uclk
+    }
+
+    if {0 == [string compare -nocase -length 4 "auto" $uclk_freq_high]} {
+        # High frequency clock is "auto".  Initially, constrain it
+        # to a maximum frequency.  Also, ignore the JSON constraint
+        # on the low frequency clock and constrain it to half of
+        # freq_max.
+        set uclk_freq_high [uclk_parse_auto_freq $uclk_freq_high $freq_max]
+        set uclk_freq_low [expr {$uclk_freq_high / 2.0}]
+
+        post_message "Target user clock high: auto ($uclk_freq_high)"
+        post_message "Target user clock low: auto ($uclk_freq_low)"
+    } elseif {0 == [string compare -nocase -length 4 "auto" $uclk_freq_low]} {
+        # Low frequency clock is "auto" and the high frequency clock is not.
+        # Ignore the high frequency constraint, setting it to 2x the low.
+        set uclk_freq_low [uclk_parse_auto_freq $uclk_freq_low $freq_max]
+        set uclk_freq_high [expr {$uclk_freq_low * 2}]
+        if {$uclk_freq_high > $freq_max} {
+            set uclk_freq_high $freq_max
+        }
+
+        post_message "Target user clock high: auto ($uclk_freq_high)"
+        post_message "Target user clock low: auto ($uclk_freq_low)"
+    } elseif {$uclk_freq_low > 0 || $uclk_freq_high > 0} {
+        # At least one clock was specified in the JSON.
+        # Were both clocks specified?  If not, complete the settings.
+        if {$uclk_freq_low == 0} {set uclk_freq_low [expr {$uclk_freq_high / 2.0}]}
+        if {$uclk_freq_high == 0} {set uclk_freq_high [expr {$uclk_freq_low * 2}]}
+
+        # Validate.  Low is supposed to be 1/2 the frequency of high and the two are
+        # aligned.  We avoid false negatives caused by floating point rounding here.
+        if {[expr {abs($uclk_freq_high / $uclk_freq_low - 2.0)}] > 0.01} {
+            error "Target user clock low ($uclk_freq_low) is supposed to be half the frequency of user clock high ($uclk_freq_high)!"
+        }
+
+        # Clamp the clocks at freq_max
+        if {$uclk_freq_high > $freq_max} {
+            set uclk_freq_high $freq_max
+        }
+        if {$uclk_freq_low > $freq_max} {
+            set uclk_freq_low $freq_max
+        }
+
+        post_message "Target user clock high: $uclk_freq_high"
+        post_message "Target user clock low: $uclk_freq_low"
+    }
+
+    return [list $uclk_freq_low $uclk_freq_high]
+}
+
+
+##
+## Parse target frequencies stored in the AFU JSON declared as "auto".
+## In auto mode, set the frequency to the maximum possible.  The design
+## will be constrained later with the achieved frequency.
+##
+## When "auto" is followed by a number, e.g. "auto-320", use the number
+## as the maximum frequency.
+##
+proc uclk_parse_auto_freq {req freq_max} {
+    set tgt_freq $freq_max
+
+    # We already know that $req begins with "auto".  If there is a
+    # dash then the maximum frequency may be specified, too.
+    if {"-" == [string index $req 4]} {
+        set f [string range $req 5 end]
+        if {[string is integer $f] && $f} {
+            set tgt_freq $f
+        }
+
+        if {$tgt_freq > $freq_max} {
+            set tgt_freq $freq_max
+        }
+    }
+
+    return $tgt_freq
+}
+
+
+##
+## Delete the file containing computed user clock frequencies.
+##
+proc delete_computed_user_clocks_file {} {
+    file delete "output_files/user_clock_freq.txt"
+}
+
+
+##
+## Save computed user clock frequencies to a file.
+##
+proc save_computed_user_clocks {uclk_freqs} {
+    set uclk_freq_low [lindex $uclk_freqs 0]
+    set uclk_freq_high [lindex $uclk_freqs 1]
+
+    post_message "Saved actual user clock high: $uclk_freq_high"
+    post_message "Saved actual user clock low: $uclk_freq_low"
+
+    set clkfile [open "output_files/user_clock_freq.txt" w]
+    puts $clkfile "# Generated by Platform Interface Manager user_clock_config.tcl"
+    puts $clkfile "afu-image/clock-frequency-low:${uclk_freq_low}"
+    puts $clkfile "afu-image/clock-frequency-high:${uclk_freq_high}"
+    close $clkfile
+}
+
+
+##
+## Load user clock frequencies that have already been computed following
+## place & route.  The script that computes them stores JSON update
+## requests in a file.
+##
+proc load_computed_user_clocks {freq_max} {
+    if {[file exists "output_files/user_clock_freq.txt"]} {
+        set fp [open "output_files/user_clock_freq.txt"]
+
+        # Contents of the file
+        set v [read $fp]
+        # Drop comments
+        set v [string trim [regsub -all -line {(^#.*$)} $v ""]]
+
+        # Drop most of the JSON field names, leaving just high:<freq>
+        # and low:<freq>.
+        set v [regsub -all {afu-image/clock-frequency-} $v ""]
+        set uclk_freqs_in [split $v]
+
+        # Sorting puts low/high in proper order
+        set uclk_freqs_in [lsort -ascii -decreasing $uclk_freqs_in]
+
+        # Extract just the numbers
+        set uclk_freqs [regsub -all {[\w]*:} $uclk_freqs_in ""]
+
+        # Clamp the high frequency clock to freq_max.  It may be out of
+        # bounds if only the low frequency clock is used.
+        if {[lindex $uclk_freqs 1] > $freq_max} {
+            lset uclk_freqs 1 $freq_max
+        }
+
+        if {[llength $uclk_freqs] != 2} {
+            error "output_files/user_clock_freq.txt should describe two clocks"
+        }
+        if {[lindex $uclk_freqs 0] > [lindex $uclk_freqs 1]} {
+            error "output_files/user_clock_freq.txt slow clock should be first"
+        }
+
+        return $uclk_freqs
+    }
+
+    # File not found
+    return [list]
+}
+
+
+##
+## Did the AFU JSON specify auto-frequency?
+##
+proc uclk_freq_is_auto {afu_json_uclk_freqs} {
+    set u_clk_auto 0
+
+    set i 0
+    while {$i < 2} {
+        # Is the requested clock frequency "auto"?
+        if {0 == [string compare -nocase -length 4 "auto" [lindex $afu_json_uclk_freqs $i]]} {
+            set u_clk_auto 1
+        }
+        incr i
+    }
+
+    return $u_clk_auto
+}
+
+
+##
+## Pick frequencies for aligned uClk_usr and uClk_usrDiv2 when given both the
+## AFU's JSON constraint and the actual, achieved, frequencies.  This function
+## is called after place and route and after the initial timing analysis.
+##
+proc uclk_pick_aligned_freqs {afu_json_uclk_freqs uclk_freqs_actual freq_max} {
+    # Get the user clock targets.  This includes parsing of "auto-<max>", where
+    # a maximum frequency is specified in the JSON.  Set FMax to 2 * freq_max in
+    # case only the div2 clock is in auto mode, in which case the primary clock
+    # is assumed not to be used.  The real FMax will eventually constrain the
+    # primary clock if it is used.
+    set uclk_tgts [get_aligned_user_clock_targets $afu_json_uclk_freqs [expr {2 * $freq_max}]]
+
+    set uclk_actual_low [lindex $uclk_freqs_actual 0]
+    set uclk_actual_high [lindex $uclk_freqs_actual 1]
+
+    set uclk_tgt_low [lindex $uclk_tgts 0]
+    set uclk_tgt_high [lindex $uclk_tgts 1]
+
+    if {0 == [string compare -nocase -length 4 "auto" [lindex $afu_json_uclk_freqs 1]]} {
+
+        # User clock high is in auto mode.  Ignore AFU JSON constraints on the low
+        # user clock.  The clock is also constrained by the achieved frequency of
+        # the low speed user clock.
+        post_message "User clock high is auto"
+        set uclk_freq_high [::tcl::mathfunc::min \
+                                $uclk_actual_high $uclk_tgt_high \
+                                [expr {2 * $uclk_actual_low}] \
+                                $freq_max]
+
+        # Round down because our user clock constraints support only one decimal
+        # point, which might be needed for the div2 clock.
+        set uclk_freq_high [expr {int(floor($uclk_freq_high))}]
+        set uclk_freq_low [expr ($uclk_freq_high / 2.0)]
+
+    } elseif {0 == [string compare -nocase -length 4 "auto" [lindex $afu_json_uclk_freqs 0]]} {
+
+        # User clock low is in auto mode and high is not.  Assume that the high clock
+        # is not used in the design and that user clock low may peak at FMax.
+        # This configuration may cause the two clocks to be unaligned, with the
+        # high clock hitting a maximum lower than 2x the low speed clock.
+        post_message "User clock low is auto and high is not.  Assuming high is unused."
+        set uclk_freq_low [::tcl::mathfunc::min $uclk_actual_low $uclk_tgt_low $freq_max]
+        set uclk_freq_low [expr {int(floor($uclk_freq_low))}]
+
+        # High clock must be set.  It may be higher than freq_max since it is assumed
+        # to be unused.  The user clock logic requires this in order to set the
+        # div2 clock correctly.
+        set uclk_freq_high [expr ($uclk_freq_low * 2)]
+
+    } else {
+        error "uclk_pick_aligned_freqs called but no user clocks are in auto mode."
+    }
+
+    return [list $uclk_freq_low $uclk_freq_high]
+}

--- a/tools/packager/afu_json_mgr.py
+++ b/tools/packager/afu_json_mgr.py
@@ -107,12 +107,15 @@ def flatten_json(subargs):
 
     entries = dict()
 
-    emit_types = (int, bool, str, float)
+    emit_types = (int, bool, str, unicode, float)
+    # Don't emit some keys.  For example, user clock frequency may not be
+    # known at compile time, so avoid emitting potentially false information.
+    skip_keys = ['clock-frequency-low', 'clock-frequency-high']
 
     # Flattan all entries in afu-image that are of type emit_types
     image = afu.afu_json['afu-image']
     for k in sorted(image.keys()):
-        if (isinstance(image[k], emit_types)):
+        if (isinstance(image[k], emit_types) and k not in skip_keys):
             tag = str(k).replace('-', '_')
             v = image[k]
             # Does it look like a number?

--- a/tools/packager/packager.py
+++ b/tools/packager/packager.py
@@ -113,6 +113,7 @@ def run_packager():
         gbs = GBS(subargs.input_gbs)
         afu = AFU.create_afu_from_gbs(gbs)
         afu.update_afu_json(subargs.set_value)
+        afu.validate(packaging=True)
         gbs.update_gbs_info(afu.afu_json)
         gbs_file = gbs.write_gbs(subargs.output_gbs)
         print("Wrote {0}".format(gbs_file))

--- a/tools/packager/schema/afu_schema_v01.json
+++ b/tools/packager/schema/afu_schema_v01.json
@@ -15,8 +15,12 @@
                     },
                     "required" : ["name"]
                 },
-                "clock-frequency-low" : {"type" : "number"},
-                "clock-frequency-high" : {"type" : "number"},
+                "clock-frequency-low" : {"type" : ["number", "string"],
+                                         "pattern" : "^auto(-[0-9.]+)?$"
+                                        },
+                "clock-frequency-high" : {"type" : ["number", "string"],
+                                          "pattern" : "^auto(-[0-9.]+)?$"
+                                         },
                 "power": {"type" : "number"},
                 "accelerator-clusters":  {
                     "type": "array",


### PR DESCRIPTION
- Update JSON schema to permit "auto" as a user clock frequency.
- Add a validation function to afu.py that runs as a GBS is written, beyond the base schema.
  New code checks that user clock frequency is a number at GBS write time.
- Improve the Python error message when jsonschema isn't present.
- Add Quartus Tcl functions to the platform interface with helper functions for
  managing user clock frequencies. These Tcl functions are pure Tcl (no Quartus),
  so they work as cross-platform library functions.