### PR TITLE
Generate CCI-P almost full signals on PCIe-only systems.

### DIFF
--- a/ase/rtl/ase_pkg.sv
+++ b/ase/rtl/ase_pkg.sv
@@ -640,32 +640,38 @@ package ase_pkg;
       end
    endfunction // isWrFenceResponse
 
-`ifdef ASE_ENABLE_INTR_FEATURE
    // isIntrRequest
    function automatic logic isIntrRequest(TxHdr_t hdr);
       begin
+`ifdef ASE_ENABLE_INTR_FEATURE
 	 if (hdr.reqtype == ASE_INTR_REQ) begin
 	    return 1;
 	 end
 	 else begin
 	    return 0;
 	 end
+`else
+	 return 0;
+`endif
       end
    endfunction
 
    // isIntrResponse
    function automatic logic isIntrResponse(RxHdr_t hdr);
       begin
+`ifdef ASE_ENABLE_INTR_FEATURE
 	 if (hdr.resptype == ASE_INTR_RSP) begin
 	    return 1;
 	 end
 	 else begin
 	    return 0;
 	 end
+`else
+	 return 0;
+`endif
       end
    endfunction
 
-`endif
 
    // ------------------------------------------- //
    // Virtual channel ease functions

--- a/ase/rtl/ccip_emulator.sv
+++ b/ase/rtl/ccip_emulator.sv
@@ -1734,7 +1734,7 @@ module ccip_emulator
        .NUM_STATIONS_FULL_THRESH (LATBUF_FULL_THRESHOLD),
        .COUNT_WIDTH         (LATBUF_COUNT_WIDTH),
        .VISIBLE_DEPTH_BASE2 (8),
-       .VISIBLE_FULL_THRESH (220),
+       .VISIBLE_FULL_THRESH (32),
        .LATBUF_MAX_TXN      (1),
        .WRITE_CHANNEL       (0)
        )
@@ -1814,7 +1814,7 @@ module ccip_emulator
        .NUM_STATIONS_FULL_THRESH (LATBUF_FULL_THRESHOLD),
        .COUNT_WIDTH         (LATBUF_COUNT_WIDTH),
        .VISIBLE_DEPTH_BASE2 (8),
-       .VISIBLE_FULL_THRESH (220),
+       .VISIBLE_FULL_THRESH (32),
        .LATBUF_MAX_TXN      (4),
        .WRITE_CHANNEL       (1)
        )

--- a/ase/rtl/platform.vh
+++ b/ase/rtl/platform.vh
@@ -124,34 +124,32 @@
 `define LAT_UNDEFINED              300
 
 `define RDWR_VL_LATRANGE           20,118
-`define RDWR_VH_LATRANGE           240,270
+`define RDWR_VH_LATRANGE           140,180
 
 `define ASE_MAX_LATENCY            300
 
 
 /*
- * Disable Transaction shuffling
- * - In integrated mode, OutOfOrder channel control is used
- * - In discrete mode, InOrder channel control is used
+ * Select transaction shuffling mode.
  *
  * Infinite bandwidth test mode (independent of platform selection)
  * `define INFINITE_BANDWIDTH_MODE
- *
- * Specific platform features like interrupts and UMsgs are explicitly
+ */
+`ifdef INFINITE_BANDWIDTH_MODE
+ `define FORWARDING_CHANNEL            inorder_wrf_channel
+`else
+ `define FORWARDING_CHANNEL            outoforder_wrf_channel
+`endif
+
+/* Specific platform features like interrupts and UMsgs are explicitly
  * selected based on platform type
  */
 // ------------------------------------------------------ //
 `ifdef FPGA_PLATFORM_INTG_XEON
- `ifdef INFINITE_BANDWIDTH_MODE
-  `define FORWARDING_CHANNEL            inorder_wrf_channel
- `else
-  `define FORWARDING_CHANNEL            outoforder_wrf_channel
- `endif
  `define ASE_ENABLE_UMSG_FEATURE
  `undef  ASE_ENABLE_INTR_FEATURE
 // ------------------------------------------------------ //
 `elsif FPGA_PLATFORM_DISCRETE
- `define FORWARDING_CHANNEL             inorder_wrf_channel
  `undef  ASE_ENABLE_UMSG_FEATURE
  `define ASE_ENABLE_INTR_FEATURE
 // ------------------------------------------------------ //


### PR DESCRIPTION
- Always use outoforder_wrf_channel.
- Tweak buffer sizes to reduce the number of buffered requests, more like HW.
- Add support for interrupt requests through outoforder_wrf_channel.
- Remove Verilog preprocessor macros for read vs. write in outoforder_wrf_channel.
  They were always defined, so weren't controlling anything.