### PR TITLE
Optimize timing register pipelines when clock crossings are also present

### DIFF
--- a/platforms/platform_db/platform_defaults/defaults_ccip.json
+++ b/platforms/platform_db/platform_defaults/defaults_ccip.json
@@ -54,8 +54,15 @@
          "reconfiguration (PR) boundary and the AFU.  An AFU may set this to",
          "1 in order to satisfy the CCI-P buffering required by the spec.",
          "",
-         "Be careful when requesting more than a single stage, since this",
-         "may lead to overruns due to late detection of almost full signals."
+         "When there is also a clock crossing, using 'clock' below, the",
+         "timing register stages are added between the clock crossing and",
+         "the AFU.  In addition, extra space is allocated in the clock",
+         "crossing FIFO to accommodate more CCI-P requests following an",
+         "almost full signal due to the latency of the extra pipeline stages.",
+         "",
+         "Be careful when requesting more than a single stage if there is",
+         "no clock crossing requested.  Extra register stages may lead to",
+         "overruns due to late detection of almost full signals."
       ],
    "add-timing-reg-stages": 0,
 

--- a/platforms/platform_db/platform_defaults/defaults_local_memory.json
+++ b/platforms/platform_db/platform_defaults/defaults_local_memory.json
@@ -17,9 +17,14 @@
       [
          "Like the same field in CCI-P, this is the recommended number",
          "of times an AFU should register local memory signals before use",
-         "in order to make successful timing closure likely.  For Avalon",
-         "MM interfaces this value is typically zero since registering",
-         "Avalon MM's waitrequest protocol is complex."
+         "in order to make successful timing closure likely.",
+         "",
+         "When a local memory clock crossing is also requested, using",
+         "the 'clock' parameter below, at least the suggested number of",
+         "timing register stages are always inserted between the clock",
+         "crossing and the AFU.  This is done because adding registers",
+         "along with a clock crossing is relatively inexpensive.  See",
+         "'add-timing-reg-stages' below for more detail."
       ],
    "suggested-timing-reg-stages": 0,
 
@@ -27,8 +32,17 @@
       [
          "Like the CCI-P add-timing-reg-stages, this field requests",
          "that the platform add pipeline stages to the local memory",
-         "signals before passing them to the AFU.  Register stages",
-         "are added using an Avalon MM pipeline bridge."
+         "signals before passing them to the AFU.",
+         "",
+         "Register stages are added using one of two methods.  When",
+         "a clock crossing is also requested for local memory, using",
+         "the 'clock' parameter below, register stages are added as",
+         "a simple, synchronous pipeline.  This is possible, despite",
+         "the Avalon waitrequest protocol, because space is left in",
+         "the clock crossing FIFO to drain the pipeline without losing",
+         "requests, even after waitrequest is asserted.  When no clock",
+         "crossing is requested, stages are added using an Avalon MM",
+         "pipeline bridge."
       ],
    "add-timing-reg-stages": 0,
 

--- a/platforms/platform_if/par/platform_if_addenda.qsf
+++ b/platforms/platform_if/par/platform_if_addenda.qsf
@@ -30,6 +30,7 @@ set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shi
 set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/avalon_mem_if_async_shim.sv
 set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/avalon_mem_if_connect.sv
 set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/avalon_mem_if_reg.sv
+set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/avalon_mem_if_reg_simple.sv
 set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/platform_utils_ccip_activity_cnt.sv
 set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/platform_utils_ccip_async_shim.sv
 set_global_assignment -name SYSTEMVERILOG_FILE $PLATFORM_IF_SRC/rtl/platform_shims/utils/platform_utils_ccip_reg.sv

--- a/platforms/platform_if/rtl/platform_shims/platform_shim_avalon_mem_if.sv
+++ b/platforms/platform_if/rtl/platform_shims/platform_shim_avalon_mem_if.sv
@@ -79,12 +79,31 @@ module platform_shim_avalon_mem_if
     //
     // How many register stages should be inserted for timing?
     //
