### PR TITLE
Add platforms directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ if(BUILD_LIBOPAE_C)
   add_subdirectory(libopae)
 endif()
 
+add_subdirectory(platforms)
 add_subdirectory(tools)
 
 option(BUILD_ASE "Enable ASE compilation" ON)


### PR DESCRIPTION
platforms directory was inadvertanly removed from cmake processing.
This adds it back.