### PR TITLE
Fix the fn table in prog_guide

### DIFF
--- a/doc/src/fpga_api/prog_guide/readme.md
+++ b/doc/src/fpga_api/prog_guide/readme.md
@@ -173,7 +173,7 @@ The table below groups important API calls by their functionality. For more info
 |           | ```fpgaWriteMMIO[32, 64]()``` |Yes| Yes| Write a 32-bit or 64-bit value to MMIO space |
 |Memory management: Shared memory | ```fpga[Prepare, Release]Buffer()``` |Yes| Yes| Manage memory buffer shared between the calling process and an accelerator |
 |              | ```fpgaGetIOVA()``` | Yes| Yes|Return the virtual address of a shared memory buffer |
-|Management: Reconfiguration | ```fpgaReconfigureSlot()``` | Replace an existing AFU with a new one |
+|Management: Reconfiguration | ```fpgaReconfigureSlot()``` | Replace an existing AFU with a new one | | |
 |Error report | ```fpgaErrStr()``` | Yes| Yes|Map an error code to a human readable string |
 
 ### FPGA Resource Properties ###


### PR DESCRIPTION
The line that include `fpgaReconfigureSlot` is missing column seperators