+    function automatic int numTimingRegStages();
+        int n_stages = 0;
+
+        // Were timing registers requested in the AFU JSON?
 `ifdef PLATFORM_PARAM_LOCAL_MEMORY_ADD_TIMING_REG_STAGES
-    localparam NUM_TIMING_REG_STAGES =
-        `PLATFORM_PARAM_LOCAL_MEMORY_ADD_TIMING_REG_STAGES;
-`else
-    localparam NUM_TIMING_REG_STAGES = 0;
+        n_stages = `PLATFORM_PARAM_LOCAL_MEMORY_ADD_TIMING_REG_STAGES;
 `endif
+
+        // Override the register request if a clock crossing is being
+        // inserted here.
+        if (LOCAL_MEMORY_CHANGE_CLOCK)
+        begin
+            // Use at least the recommended number of stages
+`ifdef PLATFORM_PARAM_LOCAL_MEMORY_SUGGESTED_TIMING_REG_STAGES
+            if (`PLATFORM_PARAM_LOCAL_MEMORY_SUGGESTED_TIMING_REG_STAGES > n_stages)
+            begin
+                n_stages = `PLATFORM_PARAM_LOCAL_MEMORY_SUGGESTED_TIMING_REG_STAGES;
+            end
+`endif
+        end
+
+        return n_stages;
+    endfunction
+
+    localparam NUM_TIMING_REG_STAGES = numTimingRegStages();
 
 
     genvar b;

--- a/platforms/platform_if/rtl/platform_shims/platform_shim_avalon_mem_if.sv
+++ b/platforms/platform_if/rtl/platform_shims/platform_shim_avalon_mem_if.sv
@@ -144,12 +144,16 @@ module platform_shim_avalon_mem_if
                         // base pipeline depth.
                         (NUM_TIMING_REG_STAGES <= 16 ? 4 : (NUM_TIMING_REG_STAGES >> 2)));
 
+                // A few extra stages to avoid off-by-one errors. There is plenty of
+                // space in FIFO, so this has no performance consequences.
+                localparam NUM_EXTRA_STAGES = (NUM_TIMING_REG_STAGES != 0) ? 4 : 0;
+
                 // Set the almost full threshold to satisfy the buffering pipeline depth
                 // plus the depth of the waitrequest pipeline plus a little extra to
                 // avoid having to worry about off-by-one errors.
                 localparam NUM_ALMFULL_SLOTS = NUM_TIMING_REG_STAGES +
                                                NUM_WAITREQUEST_STAGES +
-                                               4;
+                                               NUM_EXTRA_STAGES;
 
                 // Clock crossing bridge
                 avalon_mem_if_async_shim

--- a/platforms/platform_if/rtl/platform_shims/platform_shim_ccip.sv
+++ b/platforms/platform_if/rtl/platform_shims/platform_shim_ccip.sv
@@ -61,9 +61,7 @@ module platform_shim_ccip
 
     //
     // Has the AFU JSON requested a clock crossing for the CCI-P signals?
-    // We compute this here because it affects register stage insertion.
     //
-
 `ifdef PLATFORM_PARAM_CCI_P_CLOCK_IS_DEFAULT
     // AFU asked for default clock.
     localparam CCI_P_CHANGE_CLOCK = 0;
@@ -75,74 +73,14 @@ module platform_shim_ccip
     localparam CCI_P_CHANGE_CLOCK = 1;
 `endif
 
-
-    // ====================================================================
-    //  CCI-P auto-register for timing
-    // ====================================================================
-
-    //
-    // Register CCI-P signals according to the platform's rules.  This is
-    // typically done to relieve timing pressure.  Note that adding latency
-    // to the almost full and transmit paths counts against the sending
-    // limit to the FIU.
-    //
-    logic reg_cp2af_softReset;
-    t_if_ccip_Tx reg_af2cp_sTx;
-    t_if_ccip_Rx reg_cp2af_sRx;
-    logic [1:0] reg_cp2af_pwrState;
-    logic reg_cp2af_error;
-
     //
     // How many register stages should be inserted for timing?
     //
-    function automatic int numTimingRegStages();
-        int n_stages = 0;
-
-        // Were timing registers requested in the AFU JSON?
 `ifdef PLATFORM_PARAM_CCI_P_ADD_TIMING_REG_STAGES
-        n_stages = `PLATFORM_PARAM_CCI_P_ADD_TIMING_REG_STAGES;
+    localparam NUM_TIMING_REG_STAGES = `PLATFORM_PARAM_CCI_P_ADD_TIMING_REG_STAGES;
+`else
+    localparam NUM_TIMING_REG_STAGES = 0;
 `endif
-
-        // Override the register request if a clock crossing is being
-        // inserted here.
-        if (CCI_P_CHANGE_CLOCK)
-        begin
-            // At least one stage is required
-            if (n_stages == 0) n_stages = 1;
-            // Use at least the recommended number of stages
-`ifdef PLATFORM_PARAM_CCI_P_SUGGESTED_TIMING_REG_STAGES
-            if (`PLATFORM_PARAM_CCI_P_SUGGESTED_TIMING_REG_STAGES > n_stages)
-            begin
-                n_stages = `PLATFORM_PARAM_CCI_P_SUGGESTED_TIMING_REG_STAGES;
-            end
-`endif
-        end
-
-        return n_stages;
-    endfunction
-
-    localparam NUM_TIMING_REG_STAGES = numTimingRegStages();
-
-    platform_utils_ccip_reg
-      #(
-        .N_REG_STAGES(NUM_TIMING_REG_STAGES)
-        )
-      ccip_reg
-       (
-        .clk(pClk),
-
-        .fiu_reset(pck_cp2af_softReset),
-        .fiu_cp2af_sRx(pck_cp2af_sRx),
-        .fiu_af2cp_sTx(pck_af2cp_sTx),
-        .fiu_cp2af_pwrState(pck_cp2af_pwrState),
-        .fiu_cp2af_error(pck_cp2af_error),
-
-        .afu_reset(reg_cp2af_softReset),
-        .afu_cp2af_sRx(reg_cp2af_sRx),
-        .afu_af2cp_sTx(reg_af2cp_sTx),
-        .afu_cp2af_pwrState(reg_cp2af_pwrState),
-        .afu_cp2af_error(reg_cp2af_error)
-        );
 
 
     // ====================================================================
