### PR TITLE
ASE Klocwork fix for using safe memset() function

### DIFF
--- a/ase/api/src/enum.c
+++ b/ase/api/src/enum.c
@@ -253,7 +253,7 @@ fpga_result __FPGA_API__ fpgaGetProperties(fpga_token token,
 		FPGA_MSG("Failed to allocate memory for properties");
 		return FPGA_NO_MEMORY;
 	}
-	memset(_prop, 0, sizeof(struct _fpga_properties));
+	ase_memset(_prop, 0, sizeof(struct _fpga_properties));
 	// mark data structure as valid
 	_prop->magic = FPGA_PROPERTY_MAGIC;
 
@@ -344,7 +344,7 @@ fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 	if (ASE_TOKEN_MAGIC != _token->magic)
 		return FPGA_INVALID_PARAM;
 	//clear fpga_properties buffer
-	memset(&_iprop, 0, sizeof(struct _fpga_properties));
+	ase_memset(&_iprop, 0, sizeof(struct _fpga_properties));
 	_iprop.magic = FPGA_PROPERTY_MAGIC;
 	result = objectid_for_ase(&_iprop.object_id);
 	if (result == 0)

--- a/ase/api/src/open.c
+++ b/ase/api/src/open.c
@@ -83,7 +83,7 @@ fpga_result __FPGA_API__ fpgaOpen(fpga_token token, fpga_handle *handle, int fla
 		return FPGA_NO_MEMORY;
 	}
 
-	memset(_handle, 0, sizeof(*_handle));
+	ase_memset(_handle, 0, sizeof(*_handle));
 
 	_handle->token = token;
 	_handle->magic = FPGA_HANDLE_MAGIC;

