### PR TITLE
Use Python to generate zipped Python executables

### DIFF
--- a/tools/packager/CMakeLists.txt
+++ b/tools/packager/CMakeLists.txt
@@ -34,13 +34,13 @@ FIND_PYTHON_PKG("jsonschema" SEND_ERROR)
 ################# generate executable python zip files ########################
 
 set(PKG_COMMON_FILES
-    "afu.py gbs.py utils.py metadata/constants.py metadata/__init__.py metadata/metadata.py schema/afu_schema_v01.json")
+    afu.py gbs.py utils.py metadata/constants.py metadata/__init__.py metadata/metadata.py schema/afu_schema_v01.json)
 
-set(PKG_PYTHON_FILES "packager.py ${PKG_COMMON_FILES} README")
+set(PKG_PYTHON_FILES packager.py ${PKG_COMMON_FILES} README)
 CREATE_PYTHON_EXE(packager packager ${PKG_PYTHON_FILES})
 set(PACKAGER_BIN_LIST ${PACKAGER_BIN})
 
-set(AFU_JSON_MGR_FILES "afu_json_mgr.py ${PKG_COMMON_FILES} schema/afu_template.json")
+set(AFU_JSON_MGR_FILES afu_json_mgr.py ${PKG_COMMON_FILES} schema/afu_template.json)
 CREATE_PYTHON_EXE(afu_json_mgr afu_json_mgr ${AFU_JSON_MGR_FILES})
 list(APPEND PACKAGER_BIN_LIST ${PACKAGER_BIN})
 


### PR DESCRIPTION
- No longer depends on Unix shell commands
- No longer depends on zip program