### PR TITLE
Add with_ase (#430)

### DIFF
--- a/ase/CMakeLists.txt
+++ b/ase/CMakeLists.txt
@@ -42,7 +42,8 @@ install(FILES ${EXTRA_ASE_FILES}
 
 ## Some ASE scripts are installed in bin
 set(PLATFORM_SCRIPTS
-        afu_sim_setup)
+        afu_sim_setup
+        with_ase)
 
 foreach(SRC ${PLATFORM_SCRIPTS})
   ## Substitute CMake variables of the form @<var>@ in the source file

--- a/ase/scripts/with_ase
+++ b/ase/scripts/with_ase
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Run a binary using the ASE simulation library instead of the standard libopae-c.
+env LD_PRELOAD="libopae-c-ase.so${LD_PRELOAD:+:$LD_PRELOAD}" "$@"


### PR DESCRIPTION
with_ase loads the ASE version of libopae-c, turning software compiled for use
with hardware into a simulation run.