### PR TITLE
Add generic APIs for reading/writing objects

### DIFF
--- a/common/include/opae/sys.h
+++ b/common/include/opae/sys.h
@@ -97,43 +97,49 @@ fpga_result fpgaReadObjectBytes(fpga_token token, const char *key,
  * @brief Write a 32-bit value to an FPGA resource object as identified by a
  * string key. On Linux, this is equivalent to writing to a sysfs node with
  * 'key' as the path relative to the sysfs directory of the resource identified
- * by the token.
+ * by the handle.
  *
- * @param[in] token Token identifying a resource (accelerator or device)
+ * @param[in] handle Handle to an open resource (accelerator or device)
  * @param[in] key A key identifying the object with respect to the resource
  * @param[in] value The 32-bit value to write to the object
  *
  * @return FPGA_OK on success. FPGA_INVALID_PARAM if any of the supplied
  * parameter is invalid. FPGA_NOT_SUPPORTED if this function is not supported
  * by the current implementation of this API.
+ *
+ * @note Write operations require a handle to an open resource to avoid
+ * possible race conditions
  */
-fpga_result fpgaWriteObject32(fpga_token token, const char *key,
+fpga_result fpgaWriteObject32(fpga_handle handle, const char *key,
 			      uint32_t value);
 
 /**
  * @brief Write a 64-bit value from an FPGA resource object as identified by a
  * string key. On Linux, this is equivalent to writing to a sysfs node with
  * 'key' as the path relative to the sysfs directory of the resource identified
- * by the token.
+ * by the handle.
  *
- * @param[in] token Token identifying a resource (accelerator or device)
+ * @param[in] handle Handle to an open resource (accelerator or device)
  * @param[in] key A key identifying the object with respect to the resource
  * @param[in] value The 64-bit value to write to the object
  *
  * @return FPGA_OK on success. FPGA_INVALID_PARAM if any of the supplied
  * parameter is invalid. FPGA_NOT_SUPPORTED if this function is not supported
  * by the current implementation of this API.
+ *
+ * @note Write operations require a handle to an open resource to avoid
+ * possible race conditions
  */
-fpga_result fpgaWriteObject64(fpga_token token, const char *key,
+fpga_result fpgaWriteObject64(fpga_handle handle, const char *key,
 			      uint64_t value);
 
 /**
  * @brief Write a sequence of bytes to an FPGA resource object as identified
  * by a string key. On Linux, this is equivalent to writing to a sysfs node
  * with 'key' as the path relative to the sysfs directory of the resource
- * identified by the token.
+ * identified by the handle.
  *
- * @param[in] token Token identifying a resource (accelerator or device)
+ * @param[in] handle Handle to an open resource (accelerator or device)
  * @param[in] key A key identifying the object with respect to the resource
  * @param[in] buffer Pointer to memory to write to the the object
  * @param[in] offset Where to start writing bytes in the object
@@ -143,8 +149,11 @@ fpga_result fpgaWriteObject64(fpga_token token, const char *key,
  * @return FPGA_OK on success. FPGA_INVALID_PARAM if any of the supplied
  * parameter is invalid. FPGA_NOT_SUPPORTED if this function is not supported
  * by the current implementation of this API.
+ *
+ * @note Write operations require a handle to an open resource to avoid
+ * possible race conditions
  */
-fpga_result fpgaWriteObjectBytes(fpga_token token, const char *key,
+fpga_result fpgaWriteObjectBytes(fpga_handle handle, const char *key,
 				 uint8_t *buffer, size_t offset, size_t len);
 
 #ifdef __cplusplus

--- a/common/include/opae/sys.h
+++ b/common/include/opae/sys.h
@@ -1,0 +1,154 @@
+// Copyright(c) 2017-2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file sys.h
+ * @brief Functions to read/write from system objects.
+ * On Linux, this is used to access sysfs nodes created by the kernel driver
+ */
+#ifndef __SYS_H__
+#define __SYS_H__
+
+#include <opae/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Read a 32-bit value from an FPGA resource object as identified by a
+ * string key. On Linux, this is equivalent to reading from a sysfs node with
+ * 'key' as the path relative to the sysfs directory of the resource identified
+ * by the token.
+ *
+ * @param[in] token Token identifying a resource (accelerator or device)
+ * @param[in] key A key identifying the object with respect to the resource
+ * @param[out] value Pointer to 32-bit variable to store the object's value
+ *
+ * @return FPGA_OK on success. FPGA_INVALID_PARAM if any of the supplied
+ * parameter is invalid. FPGA_NOT_SUPPORTED if this function is not supported
+ * by the current implementation of this API.
+ */
+fpga_result fpgaReadObject32(fpga_token token, const char *key,
+			     uint32_t *value);
+
+/**
+ * @brief Read a 64-bit value from an FPGA resource object as identified by a
+ * string key. On Linux, this is equivalent to reading from a sysfs node with
+ * 'key' as the path relative to the sysfs directory of the resource identified
+ * by the token.
+ *
+ * @param[in] token Token identifying a resource (accelerator or device)
+ * @param[in] key A key identifying the object with respect to the resource
+ * @param[out] value Pointer to 64-bit variable to store the object's value
+ *
+ * @return FPGA_OK on success. FPGA_INVALID_PARAM if any of the supplied
+ * parameter is invalid. FPGA_NOT_SUPPORTED if this function is not supported
+ * by the current implementation of this API.
+ */
+fpga_result fpgaReadObject64(fpga_token token, const char *key,
+			     uint64_t *value);
+
+/**
+ * @brief Read a sequence of bytes from ann FPGA resource object as identified
+ * by a string key. On Linux, this is equivalent to reading from a sysfs node
+ * with 'key' as the path relative to the sysfs directory of the resource
+ * identified by the token.
+ *
+ * @param[in] token Token identifying a resource (accelerator or device)
+ * @param[in] key A key identifying the object with respect to the resource
+ * @param[out] buffer Pointer to memory to store the object's value
+ * @param[in] offset Start of byte sequence to read
+ * @param[in] len The number of bytes to read. This is updated with the
+ * actual number of bytes read
+ *
+ *
+ * @return FPGA_OK on success. FPGA_INVALID_PARAM if any of the supplied
+ * parameter is invalid. FPGA_NOT_SUPPORTED if this function is not supported
+ * by the current implementation of this API.
+ */
+fpga_result fpgaReadObjectBytes(fpga_token token, const char *key,
+				uint8_t *buffer, size_t offset, size_t *len);
+
+/**
+ * @brief Write a 32-bit value to an FPGA resource object as identified by a
+ * string key. On Linux, this is equivalent to writing to a sysfs node with
+ * 'key' as the path relative to the sysfs directory of the resource identified
+ * by the token.
+ *
+ * @param[in] token Token identifying a resource (accelerator or device)
+ * @param[in] key A key identifying the object with respect to the resource
+ * @param[in] value The 32-bit value to write to the object
+ *
+ * @return FPGA_OK on success. FPGA_INVALID_PARAM if any of the supplied
+ * parameter is invalid. FPGA_NOT_SUPPORTED if this function is not supported
+ * by the current implementation of this API.
+ */
+fpga_result fpgaWriteObject32(fpga_token token, const char *key,
+			      uint32_t value);
+
+/**
+ * @brief Write a 64-bit value from an FPGA resource object as identified by a
+ * string key. On Linux, this is equivalent to writing to a sysfs node with
+ * 'key' as the path relative to the sysfs directory of the resource identified
+ * by the token.
+ *
+ * @param[in] token Token identifying a resource (accelerator or device)
+ * @param[in] key A key identifying the object with respect to the resource
+ * @param[in] value The 64-bit value to write to the object
+ *
+ * @return FPGA_OK on success. FPGA_INVALID_PARAM if any of the supplied
+ * parameter is invalid. FPGA_NOT_SUPPORTED if this function is not supported
+ * by the current implementation of this API.
+ */
+fpga_result fpgaWriteObject64(fpga_token token, const char *key,
+			      uint64_t value);
+
+/**
+ * @brief Write a sequence of bytes to an FPGA resource object as identified
+ * by a string key. On Linux, this is equivalent to writing to a sysfs node
+ * with 'key' as the path relative to the sysfs directory of the resource
+ * identified by the token.
+ *
+ * @param[in] token Token identifying a resource (accelerator or device)
+ * @param[in] key A key identifying the object with respect to the resource
+ * @param[in] buffer Pointer to memory to write to the the object
+ * @param[in] offset Where to start writing bytes in the object
+ * @param[in] len The number of bytes to write
+ *
+ *
+ * @return FPGA_OK on success. FPGA_INVALID_PARAM if any of the supplied
+ * parameter is invalid. FPGA_NOT_SUPPORTED if this function is not supported
+ * by the current implementation of this API.
+ */
+fpga_result fpgaWriteObjectBytes(fpga_token token, const char *key,
+				 uint8_t *buffer, size_t offset, size_t len);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#endif /* !__SYS_H__ */

--- a/tests/mock.c
+++ b/tests/mock.c
@@ -230,7 +230,7 @@ int ioctl(int fd, unsigned long request, ...)
 			hash = stupid_hash((uint32_t*)pr->buffer_address, pr->buffer_size / 4);
 			/* write hash to file in tmp */
 			strncpy_s(hashfilename, MAX_STRLEN, mock_devs[fd].pathname, strlen(mock_devs[fd].pathname) + 1);
-			strncat_s(hashfilename, MAX_STRLEN, HASH_SUFFIX, sizeof(HASH_SUFFIX));
+			strcat_s(hashfilename, MAX_STRLEN, HASH_SUFFIX);
 
 			FILE* hashfile = fopen(hashfilename, "w");
 			if (hashfile) {


### PR DESCRIPTION
Add six APIs for reading and writing from/to an object in an FPGA
resource. The objects are identified by a string key.
For Linux, this is equivalent to reading/writing to sysfs
files with 'key' as a path relative to the resource directory in sysfs.

For each operation (read, write), three functions are defined.
* One for operating on a 32-bit value
* One for operating a 64-bit value
* One for operating on a sequence of bytes