### PR TITLE
Implement hw/lib search order to which we agreed for HW releases:

### DIFF
--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -475,13 +475,24 @@ def get_default_platform():
     if 'OPAE_ASE_DEFAULT_PLATFORM' in os.environ:
         return os.environ['OPAE_ASE_DEFAULT_PLATFORM']
 
-    # FPGA platform releases use BBS_LIB_PATH to specify a path to
-    # the release library.  The library stores the platform class.
-    # Match the ASE environment to the current platform.
-    if 'BBS_LIB_PATH' in os.environ:
-        fname = os.path.join(os.environ['BBS_LIB_PATH'],
-                             'fme-platform-class.txt')
+    # FPGA platform releases store the platform class in their
+    # hw/lib tree.  There are two variables that may point to
+    # this tree.
+    if ('BBS_LIB_PATH' in os.environ):
+        # Legacy variable, shared with afu_synth_setup and HW releases
+        hw_lib_dir = os.environ['BBS_LIB_PATH'].rstrip('/')
+    elif ('OPAE_PLATFORM_ROOT' in os.environ):
+        # Currently documented variable, pointing to a platform release
+        hw_lib_dir = os.path.join(os.environ['OPAE_PLATFORM_ROOT'].rstrip('/'),
+                                  'hw/lib')
+    else:
+        hw_lib_dir = None
+
+    # The release library stores the platform class.  Match the ASE
+    # environment to the current platform.
+    if hw_lib_dir is not None:
         try:
+            fname = os.path.join(hw_lib_dir, 'fme-platform-class.txt')
             with open(fname, 'r') as fd:
                 fpga_platform = fd.read().strip()
             return fpga_platform

--- a/platforms/scripts/afu_synth_setup
+++ b/platforms/scripts/afu_synth_setup
@@ -50,19 +50,32 @@ def errorExit(msg):
     sys.exit(1)
 
 
-# The hw/lib directory of a platform's release.
+#
+# The hw/lib directory of a platform's release.  We find the hw/lib
+# directory using the following search rules, in decreasing priority:
+#
+#   1. --lib argument to this script.
+#   2. BBS_LIB_PATH:
+#        We used to document this environment variable as the primary
+#        pointer for scripts.
+#   3. OPAE_PLATFORM_ROOT:
+#        This variable replaces all pointers to a release directory,
+#        starting with the discrete platform's 1.1 release.  The
+#        hw/lib directory is ${OPAE_PLATFORM_ROOT}/hw/lib.
+#
 def getHWLibPath(args):
     if (args.lib is not None):
         hw_lib_dir = args.lib
-    elif ('OPAE_FPGA_HW_LIB' in os.environ):
-        # Environment variable specific to afu_synth_setup
-        hw_lib_dir = os.environ['OPAE_FPGA_HW_LIB'].rstrip('/')
     elif ('BBS_LIB_PATH' in os.environ):
-        # Environment variable shared with afu_sim_setup and HW releases
+        # Legacy variable, shared with afu_sim_setup and HW releases
         hw_lib_dir = os.environ['BBS_LIB_PATH'].rstrip('/')
+    elif ('OPAE_PLATFORM_ROOT' in os.environ):
+        # Currently documented variable, pointing to a platform release
+        hw_lib_dir = os.path.join(os.environ['OPAE_PLATFORM_ROOT'].rstrip('/'),
+                                  'hw/lib')
     else:
         errorExit("Release hw/lib directory must be specified with " +
-                  "OPAE_FPGA_HW_LIB, BBS_LIB_PATH or --lib")
+                  "OPAE_PLATFORM_ROOT, BBS_LIB_PATH or --lib")
 
     # Confirm that the path looks reasonable
     if (not os.path.exists(os.path.join(hw_lib_dir,
@@ -85,6 +98,9 @@ def commands_list_getoutput(cmd, cwd=None):
             raise
     except subprocess.CalledProcessError as e:
         sys.stderr.write(e.output)
+        raise
+    except AttributeError:
+        sys.stderr.write('Error: Python 2.7 or greater required.\n')
         raise
 
     return str_out


### PR DESCRIPTION
- First check BBS_LIB_PATH (BBS hw/lib)
- Next check OPAE_PLATFORM_ROOT (top-level of a release)

- Also fixed: print a sensible error on old Python