### PR TITLE
pyopae: add pycontext to setup.py

### DIFF
--- a/pyopae/setup.py
+++ b/pyopae/setup.py
@@ -34,6 +34,7 @@ class pybind_include_dirs(object):
 extensions = [
     Extension("opae.fpga._opae",
               sources=["pyproperties.cpp",
+                       "pycontext.cpp",
                        "pyhandle.cpp",
                        "pytoken.cpp",
                        "pyshared_buffer.cpp",


### PR DESCRIPTION
Installation from package will fail without compiling this as this file
implements functions needed for context management.