@@ -150,24 +88,73 @@ module platform_shim_ccip
     //  AFU's JSON file.
     // ====================================================================
 
+    // CCI-P signals in the AFU's requested clock domain
+    logic cross_cp2af_softReset;
+    t_if_ccip_Tx cross_af2cp_sTx;
+    t_if_ccip_Rx cross_cp2af_sRx;
+    logic [1:0] cross_cp2af_pwrState;
+    logic cross_cp2af_error;
+
     generate
         if (CCI_P_CHANGE_CLOCK == 0)
         begin : nc
             // No clock crossing
             always_comb
             begin
-                afu_cp2af_softReset = reg_cp2af_softReset;
-                reg_af2cp_sTx = afu_af2cp_sTx;
-                afu_cp2af_sRx = reg_cp2af_sRx;
+                cross_cp2af_softReset = pck_cp2af_softReset;
+                pck_af2cp_sTx = cross_af2cp_sTx;
+                cross_cp2af_sRx = pck_cp2af_sRx;
 
-                afu_cp2af_pwrState = reg_cp2af_pwrState;
-                afu_cp2af_error = reg_cp2af_error;
+                cross_cp2af_pwrState = pck_cp2af_pwrState;
+                cross_cp2af_error = pck_cp2af_error;
             end
         end
         else
         begin : c
