### PR TITLE
libopae: free MMIO mappings on close

### DIFF
--- a/libopae/src/close.c
+++ b/libopae/src/close.c
@@ -30,10 +30,19 @@
 
 #include <opae/access.h>
 #include "common_int.h"
+#include "wsid_list_int.h"
 
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+
+static void unmap_mmio_region(struct wsid_map *wm)
+{
+	if (munmap((void *)wm->offset, wm->len)) {
+		FPGA_MSG("munmap failed: %s",
+			 strerror(errno));
+	}
+}
 
 fpga_result __FPGA_API__ fpgaClose(fpga_handle handle)
 {
@@ -54,7 +63,8 @@ fpga_result __FPGA_API__ fpgaClose(fpga_handle handle)
 		return FPGA_INVALID_PARAM;
 	}
 
-	wsid_cleanup(&_handle->wsid_root);
+	wsid_cleanup(&_handle->wsid_root, NULL);
+	wsid_cleanup(&_handle->mmio_root, unmap_mmio_region);
 	free_umsg_buffer(handle);
 	close(_handle->fddev);
 	if (_handle->fdfpgad >= 0)

--- a/libopae/src/wsid_list.c
+++ b/libopae/src/wsid_list.c
@@ -116,7 +116,7 @@ bool wsid_del(struct wsid_map **root, uint64_t wsid)
  *
  * @param root
  */
-void wsid_cleanup(struct wsid_map **root)
+void wsid_cleanup(struct wsid_map **root, void (*clean)(struct wsid_map * ))
 {
 	if (!*root)
 		return;
@@ -124,9 +124,13 @@ void wsid_cleanup(struct wsid_map **root)
 	while ((*root)->next) {
 		struct wsid_map *tmp = *root;
 		*root = (*root)->next;
+		if (clean)
+			clean(tmp);
 		free(tmp);
 	}
 
+	if (clean)
+		clean(*root);
 	free(*root);
 	*root = NULL;
 }

--- a/libopae/src/wsid_list.c
+++ b/libopae/src/wsid_list.c
@@ -116,7 +116,7 @@ bool wsid_del(struct wsid_map **root, uint64_t wsid)
  *
  * @param root
  */
-void wsid_cleanup(struct wsid_map **root, void (*clean)(struct wsid_map * ))
+void wsid_cleanup(struct wsid_map **root, void (*clean)(struct wsid_map *))
 {
 	if (!*root)
 		return;

--- a/libopae/src/wsid_list_int.h
+++ b/libopae/src/wsid_list_int.h
@@ -42,7 +42,7 @@ bool wsid_add(struct wsid_map **root,
 	      uint64_t index,
 	      int      flags);
 bool wsid_del(struct wsid_map **root, uint64_t wsid);
-void wsid_cleanup(struct wsid_map **root, void (*clean)(struct wsid_map * ));
+void wsid_cleanup(struct wsid_map **root, void (*clean)(struct wsid_map *));
 uint64_t wsid_gen(void);
 
 struct wsid_map *wsid_find(struct wsid_map *root, uint64_t wsid);

--- a/libopae/src/wsid_list_int.h
+++ b/libopae/src/wsid_list_int.h
@@ -42,7 +42,7 @@ bool wsid_add(struct wsid_map **root,
 	      uint64_t index,
 	      int      flags);
 bool wsid_del(struct wsid_map **root, uint64_t wsid);
-void wsid_cleanup(struct wsid_map **root);
+void wsid_cleanup(struct wsid_map **root, void (*clean)(struct wsid_map * ));
 uint64_t wsid_gen(void);
 
 struct wsid_map *wsid_find(struct wsid_map *root, uint64_t wsid);


### PR DESCRIPTION
Parameterize wsid_cleanup() with an optional callback so that work can
be done on each mapping when the list is being destroyed. Add call to
destroy handle::mmio_root in fpgaClose().