### PR TITLE
Tests: Rename test case names

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,7 +153,7 @@ target_link_libraries(mock dl safestr)
 
 add_test(NAME test_open_common_mock_drv
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  COMMAND gtapi  ${CMAKE_BINARY_DIR} --gtest_filter="*drv*:-*event_drv_05*:-*nodrv*")
+  COMMAND gtapi  ${CMAKE_BINARY_DIR} --gtest_filter="*MOCK*:-*event_drv_05*:-*nodrv*")
 
 set_tests_properties(
   test_open_common_mock_drv

--- a/tests/function/gtBuffer.cpp
+++ b/tests/function/gtBuffer.cpp
@@ -45,7 +45,7 @@ must be express and approved by Intel in writing.
 using namespace std;
 using namespace common_test;
 
-class LibopaecBufFCommonHW : public BaseFixture, public ::testing::Test {
+class LibopaecBufFCommonMOCK : public BaseFixture, public ::testing::Test {
  public:
   static const uint64_t len_min = 1024;
   static const uint64_t len_max = 4 * 1024;
@@ -84,7 +84,7 @@ TEST(LibopaecBufCommonALL, NoPrep01) {
  *             fpgaReleaseBuffer must fail if invalid wsid is passed
  *
  */
-TEST(LibopaecBufCommonHW, InvalidWSID01) {
+TEST(LibopaecBufCommonMOCK, InvalidWSID01) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h;
@@ -119,7 +119,7 @@ TEST(LibopaecBufCommonHW, InvalidWSID01) {
  *             fpgaReleaseBuffer must release a shared memory buffer.
  *
  */
-TEST(LibopaecBufCommonHW, PrepRel4K01) {
+TEST(LibopaecBufCommonMOCK, PrepRel4K01) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h;
@@ -383,7 +383,7 @@ TEST(LibopaecBufCommonALL, WriteRead01) {
  *             release a shared memory buffer.
  *
  */
-TEST(LibopaecBufCommonHW, PrepPre2MB01) {
+TEST(LibopaecBufCommonMOCK, PrepPre2MB01) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h;

--- a/tests/function/gtBuffer.cpp
+++ b/tests/function/gtBuffer.cpp
@@ -84,7 +84,7 @@ TEST(LibopaecBufCommonALL, NoPrep01) {
  *             fpgaReleaseBuffer must fail if invalid wsid is passed
  *
  */
-TEST(LibopaecBufCommonMOCK, InvalidWSID01) {
+TEST(LibopaecBufCommonMOCKHW, InvalidWSID01) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h;
@@ -119,7 +119,7 @@ TEST(LibopaecBufCommonMOCK, InvalidWSID01) {
  *             fpgaReleaseBuffer must release a shared memory buffer.
  *
  */
-TEST(LibopaecBufCommonMOCK, PrepRel4K01) {
+TEST(LibopaecBufCommonMOCKHW, PrepRel4K01) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h;
@@ -383,7 +383,7 @@ TEST(LibopaecBufCommonALL, WriteRead01) {
  *             release a shared memory buffer.
  *
  */
-TEST(LibopaecBufCommonMOCK, PrepPre2MB01) {
+TEST(LibopaecBufCommonMOCKHW, PrepPre2MB01) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h;

--- a/tests/function/gtEnumerate.cpp
+++ b/tests/function/gtEnumerate.cpp
@@ -34,7 +34,7 @@ must be express and approved by Intel in writing.
 
 using namespace common_test;
 
-class LibopaecEnumerateFCommonMOCK : public BaseFixture, public ::testing::Test {
+class LibopaecEnumerateFCommonMOCKHW : public BaseFixture, public ::testing::Test {
  protected:
   virtual void SetUp() {
     m_Properties = NULL;
@@ -312,7 +312,7 @@ TEST_F(LibopaecEnumFCommonALL, 08) {
  * @brief      fpgaEnumerate allows filtering by device object type
  *             (FPGA_ACCELERATOR).
  */
-TEST_F(LibopaecEnumerateFCommonMOCK, 09) {
+TEST_F(LibopaecEnumerateFCommonMOCKHW, 09) {
   EXPECT_EQ(FPGA_OK,
             fpgaPropertiesSetObjectType(m_Properties, FPGA_ACCELERATOR));
 
@@ -349,7 +349,7 @@ TEST_F(LibopaecEnumerateFCommonMOCK, 09) {
  * @brief      fpgaEnumerate allows filtering by device object type
  *             (FPGA_DEVICE).
  */
-TEST_F(LibopaecEnumerateFCommonMOCK, 10) {
+TEST_F(LibopaecEnumerateFCommonMOCKHW, 10) {
   EXPECT_EQ(FPGA_OK, fpgaPropertiesSetObjectType(m_Properties, FPGA_DEVICE));
 
   EXPECT_EQ(FPGA_OK, fpgaEnumerate(&m_Properties, 1, NULL, 0, &m_NumMatches));

--- a/tests/function/gtEnumerate.cpp
+++ b/tests/function/gtEnumerate.cpp
@@ -34,7 +34,7 @@ must be express and approved by Intel in writing.
 
 using namespace common_test;
 
-class LibopaecEnumerateFCommonMOCKHW : public BaseFixture, public ::testing::Test {
+class LibopaecEnumFCommonMOCKHW : public BaseFixture, public ::testing::Test {
  protected:
   virtual void SetUp() {
     m_Properties = NULL;
@@ -88,7 +88,7 @@ protected:
  * @brief      When the num_match parameter to fpgaEnumerate is NULL,
  *             the function returns FPGA_INVALID_PARAM.
  */
-TEST(LibopaecEnumerateCommonALL, 01) {
+TEST(LibopaecEnumCommonALL, 01) {
   fpga_properties prop;
   fpga_token tok;
 
@@ -102,7 +102,7 @@ TEST(LibopaecEnumerateCommonALL, 01) {
  *             than zero, but the tokens parameter is NULL, the function
  *             returns FPGA_INVALID_PARAM.
  */
-TEST(LibopaecEnumerateCommonALL, 02) {
+TEST(LibopaecEnumCommonALL, 02) {
   fpga_properties prop;
   uint32_t nummatch;
 
@@ -116,7 +116,7 @@ TEST(LibopaecEnumerateCommonALL, 02) {
  *             than zero, but the filter parameter is NULL, the function
  *             returns FPGA_INVALID_PARAM.
  */
-TEST(LibopaecEnumerateCommonALL, 03) {
+TEST(LibopaecEnumCommonALL, 03) {
   fpga_token tok;
   uint32_t nummatch;
 
@@ -130,7 +130,7 @@ TEST(LibopaecEnumerateCommonALL, 03) {
  *             but the filter parameter is non-NULL, the function
  *             returns FPGA_INVALID_PARAM.
  */
-TEST(LibopaecEnumerateCommonALL, 23) {
+TEST(LibopaecEnumCommonALL, 23) {
   fpga_properties prop;
   fpga_token tok;
   uint32_t nummatch;
@@ -147,7 +147,7 @@ TEST(LibopaecEnumerateCommonALL, 23) {
  *             system into the memory pointed to by num_matches, and
  *             returns FPGA_OK.
  */
-TEST(LibopaecEnumerateCommonALL, 04) {
+TEST(LibopaecEnumCommonALL, 04) {
   uint32_t nummatch;
 
   EXPECT_EQ(FPGA_OK, fpgaEnumerate(NULL, 0, NULL, 0, &nummatch));
@@ -162,7 +162,7 @@ TEST(LibopaecEnumerateCommonALL, 04) {
  *             limiting the number of output entries written to the
  *             memory at match, even though more may exist.
  */
-TEST(LibopaecEnumerateCommonALL, 05) {
+TEST(LibopaecEnumCommonALL, 05) {
   uint32_t nummatch;
   fpga_token match[3] = {NULL, NULL, NULL};
 
@@ -185,7 +185,7 @@ TEST(LibopaecEnumerateCommonALL, 05) {
  * @brief      fpgaEnumerate honors a "don't care" properties filter by
  *             returning all available tokens.
  */
-TEST(LibopaecEnumerateCommonALL, 06) {
+TEST(LibopaecEnumCommonALL, 06) {
   uint32_t nummatch;
   fpga_properties props;
 
@@ -312,7 +312,7 @@ TEST_F(LibopaecEnumFCommonALL, 08) {
  * @brief      fpgaEnumerate allows filtering by device object type
  *             (FPGA_ACCELERATOR).
  */
-TEST_F(LibopaecEnumerateFCommonMOCKHW, 09) {
+TEST_F(LibopaecEnumFCommonMOCKHW, 09) {
   EXPECT_EQ(FPGA_OK,
             fpgaPropertiesSetObjectType(m_Properties, FPGA_ACCELERATOR));
 
@@ -349,7 +349,7 @@ TEST_F(LibopaecEnumerateFCommonMOCKHW, 09) {
  * @brief      fpgaEnumerate allows filtering by device object type
  *             (FPGA_DEVICE).
  */
-TEST_F(LibopaecEnumerateFCommonMOCKHW, 10) {
+TEST_F(LibopaecEnumFCommonMOCKHW, 10) {
   EXPECT_EQ(FPGA_OK, fpgaPropertiesSetObjectType(m_Properties, FPGA_DEVICE));
 
   EXPECT_EQ(FPGA_OK, fpgaEnumerate(&m_Properties, 1, NULL, 0, &m_NumMatches));
@@ -728,7 +728,7 @@ TEST_F(LibopaecEnumFCommonALL, 19) {
  *             and the cloned token is equal to the original.
  *
  */
-TEST(LibopaecEnumerateCommonALL, enum_drv_020) {
+TEST(LibopaecEnumCommonALL, enum_drv_020) {
   fpga_properties props;
   uint32_t nummatch;
   fpga_token clone;
@@ -845,7 +845,7 @@ TEST_F(LibopaecEnumFCommonALL, DISABLED_enum_drv_021) {
  *             the result is FPGA_OK
  *
  */
-TEST(LibopaecEnumerateCommonALL, enum_drv_022) {
+TEST(LibopaecEnumCommonALL, enum_drv_022) {
   fpga_properties prop;
   fpga_guid guid;
   fpga_token tok;

--- a/tests/function/gtEnumerate.cpp
+++ b/tests/function/gtEnumerate.cpp
@@ -34,7 +34,7 @@ must be express and approved by Intel in writing.
 
 using namespace common_test;
 
-class LibopaecEnumFCommonHW : public BaseFixture, public ::testing::Test {
+class LibopaecEnumerateFCommonMOCK : public BaseFixture, public ::testing::Test {
  protected:
   virtual void SetUp() {
     m_Properties = NULL;
@@ -88,7 +88,7 @@ protected:
  * @brief      When the num_match parameter to fpgaEnumerate is NULL,
  *             the function returns FPGA_INVALID_PARAM.
  */
-TEST(LibopaecEnumCommonALL, 01) {
+TEST(LibopaecEnumerateCommonALL, 01) {
   fpga_properties prop;
   fpga_token tok;
 
@@ -102,7 +102,7 @@ TEST(LibopaecEnumCommonALL, 01) {
  *             than zero, but the tokens parameter is NULL, the function
  *             returns FPGA_INVALID_PARAM.
  */
-TEST(LibopaecEnumCommonALL, 02) {
+TEST(LibopaecEnumerateCommonALL, 02) {
   fpga_properties prop;
   uint32_t nummatch;
 
@@ -116,7 +116,7 @@ TEST(LibopaecEnumCommonALL, 02) {
  *             than zero, but the filter parameter is NULL, the function
  *             returns FPGA_INVALID_PARAM.
  */
-TEST(LibopaecEnumCommonALL, 03) {
+TEST(LibopaecEnumerateCommonALL, 03) {
   fpga_token tok;
   uint32_t nummatch;
 
@@ -130,7 +130,7 @@ TEST(LibopaecEnumCommonALL, 03) {
  *             but the filter parameter is non-NULL, the function
  *             returns FPGA_INVALID_PARAM.
  */
-TEST(LibopaecEnumCommonALL, 23) {
+TEST(LibopaecEnumerateCommonALL, 23) {
   fpga_properties prop;
   fpga_token tok;
   uint32_t nummatch;
@@ -147,7 +147,7 @@ TEST(LibopaecEnumCommonALL, 23) {
  *             system into the memory pointed to by num_matches, and
  *             returns FPGA_OK.
  */
-TEST(LibopaecEnumCommonALL, 04) {
+TEST(LibopaecEnumerateCommonALL, 04) {
   uint32_t nummatch;
 
   EXPECT_EQ(FPGA_OK, fpgaEnumerate(NULL, 0, NULL, 0, &nummatch));
@@ -162,7 +162,7 @@ TEST(LibopaecEnumCommonALL, 04) {
  *             limiting the number of output entries written to the
  *             memory at match, even though more may exist.
  */
-TEST(LibopaecEnumCommonALL, 05) {
+TEST(LibopaecEnumerateCommonALL, 05) {
   uint32_t nummatch;
   fpga_token match[3] = {NULL, NULL, NULL};
 
@@ -185,7 +185,7 @@ TEST(LibopaecEnumCommonALL, 05) {
  * @brief      fpgaEnumerate honors a "don't care" properties filter by
  *             returning all available tokens.
  */
-TEST(LibopaecEnumCommonALL, 06) {
+TEST(LibopaecEnumerateCommonALL, 06) {
   uint32_t nummatch;
   fpga_properties props;
 
@@ -312,7 +312,7 @@ TEST_F(LibopaecEnumFCommonALL, 08) {
  * @brief      fpgaEnumerate allows filtering by device object type
  *             (FPGA_ACCELERATOR).
  */
-TEST_F(LibopaecEnumFCommonHW, 09) {
+TEST_F(LibopaecEnumerateFCommonMOCK, 09) {
   EXPECT_EQ(FPGA_OK,
             fpgaPropertiesSetObjectType(m_Properties, FPGA_ACCELERATOR));
 
@@ -349,7 +349,7 @@ TEST_F(LibopaecEnumFCommonHW, 09) {
  * @brief      fpgaEnumerate allows filtering by device object type
  *             (FPGA_DEVICE).
  */
-TEST_F(LibopaecEnumFCommonHW, 10) {
+TEST_F(LibopaecEnumerateFCommonMOCK, 10) {
   EXPECT_EQ(FPGA_OK, fpgaPropertiesSetObjectType(m_Properties, FPGA_DEVICE));
 
   EXPECT_EQ(FPGA_OK, fpgaEnumerate(&m_Properties, 1, NULL, 0, &m_NumMatches));
@@ -728,7 +728,7 @@ TEST_F(LibopaecEnumFCommonALL, 19) {
  *             and the cloned token is equal to the original.
  *
  */
-TEST(LibopaecEnumCommonALL, enum_drv_020) {
+TEST(LibopaecEnumerateCommonALL, enum_drv_020) {
   fpga_properties props;
   uint32_t nummatch;
   fpga_token clone;
@@ -845,7 +845,7 @@ TEST_F(LibopaecEnumFCommonALL, DISABLED_enum_drv_021) {
  *             the result is FPGA_OK
  *
  */
-TEST(LibopaecEnumCommonALL, enum_drv_022) {
+TEST(LibopaecEnumerateCommonALL, enum_drv_022) {
   fpga_properties prop;
   fpga_guid guid;
   fpga_token tok;

--- a/tests/function/gtEvent.cpp
+++ b/tests/function/gtEvent.cpp
@@ -35,7 +35,7 @@ must be express and approved by Intel in writing.
 using namespace common_test;
 using namespace std;
 
-class LibopaecEventFCommonMOCK : public BaseFixture, public ::testing::Test {
+class LibopaecEventFCommonMOCKHW : public BaseFixture, public ::testing::Test {
  protected:
   virtual void SetUp() {
     m_AFUHandle = NULL;
@@ -79,7 +79,7 @@ class LibopaecEventFCommonMOCK : public BaseFixture, public ::testing::Test {
  *             FPGA_INVALID_PARAM.
  *
  */
-TEST(LibopaecEventCommonMOCK, event_01) {
+TEST(LibopaecEventCommonMOCKHW, event_01) {
   EXPECT_EQ(FPGA_INVALID_PARAM, fpgaCreateEventHandle(NULL));
 }
 
@@ -91,7 +91,7 @@ TEST(LibopaecEventCommonMOCK, event_01) {
  *             FPGA_INVALID_PARAM.
  *
  */
-TEST(LibopaecEventCommonMOCK, event_02) {
+TEST(LibopaecEventCommonMOCKHW, event_02) {
   EXPECT_EQ(FPGA_INVALID_PARAM, fpgaDestroyEventHandle(NULL));
 }
 
@@ -106,7 +106,7 @@ TEST(LibopaecEventCommonMOCK, event_02) {
  *             FPGA_INVALID_PARAM.
  *
  */
-TEST(LibopaecEventCommonMOCK, event_03) {
+TEST(LibopaecEventCommonMOCKHW, event_03) {
   fpga_event_type e = FPGA_EVENT_ERROR;
   fpga_event_handle eh;
 
@@ -150,7 +150,7 @@ TEST(LibopaecEventCommonMOCK, event_03) {
  *             FPGA_INVALID_PARAM.
  *
  */
-TEST(LibopaecEventCommonMOCK, event_04) {
+TEST(LibopaecEventCommonMOCKHW, event_04) {
   fpga_event_type e = FPGA_EVENT_ERROR;
   fpga_event_handle eh;
 
@@ -187,7 +187,7 @@ TEST(LibopaecEventCommonMOCK, event_04) {
  * @brief      Test registration and unregistration of events.
  *
  */
-TEST_F(LibopaecEventFCommonMOCK, event_drv_05) {
+TEST_F(LibopaecEventFCommonMOCKHW, event_drv_05) {
   EXPECT_EQ(FPGA_OK, fpgaRegisterEvent(m_AFUHandle, FPGA_EVENT_INTERRUPT,
                                        m_EventHandles[0], 0));
 

--- a/tests/function/gtEvent.cpp
+++ b/tests/function/gtEvent.cpp
@@ -35,7 +35,7 @@ must be express and approved by Intel in writing.
 using namespace common_test;
 using namespace std;
 
-class LibopaecEventFCommonHW : public BaseFixture, public ::testing::Test {
+class LibopaecEventFCommonMOCK : public BaseFixture, public ::testing::Test {
  protected:
   virtual void SetUp() {
     m_AFUHandle = NULL;
@@ -79,7 +79,7 @@ class LibopaecEventFCommonHW : public BaseFixture, public ::testing::Test {
  *             FPGA_INVALID_PARAM.
  *
  */
-TEST(LibopaecEventCommonHW, event_01) {
+TEST(LibopaecEventCommonMOCK, event_01) {
   EXPECT_EQ(FPGA_INVALID_PARAM, fpgaCreateEventHandle(NULL));
 }
 
@@ -91,7 +91,7 @@ TEST(LibopaecEventCommonHW, event_01) {
  *             FPGA_INVALID_PARAM.
  *
  */
-TEST(LibopaecEventCommonHW, event_02) {
+TEST(LibopaecEventCommonMOCK, event_02) {
   EXPECT_EQ(FPGA_INVALID_PARAM, fpgaDestroyEventHandle(NULL));
 }
 
@@ -106,7 +106,7 @@ TEST(LibopaecEventCommonHW, event_02) {
  *             FPGA_INVALID_PARAM.
  *
  */
-TEST(LibopaecEventCommonHW, event_03) {
+TEST(LibopaecEventCommonMOCK, event_03) {
   fpga_event_type e = FPGA_EVENT_ERROR;
   fpga_event_handle eh;
 
@@ -150,7 +150,7 @@ TEST(LibopaecEventCommonHW, event_03) {
  *             FPGA_INVALID_PARAM.
  *
  */
-TEST(LibopaecEventCommonHW, event_04) {
+TEST(LibopaecEventCommonMOCK, event_04) {
   fpga_event_type e = FPGA_EVENT_ERROR;
   fpga_event_handle eh;
 
@@ -187,7 +187,7 @@ TEST(LibopaecEventCommonHW, event_04) {
  * @brief      Test registration and unregistration of events.
  *
  */
-TEST_F(LibopaecEventFCommonHW, event_drv_05) {
+TEST_F(LibopaecEventFCommonMOCK, event_drv_05) {
   EXPECT_EQ(FPGA_OK, fpgaRegisterEvent(m_AFUHandle, FPGA_EVENT_INTERRUPT,
                                        m_EventHandles[0], 0));
 

--- a/tests/function/gtHostif.cpp
+++ b/tests/function/gtHostif.cpp
@@ -38,7 +38,7 @@ using namespace common_test;
  *             fpgaAssignPortToInterface Release port to a host interface.
  *
  */
-TEST(LibopaecHostifCommonHW, Hostif_drv_01) {
+TEST(LibopaecHostifCommonMOCK, Hostif_drv_01) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h;
@@ -60,7 +60,7 @@ TEST(LibopaecHostifCommonHW, Hostif_drv_01) {
  *             fpgaAssignPortToInterface Assign port to a host interface.
  *
  */
-TEST(LibopaecHostifCommonHW, Hostif_drv_02) {
+TEST(LibopaecHostifCommonMOCK, Hostif_drv_02) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h;

--- a/tests/function/gtMMIO.cpp
+++ b/tests/function/gtMMIO.cpp
@@ -42,7 +42,7 @@ must be express and approved by Intel in writing.
 
 using namespace common_test;
 
-class LibopaecMmioFCommonHW : public BaseFixture, public ::testing::Test {
+class LibopaecMmioFCommonMOCK : public BaseFixture, public ::testing::Test {
  public:
   uint64_t* mmio_ptr = NULL;
   uint32_t value32 = 0x12345678;

--- a/tests/function/gtOpenClose.cpp
+++ b/tests/function/gtOpenClose.cpp
@@ -35,10 +35,10 @@ must be express and approved by Intel in writing.
 using namespace common_test;
 using namespace std;
 
-class LibopaecOpenFCommonMOCK : public common_test::BaseFixture,
+class LibopaecOpenFCommonMOCKHW : public common_test::BaseFixture,
                               public ::testing::Test {};
 
-class LibopaecCloseFCommonMOCK : public common_test::BaseFixture,
+class LibopaecCloseFCommonMOCKHW : public common_test::BaseFixture,
                                public ::testing::Test {};
 
 class LibopaecOpenFCommonALL : public common_test::BaseFixture,
@@ -174,7 +174,7 @@ TEST_F(LibopaecOpenFCommonALL, 05) {
  *             but the user lacks sufficient privilege for the device,
  *             fpgaOpen returns FPGA_NO_ACCESS.
  */
-TEST_F(LibopaecOpenFCommonMOCK, 06) {
+TEST_F(LibopaecOpenFCommonMOCKHW, 06) {
   auto functor = [=]() -> void {
     fpga_handle h;
 

--- a/tests/function/gtOpenClose.cpp
+++ b/tests/function/gtOpenClose.cpp
@@ -35,10 +35,10 @@ must be express and approved by Intel in writing.
 using namespace common_test;
 using namespace std;
 
-class LibopaecOpenFCommonHW : public common_test::BaseFixture,
+class LibopaecOpenFCommonMOCK : public common_test::BaseFixture,
                               public ::testing::Test {};
 
-class LibopaecCloseFCommonHW : public common_test::BaseFixture,
+class LibopaecCloseFCommonMOCK : public common_test::BaseFixture,
                                public ::testing::Test {};
 
 class LibopaecOpenFCommonALL : public common_test::BaseFixture,
@@ -53,7 +53,7 @@ class LibopaecCloseFCommonALL : public common_test::BaseFixture,
  * @brief      Calling fpgaOpen() after fpgaClose() using the same token
  *             returns FPGA_OK.
  */
-TEST_F(LibopaecOpenFCommonHW, 02) {
+TEST_F(LibopaecOpenFCommonMOCK, 02) {
   auto functor = [=]() -> void {
     fpga_handle h = NULL;
     ASSERT_EQ(FPGA_OK, fpgaOpen(tokens[index], &h, 0));
@@ -68,7 +68,7 @@ TEST_F(LibopaecOpenFCommonHW, 02) {
               functor);          // test code
 }
 
-TEST_F(LibopaecOpenFCommonHW, 03) {
+TEST_F(LibopaecOpenFCommonMOCK, 03) {
   auto functor = [=]() -> void {
 
     fpga_handle h = NULL;
@@ -174,7 +174,7 @@ TEST_F(LibopaecOpenFCommonALL, 05) {
  *             but the user lacks sufficient privilege for the device,
  *             fpgaOpen returns FPGA_NO_ACCESS.
  */
-TEST_F(LibopaecOpenFCommonHW, 06) {
+TEST_F(LibopaecOpenFCommonMOCK, 06) {
   auto functor = [=]() -> void {
     fpga_handle h;
 
@@ -214,7 +214,7 @@ TEST(LibopaecOpenCommonALL, 07) {
  *             an already opened token returns FPGA_BUSY.
  *
  */
-TEST_F(LibopaecOpenFCommonHW, open_drv_09) {
+TEST_F(LibopaecOpenFCommonMOCK, open_drv_09) {
   auto functor = [=]() -> void {
     fpga_handle h1, h2;
 
@@ -278,7 +278,7 @@ TEST_F(LibopaecOpenFCommonALL, open_drv_10) {
  *             returns FPGA_INVALID_PARAM for a corrupted token.
  *
  */
-TEST_F(LibopaecOpenFCommonHW, open_drv_11) {
+TEST_F(LibopaecOpenFCommonMOCK, open_drv_11) {
   auto functor = [=]() -> void {
     fpga_handle h;
 

--- a/tests/function/gtUmsg.cpp
+++ b/tests/function/gtUmsg.cpp
@@ -39,7 +39,7 @@ using namespace common_test;
  *             slot.
  *
  */
-TEST(LibopaecUmsgCommonHW, Umsg_drv_01) {
+TEST(LibopaecUmsgCommonMOCK, Umsg_drv_01) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h = NULL;
@@ -64,7 +64,7 @@ TEST(LibopaecUmsgCommonHW, Umsg_drv_01) {
  *             loaded, fpgaUmsgGetNumber returns error.
  *
  */
-TEST(LibopaecUmsgCommonHW, Umsg_drv_02) {
+TEST(LibopaecUmsgCommonMOCK, Umsg_drv_02) {
   struct _fpga_token _tok;
   fpga_handle h = NULL;
   fpga_token tok = &_tok;
@@ -114,7 +114,7 @@ TEST(LibopaecUmsgCommonHW, Umsg_drv_02) {
  *             fpgaUmsgSetAttributes sets umsg hit  Enable / Disable.
  *
  */
-TEST(LibopaecUmsgCommonHW, Umsg_drv_03) {
+TEST(LibopaecUmsgCommonMOCK, Umsg_drv_03) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h = NULL;
@@ -140,7 +140,7 @@ TEST(LibopaecUmsgCommonHW, Umsg_drv_03) {
  *             loaded, fpgaUmsgSetAttributes retuns error.
  *
  */
-TEST(LibopaecUmsgCommonHW, Umsg_drv_04) {
+TEST(LibopaecUmsgCommonMOCK, Umsg_drv_04) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h = NULL;
@@ -191,7 +191,7 @@ TEST(LibopaecUmsgCommonHW, Umsg_drv_04) {
  *             fpgaGetUmsgPtr returns umsg address.
  *
  */
-TEST(LibopaecUmsgCommonHW, Umsg_drv_05) {
+TEST(LibopaecUmsgCommonMOCK, Umsg_drv_05) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h = NULL;
@@ -217,7 +217,7 @@ TEST(LibopaecUmsgCommonHW, Umsg_drv_05) {
  *             loaded, fpgaGetUmsgPtr returns uerror.
  *
  */
-TEST(LibopaecUmsgCommonHW, Umsg_drv_06) {
+TEST(LibopaecUmsgCommonMOCK, Umsg_drv_06) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h = NULL;

--- a/tests/unit/gtEnumerate.cpp
+++ b/tests/unit/gtEnumerate.cpp
@@ -52,7 +52,7 @@ using namespace intel::utils;
  *             list<br> And no exceptions are thrown
  *
  */
-TEST(LibopaecCppEnumerateCommonMOCKHW, NoFilters01) {
+TEST(LibopaecCppEnumCommonMOCKHW, NoFilters01) {
   auto accelerator_list = accelerator::enumerate({});
   EXPECT_TRUE(accelerator_list.size() > 0);
   ASSERT_NO_THROW(accelerator_list.clear());
@@ -68,7 +68,7 @@ TEST(LibopaecCppEnumerateCommonMOCKHW, NoFilters01) {
  *             thrown
  *
  */
-TEST(LibopaecCppEnumerateCommonMOCKHW, BusFilter02) {
+TEST(LibopaecCppEnumCommonMOCKHW, BusFilter02) {
   option_map::ptr_t opts(new option_map());
   // add an option with a default
   opts->add_option<uint8_t>("bus-number", option::with_argument, "bus number",

--- a/tests/unit/gtEnumerate.cpp
+++ b/tests/unit/gtEnumerate.cpp
@@ -52,7 +52,7 @@ using namespace intel::utils;
  *             list<br> And no exceptions are thrown
  *
  */
-TEST(LibopaecCppEnumCommonHW, NoFilters01) {
+TEST(LibopaecCppEnumerateCommonMOCK, NoFilters01) {
   auto accelerator_list = accelerator::enumerate({});
   EXPECT_TRUE(accelerator_list.size() > 0);
   ASSERT_NO_THROW(accelerator_list.clear());
@@ -68,7 +68,7 @@ TEST(LibopaecCppEnumCommonHW, NoFilters01) {
  *             thrown
  *
  */
-TEST(LibopaecCppEnumCommonHW, BusFilter02) {
+TEST(LibopaecCppEnumerateCommonMOCK, BusFilter02) {
   option_map::ptr_t opts(new option_map());
   // add an option with a default
   opts->add_option<uint8_t>("bus-number", option::with_argument, "bus number",

--- a/tests/unit/gtEnumerate.cpp
+++ b/tests/unit/gtEnumerate.cpp
@@ -52,7 +52,7 @@ using namespace intel::utils;
  *             list<br> And no exceptions are thrown
  *
  */
-TEST(LibopaecCppEnumerateCommonMOCK, NoFilters01) {
+TEST(LibopaecCppEnumerateCommonMOCKHW, NoFilters01) {
   auto accelerator_list = accelerator::enumerate({});
   EXPECT_TRUE(accelerator_list.size() > 0);
   ASSERT_NO_THROW(accelerator_list.clear());
@@ -68,7 +68,7 @@ TEST(LibopaecCppEnumerateCommonMOCK, NoFilters01) {
  *             thrown
  *
  */
-TEST(LibopaecCppEnumerateCommonMOCK, BusFilter02) {
+TEST(LibopaecCppEnumerateCommonMOCKHW, BusFilter02) {
   option_map::ptr_t opts(new option_map());
   // add an option with a default
   opts->add_option<uint8_t>("bus-number", option::with_argument, "bus number",

--- a/tests/unit/gtOpen.cpp
+++ b/tests/unit/gtOpen.cpp
@@ -45,7 +45,7 @@ using namespace intel::fpga;
  *             accelerator<br> Then the result is true<br>
  *
  */
-TEST(LibopaecCppOpenCommonHW, fx_open_01)
+TEST(LibopaecCppOpenCommonMOCK, fx_open_01)
 {
     auto accelerator_list = accelerator::enumerate({});
     ASSERT_GT(accelerator_list.size() , 0);

--- a/tests/unit/gtOpen.cpp
+++ b/tests/unit/gtOpen.cpp
@@ -45,7 +45,7 @@ using namespace intel::fpga;
  *             accelerator<br> Then the result is true<br>
  *
  */
-TEST(LibopaecCppOpenCommonMOCK, fx_open_01)
+TEST(LibopaecCppOpenCommonMOCKHW, fx_open_01)
 {
     auto accelerator_list = accelerator::enumerate({});
     ASSERT_GT(accelerator_list.size() , 0);

--- a/tests/unit/gtOptionParser.cpp
+++ b/tests/unit/gtOptionParser.cpp
@@ -38,7 +38,7 @@ using namespace intel::utils;
  *             the default value for that type
  *
  */
-TEST(LibopaecCppOptionsCommonMOCK, default_option_01) {
+TEST(LibopaecCppOptionsCommonMOCKHW, default_option_01) {
   option_map opts;
   opts.add_option<uint32_t>("answer", option::with_argument,
                             "test option help");
@@ -56,7 +56,7 @@ TEST(LibopaecCppOptionsCommonMOCK, default_option_01) {
  *             in the JSON string
  *
  */
-TEST(LibopaecCppOptionsCommonMOCK, parse_json_02) {
+TEST(LibopaecCppOptionsCommonMOCKHW, parse_json_02) {
   option_map opts;
   opts.add_option<uint32_t>("answer", option::with_argument, "test option help",
                             42);
@@ -79,7 +79,7 @@ TEST(LibopaecCppOptionsCommonMOCK, parse_json_02) {
  *             false
  *
  */
-TEST(LibopaecCppOptionsCommonMOCK, parse_json_03) {
+TEST(LibopaecCppOptionsCommonMOCKHW, parse_json_03) {
   option_map opts;
   opts.add_option<uint32_t>("answer", option::with_argument, "test option help",
                             42);
@@ -103,7 +103,7 @@ TEST(LibopaecCppOptionsCommonMOCK, parse_json_03) {
  *             value in the arguments vector
  *
  */
-TEST(LibopaecCppOptionsCommonMOCK, parse_arg_04) {
+TEST(LibopaecCppOptionsCommonMOCKHW, parse_arg_04) {
   optind = 1;
   option_map opts;
   opts.add_option<uint32_t>("answer", option::with_argument, "test option help",
@@ -129,7 +129,7 @@ TEST(LibopaecCppOptionsCommonMOCK, parse_arg_04) {
  *             value in the arguments vector
  *
  */
-TEST(LibopaecCppOptionsCommonMOCK, parse_arg_05) {
+TEST(LibopaecCppOptionsCommonMOCKHW, parse_arg_05) {
   optind = 1;
   option_map opts;
   opts.add_option<uint32_t>("answer", 'a', option::with_argument,
@@ -154,7 +154,7 @@ TEST(LibopaecCppOptionsCommonMOCK, parse_arg_05) {
  *             parser is equal to the non-options
  *
  */
-TEST(LibopaecCppOptionsCommonMOCK, parse_arg_06) {
+TEST(LibopaecCppOptionsCommonMOCKHW, parse_arg_06) {
   optind = 1;
   option_map opts;
   opts.add_option<uint32_t>("answer", option::with_argument, "test option help",
@@ -183,7 +183,7 @@ TEST(LibopaecCppOptionsCommonMOCK, parse_arg_06) {
  *             vector in the parser is equal to the non-options
  *
  */
-TEST(LibopaecCppOptionsCommonMOCK, parse_arg_07) {
+TEST(LibopaecCppOptionsCommonMOCKHW, parse_arg_07) {
   optind = 1;
   option_map opts;
   opts.add_option<uint32_t>("answer", option::with_argument, "test option help",

--- a/tests/unit/gtOptionParser.cpp
+++ b/tests/unit/gtOptionParser.cpp
@@ -38,7 +38,7 @@ using namespace intel::utils;
  *             the default value for that type
  *
  */
-TEST(LibopaecCppOptionsCommonHW, default_option_01) {
+TEST(LibopaecCppOptionsCommonMOCK, default_option_01) {
   option_map opts;
   opts.add_option<uint32_t>("answer", option::with_argument,
                             "test option help");
@@ -56,7 +56,7 @@ TEST(LibopaecCppOptionsCommonHW, default_option_01) {
  *             in the JSON string
  *
  */
-TEST(LibopaecCppOptionsCommonHW, parse_json_02) {
+TEST(LibopaecCppOptionsCommonMOCK, parse_json_02) {
   option_map opts;
   opts.add_option<uint32_t>("answer", option::with_argument, "test option help",
                             42);
@@ -79,7 +79,7 @@ TEST(LibopaecCppOptionsCommonHW, parse_json_02) {
  *             false
  *
  */
-TEST(LibopaecCppOptionsCommonHW, parse_json_03) {
+TEST(LibopaecCppOptionsCommonMOCK, parse_json_03) {
   option_map opts;
   opts.add_option<uint32_t>("answer", option::with_argument, "test option help",
                             42);
@@ -103,7 +103,7 @@ TEST(LibopaecCppOptionsCommonHW, parse_json_03) {
  *             value in the arguments vector
  *
  */
-TEST(LibopaecCppOptionsCommonHW, parse_arg_04) {
+TEST(LibopaecCppOptionsCommonMOCK, parse_arg_04) {
   optind = 1;
   option_map opts;
   opts.add_option<uint32_t>("answer", option::with_argument, "test option help",
@@ -129,7 +129,7 @@ TEST(LibopaecCppOptionsCommonHW, parse_arg_04) {
  *             value in the arguments vector
  *
  */
-TEST(LibopaecCppOptionsCommonHW, parse_arg_05) {
+TEST(LibopaecCppOptionsCommonMOCK, parse_arg_05) {
   optind = 1;
   option_map opts;
   opts.add_option<uint32_t>("answer", 'a', option::with_argument,
@@ -154,7 +154,7 @@ TEST(LibopaecCppOptionsCommonHW, parse_arg_05) {
  *             parser is equal to the non-options
  *
  */
-TEST(LibopaecCppOptionsCommonHW, parse_arg_06) {
+TEST(LibopaecCppOptionsCommonMOCK, parse_arg_06) {
   optind = 1;
   option_map opts;
   opts.add_option<uint32_t>("answer", option::with_argument, "test option help",
@@ -183,7 +183,7 @@ TEST(LibopaecCppOptionsCommonHW, parse_arg_06) {
  *             vector in the parser is equal to the non-options
  *
  */
-TEST(LibopaecCppOptionsCommonHW, parse_arg_07) {
+TEST(LibopaecCppOptionsCommonMOCK, parse_arg_07) {
   optind = 1;
   option_map opts;
   opts.add_option<uint32_t>("answer", option::with_argument, "test option help",


### PR DESCRIPTION
Rename test case names based on the test case naming conventions.