### PR TITLE
The PIM no longer offers auto mode for extra-timing-reg-stages.

### DIFF
--- a/platforms/afu_top_ifc_db/README.md
+++ b/platforms/afu_top_ifc_db/README.md
@@ -40,10 +40,9 @@ Each JSON database is a dictionary, supporting the following primary keys:
   offer a standard set of transformations that are common to many AFUs.  Platform
   shims may automatically instantiate clock-crossing FIFOs.  The shims may
   also insert registers to relax timing.  Clock management and register
-  insertion are controlled by parameters in an AFU's JSON file.  See the
-  add-extra-timing-reg-stages and clock module-ports parameters,
-  described in [README\_AFU](README_AFU.md) in this directory.  When not defined
-  or NULL, no shim is instantiated.
+  insertion are controlled by parameters in an AFU's JSON file.  See the clock
+  module-ports parameter, described in [README\_AFU](README_AFU.md) in this
+  directory.  When not defined or NULL, no shim is instantiated.
 
 - **parent**: String [optional]
 

--- a/platforms/afu_top_ifc_db/README_AFU.md
+++ b/platforms/afu_top_ifc_db/README_AFU.md
@@ -25,14 +25,12 @@ field:
 The interface "class" field was previously called "name".  For compatibility,
 the legacy "name" key remains supported.
 
