### PR TITLE
pyopae: Add context manager helper class

### DIFF
--- a/pyopae/CMakeLists.txt
+++ b/pyopae/CMakeLists.txt
@@ -28,6 +28,8 @@ cmake_minimum_required(VERSION 2.8.12)
 project(pyopae)
 
 set(PYOPAE_SRC opae.cpp
+	       pycontext.h
+	       pycontext.cpp
                pyproperties.h
 	       pyproperties.cpp
 	       pyhandle.h

--- a/pyopae/opae.cpp
+++ b/pyopae/opae.cpp
@@ -164,7 +164,7 @@ PYBIND11_MODULE(_opae, m) {
            py::arg("offset"), py::arg("value"), py::arg("csr_space") = 0);
 
   // define shared_buffer class
-  m.def("allocate_shared_buffer", &shared_buffer::allocate,
+  m.def("allocate_shared_buffer", shared_buffer_allocate,
         shared_buffer_doc_allocate());
   py::class_<shared_buffer, shared_buffer::ptr_t> pybuffer(
       m, "shared_buffer", py::buffer_protocol(), shared_buffer_doc());

--- a/pyopae/pycontext.h
+++ b/pyopae/pycontext.h
@@ -24,31 +24,27 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
-#include <Python.h>
-
+#include <map>
+#include <vector>
+#include <opae/cxx/core/handle.h>
 #include <opae/cxx/core/shared_buffer.h>
-#include <pybind11/pybind11.h>
-#include "pyhandle.h"
 
-const char *shared_buffer_doc();
+class buffer_registry {
+private:
+  typedef opae::fpga::types::handle::ptr_t handle_t;
+  typedef opae::fpga::types::shared_buffer::ptr_t shared_buffer_t;
+  typedef std::vector<shared_buffer_t> buffer_list_t;
+  typedef std::map<handle_t, buffer_list_t> buffer_map_t;
+public:
+  static buffer_registry & instance();
+  void register_handle(handle_t handle);
+  void add_buffer(handle_t handle, shared_buffer_t buffer);
+  void unregister_handle(handle_t handle);
 
-const char *shared_buffer_doc_allocate();
-opae::fpga::types::shared_buffer::ptr_t shared_buffer_allocate(
-    opae::fpga::types::handle::ptr_t hndl, size_t size);
-const char *shared_buffer_doc_size();
+private:
+  buffer_registry();
+  buffer_map_t buffers_;
+  static buffer_registry *instance_;
 
-const char *shared_buffer_doc_wsid();
+};
 
-const char *shared_buffer_doc_iova();
-
-const char *shared_buffer_doc_fill();
-
-const char *shared_buffer_doc_compare();
-
-const char *shared_buffer_doc_getitem();
-uint8_t shared_buffer_getitem(opae::fpga::types::shared_buffer::ptr_t buf,
-                              uint32_t offset);
-
-const char *shared_buffer_doc_getslice();
-pybind11::list shared_buffer_getslice(
-    opae::fpga::types::shared_buffer::ptr_t buf, pybind11::slice slice);

--- a/pyopae/pyhandle.cpp
+++ b/pyopae/pyhandle.cpp
@@ -25,6 +25,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "pyhandle.h"
+#include "pycontext.h"
 #include <sstream>
 
 namespace py = pybind11;
@@ -98,7 +99,10 @@ const char *handle_doc_context_enter() {
   )opaedoc";
 }
 
-handle::ptr_t handle_context_enter(handle::ptr_t hnd) { return hnd; }
+handle::ptr_t handle_context_enter(handle::ptr_t hnd) {
+  buffer_registry::instance().register_handle(hnd);
+  return hnd;
+}
 
 const char *handle_doc_context_exit() {
   return R"opaedoc(
@@ -110,6 +114,7 @@ const char *handle_doc_context_exit() {
 void handle_context_exit(opae::fpga::types::handle::ptr_t hnd, py::args args) {
   // TODO: Use args for logging exceptions
   (void)args;
+  buffer_registry::instance().unregister_handle(hnd);
   hnd->close();
 }
 

--- a/pyopae/pyshared_buffer.cpp
+++ b/pyopae/pyshared_buffer.cpp
@@ -24,9 +24,12 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #include "pyshared_buffer.h"
+#include "pycontext.h"
+#include <opae/cxx/core/handle.h>
 
 namespace py = pybind11;
 using opae::fpga::types::shared_buffer;
+using opae::fpga::types::handle;
 
 const char *shared_buffer_doc() {
   return R"opaedoc(
@@ -43,6 +46,12 @@ const char *shared_buffer_doc_allocate() {
       obect to share the buffer with.
       len: The length in bytes of the requested buffer.
   )opaedoc";
+}
+
+shared_buffer::ptr_t shared_buffer_allocate(handle::ptr_t hndl, size_t size) {
+  auto buf = shared_buffer::allocate(hndl, size);
+  buffer_registry::instance().add_buffer(hndl, buf);
+  return buf;
 }
 
 const char *shared_buffer_doc_size() {

--- a/pyopae/test_pyopae.py
+++ b/pyopae/test_pyopae.py
@@ -309,6 +309,18 @@ class TestSharedBuffer(unittest.TestCase):
         ba = bytearray(buff1)
         assert ba[0] == 0xaa
 
+    def test_conext_release(self):
+        assert self.handle
+        self.handle.close()
+        with opae.fpga.open(self.toks[0]) as h:
+            buff = opae.fpga.allocate_shared_buffer(h, 4096)
+            assert buff
+            assert buff.size() == 4096
+            assert buff.wsid() != 0
+        assert not h
+        assert buff.size() == 0
+        assert buff.wsid() == 0
+
 def trigger_port_error(value=1):
     with open(MOCK_PORT_ERROR, 'w') as fd:
         fd.write('0\n')


### PR DESCRIPTION
Add a singleton class, `buffer_registry` which is designed to be called by the
context manager enter function to register a handle. It is then called again by
the shared_buffer allocate function to associate the resulting buffer with the
handle. The context manager exit function should then call the deregister
function in the buffer_registry to release buffers associated with a handle.