### PR TITLE
Add mechanisms for selecting RTL sources based on FPGA family and Quartus versions (#345)

### DIFF
--- a/platforms/scripts/CMakeLists.txt
+++ b/platforms/scripts/CMakeLists.txt
@@ -48,16 +48,7 @@ foreach(SRC ${PLATFORM_SCRIPTS})
 endforeach(SRC)
 
 
-# Zip afu_platform_config with libraries.  Start with CMake variable substitution.
-configure_file(
-        afu_platform_config ${CMAKE_CURRENT_BINARY_DIR}/bin/afu_platform_config.py
-        @ONLY NEWLINE_STYLE UNIX)
-
-# Following variable substitution, the updated file is in a build directory.
-# The zipped file must be created without the path to the build tree.  Generate
-# a tuple (list) with the file's path and the name to call it in the zip file.
-set(AFU_PL_CFG ${CMAKE_CURRENT_BINARY_DIR}/bin/afu_platform_config.py
-               afu_platform_config.py)
+## Zip afu_platform_config and afu_platform_info with libraries.
 
 # The set of files to include in the zip file.  Pass the name of AFU_PL_CFG
 # above, which CREATE_PYTHON_EXE will detect as a path/name tuple.
@@ -67,9 +58,22 @@ set(PKG_PYTHON_FILES
     platmgr/jsondb.py
     platmgr/emitcfg.py)
 
-CREATE_PYTHON_EXE(afu_platform_config afu_platform_config ${PKG_PYTHON_FILES})
+foreach(SCRIPT afu_platform_config afu_platform_info)
+  # Start with CMake variable substitution.
+  configure_file(
+          ${SCRIPT} ${CMAKE_CURRENT_BINARY_DIR}/bin/${SCRIPT}.py
+          @ONLY NEWLINE_STYLE UNIX)
 
-# The CREATE_PYTHON_EXE macro sets PACKAGER_BIN to the generated zip file.
-install(PROGRAMS ${PACKAGER_BIN}
-        DESTINATION bin
-        COMPONENT platform)
+  # Following variable substitution, the updated file is in a build directory.
+  # The zipped file must be created without the path to the build tree.  Generate
+  # a tuple (list) with the file's path and the name to call it in the zip file.
+  set(AFU_PL_CFG ${CMAKE_CURRENT_BINARY_DIR}/bin/${SCRIPT}.py
+                 ${SCRIPT}.py)
+
+  CREATE_PYTHON_EXE(${SCRIPT} ${SCRIPT} ${PKG_PYTHON_FILES})
+
+  # The CREATE_PYTHON_EXE macro sets PACKAGER_BIN to the generated zip file.
+  install(PROGRAMS ${PACKAGER_BIN}
+          DESTINATION bin
+          COMPONENT platform)
+endforeach(SCRIPT)

--- a/platforms/scripts/afu_platform_info
+++ b/platforms/scripts/afu_platform_info
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+
+#
+# Copyright (c) 2018, Intel Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# Neither the name of the Intel Corporation nor the names of its contributors
+# may be used to endorse or promote products derived from this software
+# without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# This script extracts state from a platform database, mostly for use in
+# other scripts.
+#
+
+import os
+import sys
+import argparse
+import glob
+import json
+
+from platmgr.jsondb import jsondb
+
+
+def errorExit(msg):
+    sys.stderr.write("\nafu_platform_info error: " + msg + "\n")
+    sys.exit(1)
+
+
+#
+# Figure out the root of the base platform/AFU interface database.  The
+# database is installed along with OPAE SDK, so either find it in the
+# installation tree or in the source tree.
+#
+def getDBRootPath():
+    # CMake will update any variables marked by @ with the proper values.
+    project_src_dir = '@CMAKE_CURRENT_SOURCE_DIR@'
+    db_root_dir = '@PLATFORM_SHARE_DIR@'
+
+    # Parent directory of the running script
+    parent_dir = os.path.dirname(
+        os.path.dirname(os.path.realpath(sys.argv[0])))
+
+    # If this script is installed, the above variables are substituted.
+    if (db_root_dir[0] != '@'):
+        # The script has at least had variables substituted.  Either
+        # it is in the CMake build directory or it is installed.
+        if (os.path.isfile(os.path.join(parent_dir, 'CMakeCache.txt'))):
+            # We're in the CMake build directory.  Use the source tree's
+            # database.
+            db_root = os.path.dirname(project_src_dir)
+        else:
+            # The script is installed.  The installation path isn't known
+            # since it can be changed when using rpm --prefix.  We do
+            # guarantee that the OPAE bin and share directories have the
+            # same parent.
+            db_root = os.path.join(parent_dir, db_root_dir)
+    else:
+        # Running out of the source tree
+        db_root = parent_dir
+
+    return db_root
+
+
+def printKey(args, platform_db):
+    # Default -- key matches a top-level db field exactly
+    if ((args.key != '') and (args.key in platform_db)):
+        print(platform_db[args.key])
+        return
+
+    if (args.key == 'fpga-family'):
+        # Default value (A10) predicates fpga-family being present in the db.
+        print('A10')
+        return
+
+
+#
+# Return a list of all platform names found on the search path.
+#
+def findPlatforms(db_path):
+    platforms = set()
+    # Walk all the directories
+    for db_dir in db_path:
+        # Look for JSON files in each directory
+        for json_file in glob.glob(os.path.join(db_dir, "*.json")):
+            try:
+                with open(json_file, 'r') as f:
+                    # Does it have a platform name field?
+                    db = json.load(f)
+                    platforms.add(db['platform-name'])
+            except Exception:
+                # Give up on this file if there is any error
+                None
+
+    return sorted(list(platforms))
+
+
+#
+# Compute a directory search path given an environment variable name.
+# The final entry on the path is set to default_dir.
+#
+def getSearchPath(env_name, default_dir):
+    path = []
+
+    if (env_name in os.environ):
+        # Break path string using ':' and drop empty entries
+        path = [p for p in os.environ[env_name].split(':') if p]
+
+    # Append the database directory shipped with a release if
+    # the release containts hw/lib/platform/<default_dir>.
+    if ('OPAE_PLATFORM_ROOT' in os.environ):
+        release_db_dir = os.path.join(os.environ['OPAE_PLATFORM_ROOT'],
+                                      'hw', 'lib', 'platform',
+                                      default_dir)
+        if (os.path.isdir(release_db_dir)):
+            path.append(release_db_dir)
+
+    # Append the default directory from OPAE SDK
+    path.append(os.path.join(getDBRootPath(), default_dir))
+
+    return path
+
+
+def main():
+    # Users can extend the AFU and platform database search paths beyond
+    # the OPAE SDK defaults using environment variables.
+    afu_top_ifc_db_path = getSearchPath(
+        'OPAE_AFU_TOP_IFC_DB_PATH', 'afu_top_ifc_db')
+    platform_db_path = getSearchPath('OPAE_PLATFORM_DB_PATH', 'platform_db')
+
+    msg = '''
+afu_platform_info extracts configuration state from a platform database.
+The search path for database files is configurable with an environment
+variable using standard colon separation between paths:
+
+Platform database directories (OPAE_PLATFORM_DB_PATH):
+'''
+    for p in platform_db_path[:-1]:
+        msg += '  ' + p + '\n'
+    msg += '  ' + platform_db_path[-1] + ' [default]\n'
+
+    platform_names = findPlatforms(platform_db_path)
+    if (platform_names):
+        msg += "\n  Platforms found:\n"
+        for p in platform_names:
+            msg += '    ' + p + '\n'
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="Extract configuration state for a platform.",
+        epilog=msg)
+
+    # Positional arguments
+    parser.add_argument(
+        "platform",
+        help="""Either the name of a platform or the name of a platform
+                JSON file. If the argument is a platform name, the
+                platform JSON file will be loaded from the platform
+                database directory search path (see below).""")
+
+    parser.add_argument(
+        "-k", "--key",
+        choices=["ase-platform", "fpga-family"],
+        help="""State to fetch.""")
+
+    # Verbose/quiet
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "-v", "--verbose", action="store_true", help="Verbose output")
+    group.add_argument(
+        "-q", "--quiet", default=True,
+        action="store_true", help="Reduce output")
+    args = parser.parse_args()
+
+    # Load the platform database
+    platform = jsondb(args.platform, platform_db_path, 'platform', args.quiet)
+    platform.canonicalize()
+
+    # Load the platform default parameters
+    platform_defaults = jsondb('platform_defaults', platform_db_path,
+                               'platform-params', args.quiet)
+    platform_defaults.canonicalize()
+
+    printKey(args, platform.db)
+
+
+if __name__ == "__main__":
+    main()

