### PR TITLE
make use of opae c++ exceptions

### DIFF
--- a/libopae++/src/dma_buffer.cpp
+++ b/libopae++/src/dma_buffer.cpp
@@ -34,13 +34,7 @@ namespace types {
 dma_buffer::~dma_buffer() {
   // If the allocation was successful.
   if (virt_) {
-    fpga_result res = fpgaReleaseBuffer(handle_->get(), wsid_);
-
-    if (res != FPGA_OK) {
-      log_.error() << "fpgaReleaseBuffer() failed with (" << res
-                   << ") " << fpgaErrStr(res);
-      throw except(res, OPAECXX_HERE);
-    }
+    ASSERT_FPGA_OK(fpgaReleaseBuffer(handle_->get(), wsid_));
   }
 }
 
@@ -59,20 +53,10 @@ dma_buffer::ptr_t dma_buffer::allocate(handle::ptr_t handle, size_t len) {
 
   fpga_result res = fpgaPrepareBuffer(
       handle->get(), len, reinterpret_cast<void **>(&virt), &wsid, 0);
-  if (res == FPGA_OK) {
-    res = fpgaGetIOAddress(handle->get(), wsid, &iova);
-    if (res == FPGA_OK) {
-      p.reset(new dma_buffer(handle, len, virt, wsid, iova));
-    } else {
-      log.error() << "fpgaGetIOAddress() failed with (" << res
-                  << ") " << fpgaErrStr(res);
-      throw except(res, OPAECXX_HERE);
-    }
-  } else {
-    log.error() << "fpgaPrepareBuffer() failed with (" << res
-                << ") " << fpgaErrStr(res);
-    throw except(res, OPAECXX_HERE);
-  }
+  ASSERT_FPGA_OK(res);
+  res = fpgaGetIOAddress(handle->get(), wsid, &iova);
+  ASSERT_FPGA_OK(res);
+  p.reset(new dma_buffer(handle, len, virt, wsid, iova));
 
   return p;
 }
@@ -90,21 +74,10 @@ dma_buffer::ptr_t dma_buffer::attach(handle::ptr_t handle, uint8_t *base,
       fpgaPrepareBuffer(handle->get(), len, reinterpret_cast<void **>(&virt),
                         &wsid, FPGA_BUF_PREALLOCATED);
 
-  if (res == FPGA_OK) {
-    res = fpgaGetIOAddress(handle->get(), wsid, &iova);
-    if (res == FPGA_OK) {
-      p.reset(new dma_buffer(handle, len, virt, wsid, iova));
-    } else {
-      log.error() << "fpgaGetIOAddress() failed with (" << res
-                  << ") " << fpgaErrStr(res);
-      throw except(res, OPAECXX_HERE);
-    }
-
-  } else {
-    log.error() << "fpgaPrepareBuffer() failed with (" << res
-                << ") " << fpgaErrStr(res);
-    throw except(res, OPAECXX_HERE);
-  }
+  ASSERT_FPGA_OK(res);
+  res = fpgaGetIOAddress(handle->get(), wsid, &iova);
+  ASSERT_FPGA_OK(res);
+  p.reset(new dma_buffer(handle, len, virt, wsid, iova));
 
   return p;
 }

--- a/libopae++/src/events.cpp
+++ b/libopae++/src/events.cpp
@@ -35,13 +35,8 @@ namespace types {
 
 event::~event()
 {
-  auto res = fpgaUnregisterEvent(*handle_, type_, event_handle_);
-  if (res){
-    log_.warn("~event()") << "fpgaUnregisterEvent returned " << fpgaErrStr(res);
-  }else{
-    res = fpgaDestroyEventHandle(&event_handle_);
-    log_.warn_if(res, "~event()") << "fpgaDestroyEventHandle returned " << fpgaErrStr(res);
-  }
+  ASSERT_FPGA_OK(fpgaUnregisterEvent(*handle_, type_, event_handle_));
+  ASSERT_FPGA_OK(fpgaDestroyEventHandle(&event_handle_));
 }
 
 event::operator fpga_event_handle()
@@ -53,10 +48,8 @@ event::ptr_t event::register_event(handle::ptr_t h, event::type_t t, int flags)
 {
   event::ptr_t evptr;
   fpga_event_handle eh;
-  auto res = fpgaCreateEventHandle(&eh);
-  if (res) throw except(res, OPAECXX_HERE);
-  res = fpgaRegisterEvent(*h, t, eh, flags);
-  if (res) throw except(res, OPAECXX_HERE);
+  ASSERT_FPGA_OK(fpgaCreateEventHandle(&eh));
+  ASSERT_FPGA_OK(fpgaRegisterEvent(*h, t, eh, flags));
   evptr.reset(new event(h, t, eh));
 
   return evptr;

--- a/libopae++/src/properties.cpp
+++ b/libopae++/src/properties.cpp
@@ -60,13 +60,7 @@ properties::properties()
       object_id(&props_, fpgaPropertiesGetObjectID, fpgaPropertiesSetObjectID),
       parent(&props_, fpgaPropertiesGetParent, fpgaPropertiesSetParent),
       guid(&props_) {
-  auto res = fpgaGetProperties(nullptr, &props_);
-  if (res != FPGA_OK) {
-    props_ = nullptr;
-    log_.error() << "fpgaGetProperties() failed with (" << res
-                 << ") " << fpgaErrStr(res);
-    throw except(res, OPAECXX_HERE);
-  }
+  ASSERT_FPGA_OK(fpgaGetProperties(nullptr, &props_));
 }
 
 properties::properties(const properties &p)
@@ -95,123 +89,36 @@ properties::properties(const properties &p)
       object_id(&props_, fpgaPropertiesGetObjectID, fpgaPropertiesSetObjectID),
       parent(&props_, fpgaPropertiesGetParent, fpgaPropertiesSetParent),
       guid(&props_) {
-  auto res = fpgaCloneProperties(p.props_, &props_);
-  if (res != FPGA_OK) {
-    log_.error() << "fpgaCloneProperties() failed with (" << res
-                 << ") " << fpgaErrStr(res);
-    throw except(res, OPAECXX_HERE);
-  }
+  ASSERT_FPGA_OK(fpgaCloneProperties(p.props_, &props_));
   // make sure that we have a cached copy of
   // everything that p has cached.
-  if (p.type.is_set()) {
-    res = type.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.bus.is_set()) {
-    res = bus.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.device.is_set()) {
-    res = device.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.function.is_set()) {
-    res = function.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.socket_id.is_set()) {
-    res = socket_id.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.num_slots.is_set()) {
-    res = num_slots.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.bbs_id.is_set()) {
-    res = bbs_id.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.bbs_version.is_set()) {
-    res = bbs_version.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.vendor_id.is_set()) {
-    res = vendor_id.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.model.is_set()) {
-    res = model.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.local_memory_size.is_set()) {
-    res = local_memory_size.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.capabilities.is_set()) {
-    res = capabilities.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.num_mmio.is_set()) {
-    res = num_mmio.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.num_interrupts.is_set()) {
-    res = num_interrupts.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.accelerator_state.is_set()) {
-    res = accelerator_state.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.object_id.is_set()) {
-    res = object_id.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.parent.is_set()) {
-    res = parent.update();
-    if (res)
-      goto log_err;
-  }
-  if (p.guid.is_set()) {
-    res = guid.update();
-    if (res)
-      goto log_err;
-  }
-  return;
+  if (p.type.is_set()) type.update();
+  if (p.bus.is_set()) bus.update();
+  if (p.device.is_set()) device.update();
+  if (p.function.is_set()) function.update();
+  if (p.socket_id.is_set()) socket_id.update();
+  if (p.num_slots.is_set()) num_slots.update();
+  if (p.bbs_id.is_set()) bbs_id.update();
+  if (p.bbs_version.is_set()) bbs_version.update();
+  if (p.vendor_id.is_set()) vendor_id.update();
+  if (p.model.is_set()) model.update();
+  if (p.local_memory_size.is_set()) local_memory_size.update();
+  if (p.capabilities.is_set()) capabilities.update();
+  if (p.num_mmio.is_set()) num_mmio.update();
+  if (p.num_interrupts.is_set()) num_interrupts.update();
+  if (p.accelerator_state.is_set()) accelerator_state.update();
+  if (p.object_id.is_set()) object_id.update();
+  if (p.parent.is_set()) parent.update();
+  if (p.guid.is_set()) guid.update();
 
-log_err:
-  log_.error("copy ctor") << "property getter failed with (" << res
-               << ") " << fpgaErrStr(res);
-  throw except(res, OPAECXX_HERE);
 }
 
 properties & properties::operator =(const properties &p)
 {
-  fpga_result res;
   if (this != &p) {
 
     if (props_) {
-      if ((res = fpgaDestroyProperties(&props_)) != FPGA_OK) {
-        log_.error() << "fpgaDestroyProperties() failed with (" << res
-                     << ") " << fpgaErrStr(res);
-        throw except(res, OPAECXX_HERE); 
-      }
+      ASSERT_FPGA_OK(fpgaDestroyProperties(&props_));
       props_ = nullptr;
       type.invalidate();
       bus.invalidate();
@@ -234,112 +141,31 @@ properties & properties::operator =(const properties &p)
     }
 
     if (p.props_) {
-      if ((res = fpgaCloneProperties(p.props_, &props_)) != FPGA_OK) {
-        log_.error() << "fpgaCloneProperties() failed with (" << res
-                     << ") " << fpgaErrStr(res);
-        throw except(res, OPAECXX_HERE);
-      }
+      ASSERT_FPGA_OK(fpgaCloneProperties(p.props_, &props_));
 
       // make sure that we have a cached copy of
       // everything that p has cached.
-      if (p.type.is_set()) {
-        res = type.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.bus.is_set()) {
-        res = bus.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.device.is_set()) {
-        res = device.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.function.is_set()) {
-        res = function.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.socket_id.is_set()) {
-        res = socket_id.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.num_slots.is_set()) {
-        res = num_slots.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.bbs_id.is_set()) {
-        res = bbs_id.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.bbs_version.is_set()) {
-        res = bbs_version.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.vendor_id.is_set()) {
-        res = vendor_id.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.model.is_set()) {
-        res = model.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.local_memory_size.is_set()) {
-        res = local_memory_size.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.capabilities.is_set()) {
-        res = capabilities.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.num_mmio.is_set()) {
-        res = num_mmio.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.num_interrupts.is_set()) {
-        res = num_interrupts.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.accelerator_state.is_set()) {
-        res = accelerator_state.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.object_id.is_set()) {
-        res = object_id.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.parent.is_set()) {
-        res = parent.update();
-        if (res)
-          goto log_err;
-      }
-      if (p.guid.is_set()) {
-        res = guid.update();
-        if (res)
-          goto log_err;
-      }
+      if (p.type.is_set()) type.update();
+      if (p.bus.is_set()) bus.update();
+      if (p.device.is_set()) device.update();
+      if (p.function.is_set()) function.update();
+      if (p.socket_id.is_set()) socket_id.update();
+      if (p.num_slots.is_set()) num_slots.update();
+      if (p.bbs_id.is_set()) bbs_id.update();
+      if (p.bbs_version.is_set()) bbs_version.update();
+      if (p.vendor_id.is_set()) vendor_id.update();
+      if (p.model.is_set()) model.update();
+      if (p.local_memory_size.is_set()) local_memory_size.update();
+      if (p.capabilities.is_set()) capabilities.update();
+      if (p.num_mmio.is_set()) num_mmio.update();
+      if (p.num_interrupts.is_set()) num_interrupts.update();
+      if (p.accelerator_state.is_set()) accelerator_state.update();
+      if (p.object_id.is_set()) object_id.update();
+      if (p.parent.is_set()) parent.update();
+      if (p.guid.is_set()) guid.update();
     }
   }
   return *this;
-
-log_err:
-  log_.error("operator =") << "property getter failed with (" << res
-                           << ") " << fpgaErrStr(res);
-  throw except(res, OPAECXX_HERE);
 }
 
 properties::properties(fpga_guid guid_in) : properties(){ guid = guid_in; }
@@ -348,25 +174,14 @@ properties::properties(fpga_objtype objtype) : properties() { type = objtype; }
 
 properties::~properties() {
   if (props_ != nullptr) {
-    auto res = fpgaDestroyProperties(&props_);
-    if (res != FPGA_OK) {
-      log_.error() << "fpgaDestroyProperties() failed with (" << res
-                   << ") " << fpgaErrStr(res);
-      throw except(res, OPAECXX_HERE); 
-    }
+    ASSERT_FPGA_OK(fpgaDestroyProperties(&props_));
   }
 }
 
 properties::ptr_t properties::read(fpga_token tok) {
   opae::fpga::internal::logger log("properties::read()");
   ptr_t p(new properties());
-  auto res = fpgaGetProperties(tok, &p->props_);
-  if (res != FPGA_OK) {
-    p.reset();
-    log.error() << "fpgaGetProperties() failed with (" << res
-                << ") " << fpgaErrStr(res);
-    throw except(res, OPAECXX_HERE); 
-  }
+  ASSERT_FPGA_OK(fpgaGetProperties(tok, &p->props_));
   return p;
 }
 

--- a/tests/unit/gtCxxProperties.cpp
+++ b/tests/unit/gtCxxProperties.cpp
@@ -8,6 +8,7 @@ extern "C" {
 
 #include "gtest/gtest.h"
 #include <opae/cxx/core/token.h>
+#include <opae/cxx/core/except.h>
 #include <uuid/uuid.h>
 
 using namespace opae::fpga::types;
@@ -110,6 +111,7 @@ TEST(CxxProperties, props_ctor_01){
  */
 TEST(CxxProperties, set_objtype) {
   properties p;
+  p.type = FPGA_ACCELERATOR;
   fpga_objtype t = p.type;
   fpga_objtype other_t =
       (t == FPGA_ACCELERATOR) ? FPGA_DEVICE : FPGA_ACCELERATOR;
@@ -125,6 +127,7 @@ TEST(CxxProperties, set_objtype) {
  */
 TEST(CxxProperties, get_model) {
   properties p;
-  std::string model = p.model;
-  EXPECT_TRUE(model.empty());
+  std::string model = "";
+  // Model is currently not supported in libopae-c
+  EXPECT_THROW(model = p.model, not_supported);
 }


### PR DESCRIPTION
Update the following classes to use the `ASSERT_FPGA_OK` macro (which will throw exception when fpga_result code is not `FPGA_OK`):
* pvalue
* properties
* token
* dma_buffer
* events