### PR TITLE
c++utils: add `any_value` class

### DIFF
--- a/cmake/modules/test_config.cmake
+++ b/cmake/modules/test_config.cmake
@@ -101,6 +101,7 @@ function(Build_Test_Target Target_Name Target_LIB)
                 unit/gtOpen.cpp
                 unit/gtEnumerate.cpp
                 unit/gtOptionParser.cpp
+                unit/gtAnyValue.cpp
                 function/gtReset.cpp
                 function/gtBuffer.cpp
                 function/gtEnumerate.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ set(SRC gtmain.cpp
   unit/gtOpen.cpp
   unit/gtEnumerate.cpp
   unit/gtOptionParser.cpp
+  unit/gtAnyValue.cpp
   function/gtReset.cpp
   function/gtUmsg.cpp
   function/gtBuffer.cpp
@@ -115,6 +116,11 @@ set_tests_properties(
   test_open_common_mock_drv
   PROPERTIES
   ENVIRONMENT "LD_PRELOAD=lib/libmock.so")
+
+add_test(NAME test_any_value
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMAND gtapi  ${CMAKE_BINARY_DIR} --gtest_filter=Cxx*any*)
+
 
 ############################################################################
 ## Add Coverage Analysis ###################################################

--- a/tests/unit/gtAnyValue.cpp
+++ b/tests/unit/gtAnyValue.cpp
@@ -1,0 +1,114 @@
+/*++
+
+INTEL CONFIDENTIAL
+Copyright 2016 - 2017 Intel Corporation
+
+The source code contained or described  herein and all documents related to
+the  source  code  ("Material")  are  owned  by  Intel  Corporation  or its
+suppliers  or  licensors.  Title   to  the  Material   remains  with  Intel
+Corporation or  its suppliers  and licensors.  The Material  contains trade
+secrets  and  proprietary  and  confidential  information  of Intel  or its
+suppliers and licensors.  The Material is protected  by worldwide copyright
+and trade secret laws and treaty provisions. No part of the Material may be
+used,   copied,   reproduced,   modified,   published,   uploaded,  posted,
+transmitted,  distributed, or  disclosed in  any way  without Intel's prior
+express written permission.
+
+No license under any patent, copyright,  trade secret or other intellectual
+property  right  is  granted to  or conferred  upon  you by  disclosure  or
+delivery of the  Materials, either  expressly, by  implication, inducement,
+estoppel or otherwise. Any license  under such intellectual property rights
+must be express and approved by Intel in writing.
+
+--*/
+
+
+#include "gtest/gtest.h"
+
+#include "any_value.h"
+
+using namespace intel::utils;
+
+/**
+ * @test       any_value_01
+ *
+ * @brief      Given an any_value variable assigned from a uint64_t value<br>
+ *             When I get the value as a uint64_t type<br>
+ *             Then the value returned is equal to the original value<br>
+ *
+ */
+TEST(CxxCommonAll, any_value_01) {
+  any_value a = uint64_t(0x100);
+  auto b = a.value<uint64_t>();
+  EXPECT_EQ(0x100, b);
+}
+
+/**
+ * @test       any_value_02
+ *
+ * @brief      Given an any_value variable assigned from a uint64_t value<br>
+ *             When I get the value as a string type<br>
+ *             Then an exception of type any_value_cast_error is thrown<br>
+ *
+ */
+TEST(CxxCommonAll, any_value_02) {
+  any_value a = uint64_t(0x100);
+  EXPECT_THROW(std::string b = a.value<std::string>(), any_value_cast_error);
+}
+
+/**
+ * @test       any_value_03
+ *
+ * @brief      Given an any_value variable assigned from a string value<br>
+ *             When I get the value as a string type<br>
+ *             Then the value returned is equal to the original value<br>
+ *
+ */
+TEST(CxxCommonAll, any_value_03) {
+  any_value a = std::string("any");
+  auto b = a.value<std::string>();
+  EXPECT_STREQ("any", b.c_str());
+}
+
+/**
+ * @test       any_value_04
+ *
+ * @brief      Given an any_value variable assigned from a const char* value<br>
+ *             When I get the value as a const char* type<br>
+ *             Then the value returned is equal to the original value<br>
+ *
+ */
+TEST(CxxCommonAll, any_value_04) {
+  any_value a = static_cast<const char*>("any");
+  auto b = a.value<const char*>();
+  EXPECT_STREQ("any", b);
+}
+
+/**
+ * @test       any_value_05
+ *
+ * @brief      Given an any_value variable assigned from an int value<br>
+ *             And I assign that any_value to another variable of type any_value<br>
+ *             When I get the value as an int type<br>
+ *             Then the value returned is equal to the original value<br>
+ *
+ */
+TEST(CxxCommonAll, any_value_05) {
+  any_value a = static_cast<int>(100);
+  any_value b = a;
+  int c = b.value<int>();
+  EXPECT_EQ(100, c);
+}
+
+/**
+ * @test       any_value_06
+ *
+ * @brief      Given an any_value variable assigned from an int value<br>
+ *             When I check if the type is int
+ *             Then the result is true<br>
+ *
+ */
+TEST(CxxCommonAll, any_value_06) {
+  any_value a = static_cast<int>(100);
+  EXPECT_TRUE(a.is_type<int>());
+}

--- a/tests/unit/gtAnyValue.cpp
+++ b/tests/unit/gtAnyValue.cpp
@@ -104,11 +104,24 @@ TEST(CxxCommonAll, any_value_05) {
  * @test       any_value_06
  *
  * @brief      Given an any_value variable assigned from an int value<br>
- *             When I check if the type is int
+ *             When I check if the type is int<br>
  *             Then the result is true<br>
  *
  */
 TEST(CxxCommonAll, any_value_06) {
   any_value a = static_cast<int>(100);
   EXPECT_TRUE(a.is_type<int>());
+}
+
+/**
+ * @test       any_value_07
+ *
+ * @brief      Given an any_value variable assigned from an int value<br>
+ *             When I check if the type is a type other than int<br>
+ *             Then the result is false<br>
+ *
+ */
+TEST(CxxCommonAll, any_value_07) {
+  any_value a = static_cast<int>(100);
+  EXPECT_FALSE(a.is_type<std::string>());
 }

--- a/tools/c++utils/any_value.h
+++ b/tools/c++utils/any_value.h
@@ -1,0 +1,202 @@
+// Copyright(c) 2017, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+#include <iostream>
+#include <string>
+#include <memory>
+#include <algorithm>
+#include <type_traits>
+
+namespace intel {
+namespace utils {
+
+class any_value_cast_error : public std::exception {};
+
+/**
+ * @brief any_value is an opaque type and holder of any type
+ * It allows assigning values of arbitrary types to a variable
+ * of type any_value and later querying the value
+ */
+class any_value {
+ public:
+  /**
+   * @brief alias of the underlying storage type of the template
+   * argument
+   *
+   * @tparam T template argument to get the type of
+   */
+  template <typename T>
+  using storage_type =
+      typename std::decay<typename std::remove_reference<T>::type>::type;
+
+  /**
+   * @brief Create an any_value variable from an arbitrary variable.
+   * This allows a variable to be moved if possible to the
+   * private member variable (value_)
+   *
+   * @tparam U The type of the argument
+   * @param v The variable to copy
+   */
+  template <typename U>
+  any_value(U&& v)
+      : value_(new any_typed<storage_type<U>>(std::forward<U>(v))) {}
+
+  /**
+   * @brief Cast the underlying variable to argument type
+   *
+   * @tparam U The type to cast to
+   *
+   * @return The underlying value if its type is compatible with U
+   */
+  template <typename U>
+  U value() {
+    auto v = dynamic_cast<any_typed<storage_type<U>>*>(value_);
+    if (v == nullptr) {
+      throw any_value_cast_error();
+    }
+
+    return v->value_;
+  }
+
+  /**
+   * @brief Query if the underlying type is of type U
+   *
+   * @tparam U The type to check for
+   *
+   * @return true if the value can be casted to U, false otherwise
+   */
+  template <typename U>
+  bool is_type() {
+    return dynamic_cast<any_typed<storage_type<U>>*>(value_) != nullptr;
+  }
+
+  /**
+   * @brief Create an empty any_value variable with no underlying value
+   */
+  any_value() : value_(nullptr) {}
+
+  /**
+   * @brief Create an any_value copy variable from another one
+   * (of const type)
+   *
+   * @param other The other any_value variable to copy from
+   */
+  any_value(const any_value& other) : value_(other.clone()) {}
+
+  /**
+   * @brief Create an any_value copy variable from another one
+   *
+   * @param othe The other any_value variable to copy from
+   */
+  any_value(any_value& other) : value_(other.clone()) {}
+
+  /**
+   * @brief Create an any_value variable transfering ownership
+   * to it. The source variable is invalidated
+   *
+   * @param other The other any_value variable to move from
+   */
+  any_value(any_value&& other) : value_(other.value_) {
+    other.value_ = nullptr;
+  }
+
+  /**
+   * @brief Assign the underlying value from another any_value variable
+   *
+   * @param other The other any_value to copy from
+   *
+   * @return A reference to any_value self
+   */
+  any_value& operator=(const any_value& other) {
+    if (&other == this || value_ == other.value_) {
+      return *this;
+    }
+    if (other.value_ != nullptr) {
+      auto old_ptr = value_;
+      value_ = other.value_->clone();
+      if (old_ptr != nullptr) {
+        delete old_ptr;
+      }
+    }
+    return *this;
+  }
+
+  /**
+   * @brief Assign the underlying value from another any_value variable
+   * transfering ownership the any_value self. The other any_value
+   * variable is invalidated
+   *
+   * @param other The other any_value to copy from
+   *
+   * @return A reference to any_value self
+   */
+  any_value& operator=(any_value&& other) {
+    if (&other == this || value_ == other.value_) {
+      return *this;
+    }
+    if (other.value_ != nullptr) {
+      std::swap(value_, other.value_);
+    }
+    return *this;
+  }
+
+  /**
+   * @brief Destroy the any_value variable and its resources
+   */
+  virtual ~any_value() {
+    if (value_ != nullptr) {
+      delete value_;
+    }
+  }
+
+ private:
+  struct any_base {
+    virtual ~any_base() {}
+
+    virtual any_base* clone() const = 0;
+  };
+
+  template <typename T>
+  struct any_typed : public any_base {
+    template <typename U>
+    any_typed(U&& v) : value_(std::forward<U>(v)) {}
+    virtual ~any_typed() {}
+
+    virtual any_base* clone() const { return new any_typed<T>(value_); }
+    T value_;
+  };
+
+  any_base* clone() const {
+    if (value_ == nullptr) {
+      return nullptr;
+    }
+    return value_->clone();
+  }
+  any_base* value_;
+};
+
+}  // end of namespace utils
+}  // end of namespace intel


### PR DESCRIPTION
Add `any_value` class to replace use of boost::any.
This class was developed by looking at some online references to tips on
how to to implement the any functionality in boost.

This is a step in removing dependency on boost. If boost libraries are
needed in the future, they can be added then.