### PR TITLE
Add maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# List of maintainers for the OPAE-SDK
+#
+# Maintainers will be assigned as reviewers on every pull request in their area
+# of responsibility (which is defined by the paths of the files touched by a
+# pull request).
+
+# API specification, implementation, and samples
+/common/include/OPAE/          @OPAE/api
+/libOPAE/                      @OPAE/api
+/samples/                      @OPAE/api
+
+# Tools
+/tools/                        @OPAE/tools
+
+# ASE & platforms database
+/ase/                          @OPAE/ase
+/platforms/                    @OPAE/ase
+
+# Documentation
+/doc/                          @OPAE/doc
+
+# Build toolchain & continuous integration
+CMakeLists.txt                 @OPAE/ci
+/scripts/                      @OPAE/ci
+/tests/                        @OPAE/ci
+.travis.yml                    @OPAE/ci
+/cmake/                        @OPAE/ci
+
+# Safestring library
+/common/include/safe_string/   @OPAE/safe
+/safe_string/                  @OPAE/safe


### PR DESCRIPTION
Add references to designated maintainers for individual components of
the OPAE SDK.

See also https://github.com/blog/2392-introducing-code-owners.