### PR TITLE
Platform support changes:

### DIFF
--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -458,6 +458,23 @@ def gen_afu_json_verilog_macros(json_file):
 def get_default_platform():
     if 'OPAE_ASE_DEFAULT_PLATFORM' in os.environ:
         return os.environ['OPAE_ASE_DEFAULT_PLATFORM']
+
+    # FPGA platform releases use BBS_LIB_PATH to specify a path to
+    # the release library.  The library stores the platform class.
+    # Match the ASE environment to the current platform.
+    if 'BBS_LIB_PATH' in os.environ:
+        fname = os.path.join(os.environ['BBS_LIB_PATH'],
+                             'fme-platform-class.txt')
+        try:
+            with open(fname, 'r') as fd:
+                fpga_platform = fd.read().strip()
+            return fpga_platform
+        except Exception:
+            ase_functions.begin_red_fontcolor()
+            sys.stderr.write('Warning: expected to find FPGA platform ' +
+                             'in {0}\n\n'.format(fname))
+            ase_functions.end_red_fontcolor()
+
     return 'intg_xeon'
 
 

--- a/platforms/platform_db/discrete_pcie3_hssi40.json
+++ b/platforms/platform_db/discrete_pcie3_hssi40.json
@@ -1,0 +1,55 @@
+{
+   "version": 1,
+   "platform-name": "discrete_pcie3_hssi40",
+   "description": "First generation CCI-P-based discrete PCIe Gen3 cards with 40Gb HSSI",
+   "ase-platform": "discrete",
+   "comment":
+      [
+         "The platform offers local memory, which can be connected to the AFU",
+         "using either the preferred avalon_mm_if SystemVerilog interface object",
+         "or with the legacy two-bank collection of Avalon wires.",
+         "",
+         "10 and 40Gb HSSI are also available."
+      ],
+   "module-arguments-offered" :
+      [
+         {
+            "class": "clocks",
+            "interface": "pClk3_usr2"
+         },
+         {
+            "class": "power",
+            "interface": "2bit",
+            "optional": true
+         },
+         {
+            "class": "error",
+            "interface": "1bit",
+            "optional": true
+         },
+         {
+            "class": "cci-p",
+            "interface": "struct",
+            "params":
+               {
+                  "vc-supported": "{ 1, 0, 1, 0 }",
+                  "pclk-freq": 200,
+                  "max-bw-active-lines-c0": "{ 256, 256, 256, 256 }",
+                  "max-bw-active-lines-c1": "{ 128, 128, 128, 128 }"
+               }
+         },
+         {
+            "class": "local-memory",
+            "interface": "avalon_mm",
+            "optional": true,
+            "vector": true,
+            "max-entries": 2
+         },
+         {
+            "class": "local-memory",
+            "interface": "avalon_mm_legacy_wires_2bank",
+            "optional": true,
+            "define": [ "INCLUDE_DDR4" ]
+         }
+      ]
+}

--- a/platforms/platform_if/rtl/platform_shims/utils/platform_utils_ccip_reg.sv
+++ b/platforms/platform_if/rtl/platform_shims/utils/platform_utils_ccip_reg.sv
@@ -69,7 +69,8 @@ module platform_utils_ccip_reg
         //
         if (REGISTER_RESET && N_REG_STAGES)
         begin : reg_reset
-            (* preserve *) logic reset[N_REG_STAGES] = '{N_REG_STAGES{1'b1}};
+            (* altera_attribute = {"-name AUTO_SHIFT_REGISTER_RECOGNITION OFF; -name PRESERVE_REGISTER ON"} *)
+            logic reset[N_REG_STAGES] = '{N_REG_STAGES{1'b1}};
 
             always @(posedge clk)
             begin
@@ -97,7 +98,8 @@ module platform_utils_ccip_reg
         //
         if (REGISTER_TX && N_REG_STAGES)
         begin : reg_tx
-            (* preserve *) t_if_ccip_Tx reg_af2cp_sTx[N_REG_STAGES];
+            (* altera_attribute = {"-name AUTO_SHIFT_REGISTER_RECOGNITION OFF; -name PRESERVE_REGISTER ON"} *)
+            t_if_ccip_Tx reg_af2cp_sTx[N_REG_STAGES];
 
             // Tx to register stages
             always_ff @(posedge clk)
@@ -127,7 +129,8 @@ module platform_utils_ccip_reg
         //
         if (REGISTER_RX && N_REG_STAGES)
         begin : reg_rx
-            (* preserve *) t_if_ccip_Rx reg_cp2af_sRx[N_REG_STAGES];
+            (* altera_attribute = {"-name AUTO_SHIFT_REGISTER_RECOGNITION OFF; -name PRESERVE_REGISTER ON"} *)
+            t_if_ccip_Rx reg_cp2af_sRx[N_REG_STAGES];
 
             always_ff @(posedge clk)
             begin
@@ -156,8 +159,10 @@ module platform_utils_ccip_reg
         //
         if (REGISTER_ERROR && N_REG_STAGES)
         begin : reg_err
-            (* preserve *) logic [1:0] reg_cp2af_pwrState[N_REG_STAGES];
-            (* preserve *) logic reg_cp2af_error[N_REG_STAGES];
+            (* altera_attribute = {"-name AUTO_SHIFT_REGISTER_RECOGNITION OFF; -name PRESERVE_REGISTER ON"} *)
+            logic [1:0] reg_cp2af_pwrState[N_REG_STAGES];
+            (* altera_attribute = {"-name AUTO_SHIFT_REGISTER_RECOGNITION OFF; -name PRESERVE_REGISTER ON"} *)
+            logic reg_cp2af_error[N_REG_STAGES];
 
             always_ff @(posedge clk)
             begin


### PR DESCRIPTION
- Add a new stub for a platform with HSSI
- Teach ASE to find the physical platform using a mechanism identical to
  Quartus builds.  The current FPGA thus matches the simulation environment.
- Update tags on RTL registers used for timing relaxation based on
  experience with OpenCL.