### PR TITLE
Change AFU interface type's key from "name" to "class".

### DIFF
--- a/platforms/afu_top_ifc_db/README_AFU.md
+++ b/platforms/afu_top_ifc_db/README_AFU.md
@@ -3,12 +3,12 @@
 AFU implementations must indicate which top-level interface they expect.
 The afu\_platform\_config script matches a platform to the expected AFU
 interface.  AFUs demand a particular top-level interface either by passing
-the interface name to afu\_platform\_config's --ifc argument or by encoding
-the interface name in the AFU's packager JSON database.  The JSON option
+the interface class to afu\_platform\_config's --ifc argument or by encoding
+the interface class in the AFU's packager JSON database.  The JSON option
 offers more control, since top-level interface parameters can be modified
 and automatically inserted clock crossings may be specified.
 
-The interface encoding in JSON is in the afu-image:afu-top-interface:name
+The interface encoding in JSON is in the afu-image:afu-top-interface:class
 field:
 
 ```json
@@ -16,13 +16,16 @@ field:
    "afu-image": {
       "afu-top-interface":
          {
-            "name": "ccip_std_afu"
+            "class": "ccip_std_afu"
          }
    }
 }
 ```
 
-In addition to the name, some module-ports parameters may be
+The interface "class" field was previously called "name".  For compatibility,
+the legacy "name" key remains supported.
+
+In addition to the class, some module-ports parameters may be
 overridden in the AFU JSON database.  For example, the following
 requests automatic registering of CCI-P signals on platforms that
 need more than one register stage, makes local memory optional and
