### PR TITLE
libopae-c: add PCI segment as a property

### DIFF
--- a/common/include/opae/properties.h
+++ b/common/include/opae/properties.h
@@ -221,6 +221,27 @@ fpga_result fpgaPropertiesGetObjectType(const fpga_properties prop,
 fpga_result fpgaPropertiesSetObjectType(fpga_properties prop,
 					fpga_objtype objtype);
 /**
+ * Get the PCI segment number of a resource
+ *
+ * Returns the segment number of the queried resource.
+ *
+ * @param[in]  prop    Properties object to query
+ * @param[out] segment Pointer to a PCI segment variable of the resource 'prop'
+ *                     is associated with
+ * @returns See "Accessor Return Values" in [properties.h](#properties-h).
+ */
+fpga_result fpgaPropertiesGetSegment(const fpga_properties prop, uint16_t *segment);
+
+/**
+ * Set the PCI segment number of a resource
+ *
+ * @param[in]  prop    Properties object to modify
+ * @param[in]  segment PCI segment number of the resource 'prop' is associated with
+ * @returns See "Accessor Return Values" in [properties.h](#properties-h).
+ */
+fpga_result fpgaPropertiesSetSegment(fpga_properties prop, uint16_t segment);
+
+/**
  * Get the PCI bus number of a resource
  *
  * Returns the bus number the queried resource.

--- a/libopae/src/enum.c
+++ b/libopae/src/enum.c
@@ -54,6 +54,7 @@ struct dev_list {
 	char devpath[DEV_PATH_MAX];
 	fpga_objtype objtype;
 	fpga_guid guid;
+	uint16_t segment;
 	uint8_t bus;
 	uint8_t device;
 	uint8_t function;
@@ -123,6 +124,13 @@ static bool matches_filter(const struct dev_list *attr,
 
 	if (FIELD_VALID(_filter, FPGA_PROPERTY_OBJTYPE)) {
 		if (_filter->objtype != attr->objtype) {
+			res = false;
+			goto out_unlock;
+		}
+	}
+
+	if (FIELD_VALID(_filter, FPGA_PROPERTY_SEGMENT)) {
+		if (_filter->segment != attr->segment) {
 			res = false;
 			goto out_unlock;
 		}
@@ -349,6 +357,7 @@ static fpga_result enum_fme(const char *sysfspath, const char *name,
 
 	pdev->objtype = FPGA_DEVICE;
 
+	pdev->segment = parent->segment;
 	pdev->bus = parent->bus;
 	pdev->device = parent->device;
 	pdev->function = parent->function;
@@ -424,6 +433,7 @@ static fpga_result enum_afu(const char *sysfspath, const char *name,
 
 	pdev->objtype = FPGA_ACCELERATOR;
 
+	pdev->segment = parent->segment;
 	pdev->bus = parent->bus;
 	pdev->device = parent->device;
 	pdev->function = parent->function;
@@ -471,7 +481,7 @@ static fpga_result enum_top_dev(const char *sysfspath, struct dev_list *list,
 	int res;
 	char *p;
 	int f;
-	unsigned b, d;
+	unsigned s, b, d;
 
 	// Make sure it's a directory.
 	if (stat(sysfspath, &stats) != 0) {
@@ -513,26 +523,32 @@ static fpga_result enum_top_dev(const char *sysfspath, struct dev_list *list,
 		FPGA_MSG("Invalid link");
 		return FPGA_NO_DRIVER;
 	}
-	p += 6;
+	++p;
 
-	// 0123456
-	// bb:dd.f
+	//           11
+	// 012345678901
+	// ssss:bb:dd.f
 	f = 0;
-	sscanf_s_i(p + 6, "%d", &f);
+	sscanf_s_i(p + 11, "%d", &f);
 
 	pdev->function = (uint8_t)f;
-	*(p + 5) = 0;
+	*(p + 10) = 0;
 
 	d = 0;
-	sscanf_s_u(p + 3, "%x", &d);
+	sscanf_s_u(p + 8, "%x", &d);
 
 	pdev->device = (uint8_t)d;
-	*(p + 2) = 0;
+	*(p + 7) = 0;
 
 	b = 0;
-	sscanf_s_u(p, "%x", &b);
+	sscanf_s_u(p + 5, "%x", &b);
 
 	pdev->bus = (uint8_t)b;
+	*(p + 4) = 0;
+
+	s = 0;
+	sscanf_s_u(p, "%x", &s);
+	pdev->segment = (uint16_t)s;
 
 	// read the vendor and device ID from the 'device' path
 	uint32_t x = 0;

--- a/libopae/src/properties_int.h
+++ b/libopae/src/properties_int.h
@@ -30,15 +30,16 @@
 /** Fields common across all object types */
 #define FPGA_PROPERTY_PARENT         0
 #define FPGA_PROPERTY_OBJTYPE        1
-#define FPGA_PROPERTY_BUS            2
-#define FPGA_PROPERTY_DEVICE         3
-#define FPGA_PROPERTY_FUNCTION       4
-#define FPGA_PROPERTY_SOCKETID       5
-#define FPGA_PROPERTY_VENDORID       6
-#define FPGA_PROPERTY_DEVICEID       7
-#define FPGA_PROPERTY_GUID           8
-#define FPGA_PROPERTY_OBJECTID       9
-#define FPGA_PROPERTY_NUM_ERRORS     10
+#define FPGA_PROPERTY_SEGMENT        2
+#define FPGA_PROPERTY_BUS            3
+#define FPGA_PROPERTY_DEVICE         4
+#define FPGA_PROPERTY_FUNCTION       5
+#define FPGA_PROPERTY_SOCKETID       6
+#define FPGA_PROPERTY_VENDORID       7
+#define FPGA_PROPERTY_DEVICEID       8
+#define FPGA_PROPERTY_GUID           9
+#define FPGA_PROPERTY_OBJECTID       10
+#define FPGA_PROPERTY_NUM_ERRORS     11
 
 /** Fields for FPGA objects */
 #define FPGA_PROPERTY_NUM_SLOTS     32

--- a/libopae/src/sysfs.c
+++ b/libopae/src/sysfs.c
@@ -627,7 +627,7 @@ fpga_result sysfs_deviceid_from_path(const char *sysfspath,
  * The rlpath path is assumed to be of the form:
  * ../../devices/pci0000:5e/0000:5e:00.0/fpga/intel-fpga-dev.0
  */
-fpga_result sysfs_bdf_from_path(const char *sysfspath, int *b, int *d, int *f)
+fpga_result sysfs_sbdf_from_path(const char *sysfspath, int *s, int *b, int *d, int *f)
 {
 	int res;
 	char rlpath[SYSFS_PATH_MAX];
@@ -658,17 +658,21 @@ fpga_result sysfs_bdf_from_path(const char *sysfspath, int *b, int *d, int *f)
 		FPGA_MSG("Invalid link %s (no driver?)", rlpath);
 		return FPGA_NO_DRIVER;
 	}
-	p += 6;
+	++p;
 
-	// 0123456
-	// bb:dd.f
-	*f = (int) strtoul(p+6, NULL, 16);
-	*(p + 5) = 0;
+	//           11
+	// 012345678901
+	// ssss:bb:dd.f
+	*f = (int) strtoul(p+11, NULL, 16);
+	*(p + 10) = 0;
 
-	*d = (int) strtoul(p+3, NULL, 16);
-	*(p + 2) = 0;
+	*d = (int) strtoul(p+8, NULL, 16);
+	*(p + 7) = 0;
 
-	*b = (int) strtoul(p, NULL, 16);
+	*b = (int) strtoul(p+5, NULL, 16);
+	*(p + 4) = 0;
+
+	*s = (int) strtoul(p, NULL, 16);
 
 	return FPGA_OK;
 }

--- a/libopae/src/sysfs_int.h
+++ b/libopae/src/sysfs_int.h
@@ -65,7 +65,7 @@ fpga_result get_interface_id(fpga_handle handle, uint64_t *id_l, uint64_t *id_h)
 /*
  * sysfs utility functions.
  */
-fpga_result sysfs_bdf_from_path(const char *sysfspath, int *b, int *d, int *f);
+fpga_result sysfs_sbdf_from_path(const char *sysfspath, int *s, int *b, int *d, int *f);
 fpga_result sysfs_read_int(const char *path, int *i);
 fpga_result sysfs_read_u32(const char *path, uint32_t *u);
 fpga_result sysfs_read_u32_pair(const char *path, uint32_t *u1, uint32_t *u2,

--- a/libopae/src/types_int.h
+++ b/libopae/src/types_int.h
@@ -129,12 +129,13 @@ struct _fpga_properties {
 	// valid here means the field has been set using the API
 	// bit 0x00 - parent field is valid
 	// bit 0x01 - objtype field is valid
-	// bit 0x02 - bus field is valid
+	// bit 0x02 - segment field is valid
 	// ...
 	// up to bit 0x1F
 	fpga_guid guid;		// Applies only to accelerator types
 	fpga_token parent;
 	fpga_objtype objtype;
+	uint16_t segment;
 	uint8_t bus;
 	uint8_t device;
 	uint8_t function;

--- a/tests/function/gtEnumerate.cpp
+++ b/tests/function/gtEnumerate.cpp
@@ -864,6 +864,20 @@ TEST(LibopaecEnumCommonALL, enum_drv_022) {
 }
 
 /**
+ * @test       enum_033
+ *
+ * @brief      When the filter passed to fpgaEnumerate has a valid
+ *             segment field set, but that segment does not match any device,
+ *             fpgaEnumerate returns zero matches.
+ */
+TEST_F(LibopaecEnumFCommonALL, enum_033) {
+  EXPECT_EQ(FPGA_OK, fpgaPropertiesSetSegment(m_Properties, 0xc001));
+
+  EXPECT_EQ(FPGA_OK, fpgaEnumerate(&m_Properties, 1, NULL, 0, &m_NumMatches));
+  EXPECT_EQ(0, m_NumMatches);
+}
+
+/**
  * @test       enum_023
  *
  * @brief      When the filter passed to fpgaEnumerate has a valid
@@ -1024,6 +1038,20 @@ TEST_F(LibopaecEnumFCommonALL, enum_032) {
 
   v.minor = 4;
   EXPECT_EQ(FPGA_OK, fpgaPropertiesSetBBSVersion(m_Properties, v));
+
+  EXPECT_EQ(FPGA_OK, fpgaEnumerate(&m_Properties, 1, NULL, 0, &m_NumMatches));
+  EXPECT_EQ(0, m_NumMatches);
+}
+
+/**
+ * @test       enum_034
+ *
+ * @brief      When the filter passed to fpgaEnumerate has a valid
+ *             socket id field set, but that socket id does not match any device,
+ *             fpgaEnumerate returns zero matches.
+ */
+TEST_F(LibopaecEnumFCommonALL, enum_034) {
+  EXPECT_EQ(FPGA_OK, fpgaPropertiesSetSocketID(m_Properties, 0xff));
 
   EXPECT_EQ(FPGA_OK, fpgaEnumerate(&m_Properties, 1, NULL, 0, &m_NumMatches));
   EXPECT_EQ(0, m_NumMatches);

--- a/tests/unit/gtProperties_base.cpp
+++ b/tests/unit/gtProperties_base.cpp
@@ -398,6 +398,136 @@ TEST(LibopaecPropertiesCommonALL, nodrv_prop_019) {
   EXPECT_EQ(FPGA_INVALID_PARAM, result);
 }
 
+// * Segment field tests *//
+/**
+ * @test    nodrv_prop_225
+ * @brief   Tests: fpgaPropertiesGetSegment
+ * @details Given a non-null fpga_properties* object<br>
+ *          And it has the bus field set<br>
+ *          And it is set to a known value<br>
+ *          When I call fpgaPropertiesGetSegment with a pointer to an integer<br>
+ *          Then the return value is FPGA_OK<br>
+ *          And the output value is the known value<br>
+ */
+TEST(LibopaecPropertiesCommonALL, nodrv_prop_225) {
+  fpga_properties prop = NULL;
+  fpga_result result = fpgaGetProperties(NULL, &prop);
+
+  ASSERT_EQ(result, FPGA_OK);
+  ASSERT_FALSE(NULL == prop);
+
+  struct _fpga_properties* _prop = (struct _fpga_properties*)prop;
+
+  // set the segment field
+  SET_FIELD_VALID(_prop, FPGA_PROPERTY_SEGMENT);
+  _prop->segment = 0xc001;
+
+  // now get the segment number using the API
+  uint16_t segment = 0;
+  result = fpgaPropertiesGetSegment(prop, &segment);
+  EXPECT_EQ(result, FPGA_OK);
+  // Assert it is set to what we set it to above
+  // (Get the subfield manually)
+  EXPECT_EQ(0xc001, segment);
+
+  result = fpgaDestroyProperties(&prop);
+  ASSERT_EQ(NULL, prop);
+}
+
+/**
+ * @test    nodrv_prop_226
+ * @brief   Tests: fpgaPropertiesGetSegment
+ * @details Given a non-null fpga_properties* object<br>
+ *          And it does NOT have the bus field set<br>
+ *          When I call fpgaPropertiesGetSegment with a pointer to an integer<br>
+ *          Then the return value is FPGA_NOT_FOUND<br>
+ * */
+TEST(LibopaecPropertiesCommonALL, nodrv_prop_226) {
+  fpga_properties prop = NULL;
+  fpga_result result = fpgaGetProperties(NULL, &prop);
+
+  ASSERT_EQ(result, FPGA_OK);
+  ASSERT_TRUE(NULL != prop);
+
+  struct _fpga_properties* _prop = (struct _fpga_properties*)prop;
+
+  // make sure the FPGA_PROPERTY_SEGMENT bit is zero
+  EXPECT_EQ((_prop->valid_fields >> FPGA_PROPERTY_SEGMENT) & 1, 0);
+
+  uint16_t segment;
+  result = fpgaPropertiesGetSegment(prop, &segment);
+  EXPECT_EQ(FPGA_NOT_FOUND, result);
+
+  result = fpgaDestroyProperties(&prop);
+  ASSERT_EQ(NULL, prop);
+}
+
+/**
+ * @test    nodrv_prop_227
+ * @brief   Tests: fpgaPropertiesSetSegment
+ * @details Given a non-null fpga_properties* object<br>
+ *          And segment variable set to a known value<br>
+ *          When I call fpgaPropertiesSetSegment with the properties object and
+ *          the segment variable<br>
+ *          Then the segment field in the properties object is the known value<br>
+ */
+TEST(LibopaecPropertiesCommonALL, nodrv_prop_227) {
+  fpga_properties prop = NULL;
+  fpga_result result = fpgaGetProperties(NULL, &prop);
+  ASSERT_EQ(result, FPGA_OK);
+  ASSERT_FALSE(NULL == prop);
+
+  struct _fpga_properties* _prop = (struct _fpga_properties*)prop;
+
+  uint16_t segment = 0xc001;
+  // make sure the FPGA_PROPERTY_SEGMENT bit is zero
+  EXPECT_EQ((_prop->valid_fields >> FPGA_PROPERTY_SEGMENT) & 1, 0);
+  // Call the API to set the segment on the property
+  result = fpgaPropertiesSetSegment(prop, segment);
+
+  EXPECT_EQ(result, FPGA_OK);
+
+  // make sure the FPGA_PROPERTY_SEGMENT bit is one
+  EXPECT_EQ((_prop->valid_fields >> FPGA_PROPERTY_SEGMENT) & 1, 1);
+
+  // Assert it is set to what we set it to above
+  EXPECT_EQ(0xc001, _prop->segment);
+
+  result = fpgaDestroyProperties(&prop);
+  ASSERT_EQ(NULL, prop);
+}
+
+/**
+ * @test    nodrv_prop_228
+ * @brief   Tests: fpgaPropertiesGetSegment
+ * @details Given a null fpga_properties* object<br>
+ *          When I call fpgaPropertiesGetSegment with the null object<br>
+ *          Then the return value is FPGA_INVALID_PARAM<br>
+ * */
+TEST(LibopaecPropertiesCommonALL, nodrv_prop_228) {
+  fpga_properties prop = NULL;
+
+  uint16_t segment;
+  fpga_result result = fpgaPropertiesGetSegment(prop, &segment);
+  EXPECT_EQ(FPGA_INVALID_PARAM, result);
+}
+
+/**
+ * @test    nodrv_prop_229
+ * @brief   Tests: fpgaPropertiesSetSegment
+ * @details Given a null fpga_properties* object<br>
+ *          When I call fpgaPropertiesSetSegment with the null object<br>
+ *          Then the result is FPGA_INVALID_PARAM<br>
+ */
+TEST(LibopaecPropertiesCommonALL, nodrv_prop_229) {
+  fpga_properties prop = NULL;
+
+  // Call the API to set the segment on the property
+  fpga_result result = fpgaPropertiesSetSegment(prop, 0xc001);
+
+  EXPECT_EQ(FPGA_INVALID_PARAM, result);
+}
+
 // * Bus field tests *//
 /**
  * @test    nodrv_prop_020


### PR DESCRIPTION
Add the PCI segment portion of a PCI address as a queryable property.