--- a/ase/sw/app_backend.c
+++ b/ase/sw/app_backend.c
@@ -183,7 +183,7 @@ void *mmio_response_watcher(void *arg)
 
     // start watching for messages
     while (mmio_exist_status == ESTABLISHED) {
-		memset((void *) mmio_rsp_pkt, 0xbc, sizeof(mmio_t));
+		ase_memset((void *) mmio_rsp_pkt, 0xbc, sizeof(mmio_t));
 
 		// If received, update global message
 		ret = mqueue_recv(sim2app_mmiorsp_rx, (char *) mmio_rsp_pkt,
@@ -325,7 +325,7 @@ void session_init(void)
 	snprintf(tstamp_filepath, ASE_FILEPATH_LEN, "%s/%s", ase_workdir_path, TSTAMP_FILENAME);
 
 	// Craft a .app_lock.pid lock filepath string
-	memset(app_ready_lockpath, 0, ASE_FILEPATH_LEN);
+	ase_memset(app_ready_lockpath, 0, ASE_FILEPATH_LEN);
 	snprintf(app_ready_lockpath, ASE_FILEPATH_LEN, "%s/%s",
 			 ase_workdir_path, APP_LOCK_FILENAME);
 
@@ -1111,7 +1111,7 @@ void allocate_buffer(struct buffer_t *mem, uint64_t *suggested_vaddr)
     // Autogenerate a memname, by defualt the first region id=0 will be
     // called "/mmio", subsequent regions will be called strcat("/buf", id)
     // Initially set all characters to NULL
-    memset(mem->memname, 0, sizeof(mem->memname));
+    ase_memset(mem->memname, 0, sizeof(mem->memname));
     if (mem->is_mmiomap == 1) {
 		snprintf(mem->memname, ASE_FILENAME_LEN, "/mmio.%s",
 		 tstamp_string);
@@ -1538,7 +1538,7 @@ static int send_fd(int sock_fd, int fd, struct event_request *req)
     struct cmsghdr *cmsg;
     char buf[CMSG_SPACE(sizeof(int))];
 
-    memset(buf, 0x0, sizeof(buf));
+    ase_memset(buf, 0x0, sizeof(buf));
     struct iovec io = { .iov_base = req, .iov_len = sizeof(req) };
 
     cmsg = (struct cmsghdr *)buf;

--- a/ase/sw/ase_common.h
+++ b/ase/sw/ase_common.h
@@ -475,10 +475,12 @@ uint32_t ret_random_in_range(int, int);
 void ase_string_copy(char *, const char *, size_t);
 char *ase_getenv(const char *);
 void ase_memcpy(void *, const void *, size_t);
+void ase_memset(void *, int, size_t);
 int ase_strncmp(const char *, const char *, size_t);
 
 // Safe string equivalents
 int ase_memcpy_s(void *, size_t, const void *, size_t);
+int ase_memset_s(void *, size_t, int, size_t);
 int ase_strncpy_s(char *, size_t, const char *, size_t);
 int ase_strcmp_s(const char *, size_t, const char *, int *);
 

--- a/ase/sw/ase_ops.c
+++ b/ase/sw/ase_ops.c
@@ -293,7 +293,7 @@ char *ase_malloc(size_t size)
 		exit(1);
 #endif
 	} else {
-		memset(buffer, 0, size);
+		ase_memset(buffer, 0, size);
 		FUNC_CALL_EXIT;
 		return buffer;
 	}
@@ -606,7 +606,7 @@ void print_mmiopkt(FILE *fp, char *activity, struct mmio_t *pkt)
 	FUNC_CALL_ENTRY;
 
 	char mmio_action_type[20];
-	memset(mmio_action_type, 0, 20);
+	ase_memset(mmio_action_type, 0, 20);
 
 	snprintf(mmio_action_type, 20,
 		 "MMIO-%s-%d-%s",
@@ -757,6 +757,16 @@ void ase_memcpy(void *dest, const void *src, size_t n)
 	// Secure implementation
 	ase_memcpy_s(dest, n, src, n);
 }
+
+/*
+* ase_memset - Secure memset abstraction
+*/
+void ase_memset(void *dest, int ch, size_t n)
+{
+	// Secure implementation
+	ase_memset_s(dest, n, ch, n);
+}
+
 
 
 /*

--- a/ase/sw/ase_strings.c
+++ b/ase/sw/ase_strings.c
@@ -82,6 +82,25 @@ int ase_memcpy_s(void *dest, size_t dmax, const void *src, size_t smax)
 
 
 /*
+* ase_memset - Secure memset abstraction.  Return 0 on success.
+*/
+int ase_memset_s(void *dest, size_t dmax, int ch, size_t count)
+{
+	// No NULL pointers, maxima must be non-zero, smax must be less than dmax
+	// and dmax must be less than 256MB.
+	if ((dest == NULL) ||
+		(dmax == 0) || (count == 0) || (count > dmax) ||
+		(dmax > (256UL << 20))) {
+		ASE_DBG("Illegal parameter to ase_memset_s");
+		return -1;
+	}
+
+	memset(dest, ch, count);
+	return 0;
+}
+
+
+/*
  * ASE string copy.  Returns 0 on success.
  */
 int ase_strncpy_s(char *dest, size_t dmax, const char *src, size_t slen)

--- a/ase/sw/error_report.c
+++ b/ase/sw/error_report.c
@@ -130,7 +130,7 @@ void backtrace_handler(int sig)
 	char app_or_sim[16];
 	int cmd_ret;
 
-	memset(app_or_sim, 0, sizeof(app_or_sim));
+	ase_memset(app_or_sim, 0, sizeof(app_or_sim));
 
 #ifdef SIM_SIDE
 	snprintf(app_or_sim, 16, "Simulator ");

--- a/ase/sw/ipc_mgmt_ops.c
+++ b/ase/sw/ipc_mgmt_ops.c
@@ -52,7 +52,7 @@ void create_ipc_listfile(void)
 	FUNC_CALL_ENTRY;
 
 	// Allocate memory, fail if not possible
-    memset(ipclist_filepath, 0, ASE_FILEPATH_LEN);
+    ase_memset(ipclist_filepath, 0, ASE_FILEPATH_LEN);
 
 	// Create IPC file path length
 	snprintf(ipclist_filepath, ASE_FILEPATH_LEN, "%s/%s",

--- a/ase/sw/mem_model.c
+++ b/ase/sw/mem_model.c
@@ -195,7 +195,7 @@ void ase_dealloc_action(struct buffer_t *buf, int mq_enable)
 	FUNC_CALL_ENTRY;
 
 	char buf_str[ASE_MQ_MSGSIZE];
-	memset(buf_str, 0, ASE_MQ_MSGSIZE);
+	ase_memset(buf_str, 0, ASE_MQ_MSGSIZE);
 
 	// Traversal pointer
 	struct buffer_t *dealloc_ptr;
@@ -243,7 +243,7 @@ void ase_empty_buffer(struct buffer_t *buf)
 {
 	buf->index = 0;
 	buf->valid = ASE_BUFFER_INVALID;
-	memset(buf->memname, 0, ASE_FILENAME_LEN);
+	ase_memset(buf->memname, 0, ASE_FILENAME_LEN);
 	buf->memsize = 0;
 	buf->vbase = 0;
 	buf->pbase = 0;

--- a/ase/sw/protocol_backend.c
+++ b/ase/sw/protocol_backend.c
@@ -164,7 +164,7 @@ int ase_instance_running(void)
 void sv2c_config_dex(const char *str)
 {
 	// Allocate memory
-	memset(sv2c_config_filepath, 0, ASE_FILEPATH_LEN);
+	ase_memset(sv2c_config_filepath, 0, ASE_FILEPATH_LEN);
 
 	// Check that input string is not NULL
 	if (str == NULL) {
@@ -187,7 +187,7 @@ void sv2c_config_dex(const char *str)
 			} else {
 				ASE_ERR
 				    ("** WARNING ** +CONFIG file was not found, will revert to DEFAULTS\n");
-				memset(sv2c_config_filepath, 0,
+				ase_memset(sv2c_config_filepath, 0,
 				       ASE_FILEPATH_LEN);
 			}
 		}
@@ -203,7 +203,7 @@ void sv2c_script_dex(const char *str)
 	if (str == NULL) {
 		ASE_MSG("sv2c_script_dex => Input string is unusable\n");
 	} else {
-		memset(sv2c_script_filepath, 0, ASE_FILEPATH_LEN);
+		ase_memset(sv2c_script_filepath, 0, ASE_FILEPATH_LEN);
 		if (sv2c_script_filepath != NULL) {
 			ase_string_copy(sv2c_script_filepath, str,
 					ASE_FILEPATH_LEN);
@@ -219,7 +219,7 @@ void sv2c_script_dex(const char *str)
 			} else {
 				ASE_MSG
 				    ("** WARNING ** +SCRIPT file was not found, will revert to DEFAULTS\n");
-				memset(sv2c_script_filepath, 0,
+				ase_memset(sv2c_script_filepath, 0,
 				       ASE_FILEPATH_LEN);
 			}
 		}
@@ -498,7 +498,7 @@ int read_fd(int sock_fd)
 	struct cmsghdr *cmsg;
 	int *fdptr;
 
-	memset(buf, '\0', sizeof(buf));
+	ase_memset(buf, '\0', sizeof(buf));
 	msg.msg_iov = &io;
 	msg.msg_iovlen = 1;
 	msg.msg_control = buf;
@@ -829,7 +829,7 @@ int ase_listener(void)
 			}
 
 			// Format workspace info string
-			memset(logger_str, 0, ASE_LOGGER_LEN);
+			ase_memset(logger_str, 0, ASE_LOGGER_LEN);
 			if (ase_buffer.is_mmiomap) {
 				snprintf(logger_str + strlen(logger_str),
 					 ASE_LOGGER_LEN,
@@ -902,7 +902,7 @@ int ase_listener(void)
 				   sizeof(struct buffer_t));
 
 			// Format workspace info string
-			memset(logger_str, 0, ASE_LOGGER_LEN);
+			ase_memset(logger_str, 0, ASE_LOGGER_LEN);
 			snprintf(logger_str + strlen(logger_str),
 				 ASE_LOGGER_LEN,
 				 "\nBuffer %d Deallocated =>\n",
@@ -1042,7 +1042,7 @@ int ase_init(void)
 	create_ipc_listfile();
 
 	// Sniffer file stat path
-	memset(ccip_sniffer_file_statpath, 0, ASE_FILEPATH_LEN);
+	ase_memset(ccip_sniffer_file_statpath, 0, ASE_FILEPATH_LEN);
 	snprintf(ccip_sniffer_file_statpath, ASE_FILEPATH_LEN,
 		 "%s/ccip_warning_and_errors.txt", ase_workdir_path);
 


### PR DESCRIPTION
Added the safe version memset in ase_strings.c. This should fix the klocwork issues related to memset() in ASE. 

DCP regression tests passed at:
http://sw-pert.altera.com/pert/pert.php?test_run_id=2402072