### PR TITLE
OPAE: User PLL clock set to proper refclock  when only reference clock is is available

### DIFF
--- a/libopae/src/reconf.c
+++ b/libopae/src/reconf.c
@@ -324,7 +324,7 @@ fpga_result __FPGA_API__ fpgaReconfigureSlot(fpga_handle fpga,
 			 metadata.afu_image.afu_clusters.afu_uuid);
 
 		// Set AFU user clock
-		if (metadata.afu_image.clock_frequency_high > 0 && metadata.afu_image.clock_frequency_low > 0) {
+		if (metadata.afu_image.clock_frequency_high > 0 || metadata.afu_image.clock_frequency_low > 0) {
 			result = set_afu_userclock(fpga, metadata.afu_image.clock_frequency_high, metadata.afu_image.clock_frequency_low);
 			if (result != FPGA_OK) {
 				FPGA_ERR("Failed to set user clock");

--- a/libopae/src/usrclk/user_clk_pgm_uclock.c
+++ b/libopae/src/usrclk/user_clk_pgm_uclock.c
@@ -118,7 +118,8 @@ fpga_result __FIXME_MAKE_VISIBLE__ set_userclock(const char* sysfs_path,
 		return FPGA_INVALID_PARAM;
 	}
 
-	if (userclk_low != 0  && userclk_low > userclk_high) {
+	if (userclk_low != 0 && userclk_high != 0
+		&& userclk_low > userclk_high) {
 		FPGA_ERR("Invalid Input low frequency");
 		return FPGA_INVALID_PARAM;
 	}
@@ -137,7 +138,7 @@ fpga_result __FIXME_MAKE_VISIBLE__ set_userclock(const char* sysfs_path,
 		return FPGA_NOT_SUPPORTED;
 	}
 
-	FPGA_DBG("User clock high: %ld \n", refClock);
+	FPGA_DBG("User clock: %ld \n", refClock);
 
 	// set user clock
 	if (fi_SetFreqs(0, refClock) != 0) {

--- a/libopae/src/usrclk/user_clk_pgm_uclock.c
+++ b/libopae/src/usrclk/user_clk_pgm_uclock.c
@@ -99,16 +99,11 @@ fpga_result __FIXME_MAKE_VISIBLE__ set_userclock(const char* sysfs_path,
 					uint64_t userclk_high,
 					uint64_t userclk_low)
 {
-	uint64_t refClock  = 0;
+	uint64_t refClock = userclk_high;
 
 	if (sysfs_path == NULL) {
 		FPGA_ERR("Invalid Input parameters");
 		return FPGA_INVALID_PARAM;
-	}
-
-	// set low refclk if only one clock is avalible 
-	if ( userclk_high == 0 && userclk_low != 0 ) {
-		refClock = userclk_low;
 	}
 
 	// verify user clock freq range (100hz to 1200hz)
@@ -124,9 +119,11 @@ fpga_result __FIXME_MAKE_VISIBLE__ set_userclock(const char* sysfs_path,
 		return FPGA_INVALID_PARAM;
 	}
 
-	// set refclok to high.
-	refClock = userclk_high;
-	
+	// set low refclk if only one clock is avalible 
+	if (userclk_high == 0 && userclk_low != 0) {
+		refClock = userclk_low;
+	}
+
 	if (refClock < MIN_FPGA_FREQ){
 		FPGA_ERR("Invalid Input frequency");
 		return FPGA_INVALID_PARAM;

--- a/libopae/src/usrclk/user_clk_pgm_uclock.c
+++ b/libopae/src/usrclk/user_clk_pgm_uclock.c
@@ -99,23 +99,35 @@ fpga_result __FIXME_MAKE_VISIBLE__ set_userclock(const char* sysfs_path,
 					uint64_t userclk_high,
 					uint64_t userclk_low)
 {
+	uint64_t refClock  = 0;
+
 	if (sysfs_path == NULL) {
-		FPGA_ERR("Invalid input parameters");
+		FPGA_ERR("Invalid Input parameters");
 		return FPGA_INVALID_PARAM;
+	}
+
+	// set low refclk if only one clock is avalible 
+	if ( userclk_high == 0 && userclk_low != 0 ) {
+		refClock = userclk_low;
 	}
 
 	// verify user clock freq range (100hz to 1200hz)
 	if ((userclk_high > MAX_FPGA_FREQ) ||
-		(userclk_high < MIN_FPGA_FREQ) ||
-		(userclk_low > (MAX_FPGA_FREQ / 2)) ||
-		(userclk_low < (MIN_FPGA_FREQ / 2))) {
-
-		FPGA_ERR("Invalid input frequency");
+		(userclk_low > MAX_FPGA_FREQ)) {
+		FPGA_ERR("Invalid Input frequency");
 		return FPGA_INVALID_PARAM;
 	}
 
-	if (userclk_low > userclk_high) {
-		FPGA_ERR("Invalid input low frequency");
+	if (userclk_low != 0  && userclk_low > userclk_high) {
+		FPGA_ERR("Invalid Input low frequency");
+		return FPGA_INVALID_PARAM;
+	}
+
+	// set refclok to high.
+	refClock = userclk_high;
+	
+	if (refClock < MIN_FPGA_FREQ){
+		FPGA_ERR("Invalid Input frequency");
 		return FPGA_INVALID_PARAM;
 	}
 
@@ -125,10 +137,10 @@ fpga_result __FIXME_MAKE_VISIBLE__ set_userclock(const char* sysfs_path,
 		return FPGA_NOT_SUPPORTED;
 	}
 
-	FPGA_DBG("User clock high: %ld \n", userclk_high);
+	FPGA_DBG("User clock high: %ld \n", refClock);
 
 	// set user clock
-	if (fi_SetFreqs(0, userclk_high) != 0) {
+	if (fi_SetFreqs(0, refClock) != 0) {
 		FPGA_ERR("Failed to set user clock frequency ");
 		return FPGA_NOT_SUPPORTED;
 	}


### PR DESCRIPTION
Changes:
- Set to  refclk 1 when only refclk 1 is available
- Set to  refclk 0 when only refclk 0 is available
- Accept time specified by the low frequency clock when the high frequency clock isn't specified