-In addition to the class, some module-ports parameters may be
-overridden in the AFU JSON database.  For example, the following
-requests automatic registering of CCI-P signals on platforms that
-need more than one register stage, makes local memory optional and
-adds clock-crossing logic so that local memory's interface runs at
-the same frequency as CCI-P.  These transformations are performed
-in a shim that is automatically instantiated between the platform
-and the AFU's top-level module.
+In addition to the class, some module-ports parameters may be overridden in
+the AFU JSON database.  For example, the following makes local memory optional
+and adds clock-crossing logic so that local memory's interface runs at the
+same frequency as CCI-P.  These transformations are performed in a shim that
+is automatically instantiated between the platform and the AFU's top-level
+module.
 
 ```json
 {
@@ -42,13 +40,6 @@ and the AFU's top-level module.
             "class": "ccip_std_afu_avalon_mm",
             "module-ports" :
                [
-                  {
-                     "class": "cci-p",
-                     "params":
-                        {
-                           "add-extra-timing-reg-stages": "auto"
-                        }
-                  },
                   {
                      "class": "local-memory",
                      "optional": true,

--- a/platforms/platform_db/discrete_pcie3.json
+++ b/platforms/platform_db/discrete_pcie3.json
@@ -31,7 +31,6 @@
             "params":
                {
                   "vc-supported": "{ 1, 0, 1, 0 }",
-                  "suggested-extra-timing-reg-stages": 1,
                   "max-bw-active-lines-c0": "{ 256, 256, 256, 256 }",
                   "max-bw-active-lines-c1": "{ 128, 128, 128, 128 }"
                }

--- a/platforms/platform_db/platform_defaults/defaults_ccip.json
+++ b/platforms/platform_db/platform_defaults/defaults_ccip.json
@@ -41,44 +41,23 @@
    "comment":
       [
          "CCI-P requires that an AFU register both the request and response",
-         "signals before any combinational logic.  On some platforms, it",
-         "is easier to meet timing when there is more than one register",
-         "stage.  suggested-extra-timing-reg-stages is a platform-specific",
-         "recommendation of the number of extra CCI-P register stages",
-         "(beyond the required one) most likely to meet timing.",
-         "",
-         "Note: There is no extra platform-side buffering added for handling",
-         "extra almost full signals!  Extra buffering beyond one stage",
-         "counts against the sending limit following almost full.  Typically,",
-         "two times the number of extra inserted stages slots are lost to",
-         "buffering.  This accounts for the added latency of receiving",
-         "almost full and also accounts for extra in-flight requests beyond",
-         "CCI-P's required single buffering stage."
+         "signals before any combinational logic.  We expect that this value",
+         "will be 1 on all platforms, reflecting the expectation that an AFU",
+         "will register CCI-P Tx and Rx signals according to the CCI-P spec."
       ],
-   "suggested-extra-timing-reg-stages": 0,
+   "suggested-timing-reg-stages": 1,
 
    "comment":
       [
-         "suggested-extra-timing-reg-stages above is related to",
-         "add-extra-timing-reg-stages.  The former is a characteristic of",
-         "a platform.  It is the recommended number of extra register stages",
-         "between the partial reconfiguration boundary and the AFU to meet",
-         "timing.",
+         "add-timing-reg-stages is a request by the AFU to the platform to",
+         "insert register stages on behalf of the AFU between the partial",
+         "reconfiguration (PR) boundary and the AFU.  An AFU may set this to",
+         "1 in order to satisfy the CCI-P buffering required by the spec.",
          "",
-         "This new parameter, add-extra-timing-reg-stages is a",
-         "request by the AFU to the platform to actually insert",
-         "register stages on behalf of the AFU between the partial",
-         "reconfiguration (PR) boundary and the AFU.",
-         "",
-         "If add-extra-timing-reg-stages is set to 'auto' (use double",
-         "quotes), suggested-extra-timing-reg-stages are added.  The auto",
-         "setting maximizes the chances than an AFU will be portable across",
-         "multiple CCI-P platforms.  In addition to 'auto', this field",
-         "may also be an integer.  In that case, the specified number of",
-         "stages are added by the platform between the PR boundary and",
-         "the AFU."
+         "Be careful when requesting more than a single stage, since this",
+         "may lead to overruns due to late detection of almost full signals."
       ],
-   "add-extra-timing-reg-stages": 0,
+   "add-timing-reg-stages": 0,
 
    "comment":
       [

--- a/platforms/platform_db/platform_defaults/defaults_local_memory.json
+++ b/platforms/platform_db/platform_defaults/defaults_local_memory.json
@@ -21,21 +21,16 @@
          "MM interfaces this value is typically zero since registering",
          "Avalon MM's waitrequest protocol is complex."
       ],
-   "suggested-extra-timing-reg-stages": 0,
+   "suggested-timing-reg-stages": 0,
 
    "comment":
       [
-         "Like the CCI-P add-extra-timing-reg-stages, this field",
-         "requests that the platform add pipeline stages to the local",
-         "memory signals before passing them to the AFU.  Register stages",
-         "are added using an Avalon MM pipeline bridge.",
-         "",
-         "In addition to integer counts, the string 'auto' (use double",
-         "quotes) will cause suggested-extra-timing-reg-stages to be",
-         "added.  The 'auto' setting is intended to aid in making",
-         "AFUs portable across platforms."
+         "Like the CCI-P add-timing-reg-stages, this field requests",
+         "that the platform add pipeline stages to the local memory",
+         "signals before passing them to the AFU.  Register stages",
+         "are added using an Avalon MM pipeline bridge."
       ],
-   "add-extra-timing-reg-stages": 0,
+   "add-timing-reg-stages": 0,
 
    "comment":
       [

--- a/platforms/platform_if/rtl/device_cfg/ccip_cfg_pkg.sv
+++ b/platforms/platform_if/rtl/device_cfg/ccip_cfg_pkg.sv
@@ -79,17 +79,12 @@ package ccip_cfg_pkg;
     // Is a given request length supported, indexed by t_ccip_clLen?  (0 or 1)
     parameter int CL_LEN_SUPPORTED[4] = `PLATFORM_PARAM_CCI_P_CL_LEN_SUPPORTED;
 
-    // Recommended number of extra edge register stages for CCI-P request/response
-    // signals, not including the single stage already required by the CCI-P
-    // specification.  On some platforms, timing closure is difficult without more
-    // stages.  Note:  There is no extra platform-side buffering added for handling
-    // extra almost full signals!  Extra buffering beyond one stage counts against
-    // the sending limit following almost full.  Typically, two times the number of
-    // extra inserted stages slots are lost to buffering.  This accounts for the
-    // added latency of receiving almost full and also accounts for extra in-flight
-    // requests beyond CCI-P's required single buffering stage.
-    parameter int SUGGESTED_EXTRA_TIMING_REG_STAGES =
-        `PLATFORM_PARAM_CCI_P_SUGGESTED_EXTRA_TIMING_REG_STAGES;
+    // Recommended number of edge register stages for CCI-P request/response
+    // signals.  This is expected to be one on all platforms, reflecting the
+    // requirement in the specification that all CCI-P Tx and Rx signals be
+    // registered by the AFU.
+    parameter int SUGGESTED_TIMING_REG_STAGES =
+        `PLATFORM_PARAM_CCI_P_SUGGESTED_TIMING_REG_STAGES;
 
     // Mask of request types (e_c0_req and e_c1_req) supported by the platform.
     parameter C0_SUPPORTED_REQS = int'(`PLATFORM_PARAM_CCI_P_C0_SUPPORTED_REQS);

