### PR TITLE
Enable coveralls for coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,11 +52,22 @@ matrix:
         - libhwloc-dev
         - uuid-dev
         - doxygen
-<<<<<<< HEAD
-  - script: scripts/build-documentation.sh
-=======
   - script: scripts/coverage-gtapi-mock-drv.sh
->>>>>>> 1296709... Enable coveralls
+    cache:
+      - ccache
+      - pip
+    addons:
+      apt:
+       packages:
+        - libjson-c-dev
+        - uuid-dev
+        - doxygen
+        - lcov
+    before_install:
+      - pip install --user cpp-coveralls
+    after_success:
+      - coveralls -l $TRAVIS_BUILD_DIR/coverage_gtapi_mock_drv/coverage.info.cleaned
+  - script: scripts/build-documentation.sh
     cache: 
       - ccache
       - pip
@@ -67,11 +78,14 @@ matrix:
         - libhwloc-dev
         - uuid-dev
         - doxygen
-        - lcov
+        - pandoc
+    if: branch = master
+    install:
+      - pip install --user jinja2
+      - pip install --user requests[security]
     before_install:
-      - pip install --user cpp-coveralls
-    after_success:
-      - coveralls -l $TRAVIS_BUILD_DIR/coverage_gtapi_mock_drv/coverage.info.cleaned
+    - wget https://github.com/jgm/pandoc/releases/download/2.1.1/pandoc-2.1.1-1-amd64.deb
+    - sudo dpkg -i pandoc-2.1.1-1-amd64.deb
 env:
   global:
     secure: ejmtge9PpCihZ92AolJhTBWGTYUU49dzwR10xBd62JfDSXWs8UYu3FSGodLQcMm4XdaM0uDthJ1MzvP/CphgMCOIyzVr6XLF8JFLVLw6cP1P0Q5Kgj1qN9f8DZL3VrgyRSL7lRuxQt4qP8eXLlksEAi+PKrka2hsNnUtoX8JBYHeeos7b+Q4vq4d/PzpIrhrYIQy1RlatAAhGG8JsD3R2WdkNwK3kGUvcAwZirROfRAf+xaPRKCTHtRfNehTCu93v9n1uYdxDAWw7RJOjjYp+HUGj7XUTi28D7kcz5zOKp6Ny7Cgf3SgQqwK4xF+Jidk/g5i9V8D0Qi0oplbD6vekp0zVU6k8IWLZgtfqw9CnRV2Tv7e7a7oMUsFoKEW3pT/U1lU1fKuEddTUlf8myMoAm6VcEXXtboz2xP9svpNvDjnATU8CTtN1eEdrOpmI6FjYZv133twkfP61bEKgv05w8416/jvcil3CXnzVGFkbO2oXCr1uWe3t/JjEon8W+rgnxl9uC/QeEd1uFwOi3/UBB+ZQp8khbMz68iRSux7g+mGiZ6Ezbr0WaSIz6ZiliFykLCbpyAJduHIUCc1chF20Xq8105D/Ue4nCOnI/h/vC/BsQ5Ms+VAYk1QHPgNXKEc2pteVxHaTg7c6qoHsBV+NTkdd4QJvNuS+jzZsxao7JQ=

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,25 +52,26 @@ matrix:
         - libhwloc-dev
         - uuid-dev
         - doxygen
+<<<<<<< HEAD
   - script: scripts/build-documentation.sh
+=======
+  - script: scripts/coverage-gtapi-mock-drv.sh
+>>>>>>> 1296709... Enable coveralls
     cache: 
       - ccache
       - pip
     addons:
       apt:
-        packages:
+       packages:
         - libjson-c-dev
         - libhwloc-dev
         - uuid-dev
         - doxygen
-        - pandoc
-    if: branch = master
-    install:
-      - pip install --user jinja2
-      - pip install --user requests[security]
+        - lcov
     before_install:
-    - wget https://github.com/jgm/pandoc/releases/download/2.1.1/pandoc-2.1.1-1-amd64.deb
-    - sudo dpkg -i pandoc-2.1.1-1-amd64.deb
+      - pip install --user cpp-coveralls
+    after_success:
+      - coveralls -l $TRAVIS_BUILD_DIR/coverage_gtapi_mock_drv/coverage.info.cleaned
 env:
   global:
     secure: ejmtge9PpCihZ92AolJhTBWGTYUU49dzwR10xBd62JfDSXWs8UYu3FSGodLQcMm4XdaM0uDthJ1MzvP/CphgMCOIyzVr6XLF8JFLVLw6cP1P0Q5Kgj1qN9f8DZL3VrgyRSL7lRuxQt4qP8eXLlksEAi+PKrka2hsNnUtoX8JBYHeeos7b+Q4vq4d/PzpIrhrYIQy1RlatAAhGG8JsD3R2WdkNwK3kGUvcAwZirROfRAf+xaPRKCTHtRfNehTCu93v9n1uYdxDAWw7RJOjjYp+HUGj7XUTi28D7kcz5zOKp6Ny7Cgf3SgQqwK4xF+Jidk/g5i9V8D0Qi0oplbD6vekp0zVU6k8IWLZgtfqw9CnRV2Tv7e7a7oMUsFoKEW3pT/U1lU1fKuEddTUlf8myMoAm6VcEXXtboz2xP9svpNvDjnATU8CTtN1eEdrOpmI6FjYZv133twkfP61bEKgv05w8416/jvcil3CXnzVGFkbO2oXCr1uWe3t/JjEon8W+rgnxl9uC/QeEd1uFwOi3/UBB+ZQp8khbMz68iRSux7g+mGiZ6Ezbr0WaSIz6ZiliFykLCbpyAJduHIUCc1chF20Xq8105D/Ue4nCOnI/h/vC/BsQ5Ms+VAYk1QHPgNXKEc2pteVxHaTg7c6qoHsBV+NTkdd4QJvNuS+jzZsxao7JQ=


### PR DESCRIPTION
Run mock driver tests to generate coverage.
If the reviewers can suggest possible ways to add more test to get better numbers that would be great. This PR right essentially just enables coverage reporting via coveralls.