### PR TITLE
ASE: Disabled some debug messages in non-debug mode

### DIFF
--- a/ase/sw/ase_common.h
+++ b/ase/sw/ase_common.h
@@ -612,7 +612,7 @@ int unregister_event(int event_handle);
 // #define ASE_MSG_VIEW
 
 // Enable debug info from linked lists
-#define ASE_LL_VIEW
+// #define ASE_LL_VIEW
 
 // Print buffers as they are being alloc/dealloc
 // #define ASE_BUFFER_VIEW

--- a/ase/sw/protocol_backend.c
+++ b/ase/sw/protocol_backend.c
@@ -605,7 +605,9 @@ static void *start_socket_srv(void *args)
 				err_cnt++;
 				break;
 			}
+#ifdef ASE_DEBUG
       ASE_MSG("SIM-C : accept success\n");
+#endif
 		}
 		if (sockserver_kill)
 			break;


### PR DESCRIPTION
Accidently enabled the debug message printing for shared memory buffers. 