### PR TITLE
cxx-core: Add error API for opae-cxx-core

### DIFF
--- a/cmake/modules/test_config.cmake
+++ b/cmake/modules/test_config.cmake
@@ -111,6 +111,7 @@ function(Build_Test_Target Target_Name Target_LIB)
                 function/gtCxxReset.cpp
                 function/gtCxxMMIO.cpp
                 function/gtCxxVersion.cpp
+		function/gtCxxErrors.cpp
                 function/gtReset.cpp
                 function/gtBuffer.cpp
                 function/gtEnumerate.cpp

--- a/common/include/opae/cxx/core/errors.h
+++ b/common/include/opae/cxx/core/errors.h
@@ -1,0 +1,100 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <opae/cxx/core/token.h>
+#include <opae/types_enum.h>
+#include <memory>
+
+namespace opae {
+namespace fpga {
+namespace types {
+
+/**
+ * @brief An error object represents an error register for a resource.
+ * This is used to read out the raw value in the register. No parsing is
+ * done by this class.
+ */
+class error {
+ public:
+  typedef std::shared_ptr<error> ptr_t;
+
+  error(const error &e) = delete;
+
+  error &operator=(const error &e) = delete;
+
+  /**
+   * @brief Factory function for creating an error object.
+   *
+   * @param tok The token object representing a resource.
+   * @param num The index of the error register. This must be lower than the
+   * num_errors property of the resource.
+   *
+   * @return A shared_ptr containing the error object
+   */
+  static error::ptr_t get(token::ptr_t tok, uint32_t num);
+
+  /**
+   * @brief Get the error register name.
+   *
+   * @return A std::string object set to the error name.
+   */
+  std::string name() { return error_info_.name; }
+
+  /**
+   * @brief Indicates whether an error register can be cleared.
+   *
+   * @return A boolean value indicating if the error register can be cleared.
+   */
+  bool can_clear() { return error_info_.can_clear; }
+
+  /**
+   * @brief Read the raw value contained in the associated error register.
+   *
+   * @return A 64-bit value (unparsed) read from the error register
+   */
+  uint64_t read_value();
+
+  ~error(){}
+
+  /**
+   * @brief Get the C data structure
+   *
+   * @return The fpga_error_info that contains the name and the can_clear
+   * boolean.
+   */
+  fpga_error_info c_type() const { return error_info_; }
+
+ private:
+  error(token::ptr_t token, uint32_t num);
+  token::ptr_t token_;
+  fpga_error_info error_info_;
+  uint32_t error_num_;
+};
+
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/common/include/opae/cxx/core/properties.h
+++ b/common/include/opae/cxx/core/properties.h
@@ -56,7 +56,7 @@ class properties {
    * Useful for enumerating based on a
    * "match all" criteria.
    */
-  const static std::vector<properties> none;
+  const static std::vector<properties::ptr_t> none;
 
   properties(const properties &p) = delete;
 
@@ -107,6 +107,7 @@ class properties {
 
  public:
   pvalue<fpga_objtype> type;
+  pvalue<uint32_t> num_errors;
   pvalue<uint8_t> bus;
   pvalue<uint8_t> device;
   pvalue<uint8_t> function;

--- a/libopae++/CMakeLists.txt
+++ b/libopae++/CMakeLists.txt
@@ -53,6 +53,7 @@ set(OPAECXXCORE_SRC src/properties.cpp
                     src/shared_buffer.cpp
                     src/events.cpp
                     src/except.cpp
+		    src/errors.cpp
                     src/version.cpp)
 
 add_library(opae-cxx-core SHARED ${OPAECXXCORE_SRC})

--- a/libopae++/src/errors.cpp
+++ b/libopae++/src/errors.cpp
@@ -1,0 +1,50 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include <opae/cxx/core/errors.h>
+#include <opae/error.h>
+
+namespace opae {
+namespace fpga {
+namespace types {
+
+error::error(token::ptr_t token, uint32_t num)
+    : token_(token), error_info_(), error_num_(num) {}
+
+error::ptr_t error::get(token::ptr_t tok, uint32_t num) {
+  error::ptr_t err(new error(tok, num));
+  ASSERT_FPGA_OK(fpgaGetErrorInfo(*tok, num, &err->error_info_));
+  return err;
+}
+
+uint64_t error::read_value() {
+  uint64_t val;
+  ASSERT_FPGA_OK(fpgaReadError(*token_, error_num_, &val));
+  return val;
+}
+
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/libopae++/src/properties.cpp
+++ b/libopae++/src/properties.cpp
@@ -32,11 +32,12 @@ namespace opae {
 namespace fpga {
 namespace types {
 
-const std::vector<properties> properties::none = {};
+const std::vector<properties::ptr_t> properties::none = {};
 
 properties::properties()
     : props_(nullptr),
       type(&props_, fpgaPropertiesGetObjectType, fpgaPropertiesSetObjectType),
+      num_errors(&props_, fpgaPropertiesGetNumErrors, fpgaPropertiesSetNumErrors),
       bus(&props_, fpgaPropertiesGetBus, fpgaPropertiesSetBus),
       device(&props_, fpgaPropertiesGetDevice, fpgaPropertiesSetDevice),
       function(&props_, fpgaPropertiesGetFunction, fpgaPropertiesSetFunction),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,7 @@ add_gtfilter(CxxExcept    "LibopaecppExcept*" False)
 add_gtfilter(CxxEvent     "LibopaecppEvent*" True)
 add_gtfilter(CxxMMIO      "LibopaecppMMIO*" True)
 add_gtfilter(CxxVersion   "LibopaecppVersion*" False)
+add_gtfilter(CxxErrors    "LibopaecppErrors*" True)
 Exe_Tests("Mock_All" ${Test_Names})
 Exe_tests("Any_Value" "Cxx*any*")
 

--- a/tests/function/gtCxxErrors.cpp
+++ b/tests/function/gtCxxErrors.cpp
@@ -25,74 +25,43 @@
 // POSSIBILITY OF SUCH DAMAGE.
 #include "gtest/gtest.h"
 
-#include "opae/cxx/core/events.h"
+#include "opae/cxx/core/errors.h"
 #include "opae/cxx/core/handle.h"
 #include "opae/cxx/core/token.h"
 
-#include <fcntl.h>
 
 using namespace opae::fpga::types;
 
-class LibopaecppEventCommonALL_f1 : public ::testing::Test {
+class LibopaecppErrorsCommonALL_f1 : public ::testing::Test {
  protected:
-  LibopaecppEventCommonALL_f1() {}
+  LibopaecppErrorsCommonALL_f1() {}
 
   virtual void SetUp() override {
     tokens_ = token::enumerate({properties::get(FPGA_ACCELERATOR)});
     ASSERT_GT(tokens_.size(), 0);
-    accel_ = handle::open(tokens_[0], 0);
-    ASSERT_NE(nullptr, accel_.get());
   }
 
   virtual void TearDown() override {
-    accel_.reset();
     ASSERT_NO_THROW(tokens_.clear());
   }
 
   std::vector<token::ptr_t> tokens_;
-  handle::ptr_t accel_;
 };
 
 /**
- * @test register_event_01
- * Given an open accelerator handle object<br>
- * When I call event::register_event() with that handle<br>
- * And event type of event::type_t::error
- * Then no exception is thrown<br>
- * And I get a non-null event shared pointer<br>
+ * @test get_errors
+ * Given an OPAE resource token<br>
+ * When I call error::get() with that token<br>
+ * Then I get a non-null
+ * And I am able to read information about the error
  */
-TEST_F(LibopaecppEventCommonALL_f1, register_event_01) {
-  event::ptr_t ev;
-  ASSERT_NO_THROW(ev = event::register_event(accel_, event::type_t::error));
-  ASSERT_NE(nullptr, ev.get());
+TEST_F(LibopaecppErrorsCommonALL_f1, get_errors) {
+  for (auto t : tokens_) {
+    auto props = properties::get(t);
+    for (int i = 0; i < static_cast<uint32_t>(props->num_errors); ++i) {
+      auto err = error::get(t, i);
+      std::cout << "Error [" << err->name() << "]: " << err->read_value() << "\n";
+    }
+  }
 }
 
-/**
- * @test register_event_02
- * Given an open accelerator handle object<br>
- * When I call event::register_event() with that handle<br>
- * And event type of FPGA_EVENT_ERROR
- * Then no exception is thrown<br>
- * And I get a non-null event shared pointer<br>
- */
-TEST_F(LibopaecppEventCommonALL_f1, register_event_02) {
-  event::ptr_t ev;
-  ASSERT_NO_THROW(ev = event::register_event(accel_, FPGA_EVENT_ERROR););
-  ASSERT_NE(nullptr, ev.get());
-}
-
-/**
- * @test get_os_object
- * Given an open accelerator handle object<br>
- * And an event object created with event::register_event()<br>
- * When I call event::os_object using the event object<br>
- * Then I get a valid file descriptor for polling on the event<br>
- */
-TEST_F(LibopaecppEventCommonALL_f1, get_os_object) {
-  event::ptr_t ev;
-  ASSERT_NO_THROW(ev = event::register_event(accel_, FPGA_EVENT_ERROR););
-  ASSERT_NE(nullptr, ev.get());
-  auto fd = ev->os_object();
-  auto res = fcntl(fd, F_GETFL);
-  ASSERT_NE(res, -1);
-}

--- a/tests/function/gtCxxProperties.cpp
+++ b/tests/function/gtCxxProperties.cpp
@@ -6,10 +6,10 @@ extern "C" {
 }
 #endif
 
-#include "gtest/gtest.h"
-#include <opae/cxx/core/token.h>
 #include <opae/cxx/core/except.h>
+#include <opae/cxx/core/token.h>
 #include <uuid/uuid.h>
+#include "gtest/gtest.h"
 
 using namespace opae::fpga::types;
 const char* TEST_GUID_STR = "ae2878a7-926f-4332-aba1-2b952ad6df8e";
@@ -78,7 +78,7 @@ TEST(LibopaecppPropsCommonALL, get_guid) {
  * When I set compare its guid with the known guid
  * Then the result is true
  */
-TEST(LibopaecppPropsCommonALL, compare_guid){
+TEST(LibopaecppPropsCommonALL, compare_guid) {
   fpga_guid guid_in;
   auto p = properties::get();
   uuid_parse(TEST_GUID_STR, guid_in);
@@ -95,7 +95,7 @@ TEST(LibopaecppPropsCommonALL, compare_guid){
  * When I set compare its guid with the known guid
  * Then the result is true
  */
-TEST(LibopaecppPropsCommonALL, props_ctor_01){
+TEST(LibopaecppPropsCommonALL, props_ctor_01) {
   fpga_guid guid_in;
   uuid_parse(TEST_GUID_STR, guid_in);
   auto p = properties::get(guid_in);
@@ -130,4 +130,17 @@ TEST(LibopaecppPropsCommonALL, get_model) {
   std::string model = "";
   // Model is currently not supported in libopae-c
   EXPECT_THROW(model = p->model, not_supported);
+}
+
+/**
+ * @test set_num_errors
+ * Given a properties properties object with the num_errors property set to a
+ * known value
+ * When I get the num_errors property
+ * Then the number is the expected value
+ */
+TEST(LibopaecppPropsCommonALL, get_num_errors) {
+  auto p = properties::get();
+  p->num_errors = 9;
+  EXPECT_EQ(static_cast<uint32_t>(p->num_errors), 9);
 }


### PR DESCRIPTION
This adds the errors class in opae::fpga::types namespace which
wraps the errors API in the OPAE C API.