### PR TITLE
Add sys.c (for generic sysfs operations)

### DIFF
--- a/libopae/CMakeLists.txt
+++ b/libopae/CMakeLists.txt
@@ -57,6 +57,7 @@ set(SRC
   src/wsid_list.c
   src/token_list.c
   src/mmap.c
+  src/sys.c
   src/version.c
   src/usrclk/user_clk_pgm_uclock.c)
 

--- a/libopae/src/sys.c
+++ b/libopae/src/sys.c
@@ -35,9 +35,11 @@
 #include "safe_string/safe_string.h"
 
 #define NULL_CHECK(var)                                                        \
-	if (var == NULL) {                                                     \
-		FPGA_MSG(#var " is NULL");                                     \
-	}
+	do {                                                                   \
+		if (var == NULL) {                                             \
+			FPGA_MSG(#var " is NULL");                             \
+		}                                                              \
+	} while (false);
 
 fpga_result cat_token_sysfs_path(char *dest, fpga_token token, const char *path)
 {

--- a/libopae/src/sys.c
+++ b/libopae/src/sys.c
@@ -1,0 +1,158 @@
+// Copyright(c) 2017-2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include "common_int.h"
+#include "log_int.h"
+#include "sysfs_int.h"
+#include "types_int.h"
+#include "safe_string/safe_string.h"
+
+#define NULL_CHECK(var)                                                        \
+	if (var == NULL) {                                                     \
+		FPGA_MSG(#var " is NULL");                                     \
+	}
+
+fpga_result cat_token_sysfs_path(char *dest, fpga_token token, const char *path)
+{
+	struct _fpga_token *_token = (struct _fpga_token *)token;
+	int len = snprintf_s_ss(dest, SYSFS_PATH_MAX, "%s/%s",
+				_token->sysfspath, path);
+	if (len < 0) {
+		FPGA_ERR("error concatenating strings (%s, %s)",
+			 _token->sysfspath, path);
+		return FPGA_EXCEPTION;
+	}
+	return FPGA_OK;
+}
+
+fpga_result cat_handle_sysfs_path(char *dest, fpga_handle handle,
+				  const char *path)
+{
+	struct _fpga_handle *_handle = (struct _fpga_handle *)(handle);
+	return cat_token_sysfs_path(dest, _handle->token, path);
+}
+
+fpga_result __FPGA_API__ fpgaReadObject32(fpga_token token, const char *key,
+					  uint32_t *value)
+{
+	NULL_CHECK(token);
+	NULL_CHECK(key);
+	NULL_CHECK(value);
+
+	char objpath[SYSFS_PATH_MAX];
+
+	fpga_result res = cat_token_sysfs_path(objpath, token, key);
+	if (res) {
+		return res;
+	}
+
+	return sysfs_read_u32(objpath, value);
+}
+
+fpga_result __FPGA_API__ fpgaReadObject64(fpga_token token, const char *key,
+					  uint64_t *value)
+{
+	NULL_CHECK(token);
+	NULL_CHECK(key);
+	NULL_CHECK(value);
+
+	char objpath[SYSFS_PATH_MAX];
+	fpga_result res = cat_token_sysfs_path(objpath, token, key);
+	if (res) {
+		return res;
+	}
+
+	return sysfs_read_u64(objpath, value);
+}
+
+fpga_result __FPGA_API__ fpgaReadObjectBytes(fpga_token token, const char *key,
+					     uint8_t *buffer, size_t offset,
+					     size_t *len)
+{
+	NULL_CHECK(token);
+	NULL_CHECK(key);
+	NULL_CHECK(buffer);
+	NULL_CHECK(len);
+	(void)offset;
+
+	char objpath[SYSFS_PATH_MAX];
+	fpga_result res = cat_token_sysfs_path(objpath, token, key);
+	if (res) {
+		return res;
+	}
+
+
+	return res;
+}
+
+fpga_result __FPGA_API__ fpgaWriteObject32(fpga_handle handle, const char *key,
+					   uint32_t value)
+{
+	NULL_CHECK(handle);
+	NULL_CHECK(key);
+	char objpath[SYSFS_PATH_MAX];
+	fpga_result res = cat_handle_sysfs_path(objpath, handle, key);
+	if (res) {
+		return res;
+	}
+
+	return sysfs_write_u32(objpath, value);
+}
+
+fpga_result __FPGA_API__ fpgaWriteObject64(fpga_handle handle, const char *key,
+					   uint64_t value)
+{
+	NULL_CHECK(handle);
+	NULL_CHECK(key);
+	char objpath[SYSFS_PATH_MAX];
+	fpga_result res = cat_handle_sysfs_path(objpath, handle, key);
+	if (res) {
+		return res;
+	}
+
+	return sysfs_write_u64(objpath, value);
+}
+
+fpga_result __FPGA_API__ fpgaWriteObjectBytes(fpga_handle handle,
+					      const char *key, uint8_t *buffer,
+					      size_t offset, size_t len)
+{
+	NULL_CHECK(handle);
+	NULL_CHECK(key);
+	NULL_CHECK(buffer);
+	(void)offset;
+	(void)len;
+	char objpath[SYSFS_PATH_MAX];
+	fpga_result res = cat_handle_sysfs_path(objpath, handle, key);
+	if (res) {
+		return res;
+	}
+	return res;
+}

--- a/scripts/coverage-gtapi-mock-drv.sh
+++ b/scripts/coverage-gtapi-mock-drv.sh
@@ -37,7 +37,7 @@ trap "finish" EXIT
 
 
 cmake .. -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Coverage
-make mock gtapi fpgad _opae
+make mock gtapi fpgad _opae gtunit
 
 lcov --directory . --zerocounters
 lcov -c -i -d . -o coverage.base

--- a/scripts/test-gtapi-mock-drv.sh
+++ b/scripts/test-gtapi-mock-drv.sh
@@ -11,7 +11,7 @@ function finish() {
 trap "finish" EXIT
 
 cmake .. -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
-make mock gtapi fpgad _opae
+make mock gtapi fpgad _opae gtunit
 LD_PRELOAD="$PWD/lib/libmock.so" ./bin/fpgad -d -D $PWD -l $PWD/fpgad.log -p $PWD/fpgad.pid
 CTEST_OUTPUT_ON_FAILURE=1 make test
 result=PASSED

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,8 +67,18 @@ configure_file(${PROJECT_SOURCE_DIR}/configuration.json
 # build mock driver and unpack fake sysfs to /tmp folder
 Build_MOCk_DRV()
 
-include_directories(${CMAKE_SOURCE_DIR}/libopae/src)
-add_executable(gtunit gtunit-main.cpp mock.c unit/gtsys.cpp)
+############################################################################
+## unit tests use mock.c  ##################################################
+############################################################################
+
+include_directories(
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/libopae/src)
+set(GTUNIT_TESTS unit/gtsys.cpp)
+add_executable(gtunit
+    gtunit-main.cpp
+    mock.c
+    ${GTUNIT_TESTS})
 target_link_libraries(gtunit ${GTEST_BOTH_LIBRARIES} opae-c dl)
 add_test(NAME gtunit
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,13 @@ configure_file(${PROJECT_SOURCE_DIR}/configuration.json
 # build mock driver and unpack fake sysfs to /tmp folder
 Build_MOCk_DRV()
 
+include_directories(${CMAKE_SOURCE_DIR}/libopae/src)
+add_executable(gtunit gtunit-main.cpp mock.c unit/gtsys.cpp)
+target_link_libraries(gtunit ${GTEST_BOTH_LIBRARIES} opae-c dl)
+add_test(NAME gtunit
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMAND $<TARGET_FILE:gtunit> )
+
 ############################################################################
 ## add_gtfilter macro  #####################################################
 ############################################################################

--- a/tests/gtunit-main.cpp
+++ b/tests/gtunit-main.cpp
@@ -1,0 +1,18 @@
+/*
+ * gtsysfs.cpp
+ * Copyright (C) 2018 rrojo <rrojo@ub-rojo-vm-04.amr.corp.intel.com>
+ *
+ * Distributed under terms of the MIT license.
+ */
+#include "gtest/gtest.h"
+
+using ::testing::TestCase;
+using ::testing::TestInfo;
+using ::testing::TestPartResult;
+using ::testing::UnitTest;
+
+int main(int argc, char* argv[])
+{
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/tests/gtunit-main.cpp
+++ b/tests/gtunit-main.cpp
@@ -1,9 +1,29 @@
-/*
- * gtsysfs.cpp
- * Copyright (C) 2018 rrojo <rrojo@ub-rojo-vm-04.amr.corp.intel.com>
- *
- * Distributed under terms of the MIT license.
- */
+// Copyright(c) 2017-2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #include "gtest/gtest.h"
 
 using ::testing::TestCase;

--- a/tests/unit/gtsys.cpp
+++ b/tests/unit/gtsys.cpp
@@ -1,0 +1,49 @@
+// Copyright(c) 2017-2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifdef __cplusplus
+
+extern "C" {
+#endif
+#include <opae/sys.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "types_int.h"
+#include "gtest/gtest.h"
+#include "common_test.h"
+
+TEST(sys, read32) {
+	struct _fpga_token _tok;
+	fpga_token tok = &_tok;
+  common_test::token_for_afu0(&_tok);
+  uint32_t value = 9999;
+  auto res = fpgaReadObject32(tok, "id", &value);
+  EXPECT_EQ(res, FPGA_OK);
+  EXPECT_EQ(value, 0);
+}


### PR DESCRIPTION
Implment the functions for the fpgaObject API for reading/writing from
generic resource objects.
On Linux, this translates to reading/writing sysfs files relative to the
resource's sysfs path rooted at:

/sys/class/fpga/intel-fpga-dev.\d/intel-fpga-(fme|port).\d

This also adds a unit test executable that compiles in mock.c.
TODO:
* Implement the (Read|Write)Bytes functions
* Add more unit tests