### PR TITLE
cxx-core: add null tests

### DIFF
--- a/libopaecxx/src/errors.cpp
+++ b/libopaecxx/src/errors.cpp
@@ -34,6 +34,10 @@ error::error(token::ptr_t token, uint32_t num)
     : token_(token), error_info_(), error_num_(num) {}
 
 error::ptr_t error::get(token::ptr_t tok, uint32_t num) {
+  if (!tok) {
+    throw std::invalid_argument("token object is null");
+  }
+
   error::ptr_t err(new error(tok, num));
   ASSERT_FPGA_OK(fpgaGetErrorInfo(*tok, num, &err->error_info_));
   return err;

--- a/libopaecxx/src/events.cpp
+++ b/libopaecxx/src/events.cpp
@@ -49,6 +49,10 @@ event::operator fpga_event_handle() { return event_handle_; }
 
 event::ptr_t event::register_event(handle::ptr_t h, event::type_t t,
                                    int flags) {
+  if (!h) {
+    throw std::invalid_argument("handle object is null");
+  }
+
   event::ptr_t evptr;
   fpga_event_handle eh;
   ASSERT_FPGA_OK(fpgaCreateEventHandle(&eh));

--- a/libopaecxx/src/handle.cpp
+++ b/libopaecxx/src/handle.cpp
@@ -62,6 +62,9 @@ handle::ptr_t handle::open(fpga_token token, int flags) {
 }
 
 handle::ptr_t handle::open(token::ptr_t tok, int flags) {
+  if (!tok) {
+    throw std::invalid_argument("token object is null");
+  }
   return handle::open(*tok, flags);
 }
 

--- a/libopaecxx/src/shared_buffer.cpp
+++ b/libopaecxx/src/shared_buffer.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 
 #include <opae/cxx/core/shared_buffer.h>
+#include <exception>
 
 namespace opae {
 namespace fpga {
@@ -35,6 +36,10 @@ shared_buffer::~shared_buffer() { release(); }
 
 shared_buffer::ptr_t shared_buffer::allocate(handle::ptr_t handle, size_t len) {
   ptr_t p;
+
+  if (!handle) {
+    throw std::invalid_argument("handle object is null");
+  }
 
   if (!len) {
     throw except(OPAECXX_HERE);

--- a/libopaecxx/src/token.cpp
+++ b/libopaecxx/src/token.cpp
@@ -37,7 +37,12 @@ std::vector<token::ptr_t> token::enumerate(
   std::vector<token::ptr_t> tokens;
   std::vector<fpga_properties> c_props(props.size());
   std::transform(props.begin(), props.end(), c_props.begin(),
-                 [](properties::ptr_t p) { return p->c_type(); });
+                 [](properties::ptr_t p) {
+                   if (!p) {
+                     throw std::invalid_argument("property object is null");
+                   }
+                   return p->c_type();
+                 });
   uint32_t matches = 0;
   auto res =
       fpgaEnumerate(c_props.data(), c_props.size(), nullptr, 0, &matches);
@@ -69,8 +74,9 @@ std::vector<token::ptr_t> token::enumerate(
 
 token::~token() {
   auto res = fpgaDestroyToken(&token_);
-  if (res != FPGA_OK){
-    std::cerr << "Error while calling fpgaDestroyToken: " << fpgaErrStr(res) << "\n";
+  if (res != FPGA_OK) {
+    std::cerr << "Error while calling fpgaDestroyToken: " << fpgaErrStr(res)
+              << "\n";
   }
 }
 


### PR DESCRIPTION
Add checks for null arguments and throw invalid_argument if check fails.

While doing negative testing from Python API, these missing checks resulted in segfaults.
Putting these checks in will enable development of negative tests from Python.

TODO:
Look into possibly using except class for throwing those exceptions.