### PR TITLE
libopae: comply with new safe string checkers

### DIFF
--- a/common/include/safe_string/safe_string.h
+++ b/common/include/safe_string/safe_string.h
@@ -705,6 +705,7 @@ int snprintf_s_ss(char *dest, rsize_t dmax, const char *format, const char *s, c
 int snprintf_s_ii(char *dest, rsize_t dmax, const char *format, int a, int b);
 int sscanf_s_ii(const char *src, const char *format, int *a, int *b);
 int snprintf_s_si(char *dest, rsize_t dmax, const char *format, const char *s, int a);
+int snprintf_s_is(char *dest, rsize_t dmax, const char *format, int a, const char *s);
 int snprintf_s_sl(char *dest, rsize_t dmax, const char *format, const char *s, long a);
 int snprintf_s_il(char *dest, rsize_t dmax, const char *format, int a, long b);
 

--- a/libopae/src/enum.c
+++ b/libopae/src/enum.c
@@ -531,19 +531,19 @@ enum_top_dev(const char *sysfspath, struct dev_list *list)
 	// 0123456
 	// bb:dd.f
 	f = 0;
-	sscanf(p+6, "%d", &f);
+	sscanf_s_i(p+6, "%d", &f);
 
 	pdev->function = (uint8_t) f;
 	*(p + 5) = 0;
 
 	d = 0;
-	sscanf(p+3, "%x", &d);
+	sscanf_s_u(p+3, "%x", &d);
 
 	pdev->device = (uint8_t) d;
 	*(p + 2) = 0;
 
 	b = 0;
-	sscanf(p, "%x", &b);
+	sscanf_s_u(p, "%x", &b);
 
 	pdev->bus = (uint8_t) b;
 

--- a/libopae/src/sysfs.c
+++ b/libopae/src/sysfs.c
@@ -341,7 +341,7 @@ fpga_result sysfs_read_guid(const char *path, fpga_guid guid)
 		buf[i+2] = 0;
 
 		octet = 0;
-		sscanf(&buf[i], "%x", &octet);
+		sscanf_s_u(&buf[i], "%x", &octet);
 		guid[i/2] = (uint8_t) octet;
 
 		buf[i+2] = tmp;
@@ -533,9 +533,9 @@ fpga_result get_fpga_deviceid(fpga_handle handle,
 
 	device_id = atoi(p + 1);
 
-	snprintf(sysfs_path,
+	snprintf_s_is(sysfs_path,
 		 SYSFS_PATH_MAX,
-		 SYSFS_FPGA_CLASS_PATH SYSFS_FPGA_FMT"/%s",
+		 SYSFS_FPGA_CLASS_PATH SYSFS_FPGA_FMT "/%s",
 		 device_id,
 		 FPGA_SYSFS_DEVICEID);
 
@@ -580,9 +580,9 @@ fpga_result sysfs_deviceid_from_path(const char *sysfspath,
 
 	device_id = atoi(p + 1);
 
-	snprintf(sysfs_path,
+	snprintf_s_is(sysfs_path,
 		 SYSFS_PATH_MAX,
-		 SYSFS_FPGA_CLASS_PATH SYSFS_FPGA_FMT"/%s",
+		 SYSFS_FPGA_CLASS_PATH SYSFS_FPGA_FMT "/%s",
 		 device_id,
 		 FPGA_SYSFS_DEVICEID);
 
@@ -650,7 +650,7 @@ fpga_result sysfs_objectid_from_path(const char *sysfspath, uint64_t *object_id)
 	uint32_t minor = 0;
 	fpga_result result;
 
-	snprintf(sdevpath, SYSFS_PATH_MAX, "%s/dev", sysfspath);
+	snprintf_s_s(sdevpath, SYSFS_PATH_MAX, "%s/dev", sysfspath);
 
 	result = sysfs_read_u32_pair(sdevpath, &major, &minor, ':');
 	if (FPGA_OK != result)

--- a/safe_string/snprintf_support.c
+++ b/safe_string/snprintf_support.c
@@ -494,6 +494,39 @@ inline int snprintf_s_si(char *dest, rsize_t dmax, const char *format, const cha
 }
 
 
+
+inline int snprintf_s_is(char *dest, rsize_t dmax, const char *format, int a, const char *s)
+{
+	char pformatList[MAX_FORMAT_ELEMENTS];
+	unsigned int index = 0;
+
+	// Determine the number of format options in the format string
+	unsigned int  nfo = parse_format(format, &pformatList[0], MAX_FORMAT_ELEMENTS);
+
+	// Check that there are not too many format options
+	if ( nfo != 2 ) {
+		dest[0] = '\0';
+		return SNPRFNEGATE(ESBADFMT);
+	}
+
+	// Check first format is of integer type
+	if ( check_integer_format(pformatList[index]) == 0) {
+		dest[0] = '\0';
+		return SNPRFNEGATE(ESFMTTYP);
+	}
+	index++;
+
+	// Check that the format is for a string type
+	if ( CHK_FORMAT(FMT_STRING, pformatList[index]) == 0) {
+		dest[0] = '\0';
+		return SNPRFNEGATE(ESFMTTYP);
+	}
+
+	return snprintf(dest, dmax, format, a, s);
+}
+
+
+
 inline int snprintf_s_sl(char *dest, rsize_t dmax, const char *format, const char *s, long a)
 {
 	char pformatList[MAX_FORMAT_ELEMENTS];


### PR DESCRIPTION
Fixes instances of snprintf and sscanf in libopae.