### PR TITLE
opaec++: add .clang-format config file

### DIFF
--- a/common/include/opae/cxx/.clang-format
+++ b/common/include/opae/cxx/.clang-format
@@ -1,0 +1,2 @@
+---
+BasedOnStyle: Google

--- a/libopae++/.clang-format
+++ b/libopae++/.clang-format
@@ -1,0 +1,2 @@
+---
+BasedOnStyle: Google


### PR DESCRIPTION
According to the clang-format documentation
clang-format will use a .clang-format file in a
file's closes parent directory (if found).
This adds two .clang-format config files that can be used to format C++ files using a style based on the
Google coding style.