### PR TITLE
Enabled ctest output on failure.

### DIFF
--- a/scripts/test-gtapi-mock-drv.sh
+++ b/scripts/test-gtapi-mock-drv.sh
@@ -8,5 +8,5 @@ trap "popd" EXIT
 cmake .. -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
 make mock gtapi
 
-make test
+CTEST_OUTPUT_ON_FAILURE=1 make test
 echo "test-gtapi-mock-drv build PASSED"


### PR DESCRIPTION
Enabled ctest output on test failure to assist in debugging.