### PR TITLE
Fixed fpgaconf verbose and dry-run cmd options.

### DIFF
--- a/tools/base/fpgaconf/fpgaconf.c
+++ b/tools/base/fpgaconf/fpgaconf.c
@@ -264,11 +264,11 @@ int parse_args(int argc, char *argv[])
 			help();
 			return -1;
 
-		case 'V':    /* verbose */
+		case 'v':    /* verbose */
 			config.verbosity++;
 			break;
 
-		case 'N':    /* dry-run */
+		case 'n':    /* dry-run */
 			config.dry_run = true;
 			break;
 


### PR DESCRIPTION
The previous commit that reverted the casing to these options missed the switch cases for them so the options would always return invalid cmd. This fixes it.