### PR TITLE
c++core: clone token when creating a new handle

### DIFF
--- a/common/include/opae/cxx/core/handle.h
+++ b/common/include/opae/cxx/core/handle.h
@@ -152,6 +152,7 @@ class handle {
   handle(fpga_handle h);
 
   fpga_handle handle_;
+  fpga_token token_;
 };
 
 }  // end of namespace types

--- a/libopae++/src/handle.cpp
+++ b/libopae++/src/handle.cpp
@@ -38,7 +38,7 @@ handle::handle(fpga_handle h) : handle_(h) {}
 
 handle::~handle() {
   close();
-  // releae the cloned token
+  // release the cloned token
   auto result = fpgaDestroyToken(&token_);
   if (result != FPGA_OK) {
     std::cerr << "Error destroying token structure: " << fpgaErrStr(result)


### PR DESCRIPTION
The `fpga_handle` data stucture makes a shallow copy of the token
used when calling fpgaOpen. This change makes a clone of the token
before calling `fpgaOpen` and saves it in the C++ handle object.
This will ensure the lifetime of the token structure used to open
will be as long as the handle itself.