### PR TITLE
Accept all Platform Interface Manager platform names in ASE configuration

### DIFF
--- a/platforms/platform_db/README.md
+++ b/platforms/platform_db/README.md
@@ -34,6 +34,10 @@ Each JSON database is a dictionary, supporting the following keys:
   merged.  The parent's entry is removed and replaced with the child's
   entry.
 
+- **ase-platform**: String [required]
+
+  The name of the ASE platform that simulates the physical platform.
+
 - **module-arguments-offered**: List [required]
 
   The set of arguments offered by the platform to AFUs.  Entries in the

--- a/platforms/platform_db/discrete_pcie3.json
+++ b/platforms/platform_db/discrete_pcie3.json
@@ -2,6 +2,7 @@
    "version": 1,
    "platform-name": "discrete_pcie3",
    "description": "First generation CCI-P-based discrete PCIe Gen3 cards",
+   "ase-platform": "discrete",
    "comment":
       [
          "The platform offers local memory, which can be connected to the AFU",

--- a/platforms/platform_db/intg_xeon.json
+++ b/platforms/platform_db/intg_xeon.json
@@ -2,6 +2,7 @@
    "version": 1,
    "platform-name": "intg_xeon",
    "description": "Integrated Xeon + Arria 10 with QPI/UPI and two PCIe host channels",
+   "ase-platform": "intg_xeon",
    "module-arguments-offered" :
       [
          {

--- a/platforms/scripts/afu_platform_config
+++ b/platforms/scripts/afu_platform_config
@@ -372,6 +372,24 @@ def emitSimConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
     f.write("-F {0}/sim/platform_if_includes.txt\n".format(args.platform_if))
     f.close()
 
+    #
+    # ase_platform_name.txt holds the name of the corresponding ASE platform.
+    #
+    fn = os.path.join(f_prefix, "ase_platform_name.txt")
+    if (not args.quiet):
+        print("Writing {0}".format(fn))
+
+    try:
+        f = open(fn, "w")
+        f.write(platform_db['ase-platform'] + '\n')
+    except KeyError:
+        errorExit("Platform {0} does not define ase-platform".format(
+            platform_db['file_path']))
+    except Exception:
+        errorExit("failed to open {0} for writing.".format(fn))
+
+    f.close()
+
 
 #
 # Walk the AFU's module-argments requirements and look for corresponding


### PR DESCRIPTION
- Add mapping from physical platform name to ASE platforms in platform db.
- afu_platform_config writes ASE platform name to a file.
- Add the ability to set the default physical platform name in ASE using
  an environment variable (OPAE_ASE_DEFAULT_PLATFORM).