### PR TITLE
Link against librt when building dma tool in BIST (#299)

### DIFF
--- a/tools/fpgabist/dma/CMakeLists.txt
+++ b/tools/fpgabist/dma/CMakeLists.txt
@@ -30,7 +30,7 @@ file(GLOB CSources *.c)
 add_executable(fpga_dma_test ${CSources})
 set_install_rpath(fpga_dma_test)
 
-target_link_libraries(fpga_dma_test opae-c json-c uuid ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(fpga_dma_test opae-c json-c uuid rt ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS fpga_dma_test
         RUNTIME DESTINATION bin


### PR DESCRIPTION
Cherrypick: The DMA tool in BIST needs to link against librt

