### PR TITLE
Include coverage.cmake in source tarball

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,7 +393,6 @@ endif()
 
 # Ignore following files in the final package
 set(CPACK_SOURCE_IGNORE_FILES
-  "coverage.cmake"
   "/mybuild/"
   "/build/"
   "/.git"


### PR DESCRIPTION
Currently coverage.cmake is not included in the source tarball which results in an error from ase_add_dpic.cmake which includes this file while building. This change removes coverage.cmake from the excluded files.