### PR TITLE
Add version.c to ase/api/CMakeLists.txt

### DIFF
--- a/ase/api/CMakeLists.txt
+++ b/ase/api/CMakeLists.txt
@@ -45,6 +45,7 @@ set(ASEAPI_SRC
   ${API_DIR}/src/reconf.c
   ${API_DIR}/src/mmio.c
   ${API_DIR}/src/open.c
+  ${API_DIR}/src/version.c
   ${API_DIR}/src/umsg.c)
 
 add_library(opae-c-ase SHARED ${ASEAPI_SRC})

--- a/ase/api/CMakeLists.txt
+++ b/ase/api/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(opae-c-ase rt safestr)
 # paths. Keep current directory private.
 target_include_directories(opae-c-ase PUBLIC
   $<BUILD_INTERFACE:${OPAE_INCLUDE_DIR}>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
   $<INSTALL_INTERFACE:include>
   PRIVATE src
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/../sw>)
@@ -67,3 +68,6 @@ set_target_properties(opae-c-ase PROPERTIES
 install(TARGETS opae-c-ase
   LIBRARY DESTINATION lib
   COMPONENT opaecase)
+
+configure_file ("${CMAKE_SOURCE_DIR}/cmake/config/config.h.in"
+                "${PROJECT_BINARY_DIR}/include/config_int.h" )

--- a/ase/api/src/version.c
+++ b/ase/api/src/version.c
@@ -31,6 +31,7 @@
 #include "common_int.h"
 #include "types_int.h"
 #include "config_int.h"
+#include "ase_common.h"
 
 #include <string.h>
 
@@ -50,7 +51,7 @@ fpga_result __FPGA_API__ fpgaGetOPAECVersion(fpga_version *version)
 
 fpga_result __FPGA_API__ fpgaGetOPAECVersionString(char *version_str, size_t len)
 {
-	errno_t err = 0;
+	int err = 0;
 
 	if (!version_str) {
 		FPGA_MSG("version_str is NULL");
@@ -70,7 +71,7 @@ fpga_result __FPGA_API__ fpgaGetOPAECVersionString(char *version_str, size_t len
 
 fpga_result __FPGA_API__ fpgaGetOPAECBuildString(char *build_str, size_t len)
 {
-	errno_t err = 0;
+	int err = 0;
 
 	if (!build_str) {
 		FPGA_MSG("build_str is NULL");


### PR DESCRIPTION
Fix ASE implementation of fpgaGetOPAECBuildString and fpgaGetOPAECVersionString
Update ase/api/CMakeLists.txt

(cherry picked from commit 2d63c90e9a99007f82bf51390e13d48a630c66c9)