+            // Before crossing add some FIU-side register stages for timing.
+            logic reg_cp2af_softReset;
+            t_if_ccip_Tx reg_af2cp_sTx;
+            t_if_ccip_Rx reg_cp2af_sRx;
+            logic [1:0] reg_cp2af_pwrState;
+            logic reg_cp2af_error;
+
+            // How many register stages should be inserted for timing?
+`ifdef PLATFORM_PARAM_CCI_P_SUGGESTED_TIMING_REG_STAGES
+            // At least one stage, perhaps more.
+            localparam NUM_PRE_CROSS_REG_STAGES =
+                (`PLATFORM_PARAM_CCI_P_SUGGESTED_TIMING_REG_STAGES != 0) ?
+                    `PLATFORM_PARAM_CCI_P_SUGGESTED_TIMING_REG_STAGES : 1;
+`else
+            localparam NUM_PRE_CROSS_REG_STAGES = 1;
+`endif
+
+            platform_utils_ccip_reg
+              #(
+                .N_REG_STAGES(NUM_PRE_CROSS_REG_STAGES)
+                )
+            ccip_pre_cross_reg
+               (
+                .clk(pClk),
+
+                .fiu_reset(pck_cp2af_softReset),
+                .fiu_cp2af_sRx(pck_cp2af_sRx),
+                .fiu_af2cp_sTx(pck_af2cp_sTx),
+                .fiu_cp2af_pwrState(pck_cp2af_pwrState),
+                .fiu_cp2af_error(pck_cp2af_error),
+
+                .afu_reset(reg_cp2af_softReset),
+                .afu_cp2af_sRx(reg_cp2af_sRx),
+                .afu_af2cp_sTx(reg_af2cp_sTx),
+                .afu_cp2af_pwrState(reg_cp2af_pwrState),
+                .afu_cp2af_error(reg_cp2af_error)
+                );
+
             // Cross to the target clock
-            platform_utils_ccip_async_shim ccip_async_shim
+            platform_utils_ccip_async_shim
+              #(
+                .EXTRA_ALMOST_FULL_STAGES(2 * NUM_TIMING_REG_STAGES)
+                )
+              ccip_async_shim
                (
                 .bb_softreset(reg_cp2af_softReset),
                 .bb_clk(pClk),
@@ -176,16 +163,52 @@ module platform_shim_ccip
                 .bb_pwrState(reg_cp2af_pwrState),
                 .bb_error(reg_cp2af_error),
 
-                .afu_softreset(afu_cp2af_softReset),
+                .afu_softreset(cross_cp2af_softReset),
                 .afu_clk(afu_clk),
-                .afu_tx(afu_af2cp_sTx),
-                .afu_rx(afu_cp2af_sRx),
-                .afu_pwrState(afu_cp2af_pwrState),
-                .afu_error(afu_cp2af_error),
+                .afu_tx(cross_af2cp_sTx),
+                .afu_rx(cross_cp2af_sRx),
+                .afu_pwrState(cross_cp2af_pwrState),
+                .afu_error(cross_cp2af_error),
 
                 .async_shim_error()
                 );
         end
     endgenerate
+
+
+    // ====================================================================
+    //  Add CCI-P register stages for timing, as requested by AFU JSON.
+    //
+    //  For AFUs with both register stages and a clock crossing, we
+    //  add register stages on the AFU side. Extra space is left in the
+    //  clock crossing FIFO so that the almost full contract with the AFU
+    //  remains unchanged, despite the added latency of almost full and
+    //  the extra requests in flight.
+    //
+    //  NOTE: When no clock crossing is instantiated, register stages
+    //  added here count against the almost full sending limits!
+    //
+    // ====================================================================
+
+    platform_utils_ccip_reg
+      #(
+        .N_REG_STAGES(NUM_TIMING_REG_STAGES)
+        )
+      ccip_reg
+       (
+        .clk(afu_clk),
+
+        .fiu_reset(cross_cp2af_softReset),
+        .fiu_cp2af_sRx(cross_cp2af_sRx),
+        .fiu_af2cp_sTx(cross_af2cp_sTx),
+        .fiu_cp2af_pwrState(cross_cp2af_pwrState),
+        .fiu_cp2af_error(cross_cp2af_error),
+
+        .afu_reset(afu_cp2af_softReset),
+        .afu_cp2af_sRx(afu_cp2af_sRx),
+        .afu_af2cp_sTx(afu_af2cp_sTx),
+        .afu_cp2af_pwrState(afu_cp2af_pwrState),
+        .afu_cp2af_error(afu_cp2af_error)
+        );
 
 endmodule // platform_shim_std_ccip

--- a/platforms/platform_if/rtl/platform_shims/platform_shim_ccip_std_afu.sv
+++ b/platforms/platform_if/rtl/platform_shims/platform_shim_ccip_std_afu.sv
@@ -139,7 +139,7 @@ module platform_shim_ccip_std_afu
        (
 `ifdef PLATFORM_PARAM_LOCAL_MEMORY_CLOCK_IS_DEFAULT
         // Not used -- local memory clocks unchanged
