### PR TITLE
tools: RAS fix device id read  logic for Integrated and Discrete fpga

### DIFF
--- a/tools/ras/main.c
+++ b/tools/ras/main.c
@@ -1072,7 +1072,7 @@ fpga_result mmio_error(struct RASCommandLine *rasCmdLine)
 		return result;
 	}
 
-	if( (value != FPGA_INTEGRATED_DEVICEID) ||
+	if( (value != FPGA_INTEGRATED_DEVICEID) &&
 		(value != FPGA_DISCRETE_DEVICEID) ) {
 		FPGA_ERR("Failed  to read Device id");
 		return FPGA_NOT_SUPPORTED;


### PR DESCRIPTION
Changes:
 - Ras tool support for Integrated and Discrete fpga