### PR TITLE
Docs: Disable building docs by default

### DIFF
--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -59,7 +59,7 @@ endif(DOXYGEN_DOT_FOUND)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
                ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
 
-add_custom_target(doxygen ALL
+add_custom_target(doxygen
     ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Generating API docs" VERBATIM

--- a/doc/sphinx/CMakeLists.txt
+++ b/doc/sphinx/CMakeLists.txt
@@ -81,4 +81,5 @@ add_dependencies(docs
   copy-doxygen-files
   copy-markdown-files
   copy-include-files
-  copy-sample-files)
+  copy-sample-files
+  doxygen)


### PR DESCRIPTION
This disables building docs by default. Docs can be built by setting BUILD_SPHINX_DOC to ON.