### PR TITLE
Resolve issues with documentation upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,7 @@ matrix:
         - uuid-dev
         - doxygen
         - pandoc
-    branches:
-      only:
-      - master
+    if: branch = master
     install:
       - pip install --user jinja2
       - pip install --user requests[security]

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ matrix:
         - uuid-dev
         - doxygen
         - pandoc
+    branches:
+      only:
+      - master
     install:
       - pip install --user jinja2
       - pip install --user requests[security]

--- a/scripts/build-documentation.sh
+++ b/scripts/build-documentation.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+COMMIT_ID="$(git rev-parse HEAD)"
+TEMP=$((git describe --exact-match $COMMIT_ID) 2>&1)
+
+if [[ $TEMP == *"fatal"* ]]; then
+    echo "No new tag detected, hence builiding latest docs from master"
+    git reset --hard origin/master
+fi
 
 pip install --user -r doc/sphinx/requirements.txt
 
@@ -13,9 +20,6 @@ make
 
 echo "build Sphinx documentation FINISHED"
 
-
-COMMIT_ID="$(git rev-parse HEAD)"
-TEMP=$((git describe --exact-match $COMMIT_ID) 2>&1)
 
 if [[ $TEMP != *"fatal"* ]]; then
     echo "New tag detected; Uploading documentation under new tag on opae.github.io"

--- a/scripts/push-documentation.sh
+++ b/scripts/push-documentation.sh
@@ -8,11 +8,6 @@ setup_git() {
 
 commit_website_files() {
 
-  if [ "$1" = "latest" ]
-  then
-    git reset --hard origin/master
-  fi
-  
   mkdir upload_docs
   cd upload_docs
   git clone https://OPAE:$GIT_TOKEN@github.com/OPAE/opae.github.io.git


### PR DESCRIPTION
Right now, the decision to upload documentation to opae.github.io is based on whether the commit is tagged or not. This will not work for us since that will force an upload of documentation on any of the RC tags that we have before the actual release. Also, since the last RC tag will be an official release, there is no way to differentiate the RC tags with the final release tag and hence no way to detect when to upload the documentation automatically.

So the current approach is, Travis will run a daily build on master, that will update the latest documentation on opae.github.io. As for the release, whenever we are ready to release, I will be running the scripts locally in order to build the release tag and upload the documentation for that release in a separate directory on opae.githb.io.