### PR TITLE
c++core: Rename `dma_buffer` to `shared_buffer`

### DIFF
--- a/common/include/opae/cxx/core/shared_buffer.h
+++ b/common/include/opae/cxx/core/shared_buffer.h
@@ -41,42 +41,42 @@ namespace types {
 
 /** Host/AFU shared memory blocks
  *
- * dma_buffer abstracts a memory block that may be shared
+ * shared_buffer abstracts a memory block that may be shared
  * between the host cpu and an accelerator. The block may
- * be allocated by the dma_buffer class itself (see allocate),
+ * be allocated by the shared_buffer class itself (see allocate),
  * or it may be allocated elsewhere and then attached to
- * a dma_buffer object via attach.
+ * a shared_buffer object via attach.
  */
-class dma_buffer {
+class shared_buffer {
  public:
   typedef std::size_t size_t;
-  typedef std::shared_ptr<dma_buffer> ptr_t;
+  typedef std::shared_ptr<shared_buffer> ptr_t;
 
-  dma_buffer(const dma_buffer &) = delete;
-  dma_buffer &operator=(const dma_buffer &) = delete;
+  shared_buffer(const shared_buffer &) = delete;
+  shared_buffer &operator=(const shared_buffer &) = delete;
 
-  /** dma_buffer destructor.
+  /** shared_buffer destructor.
    */
-  virtual ~dma_buffer();
+  virtual ~shared_buffer();
 
-  /** dma_buffer factory method - allocate a dma_buffer.
+  /** shared_buffer factory method - allocate a shared_buffer.
    * @param[in] handle The handle used to allocate the buffer.
    * @param[in] len    The length in bytes of the requested buffer.
-   * @return A valid dma_buffer smart pointer on success, or an
+   * @return A valid shared_buffer smart pointer on success, or an
    * empty smart pointer on failure.
    */
-  static dma_buffer::ptr_t allocate(handle::ptr_t handle, size_t len);
+  static shared_buffer::ptr_t allocate(handle::ptr_t handle, size_t len);
 
-  /** Attach a pre-allocated buffer to a dma_buffer object.
+  /** Attach a pre-allocated buffer to a shared_buffer object.
    *
    * @param[in] handle The handle used to attach the buffer.
    * @param[in] base The base of the pre-allocated memory.
    * @param[in] len The size of the pre-allocated memory,
    * which must be a multiple of the page size.
-   * @return A valid dma_buffer smart pointer on success, or an
+   * @return A valid shared_buffer smart pointer on success, or an
    * empty smart pointer on failure.
    */
-  static dma_buffer::ptr_t attach(handle::ptr_t handle, uint8_t *base,
+  static shared_buffer::ptr_t attach(handle::ptr_t handle, uint8_t *base,
                                   size_t len);
 
   /** Retrieve the virtual address of the buffer base.
@@ -105,7 +105,7 @@ class dma_buffer {
    */
   void fill(int c);
 
-  /** Compare this dma_buffer (the first len bytes)
+  /** Compare this shared_buffer (the first len bytes)
    * to that held in other, using memcmp().
    */
   int compare(ptr_t other, size_t len) const;
@@ -142,7 +142,7 @@ class dma_buffer {
   }
 
  protected:
-  dma_buffer(handle::ptr_t handle, size_t len, uint8_t *virt, uint64_t wsid,
+  shared_buffer(handle::ptr_t handle, size_t len, uint8_t *virt, uint64_t wsid,
              uint64_t iova);
 
   handle::ptr_t handle_;

--- a/libopae++/CMakeLists.txt
+++ b/libopae++/CMakeLists.txt
@@ -50,7 +50,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 set(OPAECXXCORE_SRC src/properties.cpp
                     src/token.cpp
                     src/handle.cpp
-                    src/dma_buffer.cpp
+                    src/shared_buffer.cpp
                     src/events.cpp
                     src/except.cpp
                     src/version.cpp)

--- a/libopae++/samples/hello_fpga-1.cpp
+++ b/libopae++/samples/hello_fpga-1.cpp
@@ -30,7 +30,7 @@
 
 #include <uuid/uuid.h>
 
-#include <opae/cxx/core/dma_buffer.h>
+#include <opae/cxx/core/shared_buffer.h>
 #include <opae/cxx/core/handle.h>
 #include <opae/cxx/core/properties.h>
 #include <opae/cxx/core/token.h>
@@ -78,9 +78,9 @@ int main(__attribute__((unused)) int argc,
   auto accel = handle::open(tok, FPGA_OPEN_SHARED);
 
   // allocate buffers
-  auto dsm = dma_buffer::allocate(accel, LPBK1_DSM_SIZE);
-  auto inp = dma_buffer::allocate(accel, LPBK1_BUFFER_ALLOCATION_SIZE);
-  auto out = dma_buffer::allocate(accel, LPBK1_BUFFER_ALLOCATION_SIZE);
+  auto dsm = shared_buffer::allocate(accel, LPBK1_DSM_SIZE);
+  auto inp = shared_buffer::allocate(accel, LPBK1_BUFFER_ALLOCATION_SIZE);
+  auto out = shared_buffer::allocate(accel, LPBK1_BUFFER_ALLOCATION_SIZE);
 
   // initialize buffers
   std::fill_n(dsm->get(), LPBK1_DSM_SIZE, 0);

--- a/libopae++/src/shared_buffer.cpp
+++ b/libopae++/src/shared_buffer.cpp
@@ -25,20 +25,20 @@
 // POSSIBILITY OF SUCH DAMAGE.
 #include <cstring>
 
-#include <opae/cxx/core/dma_buffer.h>
+#include <opae/cxx/core/shared_buffer.h>
 
 namespace opae {
 namespace fpga {
 namespace types {
 
-dma_buffer::~dma_buffer() {
+shared_buffer::~shared_buffer() {
   // If the allocation was successful.
   if (virt_) {
     ASSERT_FPGA_OK(fpgaReleaseBuffer(handle_->get(), wsid_));
   }
 }
 
-dma_buffer::ptr_t dma_buffer::allocate(handle::ptr_t handle, size_t len) {
+shared_buffer::ptr_t shared_buffer::allocate(handle::ptr_t handle, size_t len) {
   ptr_t p;
 
   if (!len) {
@@ -54,12 +54,12 @@ dma_buffer::ptr_t dma_buffer::allocate(handle::ptr_t handle, size_t len) {
   ASSERT_FPGA_OK(res);
   res = fpgaGetIOAddress(handle->get(), wsid, &iova);
   ASSERT_FPGA_OK(res);
-  p.reset(new dma_buffer(handle, len, virt, wsid, iova));
+  p.reset(new shared_buffer(handle, len, virt, wsid, iova));
 
   return p;
 }
 
-dma_buffer::ptr_t dma_buffer::attach(handle::ptr_t handle, uint8_t *base,
+shared_buffer::ptr_t shared_buffer::attach(handle::ptr_t handle, uint8_t *base,
                                      size_t len) {
   ptr_t p;
 
@@ -74,18 +74,18 @@ dma_buffer::ptr_t dma_buffer::attach(handle::ptr_t handle, uint8_t *base,
   ASSERT_FPGA_OK(res);
   res = fpgaGetIOAddress(handle->get(), wsid, &iova);
   ASSERT_FPGA_OK(res);
-  p.reset(new dma_buffer(handle, len, virt, wsid, iova));
+  p.reset(new shared_buffer(handle, len, virt, wsid, iova));
 
   return p;
 }
 
-void dma_buffer::fill(int c) { ::memset(virt_, c, len_); }
+void shared_buffer::fill(int c) { ::memset(virt_, c, len_); }
 
-int dma_buffer::compare(dma_buffer::ptr_t other, size_t len) const {
+int shared_buffer::compare(shared_buffer::ptr_t other, size_t len) const {
   return ::memcmp(virt_, other->virt_, len);
 }
 
-dma_buffer::dma_buffer(handle::ptr_t handle, size_t len, uint8_t *virt,
+shared_buffer::shared_buffer(handle::ptr_t handle, size_t len, uint8_t *virt,
                        uint64_t wsid, uint64_t iova)
     : handle_(handle), len_(len), virt_(virt), wsid_(wsid), iova_(iova) {}
 

--- a/tests/unit/gtCxxBuffer.cpp
+++ b/tests/unit/gtCxxBuffer.cpp
@@ -10,7 +10,7 @@ extern "C" {
 
 #include "gtest/gtest.h"
 
-#include <opae/cxx/core/dma_buffer.h>
+#include <opae/cxx/core/shared_buffer.h>
 #include <opae/cxx/core/handle.h>
 #include <opae/cxx/core/except.h>
 
@@ -35,27 +35,27 @@ class CxxBuffer_f1 : public ::testing::Test {
 
   std::vector<token::ptr_t> tokens_;
   handle::ptr_t accel_;
-  dma_buffer::ptr_t buf_;
+  shared_buffer::ptr_t buf_;
 };
 
 /**
  * @test alloc_01
  * Given an open accelerator handle object<br>
- * When I call dma_buffer::allocate() with a length of 0<br>
+ * When I call shared_buffer::allocate() with a length of 0<br>
  * Then an exception is throw of type opae::fpga::types::except
  */
 TEST_F(CxxBuffer_f1, alloc_01) {
-  ASSERT_THROW(buf_ = dma_buffer::allocate(accel_, 0), except);
+  ASSERT_THROW(buf_ = shared_buffer::allocate(accel_, 0), except);
 }
 
 /**
  * @test alloc_02
  * Given an open accelerator handle object<br>
- * When I call dma_buffer::allocate() with a length greater than 0<br>
- * Then I get a valid dma_buffer pointer.<br>
+ * When I call shared_buffer::allocate() with a length greater than 0<br>
+ * Then I get a valid shared_buffer pointer.<br>
  */
 TEST_F(CxxBuffer_f1, alloc_02) {
-  buf_ = dma_buffer::allocate(accel_, 64);
+  buf_ = shared_buffer::allocate(accel_, 64);
   ASSERT_NE(nullptr, buf_.get());
 
   EXPECT_EQ(64, buf_->size());
@@ -65,33 +65,33 @@ TEST_F(CxxBuffer_f1, alloc_02) {
 /**
  * @test alloc_07
  * Given an open accelerator handle object and a pre-allocated buffer<br>
- * When I call dma_buffer::attach() with a length that is a multiple of the page
- * size<br> Then I get a valid dma_buffer pointer.<br>
+ * When I call shared_buffer::attach() with a length that is a multiple of the page
+ * size<br> Then I get a valid shared_buffer pointer.<br>
  */
 TEST_F(CxxBuffer_f1, alloc_07) {
   uint64_t pg_size = (uint64_t)sysconf(_SC_PAGE_SIZE);
   uint8_t *buf = (uint8_t *)malloc(pg_size);
 
-  buf_ = dma_buffer::attach(accel_, buf, pg_size);
+  buf_ = shared_buffer::attach(accel_, buf, pg_size);
   ASSERT_NE(nullptr, buf_.get());
-  EXPECT_EQ(static_cast<dma_buffer::size_t>(pg_size), buf_->size());
+  EXPECT_EQ(static_cast<shared_buffer::size_t>(pg_size), buf_->size());
   EXPECT_NE(0, buf_->iova());
   free(buf);
 }
 
 /**
  * @test fill_compare_04
- * Given a valid dma_buffer smart pointer<br>
- * When I call dma_buffer::fill(),<br>
+ * Given a valid shared_buffer smart pointer<br>
+ * When I call shared_buffer::fill(),<br>
  * Each byte of the buffer is set to the input value.<br>
- * When I call dma_buffer::compare(),<br>
+ * When I call shared_buffer::compare(),<br>
  * Then a byte-wise comparison is performed.<br>
  */
 TEST_F(CxxBuffer_f1, fill_compare_04) {
-  buf_ = dma_buffer::allocate(accel_, 4);
+  buf_ = shared_buffer::allocate(accel_, 4);
   ASSERT_NE(nullptr, buf_.get());
 
-  dma_buffer::ptr_t buf2 = dma_buffer::allocate(accel_, 4);
+  shared_buffer::ptr_t buf2 = shared_buffer::allocate(accel_, 4);
   ASSERT_NE(nullptr, buf2.get());
 
   buf_->fill(1);
@@ -101,14 +101,14 @@ TEST_F(CxxBuffer_f1, fill_compare_04) {
 
 /**
  * @test read_write_05
- * Given a valid dma_buffer smart pointer<br>
- * When I call dma_buffer::write(),<br>
+ * Given a valid shared_buffer smart pointer<br>
+ * When I call shared_buffer::write(),<br>
  * Then the requested memory block is updated.<br>
- * When I call dma_buffer::read(),<br>
+ * When I call shared_buffer::read(),<br>
  * Then the requested memory block is returned.<br>
  */
 TEST_F(CxxBuffer_f1, read_write_05) {
-  buf_ = dma_buffer::allocate(accel_, 4);
+  buf_ = shared_buffer::allocate(accel_, 4);
   ASSERT_NE(nullptr, buf_.get());
 
   buf_->write<uint32_t>(0xdecafbad, 0);


### PR DESCRIPTION
To avoid confusion with other DMA data structures, this renames the `dma_buffer` class to `shared_buffer`