### PR TITLE
Apply clang-format to c++ code

### DIFF
--- a/common/include/opae/cxx/core/dma_buffer.h
+++ b/common/include/opae/cxx/core/dma_buffer.h
@@ -24,16 +24,16 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
-#include <memory>
-#include <cstdint>
-#include <vector>
-#include <initializer_list>
 #include <chrono>
+#include <cstdint>
+#include <initializer_list>
+#include <memory>
 #include <thread>
+#include <vector>
 
 #include <opae/buffer.h>
-#include <opae/cxx/core/handle.h>
 #include <opae/cxx/core/except.h>
+#include <opae/cxx/core/handle.h>
 
 namespace opae {
 namespace fpga {
@@ -52,8 +52,8 @@ class dma_buffer {
   typedef std::size_t size_t;
   typedef std::shared_ptr<dma_buffer> ptr_t;
 
-  dma_buffer(const dma_buffer & ) = delete;
-  dma_buffer & operator =(const dma_buffer & ) = delete;
+  dma_buffer(const dma_buffer &) = delete;
+  dma_buffer &operator=(const dma_buffer &) = delete;
 
   /** dma_buffer destructor.
    */
@@ -101,7 +101,6 @@ class dma_buffer {
    */
   uint64_t iova() const { return iova_; }
 
-
   /** Write c to each byte location in the buffer.
    */
   void fill(int c);
@@ -146,14 +145,12 @@ class dma_buffer {
   dma_buffer(handle::ptr_t handle, size_t len, uint8_t *virt, uint64_t wsid,
              uint64_t iova);
 
-
   handle::ptr_t handle_;
   size_t len_;
   uint8_t *virt_;
   uint64_t wsid_;
   uint64_t iova_;
 };
-
 
 }  // end of namespace types
 }  // end of namespace fpga

--- a/common/include/opae/cxx/core/events.h
+++ b/common/include/opae/cxx/core/events.h
@@ -50,23 +50,17 @@ class event {
   /**
    * @brief C++ struct that is interchangeable with fpga_event_type enum
    */
-  struct type_t
-  {
-    type_t(fpga_event_type c_type)
-    : type_(c_type){}
+  struct type_t {
+    type_t(fpga_event_type c_type) : type_(c_type) {}
 
-    operator fpga_event_type()
-    {
-      return type_;
-    }
+    operator fpga_event_type() { return type_; }
 
-    static constexpr fpga_event_type interrupt =  FPGA_EVENT_INTERRUPT;
-    static constexpr fpga_event_type error =  FPGA_EVENT_ERROR;
-    static constexpr fpga_event_type power_thermal =  FPGA_EVENT_POWER_THERMAL;
+    static constexpr fpga_event_type interrupt = FPGA_EVENT_INTERRUPT;
+    static constexpr fpga_event_type error = FPGA_EVENT_ERROR;
+    static constexpr fpga_event_type power_thermal = FPGA_EVENT_POWER_THERMAL;
 
    private:
     fpga_event_type type_;
-
   };
 
   /**
@@ -92,7 +86,8 @@ class event {
    *
    * @return A shared ptr to an event object
    */
-  static event::ptr_t register_event(handle::ptr_t h, event::type_t t, int flags = 0);
+  static event::ptr_t register_event(handle::ptr_t h, event::type_t t,
+                                     int flags = 0);
 
  private:
   event(handle::ptr_t h, event::type_t t, fpga_event_handle event_h);

--- a/common/include/opae/cxx/core/except.h
+++ b/common/include/opae/cxx/core/except.h
@@ -29,7 +29,6 @@
 
 #include <opae/types_enum.h>
 
-
 namespace opae {
 namespace fpga {
 namespace types {
@@ -44,7 +43,7 @@ class src_location {
    */
   src_location(const char *file, const char *fn, int line) noexcept;
 
-  src_location(const src_location & other) noexcept;
+  src_location(const src_location &other) noexcept;
 
   /** Retrieve the file name component of the location.
    */
@@ -63,7 +62,6 @@ class src_location {
   const char *fn_;
   int line_;
 };
-
 
 /// Construct a src_location object for the current source line.
 #define OPAECXX_HERE \
@@ -99,7 +97,7 @@ class except : public std::exception {
    * @param[in] msg The error message as a string
    * @param[in] loc Location where the exception was constructed.
    */
-  except(fpga_result res, const char* msg, src_location loc) noexcept;
+  except(fpga_result res, const char *msg, src_location loc) noexcept;
 
   /** Convert this except to an informative string.
    */
@@ -111,7 +109,7 @@ class except : public std::exception {
 
  protected:
   fpga_result res_;
-  const char* msg_;
+  const char *msg_;
   src_location loc_;
   mutable char buf_[MAX_EXCEPT];
 };
@@ -124,16 +122,14 @@ class except : public std::exception {
  * an OPAE C API function
  */
 class invalid_param : public except {
-  public:
-
-    /** invalid_param constructor
-     *
-     * @param[in] loc Location where the exception was constructed.
-     */
-    invalid_param(src_location loc) noexcept
-    : except(FPGA_INVALID_PARAM, "failed with return code FPGA_INVALID_PARAM", loc)
-    {}
-
+ public:
+  /** invalid_param constructor
+   *
+   * @param[in] loc Location where the exception was constructed.
+   */
+  invalid_param(src_location loc) noexcept
+      : except(FPGA_INVALID_PARAM, "failed with return code FPGA_INVALID_PARAM",
+               loc) {}
 };
 
 /** busy exception
@@ -144,16 +140,13 @@ class invalid_param : public except {
  * an OPAE C API function
  */
 class busy : public except {
-  public:
-
-    /** busy constructor
-     *
-     * @param[in] loc Location where the exception was constructed.
-     */
-    busy(src_location loc) noexcept
-    : except(FPGA_BUSY, "failed with return code FPGA_BUSY", loc)
-    {}
-
+ public:
+  /** busy constructor
+   *
+   * @param[in] loc Location where the exception was constructed.
+   */
+  busy(src_location loc) noexcept
+      : except(FPGA_BUSY, "failed with return code FPGA_BUSY", loc) {}
 };
 
 /** exception exception
@@ -164,16 +157,13 @@ class busy : public except {
  * an OPAE C API function
  */
 class exception : public except {
-  public:
-
-    /** exception constructor
-     *
-     * @param[in] loc Location where the exception was constructed.
-     */
-    exception(src_location loc) noexcept
-    : except(FPGA_EXCEPTION, "failed with return code FPGA_EXCEPTION", loc)
-    {}
-
+ public:
+  /** exception constructor
+   *
+   * @param[in] loc Location where the exception was constructed.
+   */
+  exception(src_location loc) noexcept
+      : except(FPGA_EXCEPTION, "failed with return code FPGA_EXCEPTION", loc) {}
 };
 
 /** not_found exception
@@ -184,16 +174,13 @@ class exception : public except {
  * an OPAE C API function
  */
 class not_found : public except {
-  public:
-
-    /** not_found constructor
-     *
-     * @param[in] loc Location where the exception was constructed.
-     */
-    not_found(src_location loc) noexcept
-    : except(FPGA_NOT_FOUND, "failed with return code FPGA_NOT_FOUND", loc)
-    {}
-
+ public:
+  /** not_found constructor
+   *
+   * @param[in] loc Location where the exception was constructed.
+   */
+  not_found(src_location loc) noexcept
+      : except(FPGA_NOT_FOUND, "failed with return code FPGA_NOT_FOUND", loc) {}
 };
 
 /** no_memory exception
@@ -204,16 +191,13 @@ class not_found : public except {
  * an OPAE C API function
  */
 class no_memory : public except {
-  public:
-
-    /** no_memory constructor
-     *
-     * @param[in] loc Location where the exception was constructed.
-     */
-    no_memory(src_location loc) noexcept
-    : except(FPGA_NO_MEMORY, "failed with return code FPGA_NO_MEMORY", loc)
-    {}
-
+ public:
+  /** no_memory constructor
+   *
+   * @param[in] loc Location where the exception was constructed.
+   */
+  no_memory(src_location loc) noexcept
+      : except(FPGA_NO_MEMORY, "failed with return code FPGA_NO_MEMORY", loc) {}
 };
 
 /** not_supported exception
@@ -224,16 +208,14 @@ class no_memory : public except {
  * an OPAE C API function
  */
 class not_supported : public except {
-  public:
-
-    /** not_supported constructor
-     *
-     * @param[in] loc Location where the exception was constructed.
-     */
-    not_supported(src_location loc) noexcept
-    : except(FPGA_NOT_SUPPORTED, "failed with return code FPGA_NOT_SUPPORTED", loc)
-    {}
-
+ public:
+  /** not_supported constructor
+   *
+   * @param[in] loc Location where the exception was constructed.
+   */
+  not_supported(src_location loc) noexcept
+      : except(FPGA_NOT_SUPPORTED, "failed with return code FPGA_NOT_SUPPORTED",
+               loc) {}
 };
 
 /** no_driver exception
@@ -244,16 +226,13 @@ class not_supported : public except {
  * an OPAE C API function
  */
 class no_driver : public except {
-  public:
-
-    /** no_driver constructor
-     *
-     * @param[in] loc Location where the exception was constructed.
-     */
-    no_driver(src_location loc) noexcept
-    : except(FPGA_NO_DRIVER, "failed with return code FPGA_NO_DRIVER", loc)
-    {}
-
+ public:
+  /** no_driver constructor
+   *
+   * @param[in] loc Location where the exception was constructed.
+   */
+  no_driver(src_location loc) noexcept
+      : except(FPGA_NO_DRIVER, "failed with return code FPGA_NO_DRIVER", loc) {}
 };
 
 /** no_daemon exception
@@ -264,16 +243,13 @@ class no_driver : public except {
  * an OPAE C API function
  */
 class no_daemon : public except {
-  public:
-
-    /** no_daemon constructor
-     *
-     * @param[in] loc Location where the exception was constructed.
-     */
-    no_daemon(src_location loc) noexcept
-    : except(FPGA_NO_DAEMON, "failed with return code FPGA_NO_DAEMON", loc)
-    {}
-
+ public:
+  /** no_daemon constructor
+   *
+   * @param[in] loc Location where the exception was constructed.
+   */
+  no_daemon(src_location loc) noexcept
+      : except(FPGA_NO_DAEMON, "failed with return code FPGA_NO_DAEMON", loc) {}
 };
 
 /** no_access exception
@@ -284,16 +260,13 @@ class no_daemon : public except {
  * an OPAE C API function
  */
 class no_access : public except {
-  public:
-
-    /** no_access constructor
-     *
-     * @param[in] loc Location where the exception was constructed.
-     */
-    no_access(src_location loc) noexcept
-    : except(FPGA_NO_ACCESS, "failed with return code FPGA_NO_ACCESS", loc)
-    {}
-
+ public:
+  /** no_access constructor
+   *
+   * @param[in] loc Location where the exception was constructed.
+   */
+  no_access(src_location loc) noexcept
+      : except(FPGA_NO_ACCESS, "failed with return code FPGA_NO_ACCESS", loc) {}
 };
 
 /** reconf_error exception
@@ -304,51 +277,51 @@ class no_access : public except {
  * an OPAE C API function
  */
 class reconf_error : public except {
-  public:
-
-    /** reconf_error constructor
-     *
-     * @param[in] loc Location where the exception was constructed.
-     */
-    reconf_error(src_location loc) noexcept
-    : except(FPGA_RECONF_ERROR, "failed with return code FPGA_RECONF_ERROR", loc)
-    {}
-
+ public:
+  /** reconf_error constructor
+   *
+   * @param[in] loc Location where the exception was constructed.
+   */
+  reconf_error(src_location loc) noexcept
+      : except(FPGA_RECONF_ERROR, "failed with return code FPGA_RECONF_ERROR",
+               loc) {}
 };
 
 namespace detail {
 
 /** typedef function pointer that returns bool if result is FPGA_OK
  */
-typedef bool (*exception_fn)(fpga_result, const opae::fpga::types::src_location & loc);
+typedef bool (*exception_fn)(fpga_result,
+                             const opae::fpga::types::src_location &loc);
 
-/** is_ok is a template function that throws an excpetion of its template argument type
+/** is_ok is a template function that throws an excpetion of its template
+ * argument type
  *  if the result code is not FPGA_OK. Otherwise it returns true.
  */
-template<typename T>
-constexpr bool is_ok(fpga_result result, const opae::fpga::types::src_location & loc) {
+template <typename T>
+constexpr bool is_ok(fpga_result result,
+                     const opae::fpga::types::src_location &loc) {
   return result == FPGA_OK ? true : throw T(loc);
 }
 
-
-static exception_fn opae_exceptions[12] = { is_ok<opae::fpga::types::invalid_param>,
-                                            is_ok<opae::fpga::types::busy>,
-                                            is_ok<opae::fpga::types::exception>,
-                                            is_ok<opae::fpga::types::not_found>,
-                                            is_ok<opae::fpga::types::no_memory>,
-                                            is_ok<opae::fpga::types::not_supported>,
-                                            is_ok<opae::fpga::types::no_driver>,
-                                            is_ok<opae::fpga::types::no_daemon>,
-                                            is_ok<opae::fpga::types::no_access>,
-                                            is_ok<opae::fpga::types::reconf_error> };
-
+static exception_fn opae_exceptions[12] = {
+    is_ok<opae::fpga::types::invalid_param>,
+    is_ok<opae::fpga::types::busy>,
+    is_ok<opae::fpga::types::exception>,
+    is_ok<opae::fpga::types::not_found>,
+    is_ok<opae::fpga::types::no_memory>,
+    is_ok<opae::fpga::types::not_supported>,
+    is_ok<opae::fpga::types::no_driver>,
+    is_ok<opae::fpga::types::no_daemon>,
+    is_ok<opae::fpga::types::no_access>,
+    is_ok<opae::fpga::types::reconf_error>};
 
 static inline void assert_fpga_ok(fpga_result result,
-                                  const opae::fpga::types::src_location & loc) {
+                                  const opae::fpga::types::src_location &loc) {
   if (result > FPGA_OK && result <= FPGA_RECONF_ERROR)
     // our exception table above starts at invalid_param with index 0
     // but FPGA_INVALID_PARAM is actually enum 1 - let's account for that
-    opae_exceptions[result-1](result, loc);
+    opae_exceptions[result - 1](result, loc);
 }
 
 }  // end of namespace detail
@@ -356,14 +329,10 @@ static inline void assert_fpga_ok(fpga_result result,
 /// Macro to check of result is FPGA_OK
 /// If not, throw exception that corresponds
 /// to the result code
-#define ASSERT_FPGA_OK(r) \
-  opae::fpga::types::detail::assert_fpga_ok(r, \
-      opae::fpga::types::src_location(__FILE__, __func__, __LINE__));
+#define ASSERT_FPGA_OK(r)                    \
+  opae::fpga::types::detail::assert_fpga_ok( \
+      r, opae::fpga::types::src_location(__FILE__, __func__, __LINE__));
 
 }  // end of namespace types
 }  // end of namespace fpga
 }  // end of namespace opae
-
-
-
-

--- a/common/include/opae/cxx/core/handle.h
+++ b/common/include/opae/cxx/core/handle.h
@@ -24,12 +24,12 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
-#include <vector>
 #include <memory>
+#include <vector>
 
-#include <opae/types.h>
-#include <opae/enum.h>
 #include <opae/cxx/core/token.h>
+#include <opae/enum.h>
+#include <opae/types.h>
 
 namespace opae {
 namespace fpga {
@@ -46,8 +46,8 @@ class handle {
  public:
   typedef std::shared_ptr<handle> ptr_t;
 
-  handle(const handle & ) = delete;
-  handle & operator =(const handle & ) = delete;
+  handle(const handle &) = delete;
+  handle &operator=(const handle &) = delete;
 
   ~handle();
 

--- a/common/include/opae/cxx/core/properties.h
+++ b/common/include/opae/cxx/core/properties.h
@@ -24,12 +24,12 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
+#include <iostream>
 #include <map>
 #include <memory>
-#include <iostream>
 
-#include <opae/properties.h>
 #include <opae/cxx/core/pvalue.h>
+#include <opae/properties.h>
 
 namespace opae {
 namespace fpga {
@@ -67,7 +67,7 @@ class properties {
 
   /** properties may be copy-assigned.
    */
-  properties & operator =(const properties &p);
+  properties &operator=(const properties &p);
 
   /** Convert fpga_guid to properties.
    */
@@ -112,7 +112,7 @@ class properties {
   pvalue<uint64_t> bbs_id;
   pvalue<fpga_version> bbs_version;
   pvalue<uint16_t> vendor_id;
-  pvalue<char*> model;
+  pvalue<char *> model;
   pvalue<uint64_t> local_memory_size;
   pvalue<uint64_t> capabilities;
   pvalue<uint32_t> num_mmio;
@@ -121,7 +121,6 @@ class properties {
   pvalue<uint64_t> object_id;
   pvalue<fpga_token> parent;
   guid_t guid;
-
 };
 
 }  // end of namespace types

--- a/common/include/opae/cxx/core/token.h
+++ b/common/include/opae/cxx/core/token.h
@@ -24,13 +24,13 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
-#include <vector>
 #include <memory>
+#include <vector>
 
-#include <opae/types.h>
 #include <opae/access.h>
-#include <opae/enum.h>
 #include <opae/cxx/core/properties.h>
+#include <opae/enum.h>
+#include <opae/types.h>
 
 namespace opae {
 namespace fpga {

--- a/common/include/opae/cxx/core/version.h
+++ b/common/include/opae/cxx/core/version.h
@@ -33,8 +33,7 @@ namespace fpga {
 namespace types {
 
 class version {
-public:
-
+ public:
   /// @brief Get the package version information as a struct
   ///
   /// @return The package version as an `fpga_version` struct
@@ -49,7 +48,6 @@ public:
   ///
   /// @return The package build as an `std::string` object
   static std::string build();
-
 };
 
 }  // end of namespace types

--- a/libopae++/samples/hello_fpga-1.cpp
+++ b/libopae++/samples/hello_fpga-1.cpp
@@ -24,35 +24,35 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
-#include <iostream>
 #include <chrono>
+#include <iostream>
 #include <thread>
 
 #include <uuid/uuid.h>
 
+#include <opae/cxx/core/dma_buffer.h>
+#include <opae/cxx/core/handle.h>
 #include <opae/cxx/core/properties.h>
 #include <opae/cxx/core/token.h>
-#include <opae/cxx/core/handle.h>
-#include <opae/cxx/core/dma_buffer.h>
 
 using namespace opae::fpga::types;
 
-static const char* NLB0_AFUID                      = "D8424DC4-A4A3-C413-F89E-433683F9040B";
-static const uint64_t CL                           = 64;
-static const uint64_t KB                           = 1024;
-static const uint64_t MB                           = KB * 1024;
-static const uint64_t LOG2_CL                      = 6;
-static const size_t LPBK1_DSM_SIZE                 = 4*KB;
-static const size_t LPBK1_BUFFER_SIZE              = 1*KB;
-static const size_t LPBK1_BUFFER_ALLOCATION_SIZE   = 4*KB;
-static const uint64_t CSR_SRC_ADDR                 = 0x0120;
-static const uint32_t CSR_DST_ADDR                 = 0x0128;
-static const uint32_t CSR_CTL                      = 0x0138;
-static const uint32_t CSR_CFG                      = 0x0140;
-static const uint32_t CSR_NUM_LINES                = 0x0130;
-static const uint32_t DSM_STATUS_TEST_COMPLETE     = 0x40;
-static const uint64_t CSR_AFU_DSM_BASEL            = 0x0110;
-static const uint64_t CSR_AFU_DSM_BASEH            = 0x0114;
+static const char* NLB0_AFUID = "D8424DC4-A4A3-C413-F89E-433683F9040B";
+static const uint64_t CL = 64;
+static const uint64_t KB = 1024;
+static const uint64_t MB = KB * 1024;
+static const uint64_t LOG2_CL = 6;
+static const size_t LPBK1_DSM_SIZE = 4 * KB;
+static const size_t LPBK1_BUFFER_SIZE = 1 * KB;
+static const size_t LPBK1_BUFFER_ALLOCATION_SIZE = 4 * KB;
+static const uint64_t CSR_SRC_ADDR = 0x0120;
+static const uint32_t CSR_DST_ADDR = 0x0128;
+static const uint32_t CSR_CTL = 0x0138;
+static const uint32_t CSR_CFG = 0x0140;
+static const uint32_t CSR_NUM_LINES = 0x0130;
+static const uint32_t DSM_STATUS_TEST_COMPLETE = 0x40;
+static const uint64_t CSR_AFU_DSM_BASEL = 0x0110;
+static const uint64_t CSR_AFU_DSM_BASEH = 0x0114;
 
 static inline uint64_t cacheline_aligned_addr(uint64_t num) {
   return num >> LOG2_CL;
@@ -65,12 +65,12 @@ int main(__attribute__((unused)) int argc,
   filter.guid.parse(NLB0_AFUID);
   filter.type = FPGA_ACCELERATOR;
 
-  auto tokens = token::enumerate({ filter });
+  auto tokens = token::enumerate({filter});
 
   // assert we have found at least one
   if (tokens.size() < 1) {
-  	std::cerr << "accelerator not found\n";
-  	return -1;
+    std::cerr << "accelerator not found\n";
+    return -1;
   }
   token::ptr_t tok = tokens[0];
 
@@ -87,14 +87,14 @@ int main(__attribute__((unused)) int argc,
   std::fill_n(inp->get(), LPBK1_BUFFER_SIZE, 0xAF);
   std::fill_n(out->get(), LPBK1_BUFFER_SIZE, 0xBE);
 
-  //accel->reset();
+  // accel->reset();
   accel->write_csr64(CSR_AFU_DSM_BASEL, dsm->iova());
   accel->write_csr32(CSR_CTL, 0);
   accel->write_csr32(CSR_CTL, 1);
   accel->write_csr64(CSR_SRC_ADDR, cacheline_aligned_addr(inp->iova()));
   accel->write_csr64(CSR_DST_ADDR, cacheline_aligned_addr(out->iova()));
 
-  accel->write_csr64(CSR_NUM_LINES, LPBK1_BUFFER_SIZE / 1*CL);
+  accel->write_csr64(CSR_NUM_LINES, LPBK1_BUFFER_SIZE / 1 * CL);
   accel->write_csr32(CSR_CFG, 0x42000);
 
   // get ptr to device status memory - test complete
@@ -112,9 +112,11 @@ int main(__attribute__((unused)) int argc,
   accel->write_csr32(CSR_CTL, 7);
 
   // check output buffer contents
-  auto mm = std::mismatch(inp->get(), inp->get() + LPBK1_BUFFER_SIZE, out->get());
+  auto mm =
+      std::mismatch(inp->get(), inp->get() + LPBK1_BUFFER_SIZE, out->get());
   if (mm.second < out->get() + LPBK1_BUFFER_SIZE) {
-    std::cerr << "output does NOT match input at offset: " << (mm.second - out->get()) << "\n";
+    std::cerr << "output does NOT match input at offset: "
+              << (mm.second - out->get()) << "\n";
     return -1;
   }
 

--- a/libopae++/samples/simple_example.cpp
+++ b/libopae++/samples/simple_example.cpp
@@ -23,18 +23,18 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+#include <opae/cxx/core/handle.h>
 #include <opae/cxx/core/properties.h>
 #include <opae/cxx/core/token.h>
-#include <opae/cxx/core/handle.h>
-#include <uuid/uuid.h>
 #include <opae/mmio.h>
+#include <uuid/uuid.h>
 #include <iostream>
 
 using namespace opae::fpga::types;
 
 const char* NLB0 = "D8424DC4-A4A3-C413-F89E-433683F9040B";
 int main(int argc, char* argv[]) {
-  if (argc == 0){
+  if (argc == 0) {
     std::cerr << argv[0] << "\n";
   }
 

--- a/libopae++/src/events.cpp
+++ b/libopae++/src/events.cpp
@@ -33,19 +33,15 @@ namespace opae {
 namespace fpga {
 namespace types {
 
-event::~event()
-{
+event::~event() {
   ASSERT_FPGA_OK(fpgaUnregisterEvent(*handle_, type_, event_handle_));
   ASSERT_FPGA_OK(fpgaDestroyEventHandle(&event_handle_));
 }
 
-event::operator fpga_event_handle()
-{
-  return event_handle_;
-}
+event::operator fpga_event_handle() { return event_handle_; }
 
-event::ptr_t event::register_event(handle::ptr_t h, event::type_t t, int flags)
-{
+event::ptr_t event::register_event(handle::ptr_t h, event::type_t t,
+                                   int flags) {
   event::ptr_t evptr;
   fpga_event_handle eh;
   ASSERT_FPGA_OK(fpgaCreateEventHandle(&eh));
@@ -56,9 +52,7 @@ event::ptr_t event::register_event(handle::ptr_t h, event::type_t t, int flags)
 }
 
 event::event(handle::ptr_t h, event::type_t t, fpga_event_handle eh)
-    : handle_(h)
-    , type_(t)
-    , event_handle_(eh){}
+    : handle_(h), type_(t), event_handle_(eh) {}
 
 }  // end of namespace types
 }  // end of namespace fpga

--- a/libopae++/src/except.cpp
+++ b/libopae++/src/except.cpp
@@ -37,10 +37,14 @@ namespace fpga {
 namespace types {
 
 src_location::src_location(const char *file, const char *fn, int line) noexcept
-    : file_(file), fn_(fn), line_(line) {}
+    : file_(file),
+      fn_(fn),
+      line_(line) {}
 
-src_location::src_location(const src_location & other) noexcept
-    : file_(other.file_), fn_(other.fn_), line_(other.line_) {}
+src_location::src_location(const src_location &other) noexcept
+    : file_(other.file_),
+      fn_(other.fn_),
+      line_(other.line_) {}
 
 const char *src_location::file() const noexcept {
   // return a pointer to the file name component.
@@ -55,48 +59,46 @@ const char *src_location::file() const noexcept {
 }
 
 except::except(src_location loc) noexcept
-    : res_(FPGA_EXCEPTION), msg_("failed with return code FPGA_EXCEPTION"), loc_(loc) {}
+    : res_(FPGA_EXCEPTION),
+      msg_("failed with return code FPGA_EXCEPTION"),
+      loc_(loc) {}
 
-except::except(fpga_result res, const char* msg, src_location loc) noexcept
-    : res_(res), msg_(msg), loc_(loc) {}
+except::except(fpga_result res, const char *msg, src_location loc) noexcept
+    : res_(res),
+      msg_(msg),
+      loc_(loc) {}
 
-except::except(fpga_result res, src_location loc) noexcept
-    : res_(res), msg_(0), loc_(loc) {}
+except::except(fpga_result res, src_location loc) noexcept : res_(res),
+                                                             msg_(0),
+                                                             loc_(loc) {}
 
 const char *except::what() const noexcept {
   errno_t err;
   bool buf_ok = false;
-  if (msg_){
+  if (msg_) {
     err = strncpy_s(buf_, MAX_EXCEPT, msg_, 64);
-  }else{
+  } else {
     err = strncpy_s(buf_, MAX_EXCEPT, "failed with error ", 64);
-    if (err)
-      goto log_err;
+    if (err) goto log_err;
     err = strcat_s(buf_, MAX_EXCEPT, fpgaErrStr(res_));
   }
-  if (err)
-    goto log_err;
+  if (err) goto log_err;
   buf_ok = true;
 
   err = strcat_s(buf_, MAX_EXCEPT, " at: ");
-  if (err)
-    goto log_err;
+  if (err) goto log_err;
 
   err = strcat_s(buf_, MAX_EXCEPT, loc_.file());
-  if (err)
-    goto log_err;
+  if (err) goto log_err;
 
   err = strcat_s(buf_, MAX_EXCEPT, ":");
-  if (err)
-    goto log_err;
+  if (err) goto log_err;
 
   err = strcat_s(buf_, MAX_EXCEPT, loc_.fn());
-  if (err)
-    goto log_err;
+  if (err) goto log_err;
 
   err = strcat_s(buf_, MAX_EXCEPT, "():");
-  if (err)
-    goto log_err;
+  if (err) goto log_err;
 
   snprintf_s_i(buf_ + strlen(buf_), 64, "%d", loc_.line());
 
@@ -105,7 +107,7 @@ const char *except::what() const noexcept {
 log_err:
   std::cerr << "[except::what()] error with safestr operation: " << err << "\n";
 
-  buf_[sizeof(buf_)-1] = '\0';
+  buf_[sizeof(buf_) - 1] = '\0';
   return buf_ok ? const_cast<const char *>(buf_) : msg_;
 }
 

--- a/libopae++/src/properties.cpp
+++ b/libopae++/src/properties.cpp
@@ -23,10 +23,10 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#include <opae/utils.h>
+#include <opae/cxx/core/except.h>
 #include <opae/cxx/core/properties.h>
 #include <opae/cxx/core/token.h>
-#include <opae/cxx/core/except.h>
+#include <opae/utils.h>
 
 namespace opae {
 namespace fpga {
@@ -108,13 +108,10 @@ properties::properties(const properties &p)
   if (p.object_id.is_set()) object_id.update();
   if (p.parent.is_set()) parent.update();
   if (p.guid.is_set()) guid.update();
-
 }
 
-properties & properties::operator =(const properties &p)
-{
+properties &properties::operator=(const properties &p) {
   if (this != &p) {
-
     if (props_) {
       ASSERT_FPGA_OK(fpgaDestroyProperties(&props_));
       props_ = nullptr;
@@ -166,7 +163,7 @@ properties & properties::operator =(const properties &p)
   return *this;
 }
 
-properties::properties(fpga_guid guid_in) : properties(){ guid = guid_in; }
+properties::properties(fpga_guid guid_in) : properties() { guid = guid_in; }
 
 properties::properties(fpga_objtype objtype) : properties() { type = objtype; }
 

--- a/libopae++/src/token.cpp
+++ b/libopae++/src/token.cpp
@@ -23,10 +23,10 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#include <algorithm>
-#include <opae/utils.h>
-#include <opae/cxx/core/token.h>
 #include <opae/cxx/core/except.h>
+#include <opae/cxx/core/token.h>
+#include <opae/utils.h>
+#include <algorithm>
 
 namespace opae {
 namespace fpga {
@@ -55,11 +55,10 @@ std::vector<token::ptr_t> token::enumerate(
                    [](fpga_token t) { return token::ptr_t(new token(t)); });
 
     // discard our c struct token objects
-    std::for_each(c_tokens.begin(), c_tokens.end(),
-                  [](fpga_token t) {
-                    auto res = fpgaDestroyToken(&t);
-                    ASSERT_FPGA_OK(res);
-                  });
+    std::for_each(c_tokens.begin(), c_tokens.end(), [](fpga_token t) {
+      auto res = fpgaDestroyToken(&t);
+      ASSERT_FPGA_OK(res);
+    });
   } else if (res != FPGA_NOT_FOUND) {
     // throw exception except for not_found
     // we don't want to throw not_found the frist time we enumerate

--- a/libopae++/src/version.cpp
+++ b/libopae++/src/version.cpp
@@ -24,8 +24,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <opae/types.h>
 #include <opae/cxx/core/version.h>
+#include <opae/types.h>
 
 #include "config_int.h"
 
@@ -34,23 +34,15 @@ namespace fpga {
 namespace types {
 
 fpga_version version::as_struct() {
-  fpga_version version_struct = {
-    .major = INTEL_FPGA_API_VER_MAJOR,
-    .minor = INTEL_FPGA_API_VER_MINOR,
-    .patch = INTEL_FPGA_API_VER_REV
-  };
+  fpga_version version_struct = {.major = INTEL_FPGA_API_VER_MAJOR,
+                                 .minor = INTEL_FPGA_API_VER_MINOR,
+                                 .patch = INTEL_FPGA_API_VER_REV};
   return version_struct;
 }
 
-std::string version::as_string() {
-  return INTEL_FPGA_API_VERSION;
-}
+std::string version::as_string() { return INTEL_FPGA_API_VERSION; }
 
-std::string version::build() {
-  return INTEL_FPGA_API_HASH;
-}
-
-
+std::string version::build() { return INTEL_FPGA_API_HASH; }
 
 }  // end of namespace types
 }  // end of namespace fpga

--- a/scripts/test-codingstyle.sh
+++ b/scripts/test-codingstyle.sh
@@ -17,6 +17,8 @@ fi
 
 perl ./$CHECKPATCH --no-tree --no-signoff --terse -f $FILES | grep -v "need consistent spacing" | grep ERROR
 
+
+
 if [ $? -eq 0 ]; then
 	echo "test-codingstyle FAILED"
 	popd


### PR DESCRIPTION
This PR touches a lot of files but is only about code formatting.
I ran clang-format on the relevant source directories to make this. 

_TODO: Add coding style check to CI`_