### PR TITLE
cmake: install python virtual env. in build dir.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,3 +372,20 @@ if(EXISTS ${RPMBUILD_EXECUTABLE})
     COMMAND ${RPMBUILD_EXECUTABLE} -bb libopae-all.spec
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 endif(EXISTS ${RPMBUILD_EXECUTABLE})
+
+############################################################################
+## Python virtualenv #######################################################
+############################################################################
+find_package(PythonInterp REQUIRED)
+option(USE_VIRTUALENV "Install Python virtualenv in build directory" ON)
+if (USE_VIRTUALENV)
+    FIND_PYTHON_PKG(virtualenv WARNING)
+    if (virtualenv_FOUND)
+        execute_process(
+            COMMAND ${PYTHON_EXECUTABLE} -m virtualenv ${CMAKE_BINARY_DIR}
+            OUTPUT_QUIET RESULT_VARIABLE EXIT_CODE)
+        if (NOT EXIT_CODE)
+            set(PYTHON_VIRTUALENV ON INTERNAL)
+        endif(NOT EXIT_CODE)
+    endif(virtualenv_FOUND)
+endif (USE_VIRTUALENV)

--- a/cmake/modules/FindPythonPackage.cmake
+++ b/cmake/modules/FindPythonPackage.cmake
@@ -11,5 +11,7 @@ macro(FIND_PYTHON_PKG PKG_NAME ERR_LEVEL )
 
     if(STATUS_FLAG)
         message(${ERR_LEVEL} "PACKAGER depenency python ${PKG_NAME} package is missing!!!")
+    else(STATUS_FLAG)
+        set(${PKG_NAME}_FOUND TRUE)
     endif(STATUS_FLAG)
 endmacro(FIND_PYTHON_PKG)


### PR DESCRIPTION
Check for Python module, `virtualenv`, on system.
If found, call virtualenv to install a virtual Python env. in the build directory.
This is in preparation for packaging python tools as universal wheel
files and installing them in the virtual env. during the development and testing phase.
