### PR TITLE
fpgad/ap_event: Fix build failure due to -Werror=maybe-uninitialized

### DIFF
--- a/tools/base/fpgad/ap_event.c
+++ b/tools/base/fpgad/ap_event.c
@@ -137,6 +137,9 @@ void *apevent_thread(void *thread_context)
 	struct fpga_ap_event apevt_socket1;
 	struct fpga_ap_event apevt_socket2;
 
+	memset(&apevt_socket1, 0, sizeof(apevt_socket1));
+	memset(&apevt_socket2, 0, sizeof(apevt_socket2));
+
 	// Max sockets count  2
 	apevt_socket1.socket = 0;
 	apevt_socket2.socket = 1;


### PR DESCRIPTION
gcc 7.1.0 issues the following build failures due to
-Werror=maybe-uninitialized.

opae-sdk/tools/base/fpgad/ap_event.c: In function ‘apevent_thread’:
opae-sdk/tools/base/fpgad/ap_event.c:121:12: error: ‘apevt_socket2.pwr_last_state’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  } else if (event->pwr_last_state != 0 && pwr_state == 0) {
            ^
opae-sdk/tools/base/fpgad/ap_event.c:138:23: note: ‘apevt_socket2.pwr_last_state’ was declared here
  struct fpga_ap_event apevt_socket2;
                       ^~~~~~~~~~~~~
opae-sdk/tools/base/fpgad/ap_event.c:100:5: error: ‘apevt_socket2.ap2_last_event’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  if (event->ap2_last_event != 1 && ap2_event == 1) {
     ^
opae-sdk/tools/base/fpgad/ap_event.c:138:23: note: ‘apevt_socket2.ap2_last_event’ was declared here
  struct fpga_ap_event apevt_socket2;
                       ^~~~~~~~~~~~~
opae-sdk/tools/base/fpgad/ap_event.c:121:12: error: ‘apevt_socket1.pwr_last_state’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  } else if (event->pwr_last_state != 0 && pwr_state == 0) {
            ^
opae-sdk/tools/base/fpgad/ap_event.c:137:23: note: ‘apevt_socket1.pwr_last_state’ was declared here
  struct fpga_ap_event apevt_socket1;
                       ^~~~~~~~~~~~~
opae-sdk/tools/base/fpgad/ap_event.c:100:5: error: ‘apevt_socket1.ap2_last_event’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  if (event->ap2_last_event != 1 && ap2_event == 1) {
     ^
opae-sdk/tools/base/fpgad/ap_event.c:137:23: note: ‘apevt_socket1.ap2_last_event’ was declared here
  struct fpga_ap_event apevt_socket1;
                       ^~~~~~~~~~~~~
cc1: all warnings being treated as errors

The fix is quite simple. Just initialize apevt_socket1/2 at the beginning.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>