### PR TITLE
Fix dependency names for Debian packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,7 +261,7 @@ define_pkg(devel
   GROUP "devel"
   DISPLAY_NAME "opae-devel"
   DESCRIPTION "OPAE headers, sample source, and documentation"
-  DEB_DEPENDS "uuid , json-c , opae-libs"
+  DEB_DEPENDS "uuid-dev , libjson0 , opae-libs"
   )
 
   define_pkg(libs
@@ -270,7 +270,7 @@ define_pkg(devel
   GROUP "libs"
   DISPLAY_NAME "opae-libs"
   DESCRIPTION "OPAE runtime"
-  DEB_DEPENDS "uuid , json-c"
+  DEB_DEPENDS "uuid-dev , libjson0"
   )
 
 #Binary DEB packaging


### PR DESCRIPTION
The names json-c and uuid don't correspond to those in apt-cache. Modifying them to resolve dependency conflicts.