### PR TITLE
hssi: override `assign` fn to cfg i2c

### DIFF
--- a/tools/extra/integrated/hssi/e100.cpp
+++ b/tools/extra/integrated/hssi/e100.cpp
@@ -1,5 +1,31 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 #include "e100.h"
 #include <thread>
+#include "accelerator_przone.h"
 
 using namespace std;
 using namespace std::chrono;
@@ -38,7 +64,10 @@ e100::~e100()
 
 void e100::assign(accelerator::ptr_t accelerator_ptr)
 {
-    loopback::assign(accelerator_ptr);
+    accelerator_  = accelerator_ptr;
+    przone_.reset(new accelerator_przone(accelerator_));
+    // e100 uses 2 bytes for the byte address field
+    i2c_.reset(new i2c(przone_, 2));
     eth_.reset(new eth_ctrl(przone_, eth_ctrl::gbs_version::e100));
 }
 

--- a/tools/extra/integrated/hssi/e100.cpp
+++ b/tools/extra/integrated/hssi/e100.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2017-2018, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Implment e100::assign method so that it instantiates an i2c instance in 2-byte
byte-address mode as the i2c controller used for AK uses 2 bytes for the byte
address field.

Also update the copyright text for the e100.cpp file.