### PR TITLE
c++core: make properties c'tor private

### DIFF
--- a/common/include/opae/cxx/core/properties.h
+++ b/common/include/opae/cxx/core/properties.h
@@ -58,25 +58,9 @@ class properties {
    */
   const static std::vector<properties> none;
 
-  /** Construct an empty set of properties.
-   */
-  properties();
+  properties(const properties &p) = delete;
 
-  /** properties may be copied.
-   */
-  properties(const properties &p);
-
-  /** properties may be copy-assigned.
-   */
-  properties &operator=(const properties &p);
-
-  /** Convert fpga_guid to properties.
-   */
-  properties(fpga_guid guid_in);
-
-  /** Convert fpga_objtype to properties.
-   */
-  properties(fpga_objtype objtype);
+  properties &operator=(const properties &p) = delete;
 
   ~properties();
 
@@ -88,19 +72,37 @@ class properties {
    */
   operator fpga_properties() const { return props_; }
 
+  /** Create a new properties object.
+   * @return A properties smart pointer.
+   */
+  static properties::ptr_t get();
+
+  /** Create a new properties object from a guid.
+   * @param guid_in A guid to set in the properties
+   * @return A properties smart pointer with its guid initialized to guid_in
+   */
+  static properties::ptr_t get(fpga_guid guid_in);
+
+  /** Create a new properties object from an fpga_objtype.
+   * @param objtype An object type to set in the properties
+   * @return A properties smart pointer with its object type set to objtype.
+   */
+  static properties::ptr_t get(fpga_objtype objtype);
+
   /** Retrieve the properties for a given token object.
    * @param[in] t A token identifying the accelerator resource.
    * @return A properties smart pointer for the given token.
    */
-  static properties::ptr_t read(std::shared_ptr<token> t);
+  static properties::ptr_t get(std::shared_ptr<token> t);
 
   /** Retrieve the properties for a given fpga_token.
    * @param[in] t An fpga_token identifying the accelerator resource.
    * @return A properties smart pointer for the given fpga_token.
    */
-  static properties::ptr_t read(fpga_token t);
+  static properties::ptr_t get(fpga_token t);
 
  private:
+  properties();
   fpga_properties props_;
 
  public:

--- a/common/include/opae/cxx/core/token.h
+++ b/common/include/opae/cxx/core/token.h
@@ -51,7 +51,7 @@ class token {
    * @return A set of known tokens that match the search.
    */
   static std::vector<token::ptr_t> enumerate(
-      const std::vector<properties>& props);
+      const std::vector<properties::ptr_t>& props);
 
   ~token();
 

--- a/libopae++/samples/hello_fpga-1.cpp
+++ b/libopae++/samples/hello_fpga-1.cpp
@@ -61,9 +61,9 @@ static inline uint64_t cacheline_aligned_addr(uint64_t num) {
 int main(__attribute__((unused)) int argc,
          __attribute__((unused)) char* argv[]) {
   // look for accelerator with NLB0_AFUID
-  properties filter;
-  filter.guid.parse(NLB0_AFUID);
-  filter.type = FPGA_ACCELERATOR;
+  auto filter = properties::get();
+  filter->guid.parse(NLB0_AFUID);
+  filter->type = FPGA_ACCELERATOR;
 
   auto tokens = token::enumerate({filter});
 

--- a/libopae++/src/properties.cpp
+++ b/libopae++/src/properties.cpp
@@ -63,126 +63,24 @@ properties::properties()
   ASSERT_FPGA_OK(fpgaGetProperties(nullptr, &props_));
 }
 
-properties::properties(const properties &p)
-    : props_(nullptr),
-      type(&props_, fpgaPropertiesGetObjectType, fpgaPropertiesSetObjectType),
-      bus(&props_, fpgaPropertiesGetBus, fpgaPropertiesSetBus),
-      device(&props_, fpgaPropertiesGetDevice, fpgaPropertiesSetDevice),
-      function(&props_, fpgaPropertiesGetFunction, fpgaPropertiesSetFunction),
-      socket_id(&props_, fpgaPropertiesGetSocketID, fpgaPropertiesSetSocketID),
-      num_slots(&props_, fpgaPropertiesGetNumSlots, fpgaPropertiesSetNumSlots),
-      bbs_id(&props_, fpgaPropertiesGetBBSID, fpgaPropertiesSetBBSID),
-      bbs_version(&props_, fpgaPropertiesGetBBSVersion,
-                  fpgaPropertiesSetBBSVersion),
-      vendor_id(&props_, fpgaPropertiesGetVendorID, fpgaPropertiesSetVendorID),
-      device_id(&props_, fpgaPropertiesGetDeviceID, fpgaPropertiesSetDeviceID),
-      model(&props_, fpgaPropertiesGetModel, fpgaPropertiesSetModel),
-      local_memory_size(&props_, fpgaPropertiesGetLocalMemorySize,
-                        fpgaPropertiesSetLocalMemorySize),
-      capabilities(&props_, fpgaPropertiesGetCapabilities,
-                   fpgaPropertiesSetCapabilities),
-      num_mmio(&props_, fpgaPropertiesGetNumMMIO, fpgaPropertiesSetNumMMIO),
-      num_interrupts(&props_, fpgaPropertiesGetNumInterrupts,
-                     fpgaPropertiesSetNumInterrupts),
-      accelerator_state(&props_, fpgaPropertiesGetAcceleratorState,
-                        fpgaPropertiesSetAcceleratorState),
-      object_id(&props_, fpgaPropertiesGetObjectID, fpgaPropertiesSetObjectID),
-      parent(&props_, fpgaPropertiesGetParent, fpgaPropertiesSetParent),
-      guid(&props_) {
-  ASSERT_FPGA_OK(fpgaCloneProperties(p.props_, &props_));
-  // make sure that we have a cached copy of
-  // everything that p has cached.
-  if (p.type.is_set()) type.update();
-  if (p.bus.is_set()) bus.update();
-  if (p.device.is_set()) device.update();
-  if (p.function.is_set()) function.update();
-  if (p.socket_id.is_set()) socket_id.update();
-  if (p.num_slots.is_set()) num_slots.update();
-  if (p.bbs_id.is_set()) bbs_id.update();
-  if (p.bbs_version.is_set()) bbs_version.update();
-  if (p.vendor_id.is_set()) vendor_id.update();
-  if (p.device_id.is_set()) device_id.update();
-  if (p.model.is_set()) model.update();
-  if (p.local_memory_size.is_set()) local_memory_size.update();
-  if (p.capabilities.is_set()) capabilities.update();
-  if (p.num_mmio.is_set()) num_mmio.update();
-  if (p.num_interrupts.is_set()) num_interrupts.update();
-  if (p.accelerator_state.is_set()) accelerator_state.update();
-  if (p.object_id.is_set()) object_id.update();
-  if (p.parent.is_set()) parent.update();
-  if (p.guid.is_set()) guid.update();
+properties::ptr_t properties::get() {
+  properties::ptr_t props(new properties());
+  return props;
 }
 
-properties &properties::operator=(const properties &p) {
-  if (this != &p) {
-    if (props_) {
-      ASSERT_FPGA_OK(fpgaDestroyProperties(&props_));
-      props_ = nullptr;
-      type.invalidate();
-      bus.invalidate();
-      device.invalidate();
-      function.invalidate();
-      socket_id.invalidate();
-      num_slots.invalidate();
-      bbs_id.invalidate();
-      bbs_version.invalidate();
-      vendor_id.invalidate();
-      device_id.invalidate();
-      model.invalidate();
-      local_memory_size.invalidate();
-      capabilities.invalidate();
-      num_mmio.invalidate();
-      num_interrupts.invalidate();
-      accelerator_state.invalidate();
-      object_id.invalidate();
-      parent.invalidate();
-      guid.invalidate();
-    }
-
-    if (p.props_) {
-      ASSERT_FPGA_OK(fpgaCloneProperties(p.props_, &props_));
-
-      // make sure that we have a cached copy of
-      // everything that p has cached.
-      if (p.type.is_set()) type.update();
-      if (p.bus.is_set()) bus.update();
-      if (p.device.is_set()) device.update();
-      if (p.function.is_set()) function.update();
-      if (p.socket_id.is_set()) socket_id.update();
-      if (p.num_slots.is_set()) num_slots.update();
-      if (p.bbs_id.is_set()) bbs_id.update();
-      if (p.bbs_version.is_set()) bbs_version.update();
-      if (p.vendor_id.is_set()) vendor_id.update();
-      if (p.device_id.is_set()) device_id.update();
-      if (p.model.is_set()) model.update();
-      if (p.local_memory_size.is_set()) local_memory_size.update();
-      if (p.capabilities.is_set()) capabilities.update();
-      if (p.num_mmio.is_set()) num_mmio.update();
-      if (p.num_interrupts.is_set()) num_interrupts.update();
-      if (p.accelerator_state.is_set()) accelerator_state.update();
-      if (p.object_id.is_set()) object_id.update();
-      if (p.parent.is_set()) parent.update();
-      if (p.guid.is_set()) guid.update();
-    }
-  }
-  return *this;
+properties::ptr_t properties::get(fpga_guid guid_in) {
+  properties::ptr_t props(new properties());
+  props->guid = guid_in;
+  return props;
 }
 
-properties::properties(fpga_guid guid_in) : properties() { guid = guid_in; }
-
-properties::properties(fpga_objtype objtype) : properties() { type = objtype; }
-
-properties::~properties() {
-  if (props_ != nullptr) {
-    auto res = fpgaDestroyProperties(&props_);
-    if (res != FPGA_OK) {
-      std::cerr << "Error while calling fpgaDestroyProperties: "
-                << fpgaErrStr(res) << "\n";
-    }
-  }
+properties::ptr_t properties::get(fpga_objtype objtype) {
+  properties::ptr_t props(new properties());
+  props->type = objtype;
+  return props;
 }
 
-properties::ptr_t properties::read(fpga_token tok) {
+properties::ptr_t properties::get(fpga_token tok) {
   ptr_t p(new properties());
   auto res = fpgaGetProperties(tok, &p->props_);
   if (res != FPGA_OK) {
@@ -192,8 +90,18 @@ properties::ptr_t properties::read(fpga_token tok) {
   return p;
 }
 
-properties::ptr_t properties::read(token::ptr_t tok) {
-  return read(tok->c_type());
+properties::ptr_t properties::get(token::ptr_t tok) {
+  return get(tok->c_type());
+}
+
+properties::~properties() {
+  if (props_ != nullptr) {
+    auto res = fpgaDestroyProperties(&props_);
+    if (res != FPGA_OK) {
+      std::cerr << "Error while calling fpgaDestroyProperties: "
+                << fpgaErrStr(res) << "\n";
+    }
+  }
 }
 
 }  // end of namespace types

--- a/libopae++/src/token.cpp
+++ b/libopae++/src/token.cpp
@@ -33,11 +33,11 @@ namespace fpga {
 namespace types {
 
 std::vector<token::ptr_t> token::enumerate(
-    const std::vector<properties>& props) {
+    const std::vector<properties::ptr_t>& props) {
   std::vector<token::ptr_t> tokens;
   std::vector<fpga_properties> c_props(props.size());
   std::transform(props.begin(), props.end(), c_props.begin(),
-                 [](const properties& p) { return p.c_type(); });
+                 [](properties::ptr_t p) { return p->c_type(); });
   uint32_t matches = 0;
   auto res =
       fpgaEnumerate(c_props.data(), c_props.size(), nullptr, 0, &matches);

--- a/tests/function/gtCxxBuffer.cpp
+++ b/tests/function/gtCxxBuffer.cpp
@@ -22,7 +22,7 @@ class LibopaecppBufCommonALL_f1 : public ::testing::Test {
   LibopaecppBufCommonALL_f1() {}
 
   virtual void SetUp() override {
-    tokens_ = token::enumerate({FPGA_ACCELERATOR});
+    tokens_ = token::enumerate({properties::get(FPGA_ACCELERATOR)});
     ASSERT_GT(tokens_.size(), 0);
     accel_ = handle::open(tokens_[0], 0);
     ASSERT_NE(nullptr, accel_.get());

--- a/tests/function/gtCxxEvents.cpp
+++ b/tests/function/gtCxxEvents.cpp
@@ -13,7 +13,7 @@ class LibopaecppEventCommonALL_f1 : public ::testing::Test {
   LibopaecppEventCommonALL_f1() {}
 
   virtual void SetUp() override {
-    tokens_ = token::enumerate({FPGA_ACCELERATOR});
+    tokens_ = token::enumerate({properties::get(FPGA_ACCELERATOR)});
     ASSERT_GT(tokens_.size(), 0);
     accel_ = handle::open(tokens_[0], 0);
     ASSERT_NE(nullptr, accel_.get());

--- a/tests/function/gtCxxMMIO.cpp
+++ b/tests/function/gtCxxMMIO.cpp
@@ -21,7 +21,7 @@ class LibopaecppMMIOCommonALL_f1 : public ::testing::Test {
   LibopaecppMMIOCommonALL_f1() {}
 
   virtual void SetUp() override {
-    tokens_ = token::enumerate({FPGA_ACCELERATOR});
+    tokens_ = token::enumerate({properties::get(FPGA_ACCELERATOR)});
     ASSERT_GT(tokens_.size(), 0);
     accel_ = handle::open(tokens_[0], 0);
     ASSERT_NE(nullptr, accel_.get());

--- a/tests/function/gtCxxOpenClose.cpp
+++ b/tests/function/gtCxxOpenClose.cpp
@@ -22,7 +22,7 @@ using namespace opae::fpga::types;
  * And no exceptions are thrown when I release the handle and tokens<br>
  */
 TEST(LibopaecppOpenCommonALL, handle_open_01) {
-  auto tokens = token::enumerate({FPGA_ACCELERATOR});
+  auto tokens = token::enumerate({properties::get(FPGA_ACCELERATOR)});
   ASSERT_TRUE(tokens.size() > 0);
   handle::ptr_t h = handle::open(tokens[0], FPGA_OPEN_SHARED);
   ASSERT_NE(nullptr, h.get());

--- a/tests/function/gtCxxProperties.cpp
+++ b/tests/function/gtCxxProperties.cpp
@@ -23,13 +23,13 @@ const char* TEST_GUID_STR = "ae2878a7-926f-4332-aba1-2b952ad6df8e";
  */
 TEST(LibopaecppPropsCommonALL, set_guid) {
   fpga_guid guid_in, guid_out;
-  properties p;
+  auto p = properties::get();
   // set the guid to an fpga_guid
   uuid_parse(TEST_GUID_STR, guid_in);
-  p.guid = guid_in;
+  p->guid = guid_in;
 
   // now check we set the guid using C APIs
-  ASSERT_EQ(fpgaPropertiesGetGUID(p.c_type(), &guid_out), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesGetGUID(p->c_type(), &guid_out), FPGA_OK);
   EXPECT_EQ(memcmp(guid_in, guid_out, sizeof(fpga_guid)), 0);
 }
 
@@ -42,12 +42,12 @@ TEST(LibopaecppPropsCommonALL, set_guid) {
  */
 TEST(LibopaecppPropsCommonALL, parse_guid) {
   fpga_guid guid_out;
-  properties p;
+  auto p = properties::get();
   // set the guid to an fpga_guid
-  p.guid.parse(TEST_GUID_STR);
+  p->guid.parse(TEST_GUID_STR);
 
   // now check we set the guid using C APIs
-  ASSERT_EQ(fpgaPropertiesGetGUID(p.c_type(), &guid_out), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesGetGUID(p->c_type(), &guid_out), FPGA_OK);
   char guid_str[84];
   uuid_unparse(guid_out, guid_str);
   EXPECT_STREQ(TEST_GUID_STR, guid_str);
@@ -62,12 +62,12 @@ TEST(LibopaecppPropsCommonALL, parse_guid) {
  */
 TEST(LibopaecppPropsCommonALL, get_guid) {
   fpga_guid guid_in;
-  properties p;
+  auto p = properties::get();
   // set the guid using fpgaPropertiesSetGUID
   uuid_parse(TEST_GUID_STR, guid_in);
-  fpgaPropertiesSetGUID(p.c_type(), guid_in);
+  fpgaPropertiesSetGUID(p->c_type(), guid_in);
 
-  uint8_t* guid_ptr = p.guid;
+  uint8_t* guid_ptr = p->guid;
   ASSERT_NE(nullptr, guid_ptr);
   EXPECT_EQ(memcmp(guid_in, guid_ptr, sizeof(fpga_guid)), 0);
 }
@@ -80,12 +80,12 @@ TEST(LibopaecppPropsCommonALL, get_guid) {
  */
 TEST(LibopaecppPropsCommonALL, compare_guid){
   fpga_guid guid_in;
-  properties p;
+  auto p = properties::get();
   uuid_parse(TEST_GUID_STR, guid_in);
-  EXPECT_FALSE(p.guid == guid_in);
-  p.guid = guid_in;
-  ASSERT_EQ(memcmp(p.guid.c_type(), guid_in, sizeof(fpga_guid)), 0);
-  EXPECT_TRUE(p.guid == guid_in);
+  EXPECT_FALSE(p->guid == guid_in);
+  p->guid = guid_in;
+  ASSERT_EQ(memcmp(p->guid.c_type(), guid_in, sizeof(fpga_guid)), 0);
+  EXPECT_TRUE(p->guid == guid_in);
 }
 
 /**
@@ -98,9 +98,9 @@ TEST(LibopaecppPropsCommonALL, compare_guid){
 TEST(LibopaecppPropsCommonALL, props_ctor_01){
   fpga_guid guid_in;
   uuid_parse(TEST_GUID_STR, guid_in);
-  properties p(guid_in);
-  ASSERT_EQ(memcmp(p.guid.c_type(), guid_in, sizeof(fpga_guid)), 0);
-  EXPECT_TRUE(p.guid == guid_in);
+  auto p = properties::get(guid_in);
+  ASSERT_EQ(memcmp(p->guid.c_type(), guid_in, sizeof(fpga_guid)), 0);
+  EXPECT_TRUE(p->guid == guid_in);
 }
 
 /**
@@ -110,13 +110,13 @@ TEST(LibopaecppPropsCommonALL, props_ctor_01){
  * Then the property is set
  */
 TEST(LibopaecppPropsCommonALL, set_objtype) {
-  properties p;
-  p.type = FPGA_ACCELERATOR;
-  fpga_objtype t = p.type;
+  auto p = properties::get();
+  p->type = FPGA_ACCELERATOR;
+  fpga_objtype t = p->type;
   fpga_objtype other_t =
       (t == FPGA_ACCELERATOR) ? FPGA_DEVICE : FPGA_ACCELERATOR;
-  p.type = other_t;
-  EXPECT_TRUE(p.type == other_t);
+  p->type = other_t;
+  EXPECT_TRUE(p->type == other_t);
 }
 
 /**
@@ -126,8 +126,8 @@ TEST(LibopaecppPropsCommonALL, set_objtype) {
  * Then I get an empty string
  */
 TEST(LibopaecppPropsCommonALL, get_model) {
-  properties p;
+  auto p = properties::get();
   std::string model = "";
   // Model is currently not supported in libopae-c
-  EXPECT_THROW(model = p.model, not_supported);
+  EXPECT_THROW(model = p->model, not_supported);
 }

--- a/tests/function/gtCxxReset.cpp
+++ b/tests/function/gtCxxReset.cpp
@@ -11,7 +11,7 @@ using namespace opae::fpga::types;
  * Then no exceptions are thrown<br>
  */
 TEST(LibopaecppResetCommonALL, handle_reset_01) {
-  auto tokens = token::enumerate({FPGA_ACCELERATOR});
+  auto tokens = token::enumerate({properties::get(FPGA_ACCELERATOR)});
   ASSERT_TRUE(tokens.size() > 0);
   handle::ptr_t h = handle::open(tokens[0], FPGA_OPEN_SHARED);
   ASSERT_NE(nullptr, h.get());


### PR DESCRIPTION
* Make the default properties contructor private and replaces construction
of a properties objtype to a factory function called `properties::get()`.
* Add overloaded `properties::get()` functions to create properties
using one property (like object type or guid).
* delete the copy contructor and assignment operator of properties class.

The goal of this change is to
* Align the the properties C++ API with the other classes in the cxx-core library.
* Elimate the need to copy properties objects by instead using a shared_ptr
* Elimate the need to wrap properties creation in the upcoming Python bindings

TODO: Add a properties::clone() function