### PR TITLE
Fix incorrect recording of ASE installation path

### DIFF
--- a/ase/CMakeLists.txt
+++ b/ase/CMakeLists.txt
@@ -45,14 +45,17 @@ set(OPAE_SHARE_DIR     ${OPAE_SDK_SOURCE})
 set(OPAE_SHARE_DIR     ${OPAE_SDK_SOURCE} PARENT_SCOPE) # do not remove, they are not the same
 include(ase_variables_config)
 
+# This is used in scripts to find the relative installed path to ASE files
+set(ASE_INST_SHARE_DIR share/opae/ase)
+
 ############################################################################
 ## Install some directories ################################################
 ############################################################################
 
 # Install some directories
-install(DIRECTORY rtl          DESTINATION share/opae/ase COMPONENT asertl)
-install(DIRECTORY sw           DESTINATION share/opae/ase COMPONENT asesw)
-install(DIRECTORY scripts      DESTINATION share/opae/ase USE_SOURCE_PERMISSIONS COMPONENT asescripts)
+install(DIRECTORY rtl          DESTINATION ${ASE_INST_SHARE_DIR} COMPONENT asertl)
+install(DIRECTORY sw           DESTINATION ${ASE_INST_SHARE_DIR} COMPONENT asesw)
+install(DIRECTORY scripts      DESTINATION ${ASE_INST_SHARE_DIR} USE_SOURCE_PERMISSIONS COMPONENT asescripts)
 
 ############################################################################
 ## Add sub-project (ASE client, ASE server Verilog code)       #############
@@ -75,7 +78,7 @@ set(EXTRA_ASE_FILES
   ase_regress.sh)
 
 install(FILES ${EXTRA_ASE_FILES}
-  DESTINATION share/opae/ase
+  DESTINATION ${ASE_INST_SHARE_DIR}
   COMPONENT aseextra)
 
 ## Some ASE scripts are installed in bin

--- a/ase/scripts/afu_sim_setup
+++ b/ase/scripts/afu_sim_setup
@@ -46,7 +46,7 @@ import subprocess
 def getASESrcPath():
     # CMake will update any variables marked by @ with the proper values.
     project_src_dir = '@CMAKE_CURRENT_SOURCE_DIR@'
-    ase_share_dir = '@ASE_SHARE_DIR@'
+    ase_share_dir = '@ASE_INST_SHARE_DIR@'
 
     # Parent directory of the running script
     parent_dir = os.path.dirname(


### PR DESCRIPTION
The meaning of ASE_SHARE_DIR changed in commit 575fb262, which broke
afu_sim_setup's ability to find the installed ASE share tree.

This fixes issue #631 