### PR TITLE
Pass the local memory bank number as a normal signal.

### DIFF
--- a/ase/rtl/ase_top.sv
+++ b/ase/rtl/ase_top.sv
@@ -66,8 +66,6 @@ module ase_top();
    logic [1:0] pck_cp2af_pwrState;   // CCI-P AFU Power State
    logic       pck_cp2af_error;      // CCI-P Protocol Error Detected
 
-   genvar b;
-
 `ifdef PLATFORM_PROVIDES_LOCAL_MEMORY
  // Now many memory banks?
  `ifdef AFU_TOP_REQUIRES_LOCAL_MEMORY_AVALON_MM_LEGACY_WIRES_2BANK
@@ -88,14 +86,6 @@ module ase_top();
    // Interfaces for all DDR memory banks
    avalon_mem_if#(.ENABLE_LOG(1), .NUM_BANKS(NUM_LOCAL_MEM_BANKS))
       ddr4[NUM_ALLOC_MEM_BANKS](ddr4_avmm_clk, pck_cp2af_softReset);
-
-   generate
-      for (b = 0; b < NUM_LOCAL_MEM_BANKS; b = b + 1)
-      begin : bn
-         // Mostly used for debugging
-         assign ddr4[b].bank_number = b;
-      end
-   endgenerate
 
    logic ddr_reset_n;
    logic ddr_pll_ref_clk;
@@ -202,6 +192,7 @@ module ase_top();
    always #1875 ddr_pll_ref_clk = ~ddr_pll_ref_clk; // 266.666.. Mhz
 
    // emif model
+   genvar b;
    generate
       for (b = 0; b < NUM_LOCAL_MEM_BANKS; b = b + 2)
       begin : b_emul
@@ -237,6 +228,10 @@ module ase_top();
             .ddr4b_avmm_byteenable                 (ddr4[b+1].byteenable),
             .ddr4b_avmm_clk_clk                    (ddr4_avmm_clk[b+1])
          );
+
+         // Mostly used for debugging
+         assign ddr4[b].bank_number = b;
+         assign ddr4[b+1].bank_number = b+1;
       end
    endgenerate
 

--- a/platforms/platform_if/rtl/platform_shims/platform_shim_ccip_std_afu.sv
+++ b/platforms/platform_if/rtl/platform_shims/platform_shim_ccip_std_afu.sv
@@ -127,17 +127,8 @@ module platform_shim_ccip_std_afu
     logic afu_local_mem_clk[NUM_LOCAL_MEM_BANKS];
     logic afu_local_mem_reset[NUM_LOCAL_MEM_BANKS];
 
-    avalon_mem_if#(.ENABLE_LOG(0), .NUM_BANKS(NUM_LOCAL_MEM_BANKS))
+    avalon_mem_if#(.ENABLE_LOG(1), .NUM_BANKS(NUM_LOCAL_MEM_BANKS))
         afu_local_mem[NUM_LOCAL_MEM_BANKS](afu_local_mem_clk, afu_local_mem_reset);
-
-    genvar b;
-    generate
-        for (b = 0; b < NUM_LOCAL_MEM_BANKS; b = b + 1)
-        begin : bn
-            // Mostly used for debugging
-            assign afu_local_mem[b].bank_number = b;
-        end
-    endgenerate
 
 
     platform_shim_avalon_mem_if

--- a/platforms/platform_if/rtl/platform_shims/utils/avalon_mem_if_async_shim.sv
+++ b/platforms/platform_if/rtl/platform_shims/utils/avalon_mem_if_async_shim.sv
@@ -95,4 +95,6 @@ module avalon_mem_if_async_shim
         .m0_debugaccess()
         );
 
+    // Debugging signal
+    assign mem_afu.bank_number = mem_fiu.bank_number;
 endmodule // avalon_mem_if_async_shim

--- a/platforms/platform_if/rtl/platform_shims/utils/avalon_mem_if_connect.sv
+++ b/platforms/platform_if/rtl/platform_shims/utils/avalon_mem_if_connect.sv
@@ -49,6 +49,9 @@ module avalon_mem_if_connect
         mem_fiu.write = mem_afu.write;
         mem_fiu.read = mem_afu.read;
         mem_fiu.byteenable = mem_afu.byteenable;
+
+        // Debugging signal
+        mem_afu.bank_number = mem_fiu.bank_number;
     end
 
 endmodule // avalon_mem_if_connect

--- a/platforms/platform_if/rtl/platform_shims/utils/avalon_mem_if_reg.sv
+++ b/platforms/platform_if/rtl/platform_shims/utils/avalon_mem_if_reg.sv
@@ -113,6 +113,9 @@ module avalon_mem_if_reg
                     .m0_byteenable(mem_pipe[s - 1].byteenable),
                     .m0_debugaccess()
                     );
+
+                // Debugging signal
+                assign mem_pipe[s].bank_number = mem_pipe[s-1].bank_number;
             end
 
             // Map mem_afu to the last stage (wired)


### PR DESCRIPTION
Bank number is used only for debugging, but now that it is a wire instead of a parameter
it should be passed from instance to instance using combination assignments.