### PR TITLE
Fixed test_open_common_mock_drv test target.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 ############################################################################
 add_test(NAME test_open_common_mock_drv
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  COMMAND gtapi  ${CMAKE_BINARY_DIR} -v --gtest_filter=*MOCK*:*ALL*:-*event_drv_05*:*nodrv*:*Open*.03:*Open*.06:*Open*.open_drv_09:*Open*.07:*Enum*.18:*Enum*.19:*Buf*.PrepRel2MB01:*Buf*.Write01:*Buf*.WriteRead01)
+  COMMAND gtapi  ${CMAKE_BINARY_DIR} -v --gtest_filter=*MOCK*:*ALL*:-*event_drv_05*:*nodrv*:*Open*.03:*Open*.06:*Open*.open_drv_09:*Open*.07:*Enum*.18:*Enum*.19:*Buf*.PrepRel2MB01:*Buf*.Write01:*Buf*.WriteRead01:*Close*.03)
 
 set_tests_properties(
   test_open_common_mock_drv

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 ############################################################################
 add_test(NAME test_open_common_mock_drv
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  COMMAND gtapi  ${CMAKE_BINARY_DIR} -v --gtest_filter=*MOCK*:-*event_drv_05*:*nodrv*:*Open*.03:*Open*.06:*Open*.open_drv_09)
+  COMMAND gtapi  ${CMAKE_BINARY_DIR} -v --gtest_filter=*MOCK*:*ALL*:-*event_drv_05*:*nodrv*:*Open*.03:*Open*.06:*Open*.open_drv_09:*Open*.07:*Enum*.18:*Enum*.19)
 
 set_tests_properties(
   test_open_common_mock_drv

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 ############################################################################
 add_test(NAME test_open_common_mock_drv
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  COMMAND gtapi  ${CMAKE_BINARY_DIR} --gtest_filter="*MOCK*:-*event_drv_05*:-*nodrv*")
+  COMMAND gtapi  ${CMAKE_BINARY_DIR} -v --gtest_filter=*MOCK*:-*event_drv_05*:*nodrv*:*Open*.03:*Open*.06:*Open*.open_drv_09)
 
 set_tests_properties(
   test_open_common_mock_drv

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 ############################################################################
 add_test(NAME test_open_common_mock_drv
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  COMMAND gtapi  ${CMAKE_BINARY_DIR} -v --gtest_filter=*MOCK*:*ALL*:-*event_drv_05*:*nodrv*:*Open*.03:*Open*.06:*Open*.open_drv_09:*Open*.07:*Enum*.18:*Enum*.19)
+  COMMAND gtapi  ${CMAKE_BINARY_DIR} -v --gtest_filter=*MOCK*:*ALL*:-*event_drv_05*:*nodrv*:*Open*.03:*Open*.06:*Open*.open_drv_09:*Open*.07:*Enum*.18:*Enum*.19:*Buf*.PrepRel2MB01:*Buf*.Write01:*Buf*.WriteRead01)
 
 set_tests_properties(
   test_open_common_mock_drv

--- a/tests/function/gtUmsg.cpp
+++ b/tests/function/gtUmsg.cpp
@@ -193,7 +193,7 @@ TEST(LibopaecUmsgCommonMOCK, Umsg_drv_04) {
  *             fpgaGetUmsgPtr returns umsg address.
  *
  */
-TEST(LibopaecUmsgCommonMOCK, Umsg_drv_05) {
+TEST(LibopaecUmsgCommonHW, Umsg_drv_05) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h = NULL;


### PR DESCRIPTION
The previous gtest filter defined in tests/CMakeLists.txt caused the filter to be empty so none of the tests would actually be run for the target test_open_common_mock_drv. When they were actually running, four of the tests would fail for that target. This fixes the filter, disables reconfiguration so LibopaecOpenFCommonMOCK.02 can pass, and disables the three tests (LibopaecOpenFCommonMOCK.03, LibopaecOpenFCommonMOCKHW.06, LibopaecOpenFCommonMOCK.open_drv_09) that do not work with the mock driver.