### PR TITLE
Bist behavior Run only one card

### DIFF
--- a/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_dc_fifo.sv
+++ b/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_dc_fifo.sv
@@ -1,14 +1,32 @@
-// (C) 2001-2016 Altera Corporation. All rights reserved.
-// Your use of Altera Corporation's design tools, logic functions and other 
-// software and tools, and its AMPP partner logic functions, and any output 
-// files any of the foregoing (including device programming or simulation 
-// files), and any associated documentation or information are expressly subject 
-// to the terms and conditions of the Altera Program License Subscription 
-// Agreement, Altera MegaCore Function License Agreement, or other applicable 
-// license agreement, including, without limitation, that your use is for the 
-// sole purpose of programming logic devices manufactured by Altera and sold by 
-// Altera or its authorized distributors.  Please refer to the applicable 
-// agreement for further details.
+//
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// Neither the name of the Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software
+// without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 
 //

--- a/tools/fpgabist/fpgabist
+++ b/tools/fpgabist/fpgabist
@@ -34,49 +34,46 @@ import bist_common
 import bist_nlb3
 import bist_dma
 
-FEATURES = ['fme', 'port', 'temp', 'errors all']
+FEATURES = ['fme', 'port', 'temp', 'power', 'errors all']
 
 
 def main(args):
-    # TODO: Add total number of cards in system this acts a check for
-    if not vars(args)['bus'] and not vars(args)['device'] and \
-            not vars(args)['function']:
-        bdfs = bist_common.get_all_fpga_bdfs()
+    bdf = bist_common.get_all_fpga_bdfs()
+    if not bdf:
+        sys.exit("No FPGA devices found")
+    elif len(bdf) > 1 and not any([args.bus, args.device, args.function]):
+        sys.exit("Multiple cards found. Specify a bus, device or function")
     else:
-        bdfs = bist_common.get_bdf_from_args(args)
-
+        bdf = bist_common.get_bdf_from_args(args)
+        if len(bdf) > 1 or not bdf:
+            sys.exit("Could not find fpga, please try again")
+    bdf = bdf[0]
     start = "==========================================================\n\n" \
             "Beginning FPGA Built-In Self-Test\n\n"\
             "=========================================================="
     print start
-    print " This system has found {} physical device(s)\n".format(len(bdfs))
-    if len(bdfs) == 0:
-        print "No FPGA devices found"
-        sys.exit()
 
     # TODO: Add Opae version information
-    for bdf in bdfs:
-        print "Device: bus = {}, device = {}, func = {}".format(
-                bdf['bus'], bdf['device'], bdf['function'])
+    print "Device: bus = {}, device = {}, func = {}".format(
+            bdf['bus'], bdf['device'], bdf['function'])
 
-        # Display data from FPGA info
-        for feat in FEATURES:
-            cmd = "fpgainfo {} -b {}".format(feat, bdf['bus'])
-            subprocess.call(cmd, shell=True)
+    # Display data from FPGA info
+    for feature in FEATURES:
+        cmd = "fpgainfo {} -b {}".format(feature, bdf['bus'])
+        subprocess.call(cmd, shell=True)
 
-        gbs_paths = args.gbs_paths
-        for path in gbs_paths:
-            mode_name = bist_common.get_mode_from_path(path)
-            if mode_name == 'nlb_mode_3':
-                mode = bist_nlb3.Nlb3Mode()
-            elif mode_name == "dma_afu":
-                mode = bist_dma.DmaMode()
-            else:
-                print "Unknown AFU for available BIST Modes: {}\n".format(path)
-                # TODO: Print currently supported AFUs
-                sys.exit()
-            print "Running mode: {}".format(mode.name)
-            mode.run(path, bdf['bus'])
+    gbs_paths = args.gbs_paths
+    for path in gbs_paths:
+        mode_name = bist_common.get_mode_from_path(path)
+        if mode_name == 'nlb_mode_3':
+            mode = bist_nlb3.Nlb3Mode()
+        elif mode_name == "dma_afu":
+            mode = bist_dma.DmaMode()
+        else:
+            print "Unknown AFU for available BIST Modes: {}\n".format(path)
+            sys.exit()
+        print "Running mode: {}".format(mode.name)
+        mode.run(path, bdf['bus'])
 
     print "\nBuilt-in Self-Test Completed.\n"
 

--- a/tools/fpgabist/fpgabist
+++ b/tools/fpgabist/fpgabist
@@ -70,8 +70,7 @@ def main(args):
         elif mode_name == "dma_afu":
             mode = bist_dma.DmaMode()
         else:
-            print "Unknown AFU for available BIST Modes: {}\n".format(path)
-            sys.exit()
+            sys.exit("Unknown AFU for available BIST Modes: {}\n".format(path))
         print "Running mode: {}".format(mode.name)
         mode.run(path, bdf['bus'])
 


### PR DESCRIPTION
For systems with multiple card must provide a bdf using the 'b', 'd' or 'f' flags.
When there is only one card on the system the tool will default to running on the only available fpga.