### PR TITLE
drv doc: add note about binutils >= 2.25

### DIFF
--- a/doc/src/drv_arch/drv_arch.md
+++ b/doc/src/drv_arch/drv_arch.md
@@ -71,6 +71,12 @@ comparing the interface ID noted in the AF header against the interface ID
 exposed by the FME through sysfs. This check is usually done by
 user-space before calling the reconfiguration IOCTL.
 
+.. note::
+
+```
+    Platforms that support 512-byte Partial Reconfiguration require
+    binutils >= version 2.25.
+```
 
 .. note::
 


### PR DESCRIPTION
as a requirement for 512-byte PR.