### PR TITLE
c++core: rename read/write to read_csr/write_csr

### DIFF
--- a/common/include/opae/cxx/core/handle.h
+++ b/common/include/opae/cxx/core/handle.h
@@ -60,33 +60,44 @@ class handle {
    */
   operator fpga_handle() const { return handle_; }
 
-  /** Write 32-bit value to MMIO.
-   * @param[in] offset The byte offset from MMIO base to write.
-   * @param[in] value  The value to be written.
-   * @return Whether the write was successful.
+  /**
+   * @brief Read CSR from resource associated with the handle
+   *
+   * @tparam T The type of value to return.
+   *
+   * @note Only uint32_t or uint64_t are allowed.
+   *
+   * @param offset The register offset
+   * @param csr_space The CSR space to read from. Default is 0.
+   *
+   * @return The value of type T read from the CSR
    */
-  virtual bool write(uint64_t offset, uint32_t value);
+  template<typename T>
+  T read_csr(uint64_t offset, uint32_t csr_space = 0) const {
+    (void)offset;
+    (void)csr_space;
+    throw except(OPAECXX_HERE);
+  }
 
-  /** Write 64-bit value to MMIO.
-   * @param[in] offset The byte offset from MMIO base to write.
-   * @param[in] value  The value to be written.
-   * @return Whether the write was successful.
+  /**
+   * @brief Write value to CSR from resource associated with the handle
+   *
+   * @tparam T The type of value to write.
+   *
+   * @note Only uint32_t or uint64_t are allowed.
+   *
+   * @param offset The register offset.
+   * @param value The value to write to the register.
+   * @param csr_space The CSR space to read from. Default is 0.
+   *
    */
-  virtual bool write(uint64_t offset, uint64_t value);
-
-  /** Read 32-bit value from MMIO.
-   * @param[in]  offset The byte offset from MMIO base to read.
-   * @param[out] value  Receives the value read.
-   * @return Whether the read was successful.
-   */
-  virtual bool read(uint64_t offset, uint32_t &value) const;
-
-  /** Read 64-bit value from MMIO.
-   * @param[in]  offset The byte offset from MMIO base to read.
-   * @param[out] value  Receives the value read.
-   * @return Whether the read was successful.
-   */
-  virtual bool read(uint64_t offset, uint64_t &value) const;
+  template<typename T>
+  void write_csr(uint64_t offset, T value, uint32_t csr_space = 0) {
+    (void)offset;
+    (void)value;
+    (void)csr_space;
+    throw except(OPAECXX_HERE);
+  }
 
   /** Retrieve a pointer to the MMIO region.
    * @param[in] offset The byte offset to add to MMIO base.

--- a/common/include/opae/cxx/core/handle.h
+++ b/common/include/opae/cxx/core/handle.h
@@ -61,43 +61,48 @@ class handle {
   operator fpga_handle() const { return handle_; }
 
   /**
-   * @brief Read CSR from resource associated with the handle
-   *
-   * @tparam T The type of value to return.
-   *
-   * @note Only uint32_t or uint64_t are allowed.
+   * @brief Read 32 bits from a CSR belonging to a resource associated
+   * with a handle.
    *
    * @param offset The register offset
    * @param csr_space The CSR space to read from. Default is 0.
    *
-   * @return The value of type T read from the CSR
+   * @return The 32-bit value read from the CSR
    */
-  template<typename T>
-  T read_csr(uint64_t offset, uint32_t csr_space = 0) const {
-    (void)offset;
-    (void)csr_space;
-    throw except(OPAECXX_HERE);
-  }
+  uint32_t read_csr32(uint64_t offset, uint32_t csr_space = 0) const;
 
   /**
-   * @brief Write value to CSR from resource associated with the handle
-   *
-   * @tparam T The type of value to write.
-   *
-   * @note Only uint32_t or uint64_t are allowed.
+   * @brief Write 32 bitto a CSR belonging to a resource associated
+   * with a handle.
    *
    * @param offset The register offset.
-   * @param value The value to write to the register.
+   * @param value The 32-bit value to write to the register.
    * @param csr_space The CSR space to read from. Default is 0.
    *
    */
-  template<typename T>
-  void write_csr(uint64_t offset, T value, uint32_t csr_space = 0) {
-    (void)offset;
-    (void)value;
-    (void)csr_space;
-    throw except(OPAECXX_HERE);
-  }
+  void write_csr32(uint64_t offset, uint32_t value, uint32_t csr_space = 0);
+
+  /**
+   * @brief Read 64 bits from a CSR belonging to a resource associated
+   * with a handle.
+   *
+   * @param offset The register offset
+   * @param csr_space The CSR space to read from. Default is 0.
+   *
+   * @return The 64-bit value read from the CSR
+   */
+  uint64_t read_csr64(uint64_t offset, uint32_t csr_space = 0) const;
+
+  /**
+   * @brief Write 64 bitto a CSR belonging to a resource associated
+   * with a handle.
+   *
+   * @param offset The register offset.
+   * @param value The 64-bit value to write to the register.
+   * @param csr_space The CSR space to read from. Default is 0.
+   *
+   */
+  void write_csr64(uint64_t offset, uint64_t value, uint32_t csr_space = 0);
 
   /** Retrieve a pointer to the MMIO region.
    * @param[in] offset The byte offset to add to MMIO base.

--- a/libopae++/samples/hello_fpga-1.cpp
+++ b/libopae++/samples/hello_fpga-1.cpp
@@ -88,20 +88,20 @@ int main(__attribute__((unused)) int argc,
   std::fill_n(out->get(), LPBK1_BUFFER_SIZE, 0xBE);
 
   //accel->reset();
-  accel->write(CSR_AFU_DSM_BASEL, dsm->iova());
-  accel->write(CSR_CTL, static_cast<uint32_t>(0));
-  accel->write(CSR_CTL, static_cast<uint32_t>(1));
-  accel->write(CSR_SRC_ADDR, cacheline_aligned_addr(inp->iova()));
-  accel->write(CSR_DST_ADDR, cacheline_aligned_addr(out->iova()));
+  accel->write_csr<uint64_t>(CSR_AFU_DSM_BASEL, dsm->iova());
+  accel->write_csr<uint32_t>(CSR_CTL, 0);
+  accel->write_csr<uint32_t>(CSR_CTL, 1);
+  accel->write_csr<uint64_t>(CSR_SRC_ADDR, cacheline_aligned_addr(inp->iova()));
+  accel->write_csr<uint64_t>(CSR_DST_ADDR, cacheline_aligned_addr(out->iova()));
 
-  accel->write(CSR_NUM_LINES, LPBK1_BUFFER_SIZE / 1*CL);
-  accel->write(CSR_CFG, static_cast<uint32_t>(0x42000));
+  accel->write_csr<uint64_t>(CSR_NUM_LINES, LPBK1_BUFFER_SIZE / 1*CL);
+  accel->write_csr<uint32_t>(CSR_CFG, 0x42000);
 
   // get ptr to device status memory - test complete
   auto status_ptr = dsm->get() + DSM_STATUS_TEST_COMPLETE / 8;
 
   // start the test
-  accel->write(CSR_CTL, static_cast<uint32_t>(3));
+  accel->write_csr<uint32_t>(CSR_CTL, 3);
 
   // wait for test completion
   while (0 == ((*status_ptr) * 0x1)) {
@@ -109,7 +109,7 @@ int main(__attribute__((unused)) int argc,
   }
 
   // stop the device
-  accel->write(CSR_CTL, static_cast<uint32_t>(7));
+  accel->write_csr<uint32_t>(CSR_CTL, 7);
 
   // check output buffer contents
   auto mm = std::mismatch(inp->get(), inp->get() + LPBK1_BUFFER_SIZE, out->get());

--- a/libopae++/samples/hello_fpga-1.cpp
+++ b/libopae++/samples/hello_fpga-1.cpp
@@ -88,20 +88,20 @@ int main(__attribute__((unused)) int argc,
   std::fill_n(out->get(), LPBK1_BUFFER_SIZE, 0xBE);
 
   //accel->reset();
-  accel->write_csr<uint64_t>(CSR_AFU_DSM_BASEL, dsm->iova());
-  accel->write_csr<uint32_t>(CSR_CTL, 0);
-  accel->write_csr<uint32_t>(CSR_CTL, 1);
-  accel->write_csr<uint64_t>(CSR_SRC_ADDR, cacheline_aligned_addr(inp->iova()));
-  accel->write_csr<uint64_t>(CSR_DST_ADDR, cacheline_aligned_addr(out->iova()));
+  accel->write_csr64(CSR_AFU_DSM_BASEL, dsm->iova());
+  accel->write_csr32(CSR_CTL, 0);
+  accel->write_csr32(CSR_CTL, 1);
+  accel->write_csr64(CSR_SRC_ADDR, cacheline_aligned_addr(inp->iova()));
+  accel->write_csr64(CSR_DST_ADDR, cacheline_aligned_addr(out->iova()));
 
-  accel->write_csr<uint64_t>(CSR_NUM_LINES, LPBK1_BUFFER_SIZE / 1*CL);
-  accel->write_csr<uint32_t>(CSR_CFG, 0x42000);
+  accel->write_csr64(CSR_NUM_LINES, LPBK1_BUFFER_SIZE / 1*CL);
+  accel->write_csr32(CSR_CFG, 0x42000);
 
   // get ptr to device status memory - test complete
   auto status_ptr = dsm->get() + DSM_STATUS_TEST_COMPLETE / 8;
 
   // start the test
-  accel->write_csr<uint32_t>(CSR_CTL, 3);
+  accel->write_csr32(CSR_CTL, 3);
 
   // wait for test completion
   while (0 == ((*status_ptr) * 0x1)) {
@@ -109,7 +109,7 @@ int main(__attribute__((unused)) int argc,
   }
 
   // stop the device
-  accel->write_csr<uint32_t>(CSR_CTL, 7);
+  accel->write_csr32(CSR_CTL, 7);
 
   // check output buffer contents
   auto mm = std::mismatch(inp->get(), inp->get() + LPBK1_BUFFER_SIZE, out->get());

--- a/libopae++/samples/simple_example.cpp
+++ b/libopae++/samples/simple_example.cpp
@@ -56,8 +56,8 @@ int main(int argc, char* argv[]) {
     std::cout << "bus: 0x" << std::hex << props->bus << "\n";
     handle::ptr_t h = handle::open(tok, FPGA_OPEN_SHARED);
     uint64_t value1 = 0xdeadbeef, value2 = 0;
-    h->write(0x100, value1);
-    h->read(0x100, value2);
+    h->write_csr<uint64_t>(0x100, value1);
+    value2 = h->read_csr<uint64_t>(0x100);
     std::cout << "mmio @0x100: 0x" << std::hex << value2 << "\n";
     std::cout << "mmio @0x100: 0x" << std::hex
               << *reinterpret_cast<uint64_t*>(h->mmio_ptr(0x100)) << "\n";

--- a/libopae++/samples/simple_example.cpp
+++ b/libopae++/samples/simple_example.cpp
@@ -56,8 +56,8 @@ int main(int argc, char* argv[]) {
     std::cout << "bus: 0x" << std::hex << props->bus << "\n";
     handle::ptr_t h = handle::open(tok, FPGA_OPEN_SHARED);
     uint64_t value1 = 0xdeadbeef, value2 = 0;
-    h->write_csr<uint64_t>(0x100, value1);
-    value2 = h->read_csr<uint64_t>(0x100);
+    h->write_csr64(0x100, value1);
+    value2 = h->read_csr64(0x100);
     std::cout << "mmio @0x100: 0x" << std::hex << value2 << "\n";
     std::cout << "mmio @0x100: 0x" << std::hex
               << *reinterpret_cast<uint64_t*>(h->mmio_ptr(0x100)) << "\n";

--- a/libopae++/src/handle.cpp
+++ b/libopae++/src/handle.cpp
@@ -39,22 +39,6 @@ handle::handle(fpga_handle h, uint32_t mmio_region, uint8_t *mmio_base)
 
 handle::~handle() { close(); }
 
-bool handle::write(uint64_t offset, uint32_t value) {
-  return FPGA_OK == fpgaWriteMMIO32(handle_, mmio_region_, offset, value);
-}
-
-bool handle::write(uint64_t offset, uint64_t value) {
-  return FPGA_OK == fpgaWriteMMIO64(handle_, mmio_region_, offset, value);
-}
-
-bool handle::read(uint64_t offset, uint32_t &value) const {
-  return FPGA_OK == fpgaReadMMIO32(handle_, mmio_region_, offset, &value);
-}
-
-bool handle::read(uint64_t offset, uint64_t &value) const {
-  return FPGA_OK == fpgaReadMMIO64(handle_, mmio_region_, offset, &value);
-}
-
 handle::ptr_t handle::open(fpga_token token, int flags, uint32_t mmio_region) {
   fpga_handle c_handle = nullptr;
   uint8_t *mmio_base = nullptr;
@@ -125,6 +109,37 @@ void handle::reset() {
   }
 }
 
+template<>
+uint32_t handle::read_csr<uint32_t>(uint64_t offset, uint32_t csr_space) const {
+  uint32_t value = 0;
+  if (FPGA_OK == fpgaReadMMIO32(handle_, csr_space, offset, &value)){
+    return value;
+  }
+  throw except(OPAECXX_HERE);
+}
+
+template<>
+uint64_t handle::read_csr<uint64_t>(uint64_t offset, uint32_t csr_space) const {
+  uint64_t value = 0;
+  if (FPGA_OK == fpgaReadMMIO64(handle_, csr_space, offset, &value)){
+    return value;
+  }
+  throw except(OPAECXX_HERE);
+}
+
+template<>
+void handle::write_csr<uint32_t>(uint64_t offset, uint32_t value, uint32_t csr_space) {
+  if (FPGA_OK != fpgaWriteMMIO32(handle_, csr_space, offset, value)){
+    throw except(OPAECXX_HERE);
+  }
+}
+
+template<>
+void handle::write_csr<uint64_t>(uint64_t offset, uint64_t value, uint32_t csr_space) {
+  if (FPGA_OK != fpgaWriteMMIO64(handle_, csr_space, offset, value)){
+    throw except(OPAECXX_HERE);
+  }
+}
 }  // end of namespace types
 }  // end of namespace fpga
 }  // end of namespace opae

--- a/libopae++/src/handle.cpp
+++ b/libopae++/src/handle.cpp
@@ -109,8 +109,7 @@ void handle::reset() {
   }
 }
 
-template<>
-uint32_t handle::read_csr<uint32_t>(uint64_t offset, uint32_t csr_space) const {
+uint32_t handle::read_csr32(uint64_t offset, uint32_t csr_space) const {
   uint32_t value = 0;
   if (FPGA_OK == fpgaReadMMIO32(handle_, csr_space, offset, &value)){
     return value;
@@ -118,8 +117,7 @@ uint32_t handle::read_csr<uint32_t>(uint64_t offset, uint32_t csr_space) const {
   throw except(OPAECXX_HERE);
 }
 
-template<>
-uint64_t handle::read_csr<uint64_t>(uint64_t offset, uint32_t csr_space) const {
+uint64_t handle::read_csr64(uint64_t offset, uint32_t csr_space) const {
   uint64_t value = 0;
   if (FPGA_OK == fpgaReadMMIO64(handle_, csr_space, offset, &value)){
     return value;
@@ -127,15 +125,13 @@ uint64_t handle::read_csr<uint64_t>(uint64_t offset, uint32_t csr_space) const {
   throw except(OPAECXX_HERE);
 }
 
-template<>
-void handle::write_csr<uint32_t>(uint64_t offset, uint32_t value, uint32_t csr_space) {
+void handle::write_csr32(uint64_t offset, uint32_t value, uint32_t csr_space) {
   if (FPGA_OK != fpgaWriteMMIO32(handle_, csr_space, offset, value)){
     throw except(OPAECXX_HERE);
   }
 }
 
-template<>
-void handle::write_csr<uint64_t>(uint64_t offset, uint64_t value, uint32_t csr_space) {
+void handle::write_csr64(uint64_t offset, uint64_t value, uint32_t csr_space) {
   if (FPGA_OK != fpgaWriteMMIO64(handle_, csr_space, offset, value)){
     throw except(OPAECXX_HERE);
   }

--- a/scripts/test-codingstyle.sh
+++ b/scripts/test-codingstyle.sh
@@ -3,7 +3,7 @@
 pushd $(dirname $0)
 
 CHECKPATCH=checkpatch.pl
-FILES=$(find ../libopae ../common/include/opae ../ase/api/src ../ase/sw ../tools/fpgaconf ../tools/fpgad ../samples \( -iname "*.c" -or -iname "*.h" \) -and \( ! -name "srv.c" \) -and \( ! -path "../libopae/src/usrclk/*" \) )
+FILES=$(find ../libopae ../common/include/opae ../ase/api/src ../ase/sw ../tools/fpgaconf ../tools/fpgad ../samples \( -iname "*.c" -or -iname "*.h" \) -and \( ! -name "srv.c" \) -and \( ! -path "../libopae/src/usrclk/*" \) -and \( ! -path "../common/include/opae/cxx/*" \) )
 
 if [ ! -f $CHECKPATCH ]; then
 	wget --no-check-certificate https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl

--- a/scripts/test-gtapi-mock-drv.sh
+++ b/scripts/test-gtapi-mock-drv.sh
@@ -6,7 +6,8 @@ pushd mybuild_gtapi_mock_drv
 trap "popd" EXIT
 
 cmake .. -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
-make mock gtapi
-
+make mock gtapi fpgad
+./bin/fpgad -d
 make test
+kill $(cat /tmp/fpgad.pid)
 echo "test-gtapi-mock-drv build PASSED"

--- a/tests/unit/gtCxxBuffer.cpp
+++ b/tests/unit/gtCxxBuffer.cpp
@@ -13,13 +13,9 @@ extern "C" {
 #include <opae/cxx/core/dma_buffer.h>
 #include <opae/cxx/core/handle.h>
 #include <opae/cxx/core/except.h>
-#include <opae/cxx/accelerator.h>
 
-#include <opae/cxx/buffers.h>
 
 using namespace opae::fpga::types;
-using namespace opae::fpga::resource;
-using namespace opae::fpga::memory;
 
 class CxxBuffer_f1 : public ::testing::Test {
  protected:

--- a/tests/unit/gtCxxEvents.cpp
+++ b/tests/unit/gtCxxEvents.cpp
@@ -1,5 +1,7 @@
 #include "gtest/gtest.h"
 
+#include "opae/cxx/core/token.h"
+#include "opae/cxx/core/handle.h"
 #include "opae/cxx/core/events.h"
 
 using namespace opae::fpga::types;

--- a/tests/unit/gtCxxOpenClose.cpp
+++ b/tests/unit/gtCxxOpenClose.cpp
@@ -10,10 +10,8 @@ extern "C" {
 #include <opae/cxx/core/token.h>
 #include <opae/cxx/core/handle.h>
 #include <opae/cxx/core/properties.h>
-#include <opae/cxx/accelerator.h>
 
 using namespace opae::fpga::types;
-using namespace opae::fpga::resource;
 
 /**
  * @test handle_open_01

--- a/tests/unit/gtCxxReset.cpp
+++ b/tests/unit/gtCxxReset.cpp
@@ -1,9 +1,8 @@
 #include "gtest/gtest.h"
-
-#include <opae/cxx/accelerator.h>
+#include <opae/cxx/core/token.h>
+#include <opae/cxx/core/handle.h>
 
 using namespace opae::fpga::types;
-using namespace opae::fpga::resource;
 
 /**
  * @test handle_reset_01


### PR DESCRIPTION
* Rename csr read/write functions in `handle` class to read_csr<T> and
write_csr<T> to be more explicit in the operation and specify that the
functions are operating on CSRs. This is a template function where the
template argument specifies the register size (uint32_t or uint64_t for
32-bit or 64-bit respectively).
* Update samples to use updated API functions.