--- a/platforms/scripts/afu_synth_setup
+++ b/platforms/scripts/afu_synth_setup
@@ -66,6 +66,7 @@ def errorExit(msg):
 def getHWLibPath(args):
     if (args.lib is not None):
         hw_lib_dir = args.lib
+        os.environ['BBS_LIB_PATH'] = hw_lib_dir
     elif ('BBS_LIB_PATH' in os.environ):
         # Legacy variable, shared with afu_sim_setup and HW releases
         hw_lib_dir = os.environ['BBS_LIB_PATH'].rstrip('/')
@@ -208,6 +209,7 @@ def setup_build(args):
     # Configure sources, generating hw/afu.qsf in the destination tree
     cmd = ['rtl_src_config']
     cmd.append('--qsf')
+    cmd.append('--quiet')
     if (os.path.isabs(sources)):
         cmd.append('--abs')
         cmd.append(sources)
@@ -246,6 +248,7 @@ def setup_build_ipx(args, sources, build_dir):
     # Get IPX files from source list
     cmd = ['rtl_src_config']
     cmd.append('--ipx')
+    cmd.append('--quiet')
     if (os.path.isabs(sources)):
         cmd.append('--abs')
         cmd.append(sources)

--- a/platforms/scripts/rtl_src_config
+++ b/platforms/scripts/rtl_src_config
@@ -11,10 +11,12 @@
 import argparse
 import os
 import sys
