### PR TITLE
Fix bus input for fpgaconf in bist

### DIFF
--- a/tools/fpgabist/bist_common.py
+++ b/tools/fpgabist/bist_common.py
@@ -80,7 +80,7 @@ def get_mode_from_path(gbs_path):
 
 def load_gbs(gbs_file, bus_num):
     print "Attempting Partial Reconfiguration:"
-    cmd = "{} -b {} -v {}".format('fpgaconf', bus_num, gbs_file)
+    cmd = "{} -b 0x{} -v {}".format('fpgaconf', bus_num, gbs_file)
     try:
         subprocess.check_call(cmd, shell=True)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
When the fpgabist tries to do PR for certain systems, namely ones where the bus number contains a value a-f, fpgaconf cant take the input without the leading '0x'.

Bug fix to address this info.