### PR TITLE
libopae: rename local variable device_id

### DIFF
--- a/libopae/src/enum.c
+++ b/libopae/src/enum.c
@@ -87,7 +87,7 @@ matches_filter(const struct dev_list *attr, const fpga_properties filter)
 			(struct _fpga_token *) _filter->parent;
 		char spath[SYSFS_PATH_MAX];
 		char *p;
-		int device_id;
+		int device_instance;
 
 		if (FPGA_ACCELERATOR != attr->objtype) {
 			res = false; // Only accelerator can have a parent
@@ -106,12 +106,12 @@ matches_filter(const struct dev_list *attr, const fpga_properties filter)
 			goto out_unlock;
 		}
 
-		device_id = (int) strtoul(p+1, NULL, 10);
+		device_instance = (int) strtoul(p+1, NULL, 10);
 
 		snprintf_s_ii(spath, SYSFS_PATH_MAX,
 				SYSFS_FPGA_CLASS_PATH
 				SYSFS_FME_PATH_FMT,
-				device_id, device_id);
+				device_instance, device_instance);
 
 		if (strcmp(spath, ((struct _fpga_token *)
 						_filter->parent)->sysfspath)) {

--- a/libopae/src/properties.c
+++ b/libopae/src/properties.c
@@ -212,7 +212,7 @@ fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 	char spath[SYSFS_PATH_MAX];
 	char *p;
 	int b, d, f;
-	int device_id;
+	int device_instance;
 	int res;
 	errno_t e;
 	int err = 0;
@@ -256,12 +256,12 @@ fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 	p = strrchr(spath, '.');
 	ASSERT_NOT_NULL_MSG(p, "Invalid token sysfs path");
 
-	device_id = atoi(p+1);
+	device_instance = atoi(p+1);
 
 	p = strstr(_token->sysfspath, FPGA_SYSFS_AFU);
 	if (NULL != p) {
 		// AFU
-		result = sysfs_get_afu_id(device_id, _iprop.guid);
+		result = sysfs_get_afu_id(device_instance, _iprop.guid);
 		if (FPGA_OK != result)
 			return result;
 		SET_FIELD_VALID(&_iprop, FPGA_PROPERTY_GUID);
@@ -295,17 +295,17 @@ fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 		_iprop.objtype = FPGA_DEVICE;
 		SET_FIELD_VALID(&_iprop, FPGA_PROPERTY_OBJTYPE);
 		// get bitstream id
-		result = sysfs_get_pr_id(device_id, _iprop.guid);
+		result = sysfs_get_pr_id(device_instance, _iprop.guid);
 		if (FPGA_OK != result)
 			return result;
 		SET_FIELD_VALID(&_iprop, FPGA_PROPERTY_GUID);
 
-		result = sysfs_get_slots(device_id, &_iprop.u.fpga.num_slots);
+		result = sysfs_get_slots(device_instance, &_iprop.u.fpga.num_slots);
 		if (FPGA_OK != result)
 			return result;
 		SET_FIELD_VALID(&_iprop, FPGA_PROPERTY_NUM_SLOTS);
 
-		result = sysfs_get_bitstream_id(device_id, &_iprop.u.fpga.bbs_id);
+		result = sysfs_get_bitstream_id(device_instance, &_iprop.u.fpga.bbs_id);
 		if (FPGA_OK != result)
 			return result;
 		SET_FIELD_VALID(&_iprop, FPGA_PROPERTY_BBSID);
@@ -333,7 +333,7 @@ fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 	SET_FIELD_VALID(&_iprop, FPGA_PROPERTY_FUNCTION);
 
 	// only set socket id if we have it on sysfs
-	result = sysfs_get_socket_id(device_id, &_iprop.socket_id);
+	result = sysfs_get_socket_id(device_instance, &_iprop.socket_id);
 	if (0 == result)
 		SET_FIELD_VALID(&_iprop, FPGA_PROPERTY_SOCKETID);
 

--- a/libopae/src/sysfs.c
+++ b/libopae/src/sysfs.c
@@ -445,7 +445,7 @@ fpga_result get_port_sysfs(fpga_handle handle,
 	struct _fpga_token  *_token;
 	struct _fpga_handle *_handle  = (struct _fpga_handle *)handle;
 	char *p                       = 0;
-	int device_id                 = 0;
+	int device_instance           = 0;
 
 	if (sysfs_port == NULL) {
 		FPGA_ERR("Invalid output pointer");
@@ -474,11 +474,11 @@ fpga_result get_port_sysfs(fpga_handle handle,
 		return FPGA_INVALID_PARAM;
 	}
 
-	device_id = atoi(p + 1);
+	device_instance = atoi(p + 1);
 
 	snprintf_s_ii(sysfs_port, SYSFS_PATH_MAX,
 		SYSFS_FPGA_CLASS_PATH SYSFS_AFU_PATH_FMT,
-		device_id, device_id);
+		device_instance, device_instance);
 
 	return FPGA_OK;
 }
@@ -491,7 +491,7 @@ fpga_result get_fpga_deviceid(fpga_handle handle,
 	struct _fpga_handle  *_handle    = (struct _fpga_handle *)handle;
 	char sysfs_path[SYSFS_PATH_MAX]  = {0};
 	char *p                          = NULL;
-	int device_id                    = 0;
+	int device_instance              = 0;
 	fpga_result result               = FPGA_OK;
 	int err                          = 0;
 
@@ -531,12 +531,12 @@ fpga_result get_fpga_deviceid(fpga_handle handle,
 		goto out_unlock;
 	}
 
-	device_id = atoi(p + 1);
+	device_instance = atoi(p + 1);
 
 	snprintf(sysfs_path,
 		 SYSFS_PATH_MAX,
 		 SYSFS_FPGA_CLASS_PATH SYSFS_FPGA_FMT"/%s",
-		 device_id,
+		 device_instance,
 		 FPGA_SYSFS_DEVICEID);
 
 	result = sysfs_read_u64(sysfs_path, deviceid);
@@ -558,7 +558,7 @@ fpga_result sysfs_deviceid_from_path(const char *sysfspath,
 {
 	char sysfs_path[SYSFS_PATH_MAX]  = {0};
 	char *p                          = NULL;
-	int device_id                    = 0;
+	int device_instance              = 0;
 	fpga_result result               = FPGA_OK;
 
 	if (deviceid == NULL) {
@@ -578,12 +578,12 @@ fpga_result sysfs_deviceid_from_path(const char *sysfspath,
 		return FPGA_NOT_SUPPORTED;
 	}
 
-	device_id = atoi(p + 1);
+	device_instance = atoi(p + 1);
 
 	snprintf(sysfs_path,
 		 SYSFS_PATH_MAX,
 		 SYSFS_FPGA_CLASS_PATH SYSFS_FPGA_FMT"/%s",
-		 device_id,
+		 device_instance,
 		 FPGA_SYSFS_DEVICEID);
 
 	result = sysfs_read_u64(sysfs_path, deviceid);

--- a/libopae/src/token_list.c
+++ b/libopae/src/token_list.c
@@ -133,7 +133,7 @@ struct _fpga_token *token_get_parent(struct _fpga_token *_t)
 {
 	char *p;
 	char spath[SYSFS_PATH_MAX];
-	int device_id;
+	int device_instance;
 	struct token_map *itr;
 	int err = 0;
 
@@ -145,11 +145,11 @@ struct _fpga_token *token_get_parent(struct _fpga_token *_t)
 	if (!p)
 		return NULL;
 
-	device_id = atoi(p+1);
+	device_instance = atoi(p+1);
 
 	snprintf_s_ii(spath, sizeof(spath),
 			SYSFS_FPGA_CLASS_PATH SYSFS_FME_PATH_FMT,
-			device_id, device_id);
+			device_instance, device_instance);
 
 	if (pthread_mutex_lock(&global_lock)) {
 		FPGA_MSG("Failed to lock global mutex");


### PR DESCRIPTION
Rename erroneous instances of device_id to device_instance for clarity.
The variables track an instance of the fpga device, not to be confused
with the PCIe DID field of the device.