### PR TITLE
Various updates for discrete platform

### DIFF
--- a/ase/Makefile
+++ b/ase/Makefile
@@ -100,8 +100,6 @@ GLS_VERILOG_OPT = $(QUARTUS_HOME)/eda/sim_lib/altera_primitives.v
 GLS_VERILOG_OPT+= $(QUARTUS_HOME)/eda/sim_lib/220model.v
 GLS_VERILOG_OPT+= $(QUARTUS_HOME)/eda/sim_lib/sgate.v
 GLS_VERILOG_OPT+= $(QUARTUS_HOME)/eda/sim_lib/altera_mf.v
-GLS_VERILOG_OPT+= $(QUARTUS_HOME)/eda/sim_lib/stratixv_hssi_atoms.v
-GLS_VERILOG_OPT+= $(QUARTUS_HOME)/eda/sim_lib/stratixv_pcie_hip_atoms.v
 GLS_VERILOG_OPT+= $(QUARTUS_HOME)/eda/sim_lib/altera_lnsim.sv
 
 # add required files for local memory model

--- a/platforms/afu_top_ifc_db/ccip_std_afu_avalon_mm_legacy_wires.json
+++ b/platforms/afu_top_ifc_db/ccip_std_afu_avalon_mm_legacy_wires.json
@@ -13,7 +13,7 @@
          {
              "class": "local-memory",
              "interface": "avalon_mm_legacy_wires_2bank",
-             "optional": true
+             "optional": false
          }
       ]
 }

--- a/platforms/scripts/afu_synth_setup
+++ b/platforms/scripts/afu_synth_setup
@@ -145,31 +145,6 @@ def copy_build_env(hw_lib_dir, dst, force):
     if (not os.path.isdir(hw_dir)):
         os.mkdir(hw_dir)
 
-    # Make a scripts directory with clean.sh and run.sh
-    scripts_dst = os.path.join(dst, 'scripts')
-    os.mkdir(scripts_dst)
-    # The release root is two levels above hw/lib
-    release_root_dir = os.path.dirname(os.path.dirname(hw_lib_dir))
-    scripts_src = os.path.relpath(os.path.join(release_root_dir, 'bin'),
-                                  scripts_dst)
-    os.symlink(os.path.join(scripts_src, 'clean.sh'),
-               os.path.join(scripts_dst, 'clean.sh'))
-    run_sh = os.path.join(scripts_dst, 'run.sh')
-    with open(run_sh, 'w') as f:
-        # Use relative paths so generated scripts can be shipped in
-        # a tarball along with a release.
-        f.write('#!/bin/sh\n')
-        f.write('SCRIPT_DIR="$(cd "$(dirname -- "$0")" 2>/dev/null && ' +
-                'pwd -P)"\n')
-        f.write('RELEASE_DIR="$(readlink -f "${SCRIPT_DIR}/' +
-                os.path.relpath(release_root_dir, scripts_dst) +
-                '")"\n')
-        f.write('export BBS_LIB_PATH=' +
-                '${BBS_LIB_PATH:-"${RELEASE_DIR}/hw/lib"}\n')
-        f.write('"${RELEASE_DIR}/bin/run.sh" $@\n')
-    st = os.stat(run_sh)
-    os.chmod(run_sh, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-
 
 #
 # Configure the build environment


### PR DESCRIPTION
- Stop building run.sh/clean.sh script wrappers in afu_synth_setup. They were a source of problems.
- Stop importing Stratix V HSSI/PCIe atoms in ASE. Not available on some platforms.