### PR TITLE
Ensure that 'bin' directory exists

### DIFF
--- a/cmake/modules/packaging.cmake
+++ b/cmake/modules/packaging.cmake
@@ -79,6 +79,7 @@ endfunction(DEFINE_PKG)
 
 macro(CREATE_PYTHON_EXE EXE_NAME MAIN_MODULE)
 
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
     set(PACKAGER_BIN ${PROJECT_BINARY_DIR}/bin/${EXE_NAME})
 
     # Generate a __main__.py that loads the target module


### PR DESCRIPTION
When trying to configure 'packager' tool, which relies on 'bin'
directory, Python couldn't write file, because directory doesn't exist
at this time.
We need to ensure, that directory is already there, before attempting
tool configuration.