--- a/platforms/platform_if/rtl/platform_shims/README.md
+++ b/platforms/platform_if/rtl/platform_shims/README.md
@@ -11,7 +11,7 @@ AFU top-level interface descriptions: [afu\_top\_ifc\_db](../../../afu_top_ifc_d
 
 Shims typically offer automatic clock crossing and automatic platform-specific
 register stage insertion to aid in timing closure.  See the various instances of
-*clock* and *add-extra-timing-reg-stages* in
+*clock* and *add-timing-reg-stages* in
 [platform\_defaults.json](../../../platform_db/platform_defaults.json).
 
 Some modules here are sub-shims, instantiated by larger shims.  For example,

--- a/platforms/platform_if/rtl/platform_shims/platform_shim_avalon_mem_if.sv
+++ b/platforms/platform_if/rtl/platform_shims/platform_shim_avalon_mem_if.sv
@@ -81,8 +81,8 @@ module platform_shim_avalon_mem_if
         int n_stages = 0;
 
         // Were timing registers requested in the AFU JSON?
-`ifdef PLATFORM_PARAM_LOCAL_MEMORY_ADD_EXTRA_TIMING_REG_STAGES
-        n_stages = `PLATFORM_PARAM_LOCAL_MEMORY_ADD_EXTRA_TIMING_REG_STAGES;
+`ifdef PLATFORM_PARAM_LOCAL_MEMORY_ADD_TIMING_REG_STAGES
+        n_stages = `PLATFORM_PARAM_LOCAL_MEMORY_ADD_TIMING_REG_STAGES;
 `endif
 
         // Override the register request if a clock crossing is being
@@ -90,10 +90,10 @@ module platform_shim_avalon_mem_if
         if (LOCAL_MEMORY_CHANGE_CLOCK)
         begin
             // Use at least the recommended number of stages
-`ifdef PLATFORM_PARAM_LOCAL_MEMORY_SUGGESTED_EXTRA_TIMING_REG_STAGES
-            if (`PLATFORM_PARAM_LOCAL_MEMORY_SUGGESTED_EXTRA_TIMING_REG_STAGES > n_stages)
+`ifdef PLATFORM_PARAM_LOCAL_MEMORY_SUGGESTED_TIMING_REG_STAGES
+            if (`PLATFORM_PARAM_LOCAL_MEMORY_SUGGESTED_TIMING_REG_STAGES > n_stages)
             begin
-                n_stages = `PLATFORM_PARAM_LOCAL_MEMORY_SUGGESTED_EXTRA_TIMING_REG_STAGES;
+                n_stages = `PLATFORM_PARAM_LOCAL_MEMORY_SUGGESTED_TIMING_REG_STAGES;
             end
 `endif
         end

--- a/platforms/platform_if/rtl/platform_shims/platform_shim_ccip.sv
+++ b/platforms/platform_if/rtl/platform_shims/platform_shim_ccip.sv
@@ -99,8 +99,8 @@ module platform_shim_ccip
         int n_stages = 0;
 
         // Were timing registers requested in the AFU JSON?
-`ifdef PLATFORM_PARAM_CCI_P_ADD_EXTRA_TIMING_REG_STAGES
-        n_stages = `PLATFORM_PARAM_CCI_P_ADD_EXTRA_TIMING_REG_STAGES;
+`ifdef PLATFORM_PARAM_CCI_P_ADD_TIMING_REG_STAGES
+        n_stages = `PLATFORM_PARAM_CCI_P_ADD_TIMING_REG_STAGES;
 `endif
 
         // Override the register request if a clock crossing is being
@@ -110,10 +110,10 @@ module platform_shim_ccip
             // At least one stage is required
             if (n_stages == 0) n_stages = 1;
             // Use at least the recommended number of stages
-`ifdef PLATFORM_PARAM_CCI_P_SUGGESTED_EXTRA_TIMING_REG_STAGES
-            if (`PLATFORM_PARAM_CCI_P_SUGGESTED_EXTRA_TIMING_REG_STAGES > n_stages)
+`ifdef PLATFORM_PARAM_CCI_P_SUGGESTED_TIMING_REG_STAGES
+            if (`PLATFORM_PARAM_CCI_P_SUGGESTED_TIMING_REG_STAGES > n_stages)
             begin
-                n_stages = `PLATFORM_PARAM_CCI_P_SUGGESTED_EXTRA_TIMING_REG_STAGES;
+                n_stages = `PLATFORM_PARAM_CCI_P_SUGGESTED_TIMING_REG_STAGES;
             end
 `endif
         end

--- a/platforms/scripts/afu_platform_config
+++ b/platforms/scripts/afu_platform_config
@@ -260,6 +260,8 @@ def getAfuIfc(args):
         try:
             afu_ifc = data['afu-image']['afu-top-interface']
 
+            # *** Clean up legacy AFU JSON ***
+
             # The name 'module-ports' used to be 'module-arguments'.
             # Maintain compatibility with older AFUs.
             if ('module-arguments' in afu_ifc):

--- a/platforms/scripts/platmgr/emitcfg.py
+++ b/platforms/scripts/platmgr/emitcfg.py
@@ -60,24 +60,24 @@ def emitHeader(f, afu_ifc_db, platform_db, comment="//"):
 # at synthesis time in Verilog.
 #
 def computedParams(afu_port, params):
-    # Set an actual value for add-extra-timing-reg-stages if the AFU
-    # says "auto".
+    # The script used to accept "auto" for add-timing-reg-stages.
+    # This is no longer necessary, since the number of stages expected
+    # for a given interface class will be a fixed, platform-independent
+    # value.
     try:
-        n_plat_stages = params['suggested-extra-timing-reg-stages']
-        n_auto = params['add-extra-timing-reg-stages']
-        if (n_auto):
-            if (n_auto == 'auto'):
-                n_auto = n_plat_stages
-                params['add-extra-timing-reg-stages'] = n_auto
+        n_stages = params['add-timing-reg-stages']
+        if (n_stages == 'auto'):
+            n_stages = 0
+            params['add-timing-reg-stages'] = 0
 
-            # Raise ValueError if the parameter isn't a positive integer
-            if (int(n_auto) < 0):
-                raise ValueError
+        # Raise ValueError if the parameter isn't a positive integer
+        if (int(n_stages) < 0):
+            raise ValueError
     except KeyError:
         None
     except ValueError:
         errorExit(afu_port['class'].upper() +
-                  ' parameter add-extra-timing-reg-stages must be ' +
+                  ' parameter add-timing-reg-stages must be ' +
                   'either an unsigned integer or "auto"')
 
     if (afu_port['class'].upper() == 'CCI-P'):
@@ -123,7 +123,7 @@ is_params.add('clock')
 #
 platform_shim_params = set()
 platform_shim_params.add('clock')
-platform_shim_params.add('add-extra-timing-reg-stages')
+platform_shim_params.add('add-timing-reg-stages')
 
 
 #

--- a/platforms/scripts/platmgr/jsondb.py
+++ b/platforms/scripts/platmgr/jsondb.py
@@ -370,6 +370,15 @@ class jsondb(object):
                          "must be >= min-entries in {2}").format(
                              port['class'], port['interface'], fname))
 
+            # *** Clean up legacy AFU JSON ***
+
+            # 'add-extra-timing-reg-stages' -> 'add-timing-reg-stages'
+            if ('params' in port):
+                params = port['params']
+                if ('add-extra-timing-reg-stages' in params):
+                    params['add-timing-reg-stages'] = \
+                        params.pop('add-extra-timing-reg-stages')
+
     #
     # Validate a platform defaults database and add some default fields
     # to avoid having to check whether they are present.


### PR DESCRIPTION
It was too confusing and, we have decided, of little value.  Instead, interface
classes will have consistent register requirements across platforms.  Any extra
buffering required at the PR boundary will be handled by supplied libraries.

Renamed "add-extra-timing-reg-stages" to simply "add-timing-reg-stages", since
that's now exactly what the code does.