+import subprocess
+import re
 
 
 def errorExit(msg):
-    sys.stderr.write("\nError: " + msg + "\n")
+    sys.stderr.write("\nrtl_src_config error: " + msg + "\n")
     sys.exit(1)
 
 
@@ -197,7 +199,19 @@ def parseConfigFile(opts, cfg_file_name, tgt_dir):
                 c = c.strip()
                 # Drop comments
                 c = c.split('#', 1)[0]
+
                 # Replace environment variables
+                if ('OPAE_PLATFORM_FPGA_FAMILY' in c and
+                        'OPAE_PLATFORM_FPGA_FAMILY' not in os.environ):
+                    # The source requires version-specific Qsys and the
+                    # tag has not yet been determined.
+                    addDefaultFpgaFamily(opts)
+
+                if ('QUARTUS_VERSION' in c and
+                        ('QUARTUS_VERSION' not in os.environ or
+                         'QUARTUS_VERSION_MAJOR' not in os.environ)):
+                    getQuartusVersion(opts)
+
                 c = os.path.expandvars(c)
 
                 # Recursive include?
@@ -214,6 +228,117 @@ def parseConfigFile(opts, cfg_file_name, tgt_dir):
     return cfg
 
 
+#
+# The hw/lib directory of a platform's release.  We find the hw/lib
+# directory using the following search rules, in decreasing priority:
+#
+#   1. --lib argument to this script.
+#   2. BBS_LIB_PATH:
+#        We used to document this environment variable as the primary
+#        pointer for scripts.
+#   3. OPAE_PLATFORM_ROOT:
+#        This variable replaces all pointers to a release directory,
+#        starting with the discrete platform's 1.1 release.  The
+#        hw/lib directory is ${OPAE_PLATFORM_ROOT}/hw/lib.
+#
+def getHWLibPath(opts):
+    if (opts.lib is not None):
+        hw_lib_dir = opts.lib
+    elif ('BBS_LIB_PATH' in os.environ):
+        # Legacy variable, shared with afu_sim_setup and HW releases
+        hw_lib_dir = os.environ['BBS_LIB_PATH'].rstrip('/')
+    elif ('OPAE_PLATFORM_ROOT' in os.environ):
+        # Currently documented variable, pointing to a platform release
+        hw_lib_dir = os.path.join(os.environ['OPAE_PLATFORM_ROOT'].rstrip('/'),
+                                  'hw/lib')
+    else:
+        errorExit("Release hw/lib directory must be specified with " +
+                  "OPAE_PLATFORM_ROOT, BBS_LIB_PATH or --lib")
+
+    # Confirm that the path looks reasonable
+    if (not os.path.exists(os.path.join(hw_lib_dir,
+                                        'fme-ifc-id.txt'))):
+        errorExit("{0} is not a release hw/lib directory".format(hw_lib_dir))
+
+    return hw_lib_dir
+
+
+#
+# Qsys requires source files that are specific to both FPGA technology and
+# Quartus version.  We automatically define OPAE_PLATFORM_FPGA_FAMILY as an
+# environment variable, which may be used in source specification to choose
+# the right code.
+#
+def addDefaultFpgaFamily(opts):
+    # Define an environment variable for Qsys versions based on the
+    # platform.
+
+    if ('OPAE_PLATFORM_FPGA_FAMILY' not in os.environ):
+        try:
+            # Get the FPGA technology tag using afu_platform_info
+            cmd = 'afu_platform_info --key=fpga-family '
+
+            # What's the platform name?
+            plat_class_file = os.path.join(getHWLibPath(opts),
+                                           'fme-platform-class.txt')
+            with open(plat_class_file) as f:
+                cmd += f.read().strip()
+
+            proc = subprocess.Popen(cmd, shell=True,
+                                    stdout=subprocess.PIPE)
+            for line in proc.stdout:
+                os.environ['OPAE_PLATFORM_FPGA_FAMILY'] = line.strip()
+            errcode = proc.wait()
+            if (errcode):
+                errorExit("failed to set OPAE_PLATFORM_FPGA_FAMILY")
+
+            if (not opts.quiet):
+                sys.stderr.write(
+                    "Set OPAE_PLATFORM_FPGA_FAMILY to {0}\n".format(
+                        os.environ['OPAE_PLATFORM_FPGA_FAMILY']))
+        except Exception as e:
+            errorExit("failed to set OPAE_PLATFORM_FPGA_FAMILY ({0})".format(
+                str(e)))
+
+
+#
+# Invoke Quartus to load its major version number.
+#
+def getQuartusVersion(opts):
+    if ('QUARTUS_VERSION' not in os.environ or
+            'QUARTUS_VERSION_MAJOR' not in os.environ):
+        try:
+            # Get the Quartus major version number
+            proc = subprocess.Popen('quartus_sh --version', shell=True,
+                                    stdout=subprocess.PIPE)
+            ok = False
+            for line in proc.stdout:
+                line = line.strip()
+                if (line[:7] == 'Version'):
+                    ok = True
+
+                    # Just the major version number
+                    maj = re.sub(r'\D*(\d*)\..*', r'\1', line)
+                    os.environ['QUARTUS_VERSION_MAJOR'] = maj
+                    # Major.minor version
+                    maj_min = re.sub(r'\D*(\d*\.\d*)\..*', r'\1', line)
+                    os.environ['QUARTUS_VERSION'] = maj_min
+
+            errcode = proc.wait()
+            if (errcode or not ok):
+                errorExit("Failed to compute QUARTUS_VERSION")
+
+            if (not opts.quiet):
+                sys.stderr.write(
+                    "Set QUARTUS_VERSION to {0}\n".format(
+                        os.environ['QUARTUS_VERSION']))
+                sys.stderr.write(
+                    "Set QUARTUS_VERSION_MAJOR to {0}\n".format(
+                        os.environ['QUARTUS_VERSION_MAJOR']))
+        except Exception as e:
+            errorExit(str(e))
+
+
 def main(args=None):
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -227,7 +352,10 @@ are ignored, depending on the build target.  For example, SDC files are
 ignored when constructing a list for simulation.
 
 Environment variables in file paths are substituted as a configuration
