### PR TITLE
libopae-c: add generalized ctor and dtor

### DIFF
--- a/libopae/CMakeLists.txt
+++ b/libopae/CMakeLists.txt
@@ -52,7 +52,7 @@ set(SRC
   src/hostif.c
   src/event.c
   src/properties.c
-  src/log.c
+  src/init.c
   src/sysfs.c
   src/wsid_list.c
   src/token_list.c

--- a/libopae/src/init.c
+++ b/libopae/src/init.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2017, Intel Corporation
+// Copyright(c) 2017-2018, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -29,21 +29,47 @@
 #endif // HAVE_CONFIG_H
 
 #include "common_int.h"
+#include "token_list_int.h"
 
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
 
 /* global loglevel */
-static int g_loglevel = FPGA_LOG_UNDEFINED;
-static FILE *g_logfile;
+static int g_loglevel = FPGA_DEFAULT_LOGLEVEL;
+static FILE *g_logfile = NULL;
 /* mutex to protect against garbled log output */
-pthread_mutex_t log_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+static pthread_mutex_t log_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+
+void __FIXME_MAKE_VISIBLE__ fpga_print(int loglevel, char *fmt, ...)
+{
+	FILE *fp;
+	int err;
+	va_list argp;
+
+	if (loglevel > g_loglevel)
+		return;
+
+	if (loglevel == FPGA_LOG_ERROR)
+		fp = stderr;
+	else
+		fp = g_logfile == NULL ? stdout : g_logfile;
+
+	va_start(argp, fmt);
+	err = pthread_mutex_lock(&log_lock); /* ignore failure and print anyway */
+	if (err)
+		fprintf(stderr, "pthread_mutex_lock() failed: %s", strerror(err));
+	vfprintf(fp, fmt, argp);
+	err = pthread_mutex_unlock(&log_lock);
+	if (err)
+		fprintf(stderr, "pthread_mutex_unlock() failed: %s", strerror(err));
+	va_end(argp);
+}
+
 
 __attribute__((constructor))
-static void init_log(void)
+static void fpga_init(void)
 {
-	pthread_mutexattr_t mattr;
 	/* try to read loglevel from environment */
 	char *s = getenv("LIBOPAE_LOG");
 	if (s) {
@@ -69,51 +95,15 @@ static void init_log(void)
 
 	if (g_logfile == NULL)
 		g_logfile = stdout;
-
-	if (pthread_mutexattr_init(&mattr)) {
-		fprintf(stderr, "Failed to create log mutex attributes\n");
-		return;
-	}
-
-	if (pthread_mutexattr_settype(&mattr, PTHREAD_MUTEX_RECURSIVE) ||
-	    pthread_mutex_init(&log_lock, &mattr)) {
-		fprintf(stderr, "Failed to create log mutex\n");
-	}
-
-	pthread_mutexattr_destroy(&mattr);
 }
 
 __attribute__((destructor))
-static void deinit_log(void)
+static void fpga_release(void)
 {
-	if (g_logfile != NULL)
+	token_cleanup();
+
+	if (g_logfile != NULL && g_logfile != stdout) {
 		fclose(g_logfile);
+	}
+	g_logfile = NULL;
 }
-
-
-void __FIXME_MAKE_VISIBLE__ fpga_print(int loglevel, char *fmt, ...)
-{
-	FILE *fp = g_logfile == NULL ? stdout : g_logfile;
-	int err;
-
-	if (g_loglevel < 0) /* loglevel still not set? */
-		g_loglevel = FPGA_DEFAULT_LOGLEVEL;
-
-	if (loglevel > g_loglevel)
-		return;
-
-	if (loglevel == FPGA_LOG_ERROR)
-		fp = stderr;
-
-	va_list argp;
-	va_start(argp, fmt);
-	err = pthread_mutex_lock(&log_lock); /* ignore failure and print anyway */
-	if (err)
-		fprintf(stderr, "pthread_mutex_lock() failed: %s", strerror(err));
-	vfprintf(fp, fmt, argp);
-	err = pthread_mutex_unlock(&log_lock);
-	if (err)
-		fprintf(stderr, "pthread_mutex_unlock() failed: %s", strerror(err));
-	va_end(argp);
-}
-

--- a/libopae/src/init.c
+++ b/libopae/src/init.c
@@ -37,7 +37,7 @@
 
 /* global loglevel */
 static int g_loglevel = FPGA_DEFAULT_LOGLEVEL;
-static FILE *g_logfile = NULL;
+static FILE *g_logfile;
 /* mutex to protect against garbled log output */
 static pthread_mutex_t log_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
@@ -70,6 +70,8 @@ void __FIXME_MAKE_VISIBLE__ fpga_print(int loglevel, char *fmt, ...)
 __attribute__((constructor))
 static void fpga_init(void)
 {
+	g_logfile = NULL;
+
 	/* try to read loglevel from environment */
 	char *s = getenv("LIBOPAE_LOG");
 	if (s) {

--- a/libopae/src/log_int.h
+++ b/libopae/src/log_int.h
@@ -76,12 +76,11 @@
  * Logging functions
  */
 enum fpga_loglevel {
-	FPGA_LOG_UNDEFINED = -1, /* loglevel not set */
 	FPGA_LOG_ERROR = 0,      /* critical errors (always print) */
 	FPGA_LOG_MESSAGE,        /* information (i.e. explain return code */
 	FPGA_LOG_DEBUG           /* debugging (also needs #define DEBUG 1) */
 };
-#define FPGA_DEFAULT_LOGLEVEL 0
+#define FPGA_DEFAULT_LOGLEVEL FPGA_LOG_ERROR
 
 void fpga_print(int loglevel, char *fmt, ...);
 

--- a/libopae/src/token_list.c
+++ b/libopae/src/token_list.c
@@ -186,12 +186,14 @@ struct _fpga_token *token_get_parent(struct _fpga_token *_t)
  * Clean up remaining entries in linked list
  * Will delete all remaining entries
  */
-/* TODO: re-enable this
 void token_cleanup(void)
 {
 	int err = 0;
-	if (pthread_mutex_lock(&global_lock)) {
-		FPGA_MSG("Failed to lock global mutex");
+	struct error_list *p;
+
+	err = pthread_mutex_lock(&global_lock);
+	if (err) {
+		FPGA_ERR("pthread_mutex_lock() failed: %s", strerror(err));
 		return;
 	}
 
@@ -203,7 +205,7 @@ void token_cleanup(void)
 		token_root = token_root->next;
 
 		// free error list
-		struct error_list *p = tmp->_token.errors;
+		p = tmp->_token.errors;
 		while (p) {
 			struct error_list *q = p->next;
 			free(p);
@@ -215,14 +217,23 @@ void token_cleanup(void)
 		free(tmp);
 	}
 
+	// free error list
+	p = token_root->_token.errors;
+	while (p) {
+		struct error_list *q = p->next;
+		free(p);
+		p = q;
+	}
+
+	// invalidate magic (just in case)
 	token_root->_token.magic = FPGA_INVALID_MAGIC;
 	free(token_root);
+
 	token_root = NULL;
 
 out_unlock:
 	err = pthread_mutex_unlock(&global_lock);
 	if (err) {
-		FPGA_ERR("pthread_mutex_unlock() failed: %S", strerror(err));
+		FPGA_ERR("pthread_mutex_unlock() failed: %s", strerror(err));
 	}
 }
-*/

--- a/libopae/src/token_list_int.h
+++ b/libopae/src/token_list_int.h
@@ -35,6 +35,6 @@
  */
 struct _fpga_token *token_add(const char *sysfspath, const char *devpath);
 struct _fpga_token *token_get_parent(struct _fpga_token *t);
-/* void token_cleanup(void); */
+void token_cleanup(void);
 
 #endif // ___FPGA_TOKEN_LIST_INT_H__


### PR DESCRIPTION
Move log.c to init.c.
Add fpga_init() as a generalized ctor and fpga_release() as a
generalized dtor.
Call token_cleanup() from fpga_release().
Fix list walk bug in token_cleanup().
Simplify logger implementation.