### PR TITLE
Add version command by cmake replacement

### DIFF
--- a/tools/packager/CMakeLists.txt
+++ b/tools/packager/CMakeLists.txt
@@ -31,12 +31,17 @@ include(packaging)
 include(FindPythonPackage)
 FIND_PYTHON_PKG("jsonschema" SEND_ERROR)
 
+################# Add version to packager.py ########################
+configure_file(packager.py ${CMAKE_CURRENT_BINARY_DIR}/packager.py @ONLY)
+
+set(PKG_PATH_MODULE ${CMAKE_CURRENT_BINARY_DIR}/packager.py packager.py)
+
 ################# generate executable python zip files ########################
 
 set(PKG_COMMON_FILES
     afu.py gbs.py utils.py metadata/constants.py metadata/__init__.py metadata/metadata.py schema/afu_schema_v01.json)
 
-set(PKG_PYTHON_FILES packager.py ${PKG_COMMON_FILES} README)
+set(PKG_PYTHON_FILES PKG_PATH_MODULE ${PKG_COMMON_FILES} README)
 CREATE_PYTHON_EXE(packager packager ${PKG_PYTHON_FILES})
 set(PACKAGER_BIN_LIST ${PACKAGER_BIN})
 

--- a/tools/packager/packager.py
+++ b/tools/packager/packager.py
@@ -32,9 +32,11 @@ import shutil
 import argparse
 import json
 import utils
+import shlex
 from afu import AFU
 from gbs import GBS
 from metadata import metadata
+from subprocess import Popen, PIPE
 
 PACKAGER_EXEC = "packager"
 DESCRIPTION = 'Intel OPAE FPGA Packager'
@@ -75,7 +77,13 @@ def run_packager():
         print(USAGE)
 
     elif args.cmd == "version":
-        print("{0}: version {1}".format(DESCRIPTION, VERSION))
+        try:
+            cmd = shlex.split("git log -1 --oneline")
+            p = Popen(cmd, stdout=PIPE).communicate()[0]
+            version = p.split(" ")[0] if VERSION.startswith("@") else VERSION
+        except OSError:
+            version = "UNKNOWN"
+        print("{0}: version {1}".format(DESCRIPTION, version))
     elif args.cmd == "create-gbs":
         subparser.usage = "\n" + cmd_description + \
             " --rbf=<RBF_PATH> --afu-json=<AFU_JSON_PATH>"\

--- a/tools/packager/packager.py
+++ b/tools/packager/packager.py
@@ -32,11 +32,9 @@ import shutil
 import argparse
 import json
 import utils
-import shlex
 from afu import AFU
 from gbs import GBS
 from metadata import metadata
-from subprocess import Popen, PIPE
 
 PACKAGER_EXEC = "packager"
 DESCRIPTION = 'Intel OPAE FPGA Packager'
@@ -77,8 +75,20 @@ def run_packager():
         print(USAGE)
 
     elif args.cmd == "version":
-        p = subprocess.check_output('git describe --tags', shell=True)
-        version = p.split()[0] if VERSION.startswith("@") else VERSION
+        if VERSION.startswith("@"):
+            try:
+                devnull = open(os.devnull, 'w')
+                repo = subprocess.check_output('git remote -v',
+                                               shell=True,
+                                               stderr=devnull)
+                version = (subprocess.check_output('git describe --tags',
+                                                   shell=True,
+                                                   stderr=devnull).split()[0]
+                           if "opae-sdk" in repo else "UNKNOWN REPO")
+            except subprocess.CalledProcessError:
+                version = "UNKNOWN"
+        else:
+            version = VERSION
         print("{0}: version {1}".format(DESCRIPTION, version))
     elif args.cmd == "create-gbs":
         subparser.usage = "\n" + cmd_description + \

--- a/tools/packager/packager.py
+++ b/tools/packager/packager.py
@@ -38,6 +38,7 @@ from metadata import metadata
 
 PACKAGER_EXEC = "packager"
 DESCRIPTION = 'Intel OPAE FPGA Packager'
+VERSION = "@INTEL_FPGA_API_VERSION@"
 
 try:
     assert sys.version_info >= (2, 7) and sys.version_info < (3, 0, 0)
@@ -73,6 +74,8 @@ def run_packager():
     if args.cmd == "help" or not args.cmd:
         print(USAGE)
 
+    elif args.cmd == "version":
+        print("{0}: version {1}".format(DESCRIPTION, VERSION))
     elif args.cmd == "create-gbs":
         subparser.usage = "\n" + cmd_description + \
             " --rbf=<RBF_PATH> --afu-json=<AFU_JSON_PATH>"\

--- a/tools/packager/packager.py
+++ b/tools/packager/packager.py
@@ -77,12 +77,8 @@ def run_packager():
         print(USAGE)
 
     elif args.cmd == "version":
-        try:
-            cmd = shlex.split("git log -1 --oneline")
-            p = Popen(cmd, stdout=PIPE).communicate()[0]
-            version = p.split(" ")[0] if VERSION.startswith("@") else VERSION
-        except OSError:
-            version = "UNKNOWN"
+        p = subprocess.check_output('git describe --tags', shell=True)
+        version = p.split()[0] if VERSION.startswith("@") else VERSION
         print("{0}: version {1}".format(DESCRIPTION, version))
     elif args.cmd == "create-gbs":
         subparser.usage = "\n" + cmd_description + \


### PR DESCRIPTION
The existing packager.py will run as usual.  The only difference will be that when invoked from the source tree (i.e., `python ./tools/packager/packager.py version`) it prints:

`Intel OPAE FPGA Packager: version @INTEL_FPGA_API_VERSION@`

After a cmake, the installed version will print:

`Intel OPAE FPGA Packager: version 0.13.0`

I hope this satisfies all the concerns brought up in the last 2 pull requests.  Once we decide the final solution, we can change this (if necessary).

Thanks.