### PR TITLE
Update BIST tool to reflect #452 updates

### DIFF
--- a/tools/extra/fpgabist/bist_common.py
+++ b/tools/extra/fpgabist/bist_common.py
@@ -96,7 +96,7 @@ def get_mode_from_path(gbs_path):
 
 def load_gbs(gbs_file, bus_num):
     print "Attempting Partial Reconfiguration:"
-    cmd = "{} -b 0x{} -v {}".format('fpgaconf', bus_num, gbs_file)
+    cmd = "{} -B 0x{} -V {}".format('fpgaconf', bus_num, gbs_file)
     try:
         subprocess.check_call(cmd, shell=True)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
The `fpgaconf` command line options were updated for consistency, so the BIST tool needs updates to reflect the newly-changed arguments.