-        .tgt_mem_afu_clk(0),
+        .tgt_mem_afu_clk(1'b0),
 `else
         // Updated target for local memory clock
         .tgt_mem_afu_clk(`PLATFORM_PARAM_LOCAL_MEMORY_CLOCK),

--- a/platforms/platform_if/rtl/platform_shims/utils/avalon_mem_if_async_shim.sv
+++ b/platforms/platform_if/rtl/platform_shims/utils/avalon_mem_if_async_shim.sv
@@ -135,8 +135,8 @@ module avalon_mem_if_async_shim
                 // In almost full mode it is illegal for a request to arrive
                 // when s0_waitrequest is asserted. If this ever happens it
                 // means the almost full protocol has failed and that
-                // cmd_space_avail didn't forced back-pressure too late or
-                // it was ignored.
+                // cmd_space_avail forced back-pressure too late or it was
+                // ignored.
 
                 if (~mem_afu.reset && cmd_waitrequest && mem_afu.write)
                 begin

--- a/platforms/platform_if/rtl/platform_shims/utils/avalon_mem_if_async_shim.sv
+++ b/platforms/platform_if/rtl/platform_shims/utils/avalon_mem_if_async_shim.sv
@@ -49,12 +49,20 @@ module avalon_mem_if_async_shim
     parameter ADDR_WIDTH = 10,
     parameter BURST_CNT_WIDTH = 4,
 `endif
-    parameter COMMAND_FIFO_DEPTH = 128
+    parameter COMMAND_FIFO_DEPTH = 128,
+    // When non-zero, set the command buffer such that COMMAND_ALMFULL_THRESHOLD
+    // requests can be received after mem_afu.waitrequest is asserted.
+    parameter COMMAND_ALMFULL_THRESHOLD = 0
     )
    (
     avalon_mem_if.to_fiu mem_fiu,
     avalon_mem_if.to_afu mem_afu
     );
+
+    localparam SPACE_AVAIL_WIDTH = $clog2(COMMAND_FIFO_DEPTH) + 1;
+
+    logic cmd_waitrequest;
+    logic [SPACE_AVAIL_WIDTH-1:0] cmd_space_avail;
 
     platform_utils_avalon_mm_clock_crossing_bridge
       #(
@@ -72,7 +80,7 @@ module avalon_mem_if_async_shim
         .m0_clk(mem_fiu.clk),
         .m0_reset(mem_fiu.reset),
 
-        .s0_waitrequest(mem_afu.waitrequest),
+        .s0_waitrequest(cmd_waitrequest),
         .s0_readdata(mem_afu.readdata),
         .s0_readdatavalid(mem_afu.readdatavalid),
         .s0_burstcount(mem_afu.burstcount),
@@ -82,6 +90,7 @@ module avalon_mem_if_async_shim
         .s0_read(mem_afu.read),
         .s0_byteenable(mem_afu.byteenable),
         .s0_debugaccess(1'b0),
+        .s0_space_avail_data(cmd_space_avail),
 
         .m0_waitrequest(mem_fiu.waitrequest),
         .m0_readdata(mem_fiu.readdata),
@@ -94,6 +103,56 @@ module avalon_mem_if_async_shim
         .m0_byteenable(mem_fiu.byteenable),
         .m0_debugaccess()
         );
+
+    // Compute mem_afu.waitrequest
+    generate
+        if (COMMAND_ALMFULL_THRESHOLD == 0)
+        begin : no_almfull
+            // Use the usual Avalon MM protocol
+            assign mem_afu.waitrequest = cmd_waitrequest;
+        end
+        else
+        begin : almfull
+            // Treat waitrequest as an almost full signal, allowing
+            // COMMAND_ALMFULL_THRESHOLD requests after waitrequest is
+            // asserted.
+            always_ff @(posedge mem_afu.clk)
+            begin
+                if (mem_afu.reset)
+                begin
+                    mem_afu.waitrequest <= 1'b1;
+                end
+                else
+                begin
+                    mem_afu.waitrequest <= cmd_waitrequest ||
+                        (cmd_space_avail <= (SPACE_AVAIL_WIDTH)'(COMMAND_ALMFULL_THRESHOLD));
+                end
+            end
+
+            // synthesis translate_off
+            always @(negedge mem_afu.clk)
+            begin
+                // In almost full mode it is illegal for a request to arrive
+                // when s0_waitrequest is asserted. If this ever happens it
+                // means the almost full protocol has failed and that
+                // cmd_space_avail didn't forced back-pressure too late or
+                // it was ignored.
+
+                if (~mem_afu.reset && cmd_waitrequest && mem_afu.write)
+                begin
+                    $fatal("** ERROR ** local memory bank %0d dropped write transaction",
+                           mem_afu.bank_number);
+                end
+
+                if (~mem_afu.reset && cmd_waitrequest && mem_afu.read)
+                begin
+                    $fatal("** ERROR ** local memory bank %0d dropped read transaction",
+                           mem_afu.bank_number);
+                end
+            end
+            // synthesis translate_on
+        end
+    endgenerate
 
     // Debugging signal
     assign mem_afu.bank_number = mem_fiu.bank_number;

--- a/platforms/platform_if/rtl/platform_shims/utils/avalon_mem_if_reg_simple.sv
+++ b/platforms/platform_if/rtl/platform_shims/utils/avalon_mem_if_reg_simple.sv
@@ -32,8 +32,8 @@
 // A simple version of Avalon MM interface register stage insertion.
 // Waitrequest is treated as an almost full protocol, with the assumption
 // that the FIU end of the connection can handle at least as many
-// requests as the depth of the pipeline plus the latency of latency
-// of forwarding waitrequest from the FIU side to the AFU side.
+// requests as the depth of the pipeline plus the latency of
+// forwarding waitrequest from the FIU side to the AFU side.
 //
 
 `include "platform_if.vh"
