### PR TITLE
libopae-c: fix usrclk bug

### DIFF
--- a/libopae/src/usrclk/user_clk_pgm_uclock.c
+++ b/libopae/src/usrclk/user_clk_pgm_uclock.c
@@ -692,7 +692,7 @@ const char * fpac_GetErrMsg(int i_ErrMsgInx)
 
 	// Check index range
 	if (i_ErrMsgInx >= 0
-		|| i_ErrMsgInx  < QUCPU_INT_UCLOCK_NUM_ERROR_MESSAGES) {
+		&& i_ErrMsgInx  < QUCPU_INT_UCLOCK_NUM_ERROR_MESSAGES) {
 	// All okay, set the message string
 		pac_ErrMsgStr = pac_UclockErrorMsg[i_ErrMsgInx];
 	} // All okay, set the message string

--- a/tests/unit/gtUsrclk.cpp
+++ b/tests/unit/gtUsrclk.cpp
@@ -68,12 +68,12 @@ TEST(LibopaecUsrclkCommonMOCKHW, afu_usrclk_01) {
 	//Get error string for invlaid index
 	pmsg = NULL;
 	pmsg = fpac_GetErrMsg(17);
-	EXPECT_EQ(NULL, pmsg);
+	EXPECT_STREQ("ERROR: MSG INDEX OUT OF RANGE", pmsg);
 
 	//Get error string for invlaid index
 	pmsg = NULL;
 	pmsg = fpac_GetErrMsg(-1);
-	EXPECT_EQ(NULL, pmsg);
+	EXPECT_STREQ("ERROR: MSG INDEX OUT OF RANGE", pmsg);
 
 
 	fv_BugLog(1);


### PR DESCRIPTION
Fix bug in fpac_GetErrMsg() and associated unit test.