-file is loaded.
+file is loaded.  Several environment variables are defined automatically,
+including OPAE_PLATFORM_FPGA_FAMILY (the value output by "afu_platform_info
+--key=fpga-family"), QUARTUS_VERSION_MAJOR (e.g. 18) and QUARTUS_VERSION
+(e.g. 18.1).
 
 Files should be specified one per line in the configuration file.  A few
 prefixes are treated specially.  Most are directives supported by Verilog
@@ -256,8 +384,8 @@ These commands affect script parsing:
   # <comment>       All text following a '#' is ignored.''')
 
     parser.add_argument("config_file",
-                        help="""Configuration file containing RTL source file paths,
-                                preprocessor variable settings, etc.""")
+                        help="""Configuration file containing RTL source file
+                                paths, preprocessor variable settings, etc.""")
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--sim",
@@ -283,6 +411,19 @@ These commands affect script parsing:
     group.add_argument("-a", "--abs",
                        action="store_true",
                        help="""Convert paths so they are absolute.""")
+
+    # Verbose/quiet
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "-v", "--verbose", action="store_true", help="Verbose output")
+    group.add_argument(
+        "-q", "--quiet", action="store_true", help="Reduce output")
+
+    parser.add_argument('-l', '--lib', default=None,
+                        help="""FPGA platform release hw/lib directory.  If
+                                not specified, the environment variables
+                                OPAE_FPGA_HW_LIB and then BBS_LIB_PATH are
+                                checked.""")
 
     opts = parser.parse_args(args)
     cfg = parseConfigFile(opts, opts.config_file, opts.rel)


### PR DESCRIPTION
- The FPGA family tag may be stored in the platform db and extracted with a new script: afu_platform_info.
- rtl_src_config automatically defines the environment variables OPAE_PLATFORM_FPGA_FAMILY and QUARTUS_VERSION_MAJOR when it detects a reference to the tags in the list of sources.