### PR TITLE
Remove PLATFORM_NAME macro creation in PIM's Quartus script

### DIFF
--- a/platforms/platform_if/par/platform_if_addenda.qsf
+++ b/platforms/platform_if/par/platform_if_addenda.qsf
@@ -12,56 +12,6 @@ set PLATFORM_IF_SRC [file join {*}[lrange [file split $this_script] 0 end-2]]
 ## Platform interface is available.
 set_global_assignment -name VERILOG_MACRO "PLATFORM_IF_AVAIL=1"
 
-##
-## Ideally, each platform will name itself as part of the build configuration.
-## Two Verilog macros are expected:
-##
-##     PLATFORM_NAME="<string with platform name>"
-##     PLATFORM_IS_<PLATFORM_NAME>
-##
-## Older releases did not do this.  However, each older platform used a specific
-## version of Quartus.  If PLATFORM_NAME isn't already defined figure it out
-## from the Quartus version.
-##
-
-# Search the current Verilog macro space, looking for "PLATFORM_NAME".
-set platform_name ""
-set macros [get_all_global_assignments -name VERILOG_MACRO]
-foreach_in_collection m $macros {
-    if {[info exists key]} { unset key }
-    regexp {(.+)=(.+)} [lindex $m 2] full key val
-    if {[info exists key]} {
-        if {$key eq "PLATFORM_NAME"} {
-            set platform_name $val
-            puts "Platform macro is set: PLATFORM_NAME=${platform_name}"
-            break
-        }
-    }
-}
-
-# If PLATFORM_NAME isn't defined try to figure it out.
-if {$platform_name eq ""} {
-    regexp {([0-9]+).([0-9]+).([0-9]+)} $quartus(version) version major minor build
-    if {$major == 13} {
-        set platform_name "INTG_OME"
-    } elseif {$major == 16} {
-        if {$minor == 0 && $build == 0} {
-            set platform_name "INTG_BDX"
-        } else {
-            set platform_name "INTG_SKX"
-        }
-    } elseif {$major == 17} {
-        set platform_name "DISCRETE_RC"
-    } else {
-        error "PLATFORM_NAME should be defined in the base build configuration."
-    }
-
-    puts "Inferred PLATFORM_NAME=\"${platform_name}\""
-    set_global_assignment -name VERILOG_MACRO PLATFORM_IS_${platform_name}=1
-    set_global_assignment -name VERILOG_MACRO PLATFORM_NAME="${platform_name}"
-}
-
-
 ## Search path
 set_global_assignment -name SEARCH_PATH $PLATFORM_IF_SRC/rtl
 set_global_assignment -name SEARCH_PATH $PLATFORM_IF_SRC/rtl/device_if

--- a/platforms/scripts/platmgr/emitcfg.py
+++ b/platforms/scripts/platmgr/emitcfg.py
@@ -161,8 +161,8 @@ def emitConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
     f.write("`ifndef __PLATFORM_AFU_TOP_CONFIG_VH__\n" +
             "`define __PLATFORM_AFU_TOP_CONFIG_VH__\n\n")
 
-    f.write("`define PLATFORM_CLASS_NAME " +
-            platform_db['platform-name'] + "\n")
+    f.write("`define PLATFORM_CLASS_NAME \"" +
+            platform_db['platform-name'].upper() + "\"\n")
     f.write("`define PLATFORM_CLASS_NAME_IS_" +
             platform_db['platform-name'].upper() + " 1\n\n")
 


### PR DESCRIPTION
Replaced with macros defined in platform_db entries.