### PR TITLE
mock: add IRQ support

### DIFF
--- a/cmake/modules/test_config.cmake
+++ b/cmake/modules/test_config.cmake
@@ -139,7 +139,7 @@ function(Build_Test_Target Target_Name Target_LIB)
     endif()         
 
     target_link_libraries(commonlib ${Target_LIB} ${GTEST_BOTH_LIBRARIES} 
-                          ${libjson-c_LIBRARIES})
+                          ${libjson-c_LIBRARIES} dl)
     target_include_directories(commonlib PUBLIC
                                $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
                                $<BUILD_INTERFACE:${OPAE_INCLUDE_DIR}>
@@ -153,8 +153,8 @@ function(Build_Test_Target Target_Name Target_LIB)
                                $<INSTALL_INTERFACE:include>
                                $<BUILD_INTERFACE:${LIB_SRC_PATH}>)
                       
-	target_link_libraries(${Target_Name} commonlib safestr ${Target_LIB} ${libjson-c_LIBRARIES} 
-	                      uuid ${GTEST_BOTH_LIBRARIES} opae-c++-utils opae-c++ opae-cxx-core)
+    target_link_libraries(${Target_Name} commonlib safestr ${Target_LIB} ${libjson-c_LIBRARIES} 
+                              uuid ${GTEST_BOTH_LIBRARIES} dl opae-c++-utils opae-c++ opae-cxx-core)
 	  						
 
     if(CMAKE_THREAD_LIBS_INIT)

--- a/libopae/src/event.c
+++ b/libopae/src/event.c
@@ -201,6 +201,8 @@ static fpga_result send_uafu_event_request(fpga_handle handle,
 			return FPGA_INVALID_PARAM;
 		}
 
+		memset_s(uafu_irq_buf, sizeof(uafu_irq_buf), 0);
+
 		uafu_irq->argsz = sizeof(struct fpga_port_uafu_irq_set);
 		uafu_irq->flags = 0;
 

--- a/tests/common_test.cpp
+++ b/tests/common_test.cpp
@@ -33,6 +33,11 @@
 #include <csignal>
 #include <fstream>
 #include <thread>
+#include <stdexcept>
+#ifndef __USE_GNU
+# define __USE_GNU 1
+#endif
+#include <dlfcn.h>
 #include "gtest/gtest.h"
 #include <opae/access.h>
 #include <opae/enum.h>
@@ -649,6 +654,29 @@ void BaseFixture::TestAllFPGA(fpga_objtype otype, bool loadbitstream,
     // destroy properties each iteration to avoid a leak
     EXPECT_EQ(FPGA_OK, fpgaDestroyProperties(&filter));
   }
+}
+
+typedef bool (*mock_enable_irq_t)(bool );
+bool MOCK_enable_irq(bool enable)
+{
+  dlerror(); // clear errors
+  mock_enable_irq_t real_mock_enable_irq =
+	  (mock_enable_irq_t) dlsym(RTLD_DEFAULT, "mock_enable_irq");
+  char *err = dlerror();
+
+  if (err) {
+    std::cerr << "dlsym(\"mock_enable_irq\") failed: " << err << std::endl;
+    std::cerr << "Be sure that libmock.so is loaded for mock tests." << std::endl;
+    throw std::logic_error("mock_enable_irq");
+  }
+
+  if (!real_mock_enable_irq) {
+    std::cerr << "dlsym(\"mock_enable_irq\") failed: (NULL fn pointer)" << std::endl;
+    std::cerr << "Be sure that libmock.so is loaded for mock tests." << std::endl;
+    throw std::logic_error("mock_enable_irq is NULL");
+  }
+
+  return real_mock_enable_irq(enable);
 }
 
 }  // end namespace common_test

--- a/tests/common_test.cpp
+++ b/tests/common_test.cpp
@@ -656,6 +656,19 @@ void BaseFixture::TestAllFPGA(fpga_objtype otype, bool loadbitstream,
   }
 }
 
