### PR TITLE
opaecxx: Add version API

### DIFF
--- a/cmake/modules/test_config.cmake
+++ b/cmake/modules/test_config.cmake
@@ -110,6 +110,7 @@ function(Build_Test_Target Target_Name Target_LIB)
                 unit/gtCxxBuffer.cpp
                 unit/gtCxxReset.cpp
                 unit/gtCxxMMIO.cpp
+                unit/gtCxxVersion.cpp
                 function/gtReset.cpp
                 function/gtBuffer.cpp
                 function/gtEnumerate.cpp

--- a/common/include/opae/cxx/core/version.h
+++ b/common/include/opae/cxx/core/version.h
@@ -26,6 +26,8 @@
 #pragma once
 #include <string>
 
+#include <opae/types.h>
+
 namespace opae {
 namespace fpga {
 namespace types {

--- a/common/include/opae/cxx/core/version.h
+++ b/common/include/opae/cxx/core/version.h
@@ -1,0 +1,55 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+#include <string>
+
+namespace opae {
+namespace fpga {
+namespace types {
+
+class version {
+public:
+
+  /// @brief Get the package version information as a struct
+  ///
+  /// @return The package version as an `fpga_version` struct
+  static fpga_version as_struct();
+
+  /// @brief Get the package version information as a string
+  ///
+  /// @return The package version as an `std::string` object
+  static std::string as_string();
+
+  /// @brief Get the package build information as a string
+  ///
+  /// @return The package build as an `std::string` object
+  static std::string build();
+
+};
+
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/libopae++/CMakeLists.txt
+++ b/libopae++/CMakeLists.txt
@@ -53,7 +53,7 @@ set(OPAECXXCORE_SRC src/properties.cpp
                     src/dma_buffer.cpp
                     src/events.cpp
                     src/except.cpp
-		    src/version.cpp)
+                    src/version.cpp)
 
 add_library(opae-cxx-core SHARED ${OPAECXXCORE_SRC})
 target_link_libraries(opae-cxx-core opae-c)

--- a/libopae++/CMakeLists.txt
+++ b/libopae++/CMakeLists.txt
@@ -46,17 +46,14 @@ find_package(Threads)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-include_directories(
-    ${OPAE_INCLUDE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    )
 
 set(OPAECXXCORE_SRC src/properties.cpp
                     src/token.cpp
                     src/handle.cpp
                     src/dma_buffer.cpp
                     src/events.cpp
-                    src/except.cpp)
+                    src/except.cpp
+		    src/version.cpp)
 
 add_library(opae-cxx-core SHARED ${OPAECXXCORE_SRC})
 target_link_libraries(opae-cxx-core opae-c)
@@ -68,3 +65,18 @@ add_executable(hello_cxxcore samples/hello_fpga-1.cpp)
 target_link_libraries(hello_cxxcore opae-c ${CMAKE_THREAD_LIBS_INIT} opae-cxx-core )
 
 
+# Define headers for this library. PUBLIC headers are used for
+# compiling the library, and will be added to consumers' build
+# paths. Keep current directory private.
+target_include_directories(opae-cxx-core PUBLIC
+  $<BUILD_INTERFACE:${OPAE_INCLUDE_DIR}>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  PRIVATE src)
+
+############################################################################
+## Create config_int.h #########################################################
+############################################################################
+
+configure_file ("${CMAKE_SOURCE_DIR}/cmake/config/config.h.in"
+                "${PROJECT_BINARY_DIR}/include/config_int.h" )

--- a/libopae++/src/version.cpp
+++ b/libopae++/src/version.cpp
@@ -1,0 +1,57 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <opae/types.h>
+#include <opae/cxx/core/version.h>
+
+#include "config_int.h"
+
+namespace opae {
+namespace fpga {
+namespace types {
+
+fpga_version version::as_struct() {
+  fpga_version version_struct = {
+    .major = INTEL_FPGA_API_VER_MAJOR,
+    .minor = INTEL_FPGA_API_VER_MINOR,
+    .patch = INTEL_FPGA_API_VER_REV
+  };
+  return version_struct;
+}
+
+std::string version::as_string() {
+  return INTEL_FPGA_API_VERSION;
+}
+
+std::string version::build() {
+  return INTEL_FPGA_API_HASH;
+}
+
+
+
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,6 +122,7 @@ add_gtfilter(CxxBuffer "CxxBuffer*" True)
 add_gtfilter(CxxExcept "CxxExcept*" False)
 add_gtfilter(CxxEvent "CxxEvent*" True)
 add_gtfilter(CxxMMIO "CxxMMIO*" True)
+add_gtfilter(CxxVersion "CxxVersion*" False)
 
 ############################################################################
 ## Add Coverage Analysis ###################################################

--- a/tests/unit/gtCxxVersion.cpp
+++ b/tests/unit/gtCxxVersion.cpp
@@ -1,0 +1,72 @@
+/*++
+
+INTEL CONFIDENTIAL
+Copyright 2016 - 2018 Intel Corporation
+
+The source code contained or described  herein and all documents related to
+the  source  code  ("Material")  are  owned  by  Intel  Corporation  or its
+suppliers  or  licensors.  Title   to  the  Material   remains  with  Intel
+Corporation or  its suppliers  and licensors.  The Material  contains trade
+secrets  and  proprietary  and  confidential  information  of Intel  or its
+suppliers and licensors.  The Material is protected  by worldwide copyright
+and trade secret laws and treaty provisions. No part of the Material may be
+used,   copied,   reproduced,   modified,   published,   uploaded,  posted,
+transmitted,  distributed, or  disclosed in  any way  without Intel's prior
+express written permission.
+
+No license under any patent, copyright,  trade secret or other intellectual
+property  right  is  granted to  or conferred  upon  you by  disclosure  or
+delivery of the  Materials, either  expressly, by  implication, inducement,
+estoppel or otherwise. Any license  under such intellectual property rights
+must be express and approved by Intel in writing.
+
+--*/
+
+
+#include "common_test.h"
+#include "gtest/gtest.h"
+#include "config_int.h"
+#include <opae/cxx/core/version.h>
+
+using namespace common_test;
+using namespace std;
+using namespace opae::fpga::types;
+
+/**
+ * @test       as_struct
+ *
+ * @brief      When I retrieve fpga_version information using
+ *             version::as_struct() then the struct values match the
+ *             oonstants defined in config_int.h
+ */
+TEST(CxxVersion, as_struct) {
+  auto v = version::as_struct();
+	EXPECT_EQ(v.major, INTEL_FPGA_API_VER_MAJOR);
+	EXPECT_EQ(v.minor, INTEL_FPGA_API_VER_MINOR);
+	EXPECT_EQ(v.patch, INTEL_FPGA_API_VER_REV);
+}
+
+/**
+ * @test       as_string
+ *
+ * @brief      When I retrieve version information using
+ *             version::as_string() then the value returned matches
+ *             the string oonstant defined in config_int.h
+ */
+TEST(CxxVersion, as_string) {
+  auto v = version::as_string();
+	EXPECT_STREQ(v.c_str(), INTEL_FPGA_API_VERSION);
+}
+
+
+/**
+ * @test       build
+ *
+ * @brief      When I retrieve version information using
+ *             version::build() then the value returned matches
+ *             the string oonstant defined in config_int.h
+ */
+TEST(CxxVersion, build) {
+  auto v = version::build();
+	EXPECT_STREQ(v.c_str(), INTEL_FPGA_API_HASH);
+}

--- a/tests/unit/gtCxxVersion.cpp
+++ b/tests/unit/gtCxxVersion.cpp
@@ -22,11 +22,10 @@ must be express and approved by Intel in writing.
 
 --*/
 
-
-#include "common_test.h"
-#include "gtest/gtest.h"
-#include "config_int.h"
 #include <opae/cxx/core/version.h>
+#include "common_test.h"
+#include "config_int.h"
+#include "gtest/gtest.h"
 
 using namespace common_test;
 using namespace std;
@@ -41,9 +40,9 @@ using namespace opae::fpga::types;
  */
 TEST(CxxVersion, as_struct) {
   auto v = version::as_struct();
-	EXPECT_EQ(v.major, INTEL_FPGA_API_VER_MAJOR);
-	EXPECT_EQ(v.minor, INTEL_FPGA_API_VER_MINOR);
-	EXPECT_EQ(v.patch, INTEL_FPGA_API_VER_REV);
+  EXPECT_EQ(v.major, INTEL_FPGA_API_VER_MAJOR);
+  EXPECT_EQ(v.minor, INTEL_FPGA_API_VER_MINOR);
+  EXPECT_EQ(v.patch, INTEL_FPGA_API_VER_REV);
 }
 
 /**
@@ -55,9 +54,8 @@ TEST(CxxVersion, as_struct) {
  */
 TEST(CxxVersion, as_string) {
   auto v = version::as_string();
-	EXPECT_STREQ(v.c_str(), INTEL_FPGA_API_VERSION);
+  EXPECT_STREQ(v.c_str(), INTEL_FPGA_API_VERSION);
 }
-
 
 /**
  * @test       build
@@ -68,5 +66,5 @@ TEST(CxxVersion, as_string) {
  */
 TEST(CxxVersion, build) {
   auto v = version::build();
-	EXPECT_STREQ(v.c_str(), INTEL_FPGA_API_HASH);
+  EXPECT_STREQ(v.c_str(), INTEL_FPGA_API_HASH);
 }


### PR DESCRIPTION
This adds three static functions in a `version` class under `opae::fpga::types`
namespace.