### PR TITLE
FPGABIST: remove dependency on system path

### DIFF
--- a/tools/fpgabist/bist_common.py
+++ b/tools/fpgabist/bist_common.py
@@ -78,9 +78,10 @@ def get_mode_from_path(gbs_path):
     return None
 
 
-def load_gbs(gbs_file, bus_num):
+def load_gbs(obj, gbs_file, bus_num):
     print "Attempting Partial Reconfiguration:"
-    cmd = "{} -b 0x{} -v {}".format('fpgaconf', bus_num, gbs_file)
+    conf_cmd = os.path.join(obj.cwd, 'fpgaconf')
+    cmd = "{} -b 0x{} -v {}".format(conf_cmd, bus_num, gbs_file)
     try:
         subprocess.check_call(cmd, shell=True)
     except subprocess.CalledProcessError as e:
@@ -93,6 +94,7 @@ class BistMode(object):
     name = ""
     executables = {}
     dir_path = ""
+    cwd = os.path.dirname(os.path.realpath(__file__))
 
     def run(self, gbs_path, bus_num):
         raise NotImplementedError

--- a/tools/fpgabist/bist_dma.py
+++ b/tools/fpgabist/bist_dma.py
@@ -38,9 +38,10 @@ class DmaMode(bc.BistMode):
         self.executables = {'fpga_dma_test': '0'}
 
     def run(self, gbs_path, bus_num):
-        bc.load_gbs(gbs_path, bus_num)
+        bc.load_gbs(self, gbs_path, bus_num)
         for func, param in self.executables.items():
-            print "Running {} test...\n".format(func)
+            print "Running {}...\n".format(func)
+            func = os.path.join(self.cwd, func)
             cmd = "{} {}".format(func, param)
             try:
                 subprocess.check_call(cmd, shell=True)

--- a/tools/fpgabist/bist_nlb3.py
+++ b/tools/fpgabist/bist_nlb3.py
@@ -42,10 +42,11 @@ class Nlb3Mode(bc.BistMode):
         self.executables = {mode: params.format(mode) for mode in modes}
 
     def run(self, gbs_path, bus_num):
-        bc.load_gbs(gbs_path, bus_num)
+        bc.load_gbs(self, gbs_path, bus_num)
         for test, param in self.executables.items():
             print "Running fpgadiag {} test...\n".format(test)
-            cmd = "fpgadiag {}".format(param)
+            exec_cmd = os.path.join(self.cwd, 'fpgadiag')
+            cmd = "{} {}".format(exec_cmd, param)
             try:
                 subprocess.check_call(cmd, shell=True)
             except subprocess.CalledProcessError as e:

--- a/tools/fpgabist/fpgabist
+++ b/tools/fpgabist/fpgabist
@@ -39,6 +39,7 @@ FEATURES = ['fme', 'port', 'temp', 'power', 'errors all']
 
 def main(args):
     bdf = bist_common.get_all_fpga_bdfs()
+    cwd = os.path.dirname(os.path.realpath(__file__))
     if not bdf:
         sys.exit("No FPGA devices found")
     elif len(bdf) > 1 and not any([args.bus, args.device, args.function]):
@@ -59,7 +60,8 @@ def main(args):
 
     # Display data from FPGA info
     for feature in FEATURES:
-        cmd = "fpgainfo {} -b {}".format(feature, bdf['bus'])
+        func = os.path.join(cwd, 'fpgainfo')
+        cmd = "{} {} -b {}".format(func, feature, bdf['bus'])
         subprocess.call(cmd, shell=True)
 
     gbs_paths = args.gbs_paths


### PR DESCRIPTION
Before the bist tool was assuming that all of the opae tools were on the system path after install. This removes that dependency for use in the development and release flows.