### PR TITLE
fpgadiag: get pclock freq from nlb register

### DIFF
--- a/tools/fpgadiag/nlb.h
+++ b/tools/fpgadiag/nlb.h
@@ -64,6 +64,7 @@ enum class nlb0_csr : uint32_t
     num_lines   = 0x0130,
     src_addr    = 0x0120,
     dst_addr    = 0x0128,
+    status2     = 0x0170,
     mode7_args  = 0x0180,
     cmdq_sw     = 0x0190,
     cmdq_hw     = 0x0198
@@ -128,6 +129,7 @@ enum class nlb3_csr : uint32_t
     num_lines   = 0x0130,
     src_addr    = 0x0120,
     dst_addr    = 0x0128,
+    status2     = 0x0170,
     strided_acs = 0x0178,
     mode7_args  = 0x0180,
     cmdq_sw     = 0x0190,

--- a/tools/fpgadiag/nlb0.cpp
+++ b/tools/fpgadiag/nlb0.cpp
@@ -305,6 +305,18 @@ bool nlb0::setup()
     options_.get_value<bool>("suppress-hdr", suppress_header_);
     options_.get_value<bool>("csv", csv_format_);
 
+    // TODO: Infer pclock from the device id
+    // For now, get the pclock frequency from status2 register
+    // that frequency (MHz) is encoded in bits [47:32]
+    uint64_t s2 = 0;
+    if (accelerator_->read_mmio64(static_cast<uint32_t>(nlb0_csr::status2), s2)){
+      uint32_t freq = (s2 >> 32) & 0xffff;
+      if (freq > 0){
+        // frequency_ is in Hz
+        frequency_ = freq * 1E6;
+      }
+    }
+
     // FIXME: use actual size for dsm size
     dsm_ = accelerator_->allocate_buffer(dsm_size_);
     if (!dsm_) {

--- a/tools/fpgadiag/nlb3.cpp
+++ b/tools/fpgadiag/nlb3.cpp
@@ -393,6 +393,18 @@ bool nlb3::setup()
     options_.get_value<bool>("suppress-hdr", suppress_header_);
     options_.get_value<bool>("csv", csv_format_);
 
+    // TODO: Infer pclock from the device id
+    // For now, get the pclock frequency from status2 register
+    // that frequency (MHz) is encoded in bits [47:32]
+    uint64_t s2 = 0;
+    if (accelerator_->read_mmio64(static_cast<uint32_t>(nlb3_csr::status2), s2)){
+      uint32_t freq = (s2 >> 32) & 0xffff;
+      if (freq > 0){
+        // frequency_ is in Hz
+        frequency_ = freq * 1E6;
+      }
+    }
+
     // FIXME: use actual size for dsm size
     dsm_ = accelerator_->allocate_buffer(dsm_size_);
     if (!dsm_) {


### PR DESCRIPTION
The pClock frequency is static per device id but the getting the device
id from the properties is not implemented right now.
As a temporary workaround, the frequency will be encoded in status2
register (0x0170). Read the frequency from here and set it frequency_
member variable to that if it is non-zero.