### PR TITLE
make numa support in cmdq3 optional in cmake

### DIFF
--- a/tools/extra/fpgadiag/CMakeLists.txt
+++ b/tools/extra/fpgadiag/CMakeLists.txt
@@ -68,10 +68,14 @@ set_target_properties(opae-c++-nlb PROPERTIES
   VERSION ${INTEL_FPGA_API_VERSION}
   SOVERSION ${INTEL_FPGA_API_VER_MAJOR})
 
-find_library(NUMA_LIB numa)
-if (NUMA_LIB)
-    add_definitions(-DENABLE_NUMA)
-endif(NUMA_LIB)
+option(CMDQ3_USE_NUMA "Build cmdq3 with numa support" OFF)
+mark_as_advanced(CMDQ3_USE_NUMA)
+if (CMDQ3_USE_NUMA)
+    find_library(NUMA_LIB numa)
+    if (NUMA_LIB)
+        add_definitions(-DENABLE_NUMA)
+    endif(NUMA_LIB)
+endif (CMDQ3_USE_NUMA)
 
 macro(add_fpgadiag_app target_name sources)
     add_executable(${target_name} ${sources})


### PR DESCRIPTION
The CMakeLists.txt for fpgadiag (and cmdq3) currently doesn't use a CMake
package finder to find numa and instead only looks for the library.
If it finds the library but the development files (headers) aren't present
on the system, the build can run into issues trying to include numa.h.
The PR makes it a CMake option to turn on numa support in cmdq3.

_TODO: Use (and maybe develop) a numa package finder to check for numa.h_