### PR TITLE
libopaecxx: remove csr_space from handle::open

### DIFF
--- a/common/include/opae/cxx/core/handle.h
+++ b/common/include/opae/cxx/core/handle.h
@@ -64,20 +64,20 @@ class handle {
    * @brief Read 32 bits from a CSR belonging to a resource associated
    * with a handle.
    *
-   * @param offset The register offset
-   * @param csr_space The CSR space to read from. Default is 0.
+   * @param[in] offset The register offset
+   * @param[in] csr_space The CSR space to read from. Default is 0.
    *
    * @return The 32-bit value read from the CSR
    */
   uint32_t read_csr32(uint64_t offset, uint32_t csr_space = 0) const;
 
   /**
-   * @brief Write 32 bitto a CSR belonging to a resource associated
+   * @brief Write 32 bit to a CSR belonging to a resource associated
    * with a handle.
    *
-   * @param offset The register offset.
-   * @param value The 32-bit value to write to the register.
-   * @param csr_space The CSR space to read from. Default is 0.
+   * @param[in] offset The register offset.
+   * @param[in] value The 32-bit value to write to the register.
+   * @param[in] csr_space The CSR space to read from. Default is 0.
    *
    */
   void write_csr32(uint64_t offset, uint32_t value, uint32_t csr_space = 0);
@@ -86,29 +86,30 @@ class handle {
    * @brief Read 64 bits from a CSR belonging to a resource associated
    * with a handle.
    *
-   * @param offset The register offset
-   * @param csr_space The CSR space to read from. Default is 0.
+   * @param[in] offset The register offset
+   * @param[in] csr_space The CSR space to read from. Default is 0.
    *
    * @return The 64-bit value read from the CSR
    */
   uint64_t read_csr64(uint64_t offset, uint32_t csr_space = 0) const;
 
   /**
-   * @brief Write 64 bitto a CSR belonging to a resource associated
+   * @brief Write 64 bit to a CSR belonging to a resource associated
    * with a handle.
    *
-   * @param offset The register offset.
-   * @param value The 64-bit value to write to the register.
-   * @param csr_space The CSR space to read from. Default is 0.
+   * @param[in] offset The register offset.
+   * @param[in] value The 64-bit value to write to the register.
+   * @param[in] csr_space The CSR space to read from. Default is 0.
    *
    */
   void write_csr64(uint64_t offset, uint64_t value, uint32_t csr_space = 0);
 
   /** Retrieve a pointer to the MMIO region.
    * @param[in] offset The byte offset to add to MMIO base.
+   * @param[in] csr_space The desired CSR space. Default is 0.
    * @return MMIO base + offset
    */
-  uint8_t *mmio_ptr(uint64_t offset) const { return mmio_base_ + offset; }
+  uint8_t *mmio_ptr(uint64_t offset, uint32_t csr_space = 0) const;
 
   /** Open an accelerator resource, given a raw fpga_token
    *
@@ -120,8 +121,7 @@ class handle {
    * @param[in] mmio_region The zero-based index of
    * the desired MMIO region. See fpgaMapMMIO().
    */
-  static handle::ptr_t open(fpga_token token, int flags,
-                            uint32_t mmio_region = 0);
+  static handle::ptr_t open(fpga_token token, int flags);
 
   /** Open an accelerator resource, given a token object
    *
@@ -133,8 +133,7 @@ class handle {
    * @param[in] mmio_region The zero-based index of
    * the desired MMIO region. See fpgaMapMMIO().
    */
-  static handle::ptr_t open(token::ptr_t token, int flags,
-                            uint32_t mmio_region = 0);
+  static handle::ptr_t open(token::ptr_t token, int flags);
 
   /** Reset the accelerator identified by this handle
    */
@@ -144,11 +143,9 @@ class handle {
   fpga_result close();
 
  private:
-  handle(fpga_handle h, uint32_t mmio_region, uint8_t *mmio_base);
+  handle(fpga_handle h);
 
   fpga_handle handle_;
-  uint32_t mmio_region_;
-  uint8_t *mmio_base_;
   opae::fpga::internal::logger log_;
 };
 


### PR DESCRIPTION
This allows relying on the lazy mapping performed by the
fpgaReadMMIOxx() and fpgaWriteMMIOxx() accessors, enabling
access to any of the supported MMIO spaces associated with
the handle. Parameterize member fn mmio_ptr() with a csr_space
argument.