### PR TITLE
libopae: fix fpgaEnumerate() doxygen bug

### DIFF
--- a/common/include/opae/enum.h
+++ b/common/include/opae/enum.h
@@ -76,7 +76,7 @@ extern "C" {
  *                         without any filter criteria set) or pass a NULL
  *                         filters parameter with num_filters set to 0.
  * @param[in] num_filters  Number of entries in the `filters` array, or 0 to
- *                         match all FPGA resources.
+ *                         match all FPGA resources when `filters` is NULL.
  * @param[out] tokens      Pointer to an array of fpga_token variables to be
  *                         populated.  If NULL is supplied, fpgaEnumerate() will
  *                         not create any tokens, but it will return the

--- a/common/include/opae/enum.h
+++ b/common/include/opae/enum.h
@@ -71,8 +71,10 @@ extern "C" {
  * @param[in] filters      Array of `fpga_properties` objects describing the
  *                         properties of the objects that should be returned. A
  *                         resource is considered matching if its properties
- *                         match any one of the supplied filters. Passing NULL
- *                         will match all FPGA resources present in the system.
+ *                         match any one of the supplied filters. Passing an
+ *                         empty filters object (one without any filter criteria
+ *                         set) will match all FPGA resources present in the
+ *                         system.
  * @param[in] num_filters  Number of entries in the `filters` array.
  * @param[out] tokens      Pointer to an array of fpga_token variables to be
  *                         populated.  If NULL is supplied, fpgaEnumerate() will

--- a/common/include/opae/enum.h
+++ b/common/include/opae/enum.h
@@ -75,7 +75,8 @@ extern "C" {
  *                         FPGA resources, pass an empty filters object (one
  *                         without any filter criteria set) or pass a NULL
  *                         filters parameter with num_filters set to 0.
- * @param[in] num_filters  Number of entries in the `filters` array.
+ * @param[in] num_filters  Number of entries in the `filters` array, or 0 to
+ *                         match all FPGA resources.
  * @param[out] tokens      Pointer to an array of fpga_token variables to be
  *                         populated.  If NULL is supplied, fpgaEnumerate() will
  *                         not create any tokens, but it will return the

--- a/common/include/opae/enum.h
+++ b/common/include/opae/enum.h
@@ -71,10 +71,10 @@ extern "C" {
  * @param[in] filters      Array of `fpga_properties` objects describing the
  *                         properties of the objects that should be returned. A
  *                         resource is considered matching if its properties
- *                         match any one of the supplied filters. Passing an
- *                         empty filters object (one without any filter criteria
- *                         set) will match all FPGA resources present in the
- *                         system.
+ *                         match any one of the supplied filters. To match all
+ *                         FPGA resources, pass an empty filters object (one
+ *                         without any filter criteria set) or pass a NULL
+ *                         filters parameter with num_filters set to 0.
  * @param[in] num_filters  Number of entries in the `filters` array.
  * @param[out] tokens      Pointer to an array of fpga_token variables to be
  *                         populated.  If NULL is supplied, fpgaEnumerate() will


### PR DESCRIPTION
Fix the doxygen for parameter 'filters'. The docs previously mentioned
that passing NULL for 'filters' would return all fpga objects. The
correct query-all method is to pass an initialized but empty
fpga_properties object.