### PR TITLE
docs: add RPM extraction to install guide

### DIFF
--- a/doc/src/install_guide/installation_guide.md
+++ b/doc/src/install_guide/installation_guide.md
@@ -131,8 +131,8 @@ $ sudo rmmod intel-fpga-pci
 $ sudo rmmod fpga-mgr-mod
 ```
 
-## Manual Driver build/installation with RPM package ##
-Use the following command to extract the driver sources from the rpm:
+## Manual Driver build from RPM package ##
+Use the following command to extract the driver source files from the rpm:
 
 ```console
 $ mkdir opae-intel-fpga-driver-<release>

--- a/doc/src/install_guide/installation_guide.md
+++ b/doc/src/install_guide/installation_guide.md
@@ -131,6 +131,22 @@ $ sudo rmmod intel-fpga-pci
 $ sudo rmmod fpga-mgr-mod
 ```
 
+## Manual Driver build/installation with RPM package ##
+Use the following command to extract the driver sources from the rpm:
+
+```console
+$ mkdir opae-intel-fpga-driver-<release>
+$ cd opae-intel-fpga-driver-<release>
+$ rpm2cpio ../opae-intel-fpga-driver-<release>.rpm | cpio -idmv
+```
+
+Build the fpga driver from source with the following procedure:
+
+```console
+$ cd ./usr/src/intel-fpga-<release>
+$ make
+```
+
 ## OPAE SDK build/installation from OPAE SDK source ##
 Using the following command to untar the source tar ball:
 


### PR DESCRIPTION
Update the install guide with details of how to manually extract the
driver source files from an RPM. Without Debian package support,
some users are forced to use this method on Debian-based systems.