### PR TITLE
Make it possible to request any clock for CCI-P & local memory

### DIFF
--- a/platforms/platform_if/rtl/device_if/ccip_if_clock.sv
+++ b/platforms/platform_if/rtl/device_if/ccip_if_clock.sv
@@ -30,11 +30,13 @@
 
 `include "platform_if.vh"
 
+// ************************************************************************
 //
-// This module allows AFU writers to extract the clock that was chosen for
-// CCI-P in the AFU's JSON.  Use this to avoid using preprocessor macros
-// generated for platform interface configuration.
+// This module is obsolete.  Please simply use `PLATFORM_PARAM_CCI_P_CLOCK
+// to retrieve the CCI-P primary clock.
 //
+// ************************************************************************
+
 module ccip_if_clock
    (
     // CCI-P Clocks and Resets

--- a/platforms/platform_if/rtl/device_if/device_if.vh
+++ b/platforms/platform_if/rtl/device_if/device_if.vh
@@ -38,4 +38,23 @@
 import ccip_if_pkg::*;
 `include "avalon_mem_if.vh"
 
+//
+// Because CCI-P's clocks are passed as separate wires to ccip_std_afu
+// we can't simply change the primary clock for CCI-P traffic.  Here
+// we guarantee that the macro `PLATFORM_PARAM_CCI_P_CLOCK matches the
+// CCI-P clock coming out of the Platform Interface Manager.  By
+// default it is pClk.  It will only change when an AFU's JSON database
+// requests CCI-P on a different clock.
+//
+`ifndef PLATFORM_PARAM_CCI_P_CLOCK
+    `define PLATFORM_PARAM_CCI_P_CLOCK pClk
+`elsif PLATFORM_PARAM_CCI_P_CLOCK_IS_DEFAULT
+    `undef PLATFORM_PARAM_CCI_P_CLOCK
+    `define PLATFORM_PARAM_CCI_P_CLOCK pClk
+`endif
+
+// The standard reset signal is moved to the `PLATFORM_PARAM_CCI_P_CLOCK
+// domain.  Provide a macro for reset for symmetry.
+`define PLATFORM_PARAM_CCI_P_RESET pck_cp2af_softReset
+
 `endif // __DEVICE_IF_VH__

--- a/platforms/platform_if/rtl/platform_shims/platform_shim_ccip.sv
+++ b/platforms/platform_if/rtl/platform_shims/platform_shim_ccip.sv
@@ -40,10 +40,6 @@ module platform_shim_ccip
    (
     // CCI-P Clocks and Resets
     input  logic        pClk,                 // Primary CCI-P interface clock.
-    input  logic        pClkDiv2,             // Aligned, pClk divided by 2.
-    input  logic        pClkDiv4,             // Aligned, pClk divided by 4.
-    input  logic        uClk_usr,             // User clock domain. Refer to clock programming guide.
-    input  logic        uClk_usrDiv2,         // Aligned, user clock divided by 2.
     input  logic        pck_cp2af_softReset,  // CCI-P ACTIVE HIGH Soft Reset
 
     input  logic [1:0]  pck_cp2af_pwrState,   // CCI-P AFU Power State
@@ -54,6 +50,7 @@ module platform_shim_ccip
     output t_if_ccip_Tx pck_af2cp_sTx,
 
     // CCI-P structures (AFU side, AFU clock domain)
+    input  logic        afu_clk,
     output t_if_ccip_Rx afu_cp2af_sRx,
     input  t_if_ccip_Tx afu_af2cp_sTx,
     output logic        afu_cp2af_softReset,
@@ -70,9 +67,6 @@ module platform_shim_ccip
 `ifdef PLATFORM_PARAM_CCI_P_CLOCK_IS_DEFAULT
     // AFU asked for default clock.
     localparam CCI_P_CHANGE_CLOCK = 0;
-    // Change the definition of the clock macro to "pClk" instead of "default"
-    `undef PLATFORM_PARAM_CCI_P_CLOCK
-    `define PLATFORM_PARAM_CCI_P_CLOCK pClk
 `elsif PLATFORM_PARAM_CCI_P_CLOCK_IS_PCLK
     // AFU asked for pClk explicitly.
     localparam CCI_P_CHANGE_CLOCK = 0;
@@ -183,7 +177,7 @@ module platform_shim_ccip
                 .bb_error(reg_cp2af_error),
 
                 .afu_softreset(afu_cp2af_softReset),
-                .afu_clk(`PLATFORM_PARAM_CCI_P_CLOCK),
+                .afu_clk(afu_clk),
                 .afu_tx(afu_af2cp_sTx),
                 .afu_rx(afu_cp2af_sRx),
                 .afu_pwrState(afu_cp2af_pwrState),

--- a/platforms/platform_if/rtl/platform_shims/platform_shim_ccip_std_afu.sv
+++ b/platforms/platform_if/rtl/platform_shims/platform_shim_ccip_std_afu.sv
@@ -95,10 +95,6 @@ module platform_shim_ccip_std_afu
     platform_shim_ccip platform_shim_ccip
        (
         .pClk,
-        .pClkDiv2,
-        .pClkDiv4,
-        .uClk_usr,
-        .uClk_usrDiv2,
 
         .pck_cp2af_softReset,
         .pck_cp2af_pwrState,
@@ -106,6 +102,13 @@ module platform_shim_ccip_std_afu
         .pck_cp2af_sRx,
         .pck_af2cp_sTx,
 
+`ifdef PLATFORM_PARAM_CCI_P_CLOCK_IS_DEFAULT
+         // Default clock
+        .afu_clk(pClk),
+`else
+         // Updated CCI-P clock requested
+        .afu_clk(`PLATFORM_PARAM_CCI_P_CLOCK),
+`endif
         .afu_cp2af_sRx,
         .afu_af2cp_sTx,
         .afu_cp2af_softReset,
@@ -133,11 +136,13 @@ module platform_shim_ccip_std_afu
         )
       platform_shim_avalon_mem_if
        (
-        .pClk,
-        .pClkDiv2,
-        .pClkDiv4,
-        .uClk_usr,
-        .uClk_usrDiv2,
+`ifdef PLATFORM_PARAM_LOCAL_MEMORY_CLOCK_IS_DEFAULT
+        // Not used -- local memory clocks unchanged
+        .tgt_mem_afu_clk(0),
+`else
+        // Updated target for local memory clock
+        .tgt_mem_afu_clk(`PLATFORM_PARAM_LOCAL_MEMORY_CLOCK),
+`endif
 
         .mem_fiu(local_mem),
         .mem_afu(afu_local_mem),

--- a/platforms/scripts/platmgr/emitcfg.py
+++ b/platforms/scripts/platmgr/emitcfg.py
@@ -147,6 +147,10 @@ def emitConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
     if (not args.quiet):
         print("Writing {0}".format(fn))
 
+    # Regular expression for characters we might encounter that can't be
+    # in preprocessor variables.  They will all be replaced with underscores.
+    illegal_chars = re.compile('[\.\[\]-]')
+
     try:
         f = open(fn, "w")
     except Exception:
@@ -169,7 +173,7 @@ def emitConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
     for port in afu_port_list:
         afu_port = port['afu']
         name = "PLATFORM_PROVIDES_" + afu_port['class'].upper()
-        name = name.replace('-', '_')
+        name = illegal_chars.sub('_', name)
         f.write("`define " + name + " 1\n")
 
     f.write("\n\n//\n// These top-level ports are passed from the " +
@@ -182,7 +186,7 @@ def emitConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
 
         name = "AFU_TOP_REQUIRES_" + \
             afu_port['class'].upper() + "_" + afu_port['interface'].upper()
-        name = name.replace('-', '_')
+        name = illegal_chars.sub('_', name)
 
         f.write("`define " + name + " ")
         if ('num-entries' not in port):
@@ -234,13 +238,13 @@ def emitConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
         for k in sorted(params.keys()):
             name = "PLATFORM_PARAM_" + \
                 afu_port['class'].upper() + "_" + k.upper()
-            name = name.replace('-', '_')
+            name = illegal_chars.sub('_', name)
             # Skip comments and parameters with no value
             if ((k != 'comment') and (params[k] is not None)):
                 f.write('`define {0} {1}\n'.format(name, params[k]))
                 if (k in is_params):
-                    f.write('`define {0}_IS_{1} 1\n'.format(
-                        name, params[k].upper()))
+                    p = illegal_chars.sub('_', params[k].upper())
+                    f.write('`define {0}_IS_{1} 1\n'.format(name, p))
 
         f.write("\n")
 
@@ -266,6 +270,10 @@ def emitQsfConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
     if (not args.quiet):
         print("Writing {0}".format(fn))
 
+    # Regular expression for characters we might encounter that can't be
+    # in preprocessor variables.  They will all be replaced with underscores.
+    illegal_chars = re.compile('[\.\[\]-]')
+
     try:
         f = open(fn, "w")
     except Exception:
@@ -278,7 +286,7 @@ def emitQsfConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
     for port in afu_port_list:
         afu_port = port['afu']
         name = "PLATFORM_PROVIDES_" + afu_port['class'].upper()
-        name = name.replace('-', '_')
+        name = illegal_chars.sub('_', name)
         f.write("    variable " + name + " 1\n")
 
     f.write("\n    # These top-level ports are passed from the " +
@@ -289,7 +297,7 @@ def emitQsfConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
 
         name = "AFU_TOP_REQUIRES_" + \
             afu_port['class'].upper() + "_" + afu_port['interface'].upper()
-        name = name.replace('-', '_')
+        name = illegal_chars.sub('_', name)
 
         f.write("    variable " + name + " ")
         if ('num-entries' not in port):

--- a/platforms/scripts/platmgr/emitcfg.py
+++ b/platforms/scripts/platmgr/emitcfg.py
@@ -273,6 +273,31 @@ def emitQsfConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
 
     emitHeader(f, afu_ifc_db, platform_db, comment="##")
 
+    f.write('namespace eval platform_cfg {\n')
+    f.write("    # These top-level port classes are provided\n")
+    for port in afu_port_list:
+        afu_port = port['afu']
+        name = "PLATFORM_PROVIDES_" + afu_port['class'].upper()
+        name = name.replace('-', '_')
+        f.write("    variable " + name + " 1\n")
+
+    f.write("\n    # These top-level ports are passed from the " +
+            "platform to the AFU\n")
+    for port in afu_port_list:
+        afu_port = port['afu']
+        plat_port = port['plat']
+
+        name = "AFU_TOP_REQUIRES_" + \
+            afu_port['class'].upper() + "_" + afu_port['interface'].upper()
+        name = name.replace('-', '_')
+
+        f.write("    variable " + name + " ")
+        if ('num-entries' not in port):
+            f.write("1\n")
+        else:
+            f.write("{0}\n".format(port['num-entries']))
+    f.write('}\n\n')
+
     f.write(
         "source {0}/par/platform_if_addenda.qsf\n".format(args.platform_if))
     f.close()


### PR DESCRIPTION
- Clock can be any string that maps to an available clock.
- Export CCI-P clock with `PLATFORM_PARAM_CCI_P_CLOCK.  The previous method
  using a Verilog module wasn't flexible enough to handle all the possible
  clocks.
- Update the macro writing rules in afu_platform_config to deal with more
  possible illegal macro characters.
