### PR TITLE
Add another delay in clear_status command

### DIFF
--- a/tools/extra/integrated/hssi/e100.cpp
+++ b/tools/extra/integrated/hssi/e100.cpp
@@ -46,6 +46,7 @@ void e100::clear_status()
 {
     eth_->write(eth_ctrl_reg::mon_pkt_ctrl,   0, mon_ctrl_ | static_cast<uint32_t>(mon_ctrl::start));
     eth_->write(eth_ctrl_reg::mon_pkt_ctrl,   0, static_cast<uint32_t>(mon_ctrl::stop));
+    std::this_thread::sleep_for(milliseconds(10));
     mac_write(mac_reg::mac0_ctrl, mac_reg::mac_cntr_tx_ctrl, 1);
     mac_write(mac_reg::mac0_ctrl, mac_reg::mac_cntr_rx_ctrl, 1);
     this_thread::sleep_for(std::chrono::milliseconds(10));


### PR DESCRIPTION
Delay is necessary because of lack of HW synchronization