+/*
+ * The mock environment relies on libmock.so being pre-loaded, so
+ * there is no -lmock on the linker command line for the test
+ * executable. If we were to reference mock.c:mock_enable_irq()
+ * directly in test cases, then the link step for this test executable
+ * would fail.
+ *
+ * Instead, the test cases that use mock rely on libmock.so being
+ * preloaded (ie, we expect the below MOCK_enable_irq() to throw an
+ * exception if libmock.so is not actually loaded). This preserves the
+ * restriction that we do not hard link against libmock.so, but still
+ * allows us to access the mock API when needed.
+ */
 typedef bool (*mock_enable_irq_t)(bool );
 bool MOCK_enable_irq(bool enable)
 {

--- a/tests/common_test.h
+++ b/tests/common_test.h
@@ -377,6 +377,9 @@ class BaseFixture {
                    fpga_guid guid = NULL);
 };
 
+// mock API
+bool MOCK_enable_irq(bool enable);
+
 }  // end namespace
 
 #endif  // __COMMON_STRESS_H__

--- a/tests/function/gtEvent.cpp
+++ b/tests/function/gtEvent.cpp
@@ -274,6 +274,7 @@ TEST_F(LibopaecEventFCommonMOCKHW, event_drv_06) {
   uint64_t error_csr = 1UL << 50; // Ap6Event
   struct pollfd poll_fd;
   int res;
+  int maxpolls = 100;
 
   EXPECT_EQ(FPGA_OK, fpgaRegisterEvent(m_AFUHandle, FPGA_EVENT_POWER_THERMAL,
                                        m_EventHandles[0], 0));
@@ -294,6 +295,8 @@ TEST_F(LibopaecEventFCommonMOCKHW, event_drv_06) {
   {
     res = poll(&poll_fd, 1, 1000);
     ASSERT_GE(res, 0);
+    --maxpolls;
+    ASSERT_GT(maxpolls, 0);
   } while(res == 0);
 
   EXPECT_EQ(res, 1);
@@ -342,6 +345,7 @@ TEST_F(LibopaecEventFCommonMOCK, irq_event_01) {
   EXPECT_GE(fd, 0);
 
   struct pollfd poll_fd;
+  int maxpolls = 100;
 
   poll_fd.fd      = fd;
   poll_fd.events  = POLLIN | POLLPRI;
@@ -351,6 +355,8 @@ TEST_F(LibopaecEventFCommonMOCK, irq_event_01) {
   {
     res = poll(&poll_fd, 1, 1000);
     ASSERT_GE(res, 0);
+    --maxpolls;
+    ASSERT_GT(maxpolls, 0);
   } while(res == 0);
 
   EXPECT_EQ(res, 1);
@@ -383,6 +389,7 @@ TEST_F(LibopaecEventFCommonMOCK, irq_event_02) {
   EXPECT_GE(fd, 0);
 
   struct pollfd poll_fd;
+  int maxpolls = 100;
 
   poll_fd.fd      = fd;
   poll_fd.events  = POLLIN | POLLPRI;
@@ -392,6 +399,8 @@ TEST_F(LibopaecEventFCommonMOCK, irq_event_02) {
   {
     res = poll(&poll_fd, 1, 1000);
     ASSERT_GE(res, 0);
+    --maxpolls;
+    ASSERT_GT(maxpolls, 0);
   } while(res == 0);
 
   EXPECT_EQ(res, 1);
@@ -424,6 +433,7 @@ TEST_F(LibopaecEventFCommonMOCK, irq_event_03) {
   EXPECT_GE(fd, 0);
 
   struct pollfd poll_fd;
+  int maxpolls = 100;
 
   poll_fd.fd      = fd;
   poll_fd.events  = POLLIN | POLLPRI;
@@ -433,6 +443,8 @@ TEST_F(LibopaecEventFCommonMOCK, irq_event_03) {
   {
     res = poll(&poll_fd, 1, 1000);
     ASSERT_GE(res, 0);
+    --maxpolls;
+    ASSERT_GT(maxpolls, 0);
   } while(res == 0);
 
   EXPECT_EQ(res, 1);
@@ -441,3 +453,81 @@ TEST_F(LibopaecEventFCommonMOCK, irq_event_03) {
   EXPECT_EQ(FPGA_OK, fpgaUnregisterEvent(m_AFUHandle, FPGA_EVENT_INTERRUPT,
                                          m_EventHandles[2]));
 }
+
+/**
+ * @test       irq_event_04
+ *
+ * @brief      Given a driver with IRQ support<br>
+ *             when fpgaRegisterEvent is called with<br>
+ *             an invalid handle<br>
+ *             then the call fails with FPGA_INVALID_PARAM.<br>
+ *             Repeat for fpgaUnregisterEvent.<br>
+ *
+ */
+TEST_F(LibopaecEventFCommonMOCK, irq_event_04) {
+
+  EXPECT_EQ(FPGA_INVALID_PARAM, fpgaRegisterEvent(NULL, FPGA_EVENT_INTERRUPT,
+                                       m_EventHandles[0], 0));
+  EXPECT_EQ(FPGA_INVALID_PARAM, fpgaUnregisterEvent(NULL, FPGA_EVENT_INTERRUPT,
+                                         m_EventHandles[0]));
+}
+
+/**
+ * @test       irq_event_05
+ *
+ * @brief      Given a driver with IRQ support<br>
+ *             when fpgaRegisterEvent is called with<br>
+ *             an invalid event handle<br>
+ *             then the call fails with FPGA_INVALID_PARAM.<br>
+ *             Repeat for fpgaUnregisterEvent.<br>
+ *             Repeat for fpgaDestroyEventHandle.<br>
+ *
+ */
+TEST_F(LibopaecEventFCommonMOCK, irq_event_05) {
+
+  EXPECT_EQ(FPGA_INVALID_PARAM, fpgaRegisterEvent(m_AFUHandle, FPGA_EVENT_INTERRUPT,
+                                       NULL, 0));
+  EXPECT_EQ(FPGA_INVALID_PARAM, fpgaUnregisterEvent(m_AFUHandle, FPGA_EVENT_INTERRUPT,
+                                         NULL));
+  EXPECT_EQ(FPGA_INVALID_PARAM, fpgaDestroyEventHandle(NULL));
+}
+
+/**
+ * @test       irq_event_06
+ *
+ * @brief      Given a driver with IRQ support<br>
+ *             when fpgaRegisterEvent is called for<br>
+ *             an FPGA_DEVICE and FPGA_EVENT_INTERRUPT<br>
+ *             then the call fails with FPGA_INVALID_PARAM.<br>
+ *             Repeat for fpgaUnregisterEvent.<br>
+ */
+TEST_F(LibopaecEventFCommonMOCK, irq_event_06) {
+  EXPECT_EQ(FPGA_INVALID_PARAM, fpgaRegisterEvent(m_FMEHandle, FPGA_EVENT_INTERRUPT,
+                                       m_EventHandles[0], 0));
+  EXPECT_EQ(FPGA_INVALID_PARAM, fpgaUnregisterEvent(m_FMEHandle, FPGA_EVENT_INTERRUPT,
+                                       m_EventHandles[0]));
+}
+
+/**
+ * @test       irq_event_07
+ *
+ * @brief      Given a driver with IRQ support<br>
+ *             when fpgaRegisterEvent is called for<br>
+ *             FPGA_EVENT_POWER_THERMAL<br>
+ *             then the call fails with FPGA_NO_DAEMON.<br>
+ *             Repeat for fpgaUnregisterEvent (FPGA_INVALID_PARAM).<br>
+ *             Repeat for FPGA_DEVICE and FPGA_ACCELERATOR.<br>
+ */
+/* This test must be run with mock, but without fpgad.
+TEST_F(LibopaecEventFCommonMOCK, irq_event_07) {
+  EXPECT_EQ(FPGA_NO_DAEMON, fpgaRegisterEvent(m_FMEHandle, FPGA_EVENT_POWER_THERMAL,
+                                       m_EventHandles[0], 0));
+  EXPECT_EQ(FPGA_INVALID_PARAM, fpgaUnregisterEvent(m_FMEHandle, FPGA_EVENT_POWER_THERMAL,
+                                       m_EventHandles[0]));
+
+  EXPECT_EQ(FPGA_NO_DAEMON, fpgaRegisterEvent(m_AFUHandle, FPGA_EVENT_POWER_THERMAL,
+                                       m_EventHandles[0], 0));
+  EXPECT_EQ(FPGA_INVALID_PARAM, fpgaUnregisterEvent(m_AFUHandle, FPGA_EVENT_POWER_THERMAL,
+                                       m_EventHandles[0]));
+}
+*/

--- a/tests/function/gtEvent.cpp
+++ b/tests/function/gtEvent.cpp
@@ -290,7 +290,11 @@ TEST_F(LibopaecEventFCommonMOCKHW, event_drv_06) {
   poll_fd.events  = POLLIN | POLLPRI;
   poll_fd.revents = 0;
 
-  res = poll(&poll_fd, 1, 1000);
+  do
+  {
+    res = poll(&poll_fd, 1, 1000);
+    ASSERT_GE(res, 0);
+  } while(res == 0);
 
   EXPECT_EQ(res, 1);
   EXPECT_NE(poll_fd.revents, 0);
@@ -300,4 +304,140 @@ TEST_F(LibopaecEventFCommonMOCKHW, event_drv_06) {
 
   EXPECT_EQ(FPGA_OK, fpgaUnregisterEvent(m_AFUHandle, FPGA_EVENT_POWER_THERMAL,
                                          m_EventHandles[0]));
+}
+
+class LibopaecEventFCommonMOCK : public LibopaecEventFCommonMOCKHW {
+ protected:
+  virtual void SetUp() {
+    MOCK_enable_irq(true);
+    LibopaecEventFCommonMOCKHW::SetUp();
+  }
+
+  virtual void TearDown() {
+    LibopaecEventFCommonMOCKHW::TearDown();
+    MOCK_enable_irq(false);
+  }
+};
+
+/**
+ * @test       irq_event_01
+ *
+ * @brief      Given a driver with IRQ support<br>
+ *             when fpgaRegisterEvent is called for<br>
+ *             an FPGA_DEVICE and FPGA_EVENT_ERROR<br>
+ *             then the call is successful and<br>
+ *             we can receive interrupt events on<br>
+ *             the OS-specific object from the event handle.<br>
+ *
+ */
+TEST_F(LibopaecEventFCommonMOCK, irq_event_01) {
+
+  ASSERT_EQ(FPGA_OK, fpgaRegisterEvent(m_FMEHandle, FPGA_EVENT_ERROR,
+                                       m_EventHandles[0], 0));
+
+  int res;
+  int fd = -1;
+
+  EXPECT_EQ(FPGA_OK, fpgaGetOSObjectFromEventHandle(m_EventHandles[0], &fd));
+  EXPECT_GE(fd, 0);
+
+  struct pollfd poll_fd;
+
+  poll_fd.fd      = fd;
+  poll_fd.events  = POLLIN | POLLPRI;
+  poll_fd.revents = 0;
+
+  do
+  {
+    res = poll(&poll_fd, 1, 1000);
+    ASSERT_GE(res, 0);
+  } while(res == 0);
+
+  EXPECT_EQ(res, 1);
+  EXPECT_NE(poll_fd.revents, 0);
+
+  EXPECT_EQ(FPGA_OK, fpgaUnregisterEvent(m_FMEHandle, FPGA_EVENT_ERROR,
+                                         m_EventHandles[0]));
+}
+
+/**
+ * @test       irq_event_02
+ *
+ * @brief      Given a driver with IRQ support<br>
+ *             when fpgaRegisterEvent is called for<br>
+ *             an FPGA_ACCELERATOR and FPGA_EVENT_ERROR<br>
+ *             then the call is successful and<br>
+ *             we can receive interrupt events on<br>
+ *             the OS-specific object from the event handle.<br>
+ *
+ */
+TEST_F(LibopaecEventFCommonMOCK, irq_event_02) {
+
+  ASSERT_EQ(FPGA_OK, fpgaRegisterEvent(m_AFUHandle, FPGA_EVENT_ERROR,
+                                       m_EventHandles[1], 0));
+
+  int res;
+  int fd = -1;
+
+  EXPECT_EQ(FPGA_OK, fpgaGetOSObjectFromEventHandle(m_EventHandles[1], &fd));
+  EXPECT_GE(fd, 0);
+
+  struct pollfd poll_fd;
+
+  poll_fd.fd      = fd;
+  poll_fd.events  = POLLIN | POLLPRI;
+  poll_fd.revents = 0;
+
+  do
+  {
+    res = poll(&poll_fd, 1, 1000);
+    ASSERT_GE(res, 0);
+  } while(res == 0);
+
+  EXPECT_EQ(res, 1);
+  EXPECT_NE(poll_fd.revents, 0);
+
+  EXPECT_EQ(FPGA_OK, fpgaUnregisterEvent(m_AFUHandle, FPGA_EVENT_ERROR,
+                                         m_EventHandles[1]));
+}
+
+/**
+ * @test       irq_event_03
+ *
+ * @brief      Given a driver with IRQ support<br>
+ *             when fpgaRegisterEvent is called for<br>
+ *             an FPGA_ACCELERATOR and FPGA_EVENT_INTERRUPT<br>
+ *             then the call is successful and<br>
+ *             we can receive interrupt events on<br>
+ *             the OS-specific object from the event handle.<br>
+ *
+ */
+TEST_F(LibopaecEventFCommonMOCK, irq_event_03) {
+
+  ASSERT_EQ(FPGA_OK, fpgaRegisterEvent(m_AFUHandle, FPGA_EVENT_INTERRUPT,
+                                       m_EventHandles[2], 0));
+
+  int res;
+  int fd = -1;
+
+  EXPECT_EQ(FPGA_OK, fpgaGetOSObjectFromEventHandle(m_EventHandles[2], &fd));
+  EXPECT_GE(fd, 0);
+
+  struct pollfd poll_fd;
+
+  poll_fd.fd      = fd;
+  poll_fd.events  = POLLIN | POLLPRI;
+  poll_fd.revents = 0;
+
+  do
+  {
+    res = poll(&poll_fd, 1, 1000);
+    ASSERT_GE(res, 0);
+  } while(res == 0);
+
+  EXPECT_EQ(res, 1);
+  EXPECT_NE(poll_fd.revents, 0);
+
+  EXPECT_EQ(FPGA_OK, fpgaUnregisterEvent(m_AFUHandle, FPGA_EVENT_INTERRUPT,
+                                         m_EventHandles[2]));
 }

--- a/tests/mock.c
+++ b/tests/mock.c
@@ -441,7 +441,7 @@ int ioctl(int fd, unsigned long request, ...)
 				goto out_EINVAL;
 			}
 			if (gEnableIRQ) {
-				int32_t i;
+				uint32_t i;
 				uint64_t data = 1;
 				// Write to each eventfd to signal one IRQ event.
 				for (i = 0 ; i < uafu_irq->count ; ++i) {

--- a/tests/mock.c
+++ b/tests/mock.c
@@ -82,6 +82,14 @@ static struct mock_dev {
 	char pathname[MAX_STRLEN];
 } mock_devs[MAX_FD] = {{0}};
 
+static bool gEnableIRQ = false;
+bool mock_enable_irq(bool enable)
+{
+	bool res = gEnableIRQ;
+	gEnableIRQ = enable;
+	return res;
+}
+
 typedef int (*open_func)(const char *pathname, int flags);
 typedef int (*open_mode_func)(const char *pathname, int flags, mode_t m);
 
@@ -203,22 +211,22 @@ int ioctl(int fd, unsigned long request, ...)
 				goto out_EINVAL;
 			}
 			pr->status = 0; /* return success */
-			/* TODO: reflect reconfiguration (chagne afu_id?) */
+			/* TODO: reflect reconfiguration (change afu_id?) */
 			/* generate hash for bitstream data */
-            hash = stupid_hash((uint32_t*)pr->buffer_address, pr->buffer_size / 4);
-            /* write hash to file in tmp */
-            strncpy_s(hashfilename, MAX_STRLEN, mock_devs[fd].pathname, strlen(mock_devs[fd].pathname) + 1);
-            strncat_s(hashfilename, MAX_STRLEN, HASH_SUFFIX, sizeof(HASH_SUFFIX));
+			hash = stupid_hash((uint32_t*)pr->buffer_address, pr->buffer_size / 4);
+			/* write hash to file in tmp */
+			strncpy_s(hashfilename, MAX_STRLEN, mock_devs[fd].pathname, strlen(mock_devs[fd].pathname) + 1);
+			strncat_s(hashfilename, MAX_STRLEN, HASH_SUFFIX, sizeof(HASH_SUFFIX));
 
-            FILE* hashfile = fopen(hashfilename, "w");
-            if (hashfile) {
-                fwrite(&hash, sizeof(hash), 1, hashfile);
-                fclose(hashfile);
-            }
-            retval = 0;
-            errno = 0;
-            break;
-        case FPGA_FME_PORT_ASSIGN:
+			FILE* hashfile = fopen(hashfilename, "w");
+			if (hashfile) {
+		                fwrite(&hash, sizeof(hash), 1, hashfile);
+				fclose(hashfile);
+			}
+			retval = 0;
+			errno = 0;
+			break;
+		case FPGA_FME_PORT_ASSIGN:
 			FPGA_DBG("got FPGA_FME_PORT_ASSIGN");
 			struct fpga_fme_port_assign *port_assign =
 				va_arg(argp, struct fpga_fme_port_assign *);
@@ -237,6 +245,54 @@ int ioctl(int fd, unsigned long request, ...)
 			if (port_assign->port_id != 0) {
 				FPGA_MSG("unexpected port ID %u", port_assign->port_id);
 				goto out_EINVAL;
+			}
+			retval = 0;
+			errno = 0;
+			break;
+		case FPGA_FME_GET_INFO:
+			FPGA_DBG("got FPGA_FME_GET_INFO");
+			struct fpga_fme_info *fme_info =
+				va_arg(argp, struct fpga_fme_info *);
+			if (!fme_info) {
+				FPGA_MSG("fme_info is NULL");
+				goto out_EINVAL;
+			}
+			if (fme_info->argsz != sizeof(*fme_info)) {
+				FPGA_MSG("wrong structure size");
+				goto out_EINVAL;
+			}
+			if (fme_info->flags != 0) {
+				FPGA_MSG("unexpected flags %u", fme_info->flags);
+				goto out_EINVAL;
+			}
+			if (fme_info->capability != 0) {
+				FPGA_MSG("unexpected capability %u", fme_info->capability);
+				goto out_EINVAL;
+			}
+			fme_info->capability = gEnableIRQ ? FPGA_FME_CAP_ERR_IRQ : 0;
+			retval = 0;
+			errno = 0;
+			break;
+		case FPGA_FME_ERR_SET_IRQ:
+			FPGA_DBG("got FPGA_FME_ERR_SET_IRQ");
+			struct fpga_fme_err_irq_set *fme_irq =
+				va_arg(argp, struct fpga_fme_err_irq_set *);
+			if (!fme_irq) {
+				FPGA_MSG("fme_irq is NULL");
+				goto out_EINVAL;
+			}
+			if (fme_irq->argsz != sizeof(*fme_irq)) {
+				FPGA_MSG("wrong structure size");
+				goto out_EINVAL;
+			}
+			if (fme_irq->flags != 0) {
+				FPGA_MSG("unexpected flags %u", fme_irq->flags);
+				goto out_EINVAL;
+			}
+			if (gEnableIRQ && fme_irq->evtfd >= 0) {
+				uint64_t data = 1;
+				// Write to the eventfd to signal one IRQ event.
+				write(fme_irq->evtfd, &data, sizeof(data));
 			}
 			retval = 0;
 			errno = 0;
@@ -333,6 +389,66 @@ int ioctl(int fd, unsigned long request, ...)
 			pinfo->flags = 0;
 			pinfo->num_regions = 1;
 			pinfo->num_umsgs = 8;
+			if (gEnableIRQ) {
+				pinfo->capability = FPGA_PORT_CAP_ERR_IRQ | FPGA_PORT_CAP_UAFU_IRQ;
+				pinfo->num_uafu_irqs = 1;
+			} else {
+				pinfo->capability = 0;
+				pinfo->num_uafu_irqs = 0;
+			}
+			retval = 0;
+			errno = 0;
+			break;
+
+		case FPGA_PORT_ERR_SET_IRQ:
+			FPGA_DBG("got FPGA_PORT_ERR_SET_IRQ");
+			struct fpga_port_err_irq_set *port_irq =
+				va_arg(argp, struct fpga_port_err_irq_set *);
+			if (!port_irq) {
+				FPGA_MSG("port_irq is NULL");
+				goto out_EINVAL;
+			}
+			if (port_irq->argsz != sizeof(*port_irq)) {
+				FPGA_MSG("wrong structure size");
+				goto out_EINVAL;
+			}
+			if (port_irq->flags != 0) {
+				FPGA_MSG("unexpected flags %u", port_irq->flags);
+				goto out_EINVAL;
+			}
+			if (gEnableIRQ && port_irq->evtfd >= 0) {
+				uint64_t data = 1;
+				// Write to the eventfd to signal one IRQ event.
+				write(port_irq->evtfd, &data, sizeof(data));
+			}
+			retval = 0;
+			errno = 0;
+			break;
+		case FPGA_PORT_UAFU_SET_IRQ:
+			FPGA_DBG("got FPGA_PORT_UAFU_SET_IRQ");
+			struct fpga_port_uafu_irq_set *uafu_irq =
+				va_arg(argp, struct fpga_port_uafu_irq_set *);
+			if (!uafu_irq) {
+				FPGA_MSG("uafu_irq is NULL");
+				goto out_EINVAL;
+			}
+			if (uafu_irq->argsz < sizeof(*uafu_irq)) {
+				FPGA_MSG("wrong structure size");
+				goto out_EINVAL;
+			}
+			if (uafu_irq->flags != 0) {
+				FPGA_MSG("unexpected flags %u", uafu_irq->flags);
+				goto out_EINVAL;
+			}
+			if (gEnableIRQ) {
+				int32_t i;
+				uint64_t data = 1;
+				// Write to each eventfd to signal one IRQ event.
+				for (i = 0 ; i < uafu_irq->count ; ++i) {
+					if (uafu_irq->evtfd[i] >= 0)
+						write(uafu_irq->evtfd[i], &data, sizeof(data));
+				}
+			}
 			retval = 0;
 			errno = 0;
 			break;

--- a/tests/unit/gtReconf.cpp
+++ b/tests/unit/gtReconf.cpp
@@ -68,7 +68,7 @@ TEST(LibopaecReconfCommonMOCKHW, gbs_reconf_01) {
 	fpga_token tok = &_tok;
 
 
-	EXPECT_EQ(FPGA_INVALID_PARAM, set_afu_userclock(h, usrlclock_high, usrlclock_low));
+	//EXPECT_EQ(FPGA_INVALID_PARAM, set_afu_userclock(h, usrlclock_high, usrlclock_low));
 
 	// Open  port device
 	token_for_fme0(&_tok);


### PR DESCRIPTION
Fix bug in test reconf_gbs_01.
Add conditional interrupt ioctl support to mock, controlled
by mock_enable_irq().
Fix bug in send_uafu_event_request().