### PR TITLE
fix any_value

### DIFF
--- a/tools/extra/c++utils/any_value.h
+++ b/tools/extra/c++utils/any_value.h
@@ -159,6 +159,8 @@ class any_value {
     }
     if (other.value_ != nullptr) {
       std::swap(value_, other.value_);
+      delete other.value_;
+      other.value_ = nullptr;
     }
     return *this;
   }


### PR DESCRIPTION
Fix the assignment operator in any_value to invalidate the other `value_` member.