### PR TITLE
pyopae: Add MANIFEST.in template for setup.py

### DIFF
--- a/pyopae/CMakeLists.txt
+++ b/pyopae/CMakeLists.txt
@@ -28,52 +28,52 @@ cmake_minimum_required(VERSION 2.8.12)
 project(pyopae)
 set(PYOPAE_PYBIND11_VERSION "2.2")
 set(PYOPAE_SRC opae.cpp
-	       pycontext.h
-	       pycontext.cpp
+               pycontext.h
+               pycontext.cpp
                pyproperties.h
-	           pyproperties.cpp
-	           pyhandle.h
-	           pyhandle.cpp
-	           pytoken.h
-	           pytoken.cpp
-	           pyshared_buffer.h
-	           pyshared_buffer.cpp
-	           pyevents.h
-	           pyevents.cpp
-	           pyerrors.h
-	           pyerrors.cpp)
+               pyproperties.cpp
+               pyhandle.h
+               pyhandle.cpp
+               pytoken.h
+               pytoken.cpp
+               pyshared_buffer.h
+               pyshared_buffer.cpp
+               pyevents.h
+               pyevents.cpp
+               pyerrors.h
+               pyerrors.cpp)
 
 set(PYBIND_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/pybind11/include)
 include_directories(${PYBIND_INCLUDE_DIR}
-	                ${PYTHON_INCLUDE_DIRS})
+                    ${PYTHON_INCLUDE_DIRS})
 add_library(_opae MODULE ${PYOPAE_SRC})
 target_include_directories(_opae
-	PRIVATE ${PYBIND11_INCLUDE_DIR}
-	PRIVATE ${PYTHON_INCLUDE_DIRS})
+    PRIVATE ${PYBIND11_INCLUDE_DIR}
+    PRIVATE ${PYTHON_INCLUDE_DIRS})
 target_link_libraries(_opae PUBLIC opae-c opae-cxx-core)
 set_target_properties(_opae PROPERTIES PREFIX ""
-				       CXX_VISIBILITY_PRESET "hidden"
-		                       COMPILE_FLAGS "-std=c++11"
-				       LINK_FLAGS "-std=c++11"
-	                               LIBRARY_OUTPUT_DIRECTORY
-				       ${LIBRARY_OUTPUT_PATH}/python${OPAE_PYTHON_VERSION}/opae/fpga
-				      )
+                       CXX_VISIBILITY_PRESET "hidden"
+                       COMPILE_FLAGS "-std=c++11"
+                       LINK_FLAGS "-std=c++11"
+                       LIBRARY_OUTPUT_DIRECTORY
+                       ${LIBRARY_OUTPUT_PATH}/python${OPAE_PYTHON_VERSION}/opae/fpga
+                      )
 add_custom_command(TARGET _opae
-	POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy
-	${CMAKE_CURRENT_SOURCE_DIR}/opae/__init__.py
-	${LIBRARY_OUTPUT_PATH}/python${OPAE_PYTHON_VERSION}/opae
-	COMMAND ${CMAKE_COMMAND} -E copy
-	${CMAKE_CURRENT_SOURCE_DIR}/opae/fpga/__init__.py
-	${LIBRARY_OUTPUT_PATH}/python${OPAE_PYTHON_VERSION}/opae/fpga
-	COMMENT "Copying namespace package files")
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_CURRENT_SOURCE_DIR}/opae/__init__.py
+    ${LIBRARY_OUTPUT_PATH}/python${OPAE_PYTHON_VERSION}/opae
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_CURRENT_SOURCE_DIR}/opae/fpga/__init__.py
+    ${LIBRARY_OUTPUT_PATH}/python${OPAE_PYTHON_VERSION}/opae/fpga
+    COMMENT "Copying namespace package files")
 
 add_custom_command(TARGET _opae
-	POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy
-	${CMAKE_CURRENT_SOURCE_DIR}/test_pyopae.py
-	${LIBRARY_OUTPUT_PATH}/python${OPAE_PYTHON_VERSION}
-	COMMENT "Copying Python test files")
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_pyopae.py
+    ${LIBRARY_OUTPUT_PATH}/python${OPAE_PYTHON_VERSION}
+    COMMENT "Copying Python test files")
 
 
 if (BUILD_PYTHON_DIST)
@@ -85,21 +85,19 @@ if (BUILD_PYTHON_DIST)
         opae/__init__.py
         opae/fpga/__init__.py
         test_pyopae.py
-    	)
+        )
 
     set (PYDIST_STAGE_DIR ${CMAKE_CURRENT_BINARY_DIR}/stage)
 
     foreach(pyfile ${PYFILES})
-    	configure_file(${pyfile} ${PYDIST_STAGE_DIR}/${pyfile} @ONLY)
+        configure_file(${pyfile} ${PYDIST_STAGE_DIR}/${pyfile} @ONLY)
     endforeach(pyfile ${PYFILES})
 
     foreach(cppfile ${PYOPAE_SRC})
-	    file(COPY ${cppfile} DESTINATION ${PYDIST_STAGE_DIR})
+        file(COPY ${cppfile} DESTINATION ${PYDIST_STAGE_DIR})
     endforeach(cppfile ${PYOPAE_SRC})
-
-    add_custom_command(
-        TARGET _opae
-        POST_BUILD
+    file(COPY MANIFEST.in DESTINATION ${PYDIST_STAGE_DIR})
+    add_custom_target(pyopae-dist
         COMMAND ${PYTHON_EXECUTABLE} setup.py sdist
         COMMAND ${PYTHON_EXECUTABLE} setup.py build_ext
         --include-dirs=${OPAE_INCLUDE_DIR}

--- a/pyopae/MANIFEST.in
+++ b/pyopae/MANIFEST.in
@@ -1,0 +1,15 @@
+include opae.cpp
+include pycontext.h
+include pycontext.cpp
+include pyproperties.h
+include pyproperties.cpp
+include pyhandle.h
+include pyhandle.cpp
+include pytoken.h
+include pytoken.cpp
+include pyshared_buffer.h
+include pyshared_buffer.cpp
+include pyevents.h
+include pyevents.cpp
+include pyerrors.h
+include pyerrors.cpp


### PR DESCRIPTION
The MANIFEST.in template file is used by distutils as an explicit list of files
to include in the source distribution.
Without this, distutils will only include the source (.cpp) files in the source
distribution.