### PR TITLE
fpgadiag: fix "freq" option for bw calc.

### DIFF
--- a/tools/fpgadiag/nlb0.cpp
+++ b/tools/fpgadiag/nlb0.cpp
@@ -300,6 +300,8 @@ bool nlb0::setup()
             cont_timeout_ += hours(timeout_hour);
         }
     }
+
+    options_.get_value<uint32_t>("freq", frequency_);
     options_.get_value<bool>("suppress-hdr", suppress_header_);
     options_.get_value<bool>("csv", csv_format_);
 

--- a/tools/fpgadiag/nlb3.cpp
+++ b/tools/fpgadiag/nlb3.cpp
@@ -388,6 +388,8 @@ bool nlb3::setup()
             cont_timeout_ += hours(timeout_hour);
         }
     }
+
+    options_.get_value<uint32_t>("freq", frequency_);
     options_.get_value<bool>("suppress-hdr", suppress_header_);
     options_.get_value<bool>("csv", csv_format_);
 

--- a/tools/fpgadiag/nlb7.cpp
+++ b/tools/fpgadiag/nlb7.cpp
@@ -323,6 +323,7 @@ bool nlb7::setup()
         return false;
     }
 
+    options_.get_value<uint32_t>("freq", frequency_);
     options_.get_value<bool>("suppress-hdr", suppress_headers_);
     options_.get_value<bool>("csv", csv_format_);
 


### PR DESCRIPTION
Set the `frequency_` member variable for nlb0, nlb3, and nlb7 to the
value in the `freq` option. Without this, the frequency used for
bandwitdth calculations was always 400 MHz (ignoring user input).