### PR TITLE
add the default visibility to error API

### DIFF
--- a/ase/api/src/error.c
+++ b/ase/api/src/error.c
@@ -31,7 +31,9 @@
 #include "common_int.h"
 #include "opae/error.h"
 
-fpga_result fpgaReadError(fpga_token token, uint32_t error_num, uint64_t *value)
+fpga_result __FPGA_API__ fpgaReadError(fpga_token token,
+                                       uint32_t error_num,
+                                       uint64_t *value)
 {
 	UNUSED_PARAM(token);
 	UNUSED_PARAM(error_num);
@@ -39,22 +41,22 @@ fpga_result fpgaReadError(fpga_token token, uint32_t error_num, uint64_t *value)
 	return FPGA_NOT_SUPPORTED;
 }
 
-fpga_result fpgaClearError(fpga_token token, uint32_t error_num)
+fpga_result __FPGA_API__ fpgaClearError(fpga_token token, uint32_t error_num)
 {
 	UNUSED_PARAM(token);
 	UNUSED_PARAM(error_num);
 	return FPGA_NOT_SUPPORTED;
 }
 
-fpga_result fpgaClearAllErrors(fpga_token token)
+fpga_result __FPGA_API__ fpgaClearAllErrors(fpga_token token)
 {
 	UNUSED_PARAM(token);
 	return FPGA_NOT_SUPPORTED;
 }
 
-fpga_result fpgaGetErrorInfo(fpga_token token,
-			     uint32_t error_num,
-			     struct fpga_error_info *error_info)
+fpga_result __FPGA_API__ fpgaGetErrorInfo(fpga_token token,
+                                          uint32_t error_num,
+                                          struct fpga_error_info *error_info)
 {
 	UNUSED_PARAM(token);
 	UNUSED_PARAM(error_num);

--- a/ase/api/src/error.c
+++ b/ase/api/src/error.c
@@ -31,9 +31,7 @@
 #include "common_int.h"
 #include "opae/error.h"
 
-fpga_result __FPGA_API__ fpgaReadError(fpga_token token,
-                                       uint32_t error_num,
-                                       uint64_t *value)
+fpga_result __FPGA_API__ fpgaReadError(fpga_token token, uint32_t error_num, uint64_t *value)
 {
 	UNUSED_PARAM(token);
 	UNUSED_PARAM(error_num);
@@ -55,8 +53,8 @@ fpga_result __FPGA_API__ fpgaClearAllErrors(fpga_token token)
 }
 
 fpga_result __FPGA_API__ fpgaGetErrorInfo(fpga_token token,
-                                          uint32_t error_num,
-                                          struct fpga_error_info *error_info)
+			     uint32_t error_num,
+			     struct fpga_error_info *error_info)
 {
 	UNUSED_PARAM(token);
 	UNUSED_PARAM(error_num);

--- a/libopae/src/error.c
+++ b/libopae/src/error.c
@@ -40,7 +40,7 @@
 
 #include "error_int.h"
 
-fpga_result fpgaReadError(fpga_token token, uint32_t error_num, uint64_t *value)
+fpga_result __FPGA_API__ fpgaReadError(fpga_token token, uint32_t error_num, uint64_t *value)
 {
 	struct _fpga_token *_token = (struct _fpga_token *)token;
 	struct stat st;
@@ -77,7 +77,7 @@ fpga_result fpgaReadError(fpga_token token, uint32_t error_num, uint64_t *value)
 	return FPGA_NOT_FOUND;
 }
 
-fpga_result fpgaClearError(fpga_token token, uint32_t error_num)
+fpga_result __FPGA_API__ fpgaClearError(fpga_token token, uint32_t error_num)
 {
 	struct _fpga_token *_token = (struct _fpga_token *)token;
 	struct stat st;
@@ -123,7 +123,7 @@ fpga_result fpgaClearError(fpga_token token, uint32_t error_num)
 	return FPGA_NOT_FOUND;
 }
 
-fpga_result fpgaClearAllErrors(fpga_token token)
+fpga_result __FPGA_API__ fpgaClearAllErrors(fpga_token token)
 {
 	struct _fpga_token *_token = (struct _fpga_token *)token;
 	uint32_t i = 0;
@@ -151,7 +151,7 @@ fpga_result fpgaClearAllErrors(fpga_token token)
 	return FPGA_OK;
 }
 
-fpga_result fpgaGetErrorInfo(fpga_token token,
+fpga_result __FPGA_API__ fpgaGetErrorInfo(fpga_token token,
 			     uint32_t error_num,
 			     struct fpga_error_info *error_info)
 {


### PR DESCRIPTION
Add the \_\_FPGA_API\_\_ macro to make the error API functions visible when linking
with other modules.