@@ -36,7 +39,7 @@ and the AFU's top-level module.
    "afu-image": {
       "afu-top-interface":
          {
-            "name": "ccip_std_afu_avalon_mm",
+            "class": "ccip_std_afu_avalon_mm",
             "module-ports" :
                [
                   {

--- a/platforms/afu_top_ifc_db/ccip_std_afu.sv.template
+++ b/platforms/afu_top_ifc_db/ccip_std_afu.sv.template
@@ -28,7 +28,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import ccip_if_pkg::*;
+`include "platform_if.vh"
 
 module ccip_std_afu
    (

--- a/platforms/afu_top_ifc_db/ccip_std_afu_avalon_mm.sv.template
+++ b/platforms/afu_top_ifc_db/ccip_std_afu_avalon_mm.sv.template
@@ -28,7 +28,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-`include "device_if.vh"
+`include "platform_if.vh"
 
 module ccip_std_afu
   #(

--- a/platforms/afu_top_ifc_db/ccip_std_afu_avalon_mm_legacy_wires.sv.template
+++ b/platforms/afu_top_ifc_db/ccip_std_afu_avalon_mm_legacy_wires.sv.template
@@ -28,7 +28,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import ccip_if_pkg::*;
+`include "platform_if.vh"
 
 module ccip_std_afu
   #(

--- a/platforms/scripts/afu_platform_config
+++ b/platforms/scripts/afu_platform_config
@@ -217,7 +217,7 @@ def getAfuIfc(args):
 
     if (args.ifc):
         # Interface name specified on the command line
-        afu_ifc['name'] = args.ifc
+        afu_ifc['class'] = args.ifc
         afu_ifc['file_path'] = None
         afu_ifc['file_name'] = None
     else:
@@ -260,18 +260,23 @@ def getAfuIfc(args):
         try:
             afu_ifc = data['afu-image']['afu-top-interface']
 
-            # The name 'module-ports' used to be 'module-arguments'
+            # The name 'module-ports' used to be 'module-arguments'.
             # Maintain compatibility with older AFUs.
             if ('module-arguments' in afu_ifc):
                 afu_ifc['module-ports'] = afu_ifc.pop('module-arguments')
+
+            # The interface 'class' used to be called 'name'.
+            # Maintain compatibility with older AFUs.
+            if ('name' in afu_ifc):
+                afu_ifc['class'] = afu_ifc.pop('name')
         except Exception:
             # The JSON file doesn't name the top-level interface.
             # Was a default specified on the command line?
             if (args.default_ifc):
                 afu_ifc = dict()
-                afu_ifc['name'] = args.default_ifc
+                afu_ifc['class'] = args.default_ifc
             else:
-                errorExit("No afu-image:afu-top-interface:name found " +
+                errorExit("No afu-image:afu-top-interface:class found " +
                           "in {0}".format(afu_json))
 
         afu_ifc['file_path'] = afu_json
@@ -517,7 +522,7 @@ Platform database directories (OPAE_PLATFORM_DB_PATH):
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "-i", "--ifc",
-        help="""The AFU's top-level interface name or the full pathname of a
+        help="""The AFU's top-level interface class or the full pathname of a
                 JSON top-level interface descriptor. (E.g. ccip_std_afu)""")
     group.add_argument(
         "-s", "--src",
@@ -531,7 +536,7 @@ Platform database directories (OPAE_PLATFORM_DB_PATH):
 
     parser.add_argument(
         "--default-ifc",
-        help="""The default top-level interface name if no interface is
+        help="""The default top-level interface class if no interface is
                 specified in the AFU's JSON descriptor.""")
 
     if_default = os.path.join(getDBRootPath(), "platform_if")
@@ -574,7 +579,7 @@ Platform database directories (OPAE_PLATFORM_DB_PATH):
     platform_defaults.canonicalize()
 
     # Load the AFU top-level interface database
-    afu_ifc = jsondb(afu_ifc_req['name'], afu_top_ifc_db_path, 'AFU',
+    afu_ifc = jsondb(afu_ifc_req['class'], afu_top_ifc_db_path, 'AFU',
                      args.quiet)
     injectAfuIfcChanges(args, afu_ifc.db, afu_ifc_req)
     afu_ifc.canonicalize()

--- a/tools/packager/afu.py
+++ b/tools/packager/afu.py
@@ -77,6 +77,7 @@ class AFU(object):
             raise Exception("Cannot find {0}".format(afu_desc_file))
 
         self.afu_json = json.load(open(self.afu_desc_file, "r"))
+        self.compat_update()
 
         if not self.validate():
             raise Exception("Accelerator description file failed validation!")
@@ -84,9 +85,21 @@ class AFU(object):
     # Load AFU JSON file given an open file handle
     def load_afu_desc_file_hdl(self, afu_desc_file_hdl):
         self.afu_json = json.load(afu_desc_file_hdl)
+        self.compat_update()
 
         if not self.validate():
             raise Exception("Accelerator description file failed validation!")
+
+    # Update/rename fields as needed to maintain backward compatibility
+    def compat_update(self):
+        try:
+            afu_ifc = self.afu_json['afu-image']['afu-top-interface']
+            # The interface 'class' used to be called 'name'.
+            # Maintain compatibility with older AFUs.
+            if ('name' in afu_ifc):
+                afu_ifc['class'] = afu_ifc.pop('name')
+        except KeyError as e:
+            None
 
     def validate(self, packaging=False):
         if self.afu_json == {}:

--- a/tools/packager/afu_json_mgr.py
+++ b/tools/packager/afu_json_mgr.py
@@ -75,7 +75,7 @@ def create_json(subargs):
 
     # Top-level interface specified?
     if (subargs.top_ifc):
-        afu.update_afu_json(['afu-image/afu-top-interface/name:' +
+        afu.update_afu_json(['afu-image/afu-top-interface/class:' +
                              subargs.top_ifc])
 
     # Either set the specified UUID or pick one
@@ -130,7 +130,7 @@ def flatten_json(subargs):
     try:
         # May not be present.  (Will become required eventually.)
         entries['afu_top_ifc'] = '"' + \
-            afu.afu_json['afu-image']['afu-top-interface']['name'] + '"'
+            afu.afu_json['afu-image']['afu-top-interface']['class'] + '"'
     except Exception:
         None
 

--- a/tools/packager/schema/afu_schema_v01.json
+++ b/tools/packager/schema/afu_schema_v01.json
@@ -11,9 +11,9 @@
                 "afu-top-interface": {
                     "type" : "object",
                     "properties" : {
-                        "name" : {"type" : "string"}
+                        "class" : {"type" : "string"}
                     },
-                    "required" : ["name"]
+                    "required" : ["class"]
                 },
                 "clock-frequency-low" : {"type" : ["number", "string"],
                                          "pattern" : "^auto(-[0-9.]+)?$"

--- a/tools/packager/schema/afu_template.json
+++ b/tools/packager/schema/afu_template.json
@@ -4,7 +4,7 @@
       "power": 0,
       "afu-top-interface":
          {
-            "name": "ccip_std_afu"
+            "class": "ccip_std_afu"
          },
       "accelerator-clusters":
          [


### PR DESCRIPTION
Using "name" was a source of confusion every time I explained the PIM's AFU
JSON.  They would see "afu-top-interface:name" and think that's the module
name, which was a reasonable assumption.  It isn't.  Instead, it is the class
of the interface, defining the ports and not the module name.

For compatibility, the legacy key "name" is accepted as a synonym.