### PR TITLE
add cmake vars to indicate if py pkgs found

### DIFF
--- a/cmake/modules/FindPythonPackage.cmake
+++ b/cmake/modules/FindPythonPackage.cmake
@@ -18,6 +18,9 @@ macro(FIND_PYTHON_PKG PKG_NAME ERR_LEVEL )
 
     if(STATUS_FLAG)
         message(${ERR_LEVEL} "PACKAGER depenency python ${PKG_NAME} package is missing!!!")
+    else(STATUS_FLAG)
+	set(${PKG_NAME}_FOUND TRUE)
     endif(STATUS_FLAG)
+
   endif()  
 endmacro(FIND_PYTHON_PKG)


### PR DESCRIPTION
This is so that callers of this macro can check if a module is installed or not.