### PR TITLE
Handle Qsys IPX file hierarchy

### DIFF
--- a/platforms/platform_if/rtl/platform_shims/platform_shim_ccip_std_afu.sv
+++ b/platforms/platform_if/rtl/platform_shims/platform_shim_ccip_std_afu.sv
@@ -127,7 +127,7 @@ module platform_shim_ccip_std_afu
     logic afu_local_mem_clk[NUM_LOCAL_MEM_BANKS];
     logic afu_local_mem_reset[NUM_LOCAL_MEM_BANKS];
 
-    avalon_mem_if#(.ENABLE_LOG(1))
+    avalon_mem_if#(.ENABLE_LOG(0))
         afu_local_mem[NUM_LOCAL_MEM_BANKS](afu_local_mem_clk, afu_local_mem_reset);
 
     platform_shim_avalon_mem_if

--- a/platforms/scripts/afu_synth_setup
+++ b/platforms/scripts/afu_synth_setup
@@ -237,6 +237,37 @@ def setup_build(args):
     cmd.append('--verilog-hdr=../hw/afu_json_info.vh')
     subprocess.check_call(cmd, cwd=build_dir)
 
+    # Handle Qsys IPX file discovery
+    setup_build_ipx(args, sources, build_dir)
+
+
+# Construct the Qsys components.ipx file in the build directory, if needed.
+def setup_build_ipx(args, sources, build_dir):
+    # Get IPX files from source list
+    cmd = ['rtl_src_config']
+    cmd.append('--ipx')
+    if (os.path.isabs(sources)):
+        cmd.append('--abs')
+        cmd.append(sources)
+    else:
+        cmd.append(os.path.relpath(sources, build_dir))
+    ipx = commands_list_getoutput(cmd, cwd=build_dir)
+    ipx = ipx.strip()
+    # Anything to do?
+    if (len(ipx) == 0):
+        return
+    ipx = ipx.split('\n')
+
+    # Emit components.ipx
+    with open(os.path.join(build_dir, 'components.ipx'), 'w') as f:
+        f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+        f.write('<library>\n')
+        for p in ipx:
+            # Just point to the directory containing the IPX file
+            ipx_path = os.path.dirname(p)
+            f.write('  <path path="{0}/*" />\n'.format(ipx_path))
+        f.write('</library>\n')
+
 
 def main():
     import argparse

--- a/platforms/scripts/rtl_src_config
+++ b/platforms/scripts/rtl_src_config
@@ -43,6 +43,11 @@ qsys_tag_map = {
     '.ip':   'IP_FILE'
 }
 
+# QSYS ipx tag.
+qsys_ipx_tag_map = {
+    '.ipx':  'IPX_FILE'
+}
+
 # JSON-only tags.
 json_tag_map = {
     '.json': 'MISC_FILE'
@@ -59,20 +64,18 @@ sim_tag_map = {
     '.json': 'MISC_FILE'
 }
 
-#
-# Return the Quartus tag for a given file extension.
-#
 
-
-def quartusTag(filename):
+def validateTag(filename):
     _basename, ext = os.path.splitext(filename)
     ext = ext.lower()
 
-    if (ext not in quartus_tag_map):
+    if (ext not in quartus_tag_map and
+            ext not in qsys_tag_map and
+            ext not in qsys_ipx_tag_map and
+            ext not in json_tag_map and
+            ext not in sim_tag_map):
         errorExit(
             "unrecognized file extension '{0}' ({1})".format(ext, filename))
-
-    return quartus_tag_map[ext]
 
 
 def lookupTag(filename, db):
@@ -90,7 +93,7 @@ def lookupTag(filename, db):
 #
 def emitCfg(opts, cfg):
     # Filtering for specific file types?
-    file_type_filter = opts.qsys or opts.json
+    file_type_filter = opts.qsys or opts.ipx or opts.json
 
     if (not file_type_filter):
         # First emit all preprocessor configuration
@@ -125,20 +128,22 @@ def emitCfg(opts, cfg):
             if (not opts.sim and not file_type_filter):
                 print("source " + c[3:])
         else:
-            # Always ask for the Quartus tag since it has the
-            # side-effect of validating the suffix.
-            tag = quartusTag(c)
+            validateTag(c)
+            tag = lookupTag(c, quartus_tag_map)
 
             if (opts.sim):
                 if (lookupTag(c, sim_tag_map)):
                     print(c)
-            elif (opts.qsys):
-                if (lookupTag(c, qsys_tag_map)):
-                    print(c)
             elif (opts.json):
                 if (lookupTag(c, json_tag_map)):
                     print(c)
-            else:
+            elif (opts.qsys):
+                if (lookupTag(c, qsys_tag_map)):
+                    print(c)
+            elif (opts.ipx):
+                if (lookupTag(c, qsys_ipx_tag_map)):
+                    print(c)
+            elif (tag is not None):
                 print('set_global_assignment -name {0} "{1}"'.format(tag, c))
 
 
@@ -264,6 +269,9 @@ These commands affect script parsing:
     group.add_argument("--qsys",
                        action="store_true",
                        help="""Emit only QSYS and IP file names.""")
+    group.add_argument("--ipx",
+                       action="store_true",
+                       help="""Emit only QSYS IPX file names.""")
     group.add_argument("--json",
                        action="store_true",
                        help="""Emit only JSON file names.""")


### PR DESCRIPTION
- Allow IPX files in rtl_src_config.
- Generate a master components.ipx, pointing to the sub-IPX files, in the Quartus build.