### PR TITLE
Make fix for fpgadiag CLI change in fpgabist

### DIFF
--- a/tools/extra/pac/fpgabist/bist_nlb3.py
+++ b/tools/extra/pac/fpgabist/bist_nlb3.py
@@ -45,7 +45,7 @@ class Nlb3Mode(bc.BistMode):
         bc.load_gbs(gbs_path, bus_num)
         for test, param in self.executables.items():
             print "Running fpgadiag {} test...\n".format(test)
-            cmd = "fpgadiag {}".format(param)
+            cmd = "fpgadiag -B {} {}".format(bus_num, param)
             try:
                 subprocess.check_call(cmd, shell=True)
             except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Adding `B` parameter for fpgadiag, for use in fpgabist tool.
Complies with the CLI changes in PR:
**https://github.com/OPAE/opae-sdk/pull/483**