@@ -92,19 +92,17 @@ module avalon_mem_if_reg_simple
             end
 
 
-            logic [N_WAITREQUEST_STAGES:1] mem_waitrequest_pipe;
+            // waitrequest is a shift register, with mem_fiu.waitrequest entering
+            // at bit 0.
+            logic [N_WAITREQUEST_STAGES:0] mem_waitrequest_pipe;
+            assign mem_waitrequest_pipe[0] = mem_fiu.waitrequest;
 
             always_ff @(posedge mem_fiu.clk)
             begin
-                if (mem_fiu.reset)
-                begin
-                    mem_waitrequest_pipe <= {N_WAITREQUEST_STAGES{1'b1}};
-                end
-                else
-                begin
-                    mem_waitrequest_pipe <=
-                        { mem_waitrequest_pipe[N_WAITREQUEST_STAGES-1:1], mem_fiu.waitrequest };
-                end
+                // Shift the waitrequest pipeline
+                mem_waitrequest_pipe[N_WAITREQUEST_STAGES:1] <=
+                    mem_fiu.reset ? {N_WAITREQUEST_STAGES{1'b1}} :
+                                    mem_waitrequest_pipe[N_WAITREQUEST_STAGES-1:0];
             end
 
 

--- a/platforms/platform_if/rtl/platform_shims/utils/avalon_mem_if_reg_simple.sv
+++ b/platforms/platform_if/rtl/platform_shims/utils/avalon_mem_if_reg_simple.sv
@@ -85,6 +85,12 @@ module avalon_mem_if_reg_simple
                     mem_pipe[s-1].write <= mem_pipe[s].write;
                     mem_pipe[s-1].read <= mem_pipe[s].read;
                     mem_pipe[s-1].byteenable <= mem_pipe[s].byteenable;
+
+                    if (mem_fiu.reset)
+                    begin
+                        mem_pipe[s-1].write <= 1'b0;
+                        mem_pipe[s-1].read <= 1'b0;
+                    end
                 end
 
                 // Debugging signal

--- a/platforms/platform_if/rtl/platform_shims/utils/platform_utils_ccip_async_shim.sv
+++ b/platforms/platform_if/rtl/platform_shims/utils/platform_utils_ccip_async_shim.sv
@@ -49,7 +49,10 @@ module platform_utils_ccip_async_shim
     parameter C2TX_DEPTH_RADIX      = $clog2(ccip_cfg_pkg::MAX_OUTSTANDING_MMIO_RD_REQS),
 
     parameter C0RX_DEPTH_RADIX      = $clog2(2 * ccip_cfg_pkg::C0_MAX_BW_ACTIVE_LINES[0]),
-    parameter C1RX_DEPTH_RADIX      = $clog2(2 * ccip_cfg_pkg::C1_MAX_BW_ACTIVE_LINES[0])
+    parameter C1RX_DEPTH_RADIX      = $clog2(2 * ccip_cfg_pkg::C1_MAX_BW_ACTIVE_LINES[0]),
+
+    // Extra space to add to almust full buffering
+    parameter EXTRA_ALMOST_FULL_STAGES = 0
     )
    (
     // ---------------------------------- //
@@ -86,17 +89,21 @@ module platform_utils_ccip_async_shim
 
     // TX buffers just need to be large enough to avoid pipeline back pressure.
     // The TX rate limiter is the slower of the AFU and BB clocks, not the TX buffer.
-    localparam C0TX_DEPTH_RADIX = $clog2(3 * CCIP_TX_ALMOST_FULL_THRESHOLD);
+    localparam C0TX_DEPTH_RADIX = $clog2(3 * CCIP_TX_ALMOST_FULL_THRESHOLD +
+                                         EXTRA_ALMOST_FULL_STAGES);
 
     // Leave a little extra room in Tx buffers to avoid overflow
     localparam C0TX_ALMOST_FULL_THRESHOLD = CCIP_TX_ALMOST_FULL_THRESHOLD +
-                                            (CCIP_TX_ALMOST_FULL_THRESHOLD / 2);
+                                            (CCIP_TX_ALMOST_FULL_THRESHOLD / 2) +
+                                            EXTRA_ALMOST_FULL_STAGES;
 
     // Write buffers are slightly larger because even 4-line write requests
     // send a line at a time.
-    localparam C1TX_DEPTH_RADIX = $clog2(4 * CCIP_TX_ALMOST_FULL_THRESHOLD);
+    localparam C1TX_DEPTH_RADIX = $clog2(4 * CCIP_TX_ALMOST_FULL_THRESHOLD +
+                                         EXTRA_ALMOST_FULL_STAGES);
     localparam C1TX_ALMOST_FULL_THRESHOLD = CCIP_TX_ALMOST_FULL_THRESHOLD +
-                                            (CCIP_TX_ALMOST_FULL_THRESHOLD / 2);
+                                            (CCIP_TX_ALMOST_FULL_THRESHOLD / 2) +
+                                            EXTRA_ALMOST_FULL_STAGES;
 
     //
     // Reset synchronizer

--- a/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/README
+++ b/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/README
@@ -11,4 +11,16 @@ Extracted components include:
   * Qsys Avalon-MM Pipeline Bridge
 
 
-Note: copyrights should be changed to BSD/MIT licenses.
+Notes
+
+(1) Copyrights should be changed to BSD/MIT licenses.
+
+(2) platform_utils_avalon_mm_clock_crossing_bridge.v must be modified by hand
+    (as of 18.0) to export the s0_space_avail_data port so that the clock crossing
+    FIFO can be used. This allows us to transform the waitrequest protocol into
+    an almost full protocol. Using almost full, pipelines can be added without
+    flow control at each stage.
+
+    Suggested method: first check in the base copy of
+    platform_utils_avalon_mm_clock_crossing_bridge.v and then edit it and check
+    in the changed version. This way we have a history of changes.

--- a/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/gen_platform_ip.sh
+++ b/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/gen_platform_ip.sh
@@ -79,3 +79,5 @@ sed -e 's/^REPLACE/\n## Apply the constraints\napply_sdc_pre_dcfifo "platform_ut
 
 echo
 echo "  *** The copyrights must still be changed to BSD/MIT licenses.  Do this by hand. ***"
+echo
+echo "  +++ platform_utils_avalon_mm_clock_crossing_bridge.v must be edited. See README. +++"

--- a/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_mm_clock_crossing_bridge.v
+++ b/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_mm_clock_crossing_bridge.v
@@ -62,7 +62,8 @@ module platform_utils_avalon_mm_clock_crossing_bridge
     // --------------------------------------
     // Derived parameters
     // --------------------------------------
-    parameter BYTEEN_WIDTH = DATA_WIDTH / SYMBOL_WIDTH
+    parameter BYTEEN_WIDTH = DATA_WIDTH / SYMBOL_WIDTH,
+    parameter COMMAND_COUNT_WIDTH = log2ceil(COMMAND_FIFO_DEPTH)
 )
 (
     input                           s0_clk,
@@ -81,6 +82,9 @@ module platform_utils_avalon_mm_clock_crossing_bridge
     input                           s0_read,  
     input  [BYTEEN_WIDTH-1:0]       s0_byteenable,  
     input                           s0_debugaccess,
+    // Added for OPAE to the base bridge implementation in order to build
+    // almost full protocols, using the command FIFO as a buffer.
+    output [COMMAND_COUNT_WIDTH:0]  s0_space_avail_data,
 
     input                           m0_waitrequest,
     input  [DATA_WIDTH-1:0]         m0_readdata,
@@ -135,7 +139,9 @@ module platform_utils_avalon_mm_clock_crossing_bridge
         .FIFO_DEPTH       (COMMAND_FIFO_DEPTH),
         .WR_SYNC_DEPTH    (MASTER_SYNC_DEPTH),
         .RD_SYNC_DEPTH    (SLAVE_SYNC_DEPTH),
-        .BACKPRESSURE_DURING_RESET (1)
+        .BACKPRESSURE_DURING_RESET (1),
+        // Added for OPAE to drive s0_space_avail_data
+        .USE_SPACE_AVAIL_IF (1)
     ) 
     cmd_fifo
     (
@@ -177,7 +183,7 @@ module platform_utils_avalon_mm_clock_crossing_bridge
         .almost_full_data(),
         .almost_empty_valid(),
         .almost_empty_data(),
-        .space_avail_data()
+        .space_avail_data(s0_space_avail_data)
         
     );
 

--- a/platforms/platform_if/sim/platform_if_addenda.txt
+++ b/platforms/platform_if/sim/platform_if_addenda.txt
@@ -24,6 +24,7 @@
 ../rtl/platform_shims/utils/avalon_mem_if_async_shim.sv
 ../rtl/platform_shims/utils/avalon_mem_if_connect.sv
 ../rtl/platform_shims/utils/avalon_mem_if_reg.sv
+../rtl/platform_shims/utils/avalon_mem_if_reg_simple.sv
 ../rtl/platform_shims/utils/platform_utils_ccip_activity_cnt.sv
 ../rtl/platform_shims/utils/platform_utils_ccip_async_shim.sv
 ../rtl/platform_shims/utils/platform_utils_ccip_reg.sv


### PR DESCRIPTION
Take advantage of the clock crossing FIFO when the PIM is inserting both a clock crossing and pipeline stages for timing on both local memory or CCI-P signals. By leaving extra space in the clock crossing FIFO, local memory's Avalon waitrequest can be turned into something closer to an almost full protocol. The FIFO can consume all in-flight requests from the pipeline without losing them.

For CCI-P, leaving extra space in the clock crossing FIFO allows for longer timing pipelines without affecting the legal count of requests following almost full in the AFU.