### PR TITLE
remove parameter name from property_map::set

### DIFF
--- a/tools/extra/libopae++/property_map.h
+++ b/tools/extra/libopae++/property_map.h
@@ -78,7 +78,7 @@ public:
             {
                 value = opt->value<T>();
             }
-            catch(const intel::utils::any_value_cast_error & bac)
+            catch(const intel::utils::any_value_cast_error &)
             {
                 return false;
             }


### PR DESCRIPTION
The parameter is unused in the implementation of the function