### PR TITLE
Add ability to register ioctl handlers

### DIFF
--- a/testing/mock/CMakeLists.txt
+++ b/testing/mock/CMakeLists.txt
@@ -3,7 +3,9 @@ cmake_minimum_required (VERSION 2.8)
 # projectname is the same as the main-executable
 project(test_system)
 
-add_library(test_system SHARED EXCLUDE_FROM_ALL test_system.cpp)
+add_library(test_system SHARED EXCLUDE_FROM_ALL
+    test_system.cpp
+    ioctl_handlers.cpp)
 target_link_libraries(test_system dl)
 target_include_directories(test_system PUBLIC
   $<BUILD_INTERFACE:${OPAE_INCLUDE_DIR}>

--- a/testing/mock/ioctl_handlers.cpp
+++ b/testing/mock/ioctl_handlers.cpp
@@ -1,0 +1,59 @@
+// Copyright(c) 2017-2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+/*
+ * ioctl_handlers.cpp
+ */
+#include "ioctl_handlers.h"
+#include <fcntl.h>
+#include <linux/ioctl.h>
+#include <cstdarg>
+#include "intel-fpga.h"
+#include "test_system.h"
+
+namespace opae {
+namespace testing {
+
+template <typename T>
+static int validate_argp(mock_object* mock, int request, va_list argp) {
+  T* ptr = va_arg(argp, T*);
+  if (ptr->argsz != sizeof(*ptr)) {
+    return -1;
+  }
+
+  return 0;
+}
+
+#define DEFAULT_IOCTL_HANDLER(_REQ, _S)                               \
+  namespace {                                                          \
+  static bool r##_S = test_system::instance()->register_ioctl_handler( \
+      _REQ, validate_argp<_S>);                                        \
+  }
+
+DEFAULT_IOCTL_HANDLER(FPGA_FME_PORT_RELEASE, fpga_fme_port_release);
+DEFAULT_IOCTL_HANDLER(FPGA_FME_PORT_PR, fpga_fme_port_pr);
+
+}  // end of namespace testing
+}  // end of namespace opae

--- a/testing/mock/test_system.cpp
+++ b/testing/mock/test_system.cpp
@@ -194,6 +194,12 @@ void test_system::finalize() {
   fds_.clear();
 }
 
+bool test_system::register_ioctl_handler(int request, ioctl_handler_t h) {
+  bool alhready_registered = ioctl_handlers_.find(request) != ioctl_handlers_.end();
+  ioctl_handlers_[request] = h;
+  return alhready_registered;
+}
+
 uint32_t get_device_id(const std::string &sysclass) {
   uint32_t res(0);
   std::ifstream fs;
@@ -249,12 +255,17 @@ int test_system::open(const std::string &path, int flags, mode_t mode) {
 int test_system::close(int fd) { return close_(fd); }
 
 int test_system::ioctl(int fd, unsigned long request, va_list argp) {
-  auto it = fds_.find(fd);
-  if (it == fds_.end()) {
+  auto mock_it = fds_.find(fd);
+  if (mock_it == fds_.end()) {
     char *arg = va_arg(argp, char *);
     return ioctl_(fd, request, arg);
   }
-  return it->second->ioctl(request, argp);
+
+  auto handler_it = ioctl_handlers_.find(request);
+  if (handler_it != ioctl_handlers_.end()) {
+    return handler_it->second(mock_it->second, request, argp);
+  }
+  return mock_it->second->ioctl(request, argp);
 }
 
 DIR *test_system::opendir(const char *path) {

--- a/testing/mock/test_system.h
+++ b/testing/mock/test_system.h
@@ -106,6 +106,7 @@ struct test_platform {
 
 class test_system {
  public:
+  typedef int (*ioctl_handler_t)(mock_object*, int, va_list);
   static test_system *instance();
 
   void set_root(const char *root);
@@ -126,10 +127,13 @@ class test_system {
   int xstat(int ver, const char *path, stat_t *buf);
   int lstat(int ver, const char *path, stat_t *buf);
 
+  bool register_ioctl_handler(int request, ioctl_handler_t);
+
  private:
   test_system();
   std::string root_;
   std::map<int, mock_object *> fds_;
+  std::map<int, ioctl_handler_t> ioctl_handlers_;
   static test_system *instance_;
 
   typedef int (*open_func)(const char *pathname, int flags);


### PR DESCRIPTION
Add `test_system::register_ioctl_handler` function which registers a
ioctl handler function using the request code.
Add `ioctl_handlers.cpp` which defines a macro to register default
handlers. These deault handlers simply validate the va_arg structure
with the type used in the macro.