### PR TITLE
Support local memory widths that aren't 512 bits

### DIFF
--- a/ase/rtl/ase_top.sv
+++ b/ase/rtl/ase_top.sv
@@ -199,6 +199,7 @@ module ase_top();
          emif_ddr4
           #(
             .DDR_ADDR_WIDTH(`PLATFORM_PARAM_LOCAL_MEMORY_ADDR_WIDTH),
+            .DDR_DATA_WIDTH(`PLATFORM_PARAM_LOCAL_MEMORY_DATA_WIDTH),
             .INSTANCE_ID(b)
             )
           emif_ddr4

--- a/ase/rtl/device_models/dcp_emif_model_advanced/emif_ddr4.v
+++ b/ase/rtl/device_models/dcp_emif_model_advanced/emif_ddr4.v
@@ -4,7 +4,11 @@
 
 `timescale 1 ps / 1 ps
 module emif_ddr4 #(
-	parameter DDR_ADDR_WIDTH = 26
+	// To be fixed: These are all currently ignored.
+	parameter DDR_ADDR_WIDTH = 26,
+	parameter DDR_DATA_WIDTH = 512,
+	parameter SYMBOL_WIDTH = 8,
+	parameter NUM_SYMBOLS = (DDR_DATA_WIDTH + SYMBOL_WIDTH - 1) / SYMBOL_WIDTH
 ) (
 		output wire         ddr4a_avmm_waitrequest,                     //                    ddr4a_avmm.waitrequest
 		output wire [511:0] ddr4a_avmm_readdata,                        //                              .readdata

--- a/platforms/platform_if/rtl/device_if/avalon_mem_if.vh
+++ b/platforms/platform_if/rtl/device_if/avalon_mem_if.vh
@@ -60,7 +60,7 @@ interface avalon_mem_if
     );
 
     // Number of bytes in a data line
-    localparam DATA_N_BYTES = DATA_WIDTH / 8;
+    localparam DATA_N_BYTES = (DATA_WIDTH + 7) / 8;
 
     // Signals
     logic                       waitrequest;

--- a/platforms/scripts/platmgr/emitcfg.py
+++ b/platforms/scripts/platmgr/emitcfg.py
@@ -123,7 +123,18 @@ is_params.add('clock')
 #
 platform_shim_params = set()
 platform_shim_params.add('clock')
+platform_shim_params.add('addr-width')
+platform_shim_params.add('data-width')
 platform_shim_params.add('add-timing-reg-stages')
+
+
+#
+# Some platform_shim_params can be validated here.  These parameters must
+# be less than or equal to the value from the platform.
+#
+platform_shim_le_params = set()
+platform_shim_le_params.add('addr-width')
+platform_shim_le_params.add('data-width')
 
 
 #
@@ -238,6 +249,20 @@ def emitConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
                     errorExit(
                         ('Illegal AFU attempt to override "{0}" ' +
                          'parameter "{1}"').format(key, k))
+
+                # The parameter may be overridden. Is the value legal?
+                if ((k in platform_shim_le_params) and
+                        (afu_port['params'][k] > params[k])):
+                    errorExit(
+                        ('Illegal AFU parameter override value "{0}" ' +
+                         'parameter "{1}" ({2} > {3})').format(
+                             key, k, afu_port['params'][k], params[k]))
+                if ((k in platform_shim_le_params) and
+                        (afu_port['params'][k] <= 0)):
+                    errorExit(
+                        ('Illegal AFU parameter override value "{0}" ' +
+                         'parameter "{1}" ({2} <= 0)').format(
+                             key, k, afu_port['params'][k]))
 
                 params[k] = afu_port['params'][k]
 


### PR DESCRIPTION
- ASE models whatever width the platform or AFU configure.
- AFU JSON may now request any local memory data or address width that is no
  larger than the platform's memory interface.