### PR TITLE
modify FindPythonPackage to use Python found

### DIFF
--- a/cmake/modules/FindPythonPackage.cmake
+++ b/cmake/modules/FindPythonPackage.cmake
@@ -1,13 +1,13 @@
 # - Find python package installation status
 #
-# ERR_LEVEL: 
-#     SEND_ERROR     = CMake Error, continue processing 
+# ERR_LEVEL:
+#     SEND_ERROR     = CMake Error, continue processing
 #     WARNING        = CMake Warning, continue processing
 #     FATAL_ERROR    = CMake Error, stop processing and generation
 #
 
 if (NOT PYTHON_EXECUTABLE)
-    find_package(PythonInterp REQUIRED)
+    find_package(PythonInterp 2.7 REQUIRED)
 endif (NOT PYTHON_EXECUTABLE)
 
 macro(FIND_PYTHON_PKG PKG_NAME ERR_LEVEL )

--- a/cmake/modules/FindPythonPackage.cmake
+++ b/cmake/modules/FindPythonPackage.cmake
@@ -6,8 +6,12 @@
 #     FATAL_ERROR    = CMake Error, stop processing and generation
 #
 
+if (NOT PYTHON_EXECUTABLE)
+    find_package(PythonInterp REQUIRED)
+endif (NOT PYTHON_EXECUTABLE)
+
 macro(FIND_PYTHON_PKG PKG_NAME ERR_LEVEL )
-    execute_process( COMMAND python -c "import ${PKG_NAME}" ERROR_QUIET RESULT_VARIABLE  STATUS_FLAG)
+    execute_process( COMMAND ${PYTHON_EXECUTABLE} -c "import ${PKG_NAME}" ERROR_QUIET RESULT_VARIABLE  STATUS_FLAG)
 
     if(STATUS_FLAG)
         message(${ERR_LEVEL} "PACKAGER depenency python ${PKG_NAME} package is missing!!!")


### PR DESCRIPTION
Add find_package(PythonInter...) to the beginning of the file
(outside of the macro) so that cmake finds the Python interpreter
and uses it when checking for existence of a module.