### PR TITLE
 Compile Qsys when configuring ASE simulation.

### DIFF
--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -225,19 +225,19 @@ def config_sources(fd, filelist):
 
             # Verilog or SystemVerilog?
             for ext in VLOG_EXTENSIONS:
-                if (sl[-len(ext):] == ext):
+                if (sl.endswith(ext)):
                     vlog_srcs.append(s)
                     vlog_found = True
                     break
 
             # VHDL?
             for ext in VHD_EXTENSIONS:
-                if (sl[-len(ext):] == ext):
+                if (sl.endswith(ext)):
                     vhdl_srcs.append(s)
                     vhdl_found = True
                     break
 
-            if (sl[-5:] == '.json'):
+            if (sl.endswith('.json')):
                 json_srcs.append(s)
 
     qsys_sim_files = config_qsys_sources(filelist, vlog_srcs)
@@ -314,7 +314,7 @@ def config_qsys_sources(filelist, vlog_srcs):
             ip_dirs.append(os.path.splitext(s)[0])
 
             # Collect all qsys files
-            if (s.lower()[-5:] == '.qsys'):
+            if (s.lower().endswith('.qsys')):
                 qsys_srcs.append(s)
 
     # Any Qsys files found?
@@ -399,7 +399,7 @@ def config_qsys_sources(filelist, vlog_srcs):
             for dir, subdirs, files in os.walk(d):
                 for fn in files:
                     if ((os.path.basename(dir) == 'synth') and
-                            (fn[-2:] == '.v' or fn[-3:] == '.sv')):
+                            (fn.endswith('.v') or fn.endswith('.sv'))):
                         full_path = os.path.join(dir, fn)
                         # Is the module (file) name new?
                         if (fn not in sim_files_found and

--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -73,7 +73,7 @@ VHDL_FILE_LIST = os.getcwd() + "/vhdl_files.list"
 VLOG_FILE_LIST = os.getcwd() + "/vlog_files.list"
 
 # Forbidden characters
-SPECIAL_CHARS = '\[]~!@#$%^&*(){}:;+$\''
+SPECIAL_CHARS = '\\[]~!@#$%^&*(){}:;+$\''
 
 
 # DO NOT MODIFY BELOW THIS COMMENT BLOCK     #
@@ -213,14 +213,14 @@ def config_sources(fd, filelist):
             # follows a simulator command.
             spl = s.split(' ')
             if (len(spl) > 1):
-                s = spl[0] + ' ' + '\ '.join(spl[1:])
+                s = spl[0] + ' ' + '\\ '.join(spl[1:])
             vlog_srcs.append(s)
             vlog_found = True
         else:
             # Convert extensions to lower case for comparison
             sl = s.lower()
             # Escape spaces in pathnames
-            s = s.replace(' ', '\ ')
+            s = s.replace(' ', '\\ ')
 
             # Verilog or SystemVerilog?
             for ext in VLOG_EXTENSIONS:
@@ -311,7 +311,7 @@ def config_qsys_sources(filelist, vlog_srcs):
     for s in srcs:
         if (s):
             # Escape spaces in pathnames
-            s = s.replace(' ', '\ ')
+            s = s.replace(' ', '\\ ')
             # Record all build target directories
             ip_dirs.append(os.path.splitext(s)[0])
 

--- a/platforms/scripts/platmgr/emitcfg.py
+++ b/platforms/scripts/platmgr/emitcfg.py
@@ -368,6 +368,16 @@ def emitSimConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
     emitHeader(f, afu_ifc_db, platform_db)
 
     f.write("-F {0}/sim/platform_if_includes.txt\n".format(args.platform_if))
+
+    # Legacy AFUs may need INCLUDE_DDR4 defined without having to include
+    # platform_if.vh.  If INCLUDE_DDR4 is defined, then force it here.
+    for port in afu_port_list:
+        afu_port = port['afu']
+        plat_port = port['plat']
+        if ('INCLUDE_DDR4' in afu_port['define'] or
+                'INCLUDE_DDR4' in plat_port['define']):
+            f.write('+define+INCLUDE_DDR4\n')
+
     f.close()
 
     #


### PR DESCRIPTION
This eliminates the last significant difference between the ASE configuration
provided in OPAE and the ASE configuration shipped with discrete cards.  It was
a source of confusion in documentation, since we generally advised the use of
afu_sim_setup, which invokes generate_ase_environment.py.  For AFUs with Qsys,
we suggested a different script.  All shipped AFUs can now use the same
afu_sim_setup for configuration.