### PR TITLE
pyopae: implement setitem in shared_buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${OPAE_SDK_SOURCE}/cmake/modules")
 ############################################################################
 set(OPAE_PYTHON_VERSION 2.7 CACHE STRING "Python version to use for building/distributing pyopae")
 set_property(CACHE OPAE_PYTHON_VERSION PROPERTY STRINGS 2.7 3.6 3.5 3.4 3.3)
-find_package(PythonLibs ${OPAE_PYTHON_VERSION})
 find_package(PythonInterp ${OPAE_PYTHON_VERSION})
+find_package(PythonLibs ${OPAE_PYTHON_VERSION})
 
 ############################################################################
 ## Other setup and dependencies ############################################

--- a/pyopae/opae.cpp
+++ b/pyopae/opae.cpp
@@ -179,6 +179,7 @@ PYBIND11_MODULE(_opae, m) {
             py::format_descriptor<uint8_t>::format(), b.size());
       })
       .def("__getitem__", shared_buffer_getitem, shared_buffer_doc_getitem())
+      .def("__setitem__", shared_buffer_setitem, shared_buffer_doc_setitem())
       .def("__getitem__", shared_buffer_getslice, shared_buffer_doc_getslice());
 
 

--- a/pyopae/pyshared_buffer.cpp
+++ b/pyopae/pyshared_buffer.cpp
@@ -90,6 +90,19 @@ uint8_t shared_buffer_getitem(shared_buffer::ptr_t buf, uint32_t offset) {
   return *(buf->c_type() + offset);
 }
 
+const char *shared_buffer_doc_setitem() {
+  return R"opaedoc(
+    Set the bytes at the given offset using all bytes in the argument.
+  )opaedoc";
+}
+
+void shared_buffer_setitem(opae::fpga::types::shared_buffer::ptr_t buf,
+                           uint32_t offset, pybind11::int_ item) {
+  int *ptr =
+      reinterpret_cast<int *>(const_cast<uint8_t *>(buf->c_type() + offset));
+  *ptr = item.cast<int>();
+}
+
 const char *shared_buffer_doc_getslice() {
   return R"opaedoc(
     Get a slice of the bytes as determined by the slice arguments ([start:stop:step])

--- a/pyopae/pyshared_buffer.h
+++ b/pyopae/pyshared_buffer.h
@@ -48,5 +48,10 @@ const char *shared_buffer_doc_getitem();
 uint8_t shared_buffer_getitem(opae::fpga::types::shared_buffer::ptr_t buf,
                               uint32_t offset);
 
+const char *shared_buffer_doc_setitem();
+void shared_buffer_setitem(opae::fpga::types::shared_buffer::ptr_t buf,
+                           uint32_t offset, pybind11::int_ item);
+
 const char *shared_buffer_doc_getslice();
-pybind11::list shared_buffer_getslice(opae::fpga::types::shared_buffer::ptr_t buf, pybind11::slice slice);
+pybind11::list shared_buffer_getslice(
+    opae::fpga::types::shared_buffer::ptr_t buf, pybind11::slice slice);

--- a/pyopae/test_pyopae.py
+++ b/pyopae/test_pyopae.py
@@ -25,6 +25,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import json
 import select
+import struct
 import subprocess
 import threading
 import time
@@ -308,6 +309,8 @@ class TestSharedBuffer(unittest.TestCase):
         assert mv[-1] == '\xaa'
         ba = bytearray(buff1)
         assert ba[0] == 0xaa
+        buff1[42] = int(65536)
+        assert struct.unpack('<L', (bytearray(buff1[42:46])))[0] == 65536
 
 def trigger_port_error(value=1):
     with open(MOCK_PORT_ERROR, 'w') as fd:


### PR DESCRIPTION
This implements the shared_buffer __setitem__ protocol method.
NOTE: This currently only works on the argument type being of type `int`