### PR TITLE
Add buffer unit tests

### DIFF
--- a/libopae/src/buffer.c
+++ b/libopae/src/buffer.c
@@ -73,7 +73,7 @@
 /*
  * Allocate (mmap) new buffer
  */
-static fpga_result buffer_allocate(void **addr, uint64_t len, int flags)
+fpga_result buffer_allocate(void **addr, uint64_t len, int flags)
 {
 	void *addr_local = NULL;
 
@@ -114,7 +114,7 @@ static fpga_result buffer_allocate(void **addr, uint64_t len, int flags)
 /*
  * Release (unmap) allocated buffer
  */
-static fpga_result buffer_release(void *addr, uint64_t len)
+fpga_result buffer_release(void *addr, uint64_t len)
 {
 	/* If the buffer allocation was backed by hugepages, then
 	 * len must be rounded up to the nearest hugepage size,

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -14,7 +14,7 @@ function finish {
 
 	lcov --directory coverage_files --capture --output-file coverage.info
 	lcov -a coverage.base -a coverage.info --output-file coverage.total
-	lcov --remove coverage.total '/usr/**' 'tests/**' '*/**/CMakeFiles*' '/usr/*' 'safe_string/**' 'tools/**' 'pybind11/*' --output-file coverage.info.cleaned
+	lcov --remove coverage.total '/usr/**' 'tests/**' '*/**/CMakeFiles*' '/usr/*' 'safe_string/**' 'tools/**' 'pybind11/*' 'testing/**' --output-file coverage.info.cleaned
 	genhtml --function-coverage -o coverage_report coverage.info.cleaned
 	popd
 }
@@ -36,5 +36,5 @@ make munit-opae-c
 
 lcov --directory . --zerocounters
 lcov -c -i -d . -o coverage.base
-./bin/munit-opae-c --gtest_filter="enum*"
+./bin/munit-opae-c --gtest_filter="enum*:buffer*"
 

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -15,6 +15,7 @@ add_subdirectory(mock)
 
 set(MUNIT_SRC mock/mock.c
               unit/munit-enum-c.cpp
+              unit/munit-buffer-c.cpp
               unit/munit-wsid_list.cpp
               unit/munit-sysfs.cpp
               ${CMAKE_SOURCE_DIR}/libopae/src/bitstream.c

--- a/testing/mock/test_system.cpp
+++ b/testing/mock/test_system.cpp
@@ -33,16 +33,20 @@
 #include <algorithm>
 #include "c_test_system.h"
 
+namespace opae {
+namespace testing {
+
 int mock_fme::ioctl(int request, va_list argp) {
-  (void) request;
-  (void) argp;
-  return 0; }
+  (void)request;
+  (void)argp;
+  return 0;
+}
 
 int mock_port::ioctl(int request, va_list argp) {
-  (void) request;
-  (void) argp;
-  return 0; }
-
+  (void)request;
+  (void)argp;
+  return 0;
+}
 
 #define ASSERT_FN(fn)                              \
   do {                                             \
@@ -81,6 +85,7 @@ static platform_db PLATFORMS = {
                        .device = 0,
                        .function = 0,
                        .socket_id = 0,
+                       .num_slots = 1,
                        .fme_object_id = 0xf500000,
                        .port_object_id = 0xf400000,
                        .vendor_id = 0x8086,
@@ -98,10 +103,9 @@ bool test_platform::exists(const std::string &key) {
 
 std::vector<std::string> test_platform::keys(bool sorted) {
   std::vector<std::string> keys(PLATFORMS.size());
-  std::transform(PLATFORMS.begin(), PLATFORMS.end(), keys.begin(),
-                 [](const std::pair<std::string, test_platform> &it) {
-                   return it.first;
-                 });
+  std::transform(
+      PLATFORMS.begin(), PLATFORMS.end(), keys.begin(),
+      [](const std::pair<std::string, test_platform> &it) { return it.first; });
   if (sorted) {
     std::sort(keys.begin(), keys.end());
   }
@@ -229,34 +233,39 @@ int test_system::lstat(int ver, const char *path, struct stat *buf) {
   return lstat_(ver, syspath.c_str(), buf);
 }
 
+}  // end of namespace testing
+}  // end of namespace opae
+
 // C functions
 
 int opae_test_open(const char *path, int flags) {
-  return test_system::instance()->open(path, flags);
+  return opae::testing::test_system::instance()->open(path, flags);
 }
 
 int opae_test_open_create(const char *path, int flags, mode_t mode) {
-  return test_system::instance()->open(path, flags, mode);
+  return opae::testing::test_system::instance()->open(path, flags, mode);
 }
 
-int opae_test_close(int fd) { return test_system::instance()->close(fd); }
+int opae_test_close(int fd) {
+  return opae::testing::test_system::instance()->close(fd);
+}
 
 int opae_test_ioctl(int fd, unsigned long request, va_list argp) {
-  return test_system::instance()->ioctl(fd, request, argp);
+  return opae::testing::test_system::instance()->ioctl(fd, request, argp);
 }
 
 DIR *opae_test_opendir(const char *name) {
-  return test_system::instance()->opendir(name);
+  return opae::testing::test_system::instance()->opendir(name);
 }
 
 ssize_t opae_test_readlink(const char *path, char *buf, size_t bufsize) {
-  return test_system::instance()->readlink(path, buf, bufsize);
+  return opae::testing::test_system::instance()->readlink(path, buf, bufsize);
 }
 
 int opae_test_xstat(int ver, const char *path, struct stat *buf) {
-  return test_system::instance()->xstat(ver, path, buf);
+  return opae::testing::test_system::instance()->xstat(ver, path, buf);
 }
 
 int opae_test_lstat(int ver, const char *path, struct stat *buf) {
-  return test_system::instance()->lstat(ver, path, buf);
+  return opae::testing::test_system::instance()->lstat(ver, path, buf);
 }

--- a/testing/mock/test_system.h
+++ b/testing/mock/test_system.h
@@ -31,6 +31,20 @@
 #include <string>
 #include <vector>
 
+typedef struct stat stat_t;
+
+namespace opae {
+namespace testing {
+
+constexpr size_t KiB(size_t n){
+  return n*1024;
+}
+constexpr size_t MiB(size_t n){
+  return n*1024*KiB(1);
+}
+
+
+
 class mock_object {
  public:
   enum type_t { sysfs_attr = 0, fme, afu };
@@ -106,8 +120,8 @@ class test_system {
 
   DIR *opendir(const char *name);
   ssize_t readlink(const char *path, char *buf, size_t bufsize);
-  int xstat(int ver, const char *path, struct stat *buf);
-  int lstat(int ver, const char *path, struct stat *buf);
+  int xstat(int ver, const char *path, stat_t *buf);
+  int lstat(int ver, const char *path, stat_t *buf);
 
  private:
   test_system();
@@ -133,5 +147,8 @@ class test_system {
   __xstat_func xstat_;
   __xstat_func lstat_;
 };
+
+} // end of namespace testing
+} // end of namespace opae
 
 #endif /* !_TEST_SYSTEM_H */

--- a/testing/unit/munit-buffer-c.cpp
+++ b/testing/unit/munit-buffer-c.cpp
@@ -1,0 +1,135 @@
+// Copyright(c) 2017-2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include <opae/fpga.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <tuple>
+#include "gtest/gtest.h"
+#include "test_system.h"
+
+struct buffer_params {
+  fpga_result result;
+  size_t size;
+  int flags;
+};
+
+using namespace opae::testing;
+
+class buffer_prepare
+    : public ::testing::TestWithParam<std::tuple<std::string, buffer_params>> {
+ protected:
+  buffer_prepare() : tmpsysfs_("mocksys-XXXXXX"), handle_(nullptr) {}
+
+  virtual void SetUp() override {
+    auto tpl = GetParam();
+    std::string platform_key = std::get<0>(tpl);
+    ASSERT_TRUE(test_platform::exists(platform_key));
+    platform_ = test_platform::get(platform_key);
+    system_ = test_system::instance();
+    system_->initialize();
+    tmpsysfs_ = system_->prepare_syfs(platform_);
+
+    ASSERT_EQ(fpgaGetProperties(nullptr, &filter_), FPGA_OK);
+    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
+    ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
+                            &num_matches_),
+              FPGA_OK);
+    ASSERT_EQ(fpgaOpen(tokens_[0], &handle_, 0), FPGA_OK);
+  }
+
+  virtual void TearDown() override {
+    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
+    if (handle_ != nullptr) EXPECT_EQ(fpgaClose(handle_), FPGA_OK);
+    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
+      std::string cmd = "rm -rf " + tmpsysfs_;
+      std::system(cmd.c_str());
+    }
+    system_->finalize();
+  }
+
+  std::string tmpsysfs_;
+  fpga_properties filter_;
+  std::array<fpga_token, 2> tokens_;
+  fpga_handle handle_;
+  uint32_t num_matches_;
+  test_platform platform_;
+  test_system *system_;
+};
+
+// TEST_P(buffer_prepare, buffer_allocate) {
+//  void **addr = 0;
+//  uint64_t len = 0;
+//  int flags = 0;
+//  auto res = buffer_allocate(addr, len, flags);
+//  EXPECT_EQ(res, FPGA_OK);
+//}
+//
+// TEST_P(buffer_prepare, buffer_release) {
+//  void *addr = 0;
+//  uint64_t len = 0;
+//  auto res = buffer_release(addr, len);
+//  EXPECT_EQ(res, FPGA_OK);
+//}
+
+TEST_P(buffer_prepare, fpgaPrepareBuffer) {
+  buffer_params params = std::get<1>(GetParam());
+  void *buf_addr = 0;
+  uint64_t wsid = 0;
+  uint64_t ioaddr = 0;
+  auto res =
+      fpgaPrepareBuffer(handle_, params.size, &buf_addr, &wsid, params.flags);
+
+  EXPECT_EQ(res, params.result) << "result is " << fpgaErrStr(res);
+  if (params.size > 0 && params.result == FPGA_OK) {
+    EXPECT_EQ(res = fpgaGetIOAddress(handle_, wsid, &ioaddr), FPGA_OK)
+        << "result is " << fpgaErrStr(res);
+    EXPECT_EQ(res = fpgaReleaseBuffer(handle_, wsid), FPGA_OK)
+        << "result is " << fpgaErrStr(res);
+  }
+}
+
+namespace {
+std::vector<buffer_params> params{
+    buffer_params{FPGA_INVALID_PARAM, 0, 0},
+    buffer_params{FPGA_OK, KiB(1), 0},
+    buffer_params{FPGA_OK, KiB(4), 0},
+    buffer_params{FPGA_OK, MiB(1), 0},
+    buffer_params{FPGA_OK, MiB(2), 0},
+    buffer_params{FPGA_INVALID_PARAM, 11247, FPGA_BUF_PREALLOCATED}};
+}
+
+INSTANTIATE_TEST_CASE_P(
+    buffer_c, buffer_prepare,
+    ::testing::Combine(::testing::ValuesIn(test_platform::keys()),
+                       ::testing::ValuesIn(params)));

--- a/testing/unit/munit-enum-c.cpp
+++ b/testing/unit/munit-enum-c.cpp
@@ -47,6 +47,8 @@ extern "C" {
 #include "gtest/gtest.h"
 #include "test_system.h"
 
+using namespace opae::testing;
+
 class enum_c_p : public ::testing::TestWithParam<std::string> {
  protected:
   enum_c_p() : tmpsysfs("mocksys-XXXXXX") {}


### PR DESCRIPTION
* Make buffer_allocate and buffer_release non-static so that they may be
called from a test if needed
* Put test_system and friends inside opae::testing namespace
* Add buffer_prepare parameterized tests (still need to add negative
tests)