### PR TITLE
opaecxx: Add os_object API to event class

### DIFF
--- a/common/include/opae/cxx/core/events.h
+++ b/common/include/opae/cxx/core/events.h
@@ -89,11 +89,23 @@ class event {
   static event::ptr_t register_event(handle::ptr_t h, event::type_t t,
                                      int flags = 0);
 
+  /**
+   * @brief Get OS Object from the event object
+   *
+   * Get an OS specific object from the event which can be used to subscribe for
+   * events. On Linux, the object corresponds to a file descriptor that can be
+   * used with select/poll/epoll calls.
+   *
+   * @return An integer object representing the OS object
+   */
+  int os_object() const;
+
  private:
   event(handle::ptr_t h, event::type_t t, fpga_event_handle event_h);
   handle::ptr_t handle_;
   event::type_t type_;
   fpga_event_handle event_handle_;
+  int os_object_;
 };
 
 }  // end of namespace types

--- a/libopae++/src/events.cpp
+++ b/libopae++/src/events.cpp
@@ -54,7 +54,7 @@ event::ptr_t event::register_event(handle::ptr_t h, event::type_t t,
 int event::os_object() const { return os_object_; }
 
 event::event(handle::ptr_t h, event::type_t t, fpga_event_handle eh)
-    : handle_(h), type_(t), event_handle_(eh), os_object_(0) {}
+    : handle_(h), type_(t), event_handle_(eh), os_object_(-1) {}
 
 }  // end of namespace types
 }  // end of namespace fpga

--- a/libopae++/src/events.cpp
+++ b/libopae++/src/events.cpp
@@ -47,12 +47,14 @@ event::ptr_t event::register_event(handle::ptr_t h, event::type_t t,
   ASSERT_FPGA_OK(fpgaCreateEventHandle(&eh));
   ASSERT_FPGA_OK(fpgaRegisterEvent(*h, t, eh, flags));
   evptr.reset(new event(h, t, eh));
-
+  ASSERT_FPGA_OK(fpgaGetOSObjectFromEventHandle(eh, &evptr->os_object_));
   return evptr;
 }
 
+int event::os_object() const { return os_object_; }
+
 event::event(handle::ptr_t h, event::type_t t, fpga_event_handle eh)
-    : handle_(h), type_(t), event_handle_(eh) {}
+    : handle_(h), type_(t), event_handle_(eh), os_object_(0) {}
 
 }  // end of namespace types
 }  // end of namespace fpga

--- a/tests/unit/gtCxxEvents.cpp
+++ b/tests/unit/gtCxxEvents.cpp
@@ -1,8 +1,10 @@
 #include "gtest/gtest.h"
 
-#include "opae/cxx/core/token.h"
-#include "opae/cxx/core/handle.h"
 #include "opae/cxx/core/events.h"
+#include "opae/cxx/core/handle.h"
+#include "opae/cxx/core/token.h"
+
+#include <fcntl.h>
 
 using namespace opae::fpga::types;
 
@@ -26,7 +28,6 @@ class CxxEvent_f1 : public ::testing::Test {
   handle::ptr_t accel_;
 };
 
-
 /**
  * @test register_event_01
  * Given an open accelerator handle object<br>
@@ -35,11 +36,9 @@ class CxxEvent_f1 : public ::testing::Test {
  * Then no exception is thrown<br>
  * And I get a non-null event shared pointer<br>
  */
-TEST_F(CxxEvent_f1, register_event_01){
+TEST_F(CxxEvent_f1, register_event_01) {
   event::ptr_t ev;
-  ASSERT_NO_THROW(
-      ev = event::register_event(accel_, event::type_t::error)
-      );
+  ASSERT_NO_THROW(ev = event::register_event(accel_, event::type_t::error));
   ASSERT_NE(nullptr, ev.get());
 }
 
@@ -51,10 +50,24 @@ TEST_F(CxxEvent_f1, register_event_01){
  * Then no exception is thrown<br>
  * And I get a non-null event shared pointer<br>
  */
-TEST_F(CxxEvent_f1, register_event_02){
+TEST_F(CxxEvent_f1, register_event_02) {
   event::ptr_t ev;
-  ASSERT_NO_THROW(
-      ev = event::register_event(accel_, FPGA_EVENT_ERROR);
-      );
+  ASSERT_NO_THROW(ev = event::register_event(accel_, FPGA_EVENT_ERROR););
   ASSERT_NE(nullptr, ev.get());
+}
+
+/**
+ * @test get_os_object
+ * Given an open accelerator handle object<br>
+ * And an event object created with event::register_event()<br>
+ * When I call event::os_object using the event object<br>
+ * Then I get a valid file descriptor for polling on the event<br>
+ */
+TEST_F(CxxEvent_f1, get_os_object) {
+  event::ptr_t ev;
+  ASSERT_NO_THROW(ev = event::register_event(accel_, FPGA_EVENT_ERROR););
+  ASSERT_NE(nullptr, ev.get());
+  auto fd = ev->os_object();
+  auto res = fcntl(fd, F_GETFL);
+  ASSERT_NE(res, -1);
 }


### PR DESCRIPTION
* Add a call to `fpgaGetOSObjectFromEventHandle` in event factory fn
* Store that os object in the event object
* Return that os object when calling `os_object` fn from an event object