### PR TITLE
Remove 32-bit sysfs write operations

### DIFF
--- a/common/include/opae/sysobject.h
+++ b/common/include/opae/sysobject.h
@@ -99,26 +99,6 @@ fpga_result fpgaReadObjectBytes(fpga_token token, const char *key,
 				uint8_t *buffer, size_t offset, size_t *len);
 
 /**
- * @brief Write a 32-bit value to an FPGA resource object as identified by a
- * string key. On Linux, this is equivalent to writing to a sysfs node with
- * 'key' as the path relative to the sysfs directory of the resource identified
- * by the handle.
- *
- * @param[in] handle Handle to an open resource (accelerator or device)
- * @param[in] key A key identifying the object with respect to the resource
- * @param[in] value The 32-bit value to write to the object
- *
- * @return FPGA_OK on success. FPGA_INVALID_PARAM if any of the supplied
- * parameter is invalid. FPGA_NOT_SUPPORTED if this function is not supported
- * by the current implementation of this API.
- *
- * @note Write operations require a handle to an open resource to avoid
- * possible race conditions
- */
-fpga_result fpgaWriteObject32(fpga_handle handle, const char *key,
-			      uint32_t value);
-
-/**
  * @brief Write a 64-bit value from an FPGA resource object as identified by a
  * string key. On Linux, this is equivalent to writing to a sysfs node with
  * 'key' as the path relative to the sysfs directory of the resource identified

--- a/libopae/src/sysfs.c
+++ b/libopae/src/sysfs.c
@@ -273,54 +273,6 @@ out_close:
 	return FPGA_EXCEPTION;
 }
 
-fpga_result __FIXME_MAKE_VISIBLE__ sysfs_write_u32(const char *path, uint32_t u)
-{
-	int fd                     = -1;
-	int res                    = 0;
-	char buf[SYSFS_PATH_MAX]   = {0};
-	int b                      = 0;
-
-	if (path == NULL) {
-		FPGA_ERR("Invalid input path");
-		return FPGA_INVALID_PARAM;
-	}
-
-	fd = open(path, O_WRONLY);
-	if (fd < 0) {
-		FPGA_MSG("open(%s) failed: %s", path, strerror(errno));
-		return FPGA_NOT_FOUND;
-	}
-
-	if ((off_t)-1 == lseek(fd, 0, SEEK_SET)) {
-		FPGA_MSG("seek: %s", strerror(errno));
-		goto out_close;
-	}
-
-	snprintf_s_l(buf, sizeof(buf), "0x%x", u);
-
-	do {
-		res = write(fd, buf + b, sizeof(buf) -b);
-		if (res <= 0) {
-			FPGA_ERR("Failed to write");
-			goto out_close;
-		}
-		b += res;
-
-		if ((unsigned)b > sizeof(buf) || b <= 0) {
-			FPGA_MSG("Unexpected size reading from %s", path);
-			goto out_close;
-		}
-
-	} while (buf[b - 1] != '\n' && buf[b - 1] != '\0' && (unsigned)b < sizeof(buf));
-
-	close(fd);
-	return FPGA_OK;
-
-out_close:
-	close(fd);
-	return FPGA_EXCEPTION;
-}
-
 fpga_result __FIXME_MAKE_VISIBLE__ sysfs_write_u64(const char *path, uint64_t u)
 {
 	int fd                     = -1;

--- a/libopae/src/sysfs_int.h
+++ b/libopae/src/sysfs_int.h
@@ -71,7 +71,6 @@ fpga_result sysfs_read_u32(const char *path, uint32_t *u);
 fpga_result sysfs_read_u32_pair(const char *path, uint32_t *u1, uint32_t *u2,
 				 char sep);
 fpga_result sysfs_read_u64(const char *path, uint64_t *u);
-fpga_result sysfs_write_u32(const char *path, uint32_t u);
 fpga_result sysfs_write_u64(const char *path, uint64_t u);
 fpga_result sysfs_read_guid(const char *path, fpga_guid guid);
 fpga_result sysfs_get_socket_id(int dev, uint8_t *socket_id);

--- a/libopae/src/sysobject.c
+++ b/libopae/src/sysobject.c
@@ -194,20 +194,6 @@ fpga_result __FPGA_API__ fpgaReadObjectBytes(fpga_token token, const char *key,
 	return res;
 }
 
-fpga_result __FPGA_API__ fpgaWriteObject32(fpga_handle handle, const char *key,
-					   uint32_t value)
-{
-	NULL_CHECK(handle);
-	NULL_CHECK(key);
-	char objpath[SYSFS_PATH_MAX];
-	fpga_result res = cat_handle_sysfs_path(objpath, handle, key);
-	if (res) {
-		return res;
-	}
-
-	return sysfs_write_u32(objpath, value);
-}
-
 fpga_result __FPGA_API__ fpgaWriteObject64(fpga_handle handle, const char *key,
 					   uint64_t value)
 {

--- a/scripts/coverage-gtapi-mock-drv.sh
+++ b/scripts/coverage-gtapi-mock-drv.sh
@@ -37,7 +37,7 @@ trap "finish" EXIT
 
 
 cmake .. -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Coverage
-make mock gtapi fpgad _opae gtunit
+make mock gtapi fpgad _opae opae-c-munit
 
 lcov --directory . --zerocounters
 lcov -c -i -d . -o coverage.base

--- a/scripts/test-gtapi-mock-drv.sh
+++ b/scripts/test-gtapi-mock-drv.sh
@@ -11,7 +11,7 @@ function finish() {
 trap "finish" EXIT
 
 cmake .. -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
-make mock gtapi fpgad _opae gtunit
+make mock gtapi fpgad _opae opae-c-munit
 LD_PRELOAD="$PWD/lib/libmock.so" ./bin/fpgad -d -D $PWD -l $PWD/fpgad.log -p $PWD/fpgad.pid
 CTEST_OUTPUT_ON_FAILURE=1 make test
 result=PASSED

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,14 +75,14 @@ include_directories(
     ${GTEST_INCLUDE_DIRS}
     ${CMAKE_SOURCE_DIR}/libopae/src)
 set(GTUNIT_TESTS unit/gtsys.cpp)
-add_executable(gtunit
+add_executable(opae-c-munit
     gtunit-main.cpp
     mock.c
     ${GTUNIT_TESTS})
-target_link_libraries(gtunit ${GTEST_BOTH_LIBRARIES} opae-c dl)
-add_test(NAME gtunit-sysobject
+target_link_libraries(opae-c-munit ${GTEST_BOTH_LIBRARIES} opae-c dl)
+add_test(NAME munit-sysobject
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    COMMAND $<TARGET_FILE:gtunit> "--gtest_filter=sysobject*")
+    COMMAND $<TARGET_FILE:opae-c-munit> "--gtest_filter=sysobject*")
 
 ############################################################################
 ## add_gtfilter macro  #####################################################

--- a/tests/unit/gtsysfs.cpp
+++ b/tests/unit/gtsysfs.cpp
@@ -182,17 +182,6 @@ TEST(LibopaecsysfsCommonMOCKHW, fpga_sysfs_02) {
 	EXPECT_EQ(result, FPGA_OK);
 
 	//Invalid input parameters
-	result = sysfs_write_u32(NULL, 0);
-	EXPECT_NE(result, FPGA_OK);
-
-	result = sysfs_write_u32("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0", 0x100);
-	EXPECT_NE(result, FPGA_OK);
-
-	//valid path 
-	result = sysfs_write_u32("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0/socket_id", 0);
-	EXPECT_EQ(result, FPGA_OK);
-
-	//Invalid input parameters
 	result = sysfs_write_u64(NULL, 0);
 	EXPECT_NE(result, FPGA_OK);
 


### PR DESCRIPTION
* Remote 32-bit sysfs write operations
  Generic 32-bit sysfs write operations are not supported yet.
  The kernel documentation for sysfs recommends reading entire
  contents of a sysfs file, modifying it with the intended bytes, and then
  writing back the buffer. Rather that implementing that for 32-bit
  objects, this removes this operation for now.
* Rename mock unit test executable