### PR TITLE
tests: static, compiler fixes

### DIFF
--- a/cmake/config/config.h.in
+++ b/cmake/config/config.h.in
@@ -225,3 +225,5 @@
 
 #cmakedefine INTEL_FPGA_API_VERSION "@INTEL_FPGA_API_VERSION@"
 #cmakedefine INTEL_FPGA_API_HASH    "@INTEL_FPGA_API_HASH@"
+
+#define STATIC static

--- a/cmake/modules/compiler_config.cmake
+++ b/cmake/modules/compiler_config.cmake
@@ -51,13 +51,13 @@ endfunction(SET_CACHED_VARIABLE)
 # Should come before enabling language.
 
 
-set(CMAKE_C_FLAGS_DEBUG            "-g -O0 -Wall -Wextra -Werror -Wno-unused-parameter")
+set(CMAKE_C_FLAGS_DEBUG            "-g -O0 -Wall -Wextra -Werror")
 set(CMAKE_CXX_FLAGS_DEBUG          "-g -O0 -Wall -Wextra -Werror")
 
 set(CMAKE_C_FLAGS_RELEASE          "-O2 -Wall -Wextra -Werror")
 set(CMAKE_CXX_FLAGS_RELEASE        "-O2 -Wall -Wextra -Werror")
 
-set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-g -O2 -Wall -Wextra -Werror -Wno-unused-parameter")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-g -O2 -Wall -Wextra -Werror")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O2 -Wall -Wextra -Werror")
 
 set(CMAKE_C_FLAGS_MINSIZEREL       "-Os -Wall -Wextra -Werror")

--- a/libopae/pluginmgr.c
+++ b/libopae/pluginmgr.c
@@ -176,6 +176,7 @@ int opae_plugin_mgr_initialize(const char *cfg_file)
 	opae_api_adapter_table *adapter;
 
 	// TODO: parse config file
+	UNUSED_PARAM(cfg_file);
 	opae_plugin_mgr_parse_config();
 
 

--- a/libopae/plugins/xfpga/CMakeLists.txt
+++ b/libopae/plugins/xfpga/CMakeLists.txt
@@ -60,7 +60,8 @@ set(SRC
   version.c
   usrclk/user_clk_pgm_uclock.c
   plugin.c
-  sysobject.c)
+  sysobject.c
+  manage.c)
 
 # Define target
 add_library(xfpga MODULE ${SRC})

--- a/libopae/plugins/xfpga/bitstream.c
+++ b/libopae/plugins/xfpga/bitstream.c
@@ -24,6 +24,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
 #include <uuid/uuid.h>
 #include <json-c/json.h>
 #include <sys/types.h>
@@ -73,13 +77,13 @@ fpga_result string_to_guid(const char *guid, fpga_guid *result)
 	return FPGA_OK;
 }
 
-static json_bool get_json_object(json_object **object, json_object **parent,
+STATIC json_bool get_json_object(json_object **object, json_object **parent,
 				char *field_name)
 {
 	return json_object_object_get_ex(*parent, field_name, &(*object));
 }
 
-static uint64_t read_int_from_bitstream(const uint8_t *bitstream, uint8_t size)
+STATIC uint64_t read_int_from_bitstream(const uint8_t *bitstream, uint8_t size)
 {
 	uint64_t ret = 0;
 	switch (size) {
@@ -103,7 +107,7 @@ static uint64_t read_int_from_bitstream(const uint8_t *bitstream, uint8_t size)
 	return ret;
 }
 
-static int64_t int64_be_to_le(int64_t val)
+STATIC int64_t int64_be_to_le(int64_t val)
 {
 	val = ((val << 8) & 0xFF00FF00FF00FF00ULL) |
 					((val >> 8) & 0x00FF00FF00FF00FFULL);

--- a/libopae/plugins/xfpga/buffer.c
+++ b/libopae/plugins/xfpga/buffer.c
@@ -73,7 +73,7 @@
 /*
  * Allocate (mmap) new buffer
  */
-fpga_result buffer_allocate(void **addr, uint64_t len, int flags)
+STATIC fpga_result buffer_allocate(void **addr, uint64_t len, int flags)
 {
 	void *addr_local = NULL;
 
@@ -114,7 +114,7 @@ fpga_result buffer_allocate(void **addr, uint64_t len, int flags)
 /*
  * Release (unmap) allocated buffer
  */
-fpga_result buffer_release(void *addr, uint64_t len)
+STATIC fpga_result buffer_release(void *addr, uint64_t len)
 {
 	/* If the buffer allocation was backed by hugepages, then
 	 * len must be rounded up to the nearest hugepage size,

--- a/libopae/plugins/xfpga/close.c
+++ b/libopae/plugins/xfpga/close.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-static void unmap_mmio_region(struct wsid_map *wm)
+STATIC void unmap_mmio_region(struct wsid_map *wm)
 {
 	if (munmap((void *)wm->offset, wm->len)) {
 		FPGA_MSG("munmap failed: %s",

--- a/libopae/plugins/xfpga/enum.c
+++ b/libopae/plugins/xfpga/enum.c
@@ -72,7 +72,7 @@ struct dev_list {
 	struct dev_list *fme;
 };
 
-bool matches_filter(const struct dev_list *attr, const fpga_properties filter)
+STATIC bool matches_filter(const struct dev_list *attr, const fpga_properties filter)
 {
 	struct _fpga_properties *_filter = (struct _fpga_properties *)filter;
 	bool res = true;
@@ -278,7 +278,7 @@ out_unlock:
 	return res;
 }
 
-bool matches_filters(const struct dev_list *attr, const fpga_properties *filter,
+STATIC bool matches_filters(const struct dev_list *attr, const fpga_properties *filter,
 		     uint32_t num_filter)
 {
 	uint32_t i;
@@ -294,7 +294,7 @@ bool matches_filters(const struct dev_list *attr, const fpga_properties *filter,
 	return false;
 }
 
-struct dev_list *add_dev(const char *sysfspath, const char *devpath,
+STATIC struct dev_list *add_dev(const char *sysfspath, const char *devpath,
 			 struct dev_list *parent)
 {
 	struct dev_list *pdev;
@@ -326,7 +326,7 @@ out_free:
 	return NULL;
 }
 
-fpga_result enum_fme(const char *sysfspath, const char *name,
+STATIC fpga_result enum_fme(const char *sysfspath, const char *name,
 		     struct dev_list *parent)
 {
 	fpga_result result;
@@ -402,7 +402,7 @@ fpga_result enum_fme(const char *sysfspath, const char *name,
 	return FPGA_OK;
 }
 
-fpga_result enum_afu(const char *sysfspath, const char *name,
+STATIC fpga_result enum_afu(const char *sysfspath, const char *name,
 		     struct dev_list *parent)
 {
 	fpga_result result;
@@ -465,7 +465,7 @@ fpga_result enum_afu(const char *sysfspath, const char *name,
 	return FPGA_OK;
 }
 
-fpga_result enum_top_dev(const char *sysfspath, struct dev_list *list,
+STATIC fpga_result enum_top_dev(const char *sysfspath, struct dev_list *list,
 			 bool include_port)
 {
 	fpga_result result = FPGA_NOT_FOUND;

--- a/libopae/plugins/xfpga/event.c
+++ b/libopae/plugins/xfpga/event.c
@@ -92,7 +92,7 @@ fpga_result send_event_request(int conn_socket, int fd, struct event_request *re
 
 }
 
-static fpga_result send_fme_event_request(fpga_handle handle,
+STATIC fpga_result send_fme_event_request(fpga_handle handle,
 	fpga_event_handle event_handle, int fme_operation)
 {
 	int fd = FILE_DESCRIPTOR(event_handle);
@@ -131,7 +131,7 @@ static fpga_result send_fme_event_request(fpga_handle handle,
 	return FPGA_OK;
 }
 
-static fpga_result send_port_event_request(fpga_handle handle,
+STATIC fpga_result send_port_event_request(fpga_handle handle,
 	fpga_event_handle event_handle, int port_operation)
 {
 	int fd = FILE_DESCRIPTOR(event_handle);
@@ -170,7 +170,7 @@ static fpga_result send_port_event_request(fpga_handle handle,
 	return FPGA_OK;
 }
 
-static fpga_result send_uafu_event_request(fpga_handle handle,
+STATIC fpga_result send_uafu_event_request(fpga_handle handle,
 	fpga_event_handle event_handle, uint32_t flags, int uafu_operation)
 {
 	int fd = FILE_DESCRIPTOR(event_handle);
@@ -231,7 +231,7 @@ static fpga_result send_uafu_event_request(fpga_handle handle,
  * Uses driver ioctls to determine whether the driver supports interrupts
  * on this platform. objtype is an output parameter.
  */
-static fpga_result check_interrupts_supported(fpga_handle handle, fpga_objtype *objtype)
+STATIC fpga_result check_interrupts_supported(fpga_handle handle, fpga_objtype *objtype)
 {
 	fpga_result res = FPGA_OK;
 	fpga_result destroy_res = FPGA_OK;
@@ -293,7 +293,7 @@ destroy_prop:
 	return res;
 }
 
-static fpga_result driver_register_event(fpga_handle handle,
+STATIC fpga_result driver_register_event(fpga_handle handle,
 	fpga_event_type event_type,
 	fpga_event_handle event_handle,
 	uint32_t flags)
@@ -332,7 +332,7 @@ static fpga_result driver_register_event(fpga_handle handle,
 	}
 }
 
-static fpga_result driver_unregister_event(fpga_handle handle,
+STATIC fpga_result driver_unregister_event(fpga_handle handle,
 	fpga_event_type event_type, fpga_event_handle event_handle)
 {
 	fpga_objtype objtype;
@@ -369,7 +369,7 @@ static fpga_result driver_unregister_event(fpga_handle handle,
 	}
 }
 
-static fpga_result daemon_register_event(fpga_handle handle,
+STATIC fpga_result daemon_register_event(fpga_handle handle,
 					 fpga_event_type event_type,
 					 fpga_event_handle event_handle,
 					 uint32_t flags)
@@ -438,7 +438,7 @@ out_close_conn:
 	return result;
 }
 
-static fpga_result daemon_unregister_event(fpga_handle handle,
+STATIC fpga_result daemon_unregister_event(fpga_handle handle,
 					   fpga_event_type event_type)
 {
 	fpga_result result = FPGA_OK;

--- a/libopae/plugins/xfpga/init.c
+++ b/libopae/plugins/xfpga/init.c
@@ -68,7 +68,7 @@ void __FIXME_MAKE_VISIBLE__ fpga_print(int loglevel, char *fmt, ...)
 
 
 __attribute__((constructor))
-static void fpga_init(void)
+STATIC void fpga_init(void)
 {
 	g_logfile = NULL;
 
@@ -100,7 +100,7 @@ static void fpga_init(void)
 }
 
 __attribute__((destructor))
-static void fpga_release(void)
+STATIC void fpga_release(void)
 {
 	token_cleanup();
 

--- a/libopae/plugins/xfpga/manage.c
+++ b/libopae/plugins/xfpga/manage.c
@@ -37,6 +37,11 @@ fpga_result __FPGA_API__ xfpga_fpgaAssignToInterface(fpga_handle fpga, fpga_toke
 	FPGA_MSG("xfpga_fpgaAssignToInterface not supported");
 	fpga_result result = FPGA_NOT_SUPPORTED;
 
+	UNUSED_PARAM(fpga);
+	UNUSED_PARAM(accelerator);
+	UNUSED_PARAM(host_interface);
+	UNUSED_PARAM(flags);
+
 	return result;
 }
 
@@ -44,6 +49,9 @@ fpga_result __FPGA_API__ xfpga_fpgaReleaseFromInterface(fpga_handle fpga, fpga_t
 {
 	FPGA_MSG("xfpga_fpgaReleaseFromInterface not supported");
 	fpga_result result = FPGA_NOT_SUPPORTED;
+
+	UNUSED_PARAM(fpga);
+	UNUSED_PARAM(accelerator);
 
 	return result;
 }

--- a/libopae/plugins/xfpga/mmio.c
+++ b/libopae/plugins/xfpga/mmio.c
@@ -45,7 +45,7 @@
 #define AFU_SIZE	0x40000
 #define AFU_OFFSET	0
 
-static fpga_result port_get_region_info(fpga_handle handle,
+STATIC fpga_result port_get_region_info(fpga_handle handle,
 				 uint32_t mmio_num,
 				 uint32_t *flags,
 				 uint64_t *size,
@@ -88,7 +88,7 @@ out_unlock:
 	return result;
 }
 
-static fpga_result port_mmap_region(fpga_handle handle,
+STATIC fpga_result port_mmap_region(fpga_handle handle,
 			     void **vaddr,
 			     uint64_t size,
 			     uint32_t flags,
@@ -129,7 +129,7 @@ out_unlock:
 	return result;
 }
 
-static fpga_result map_mmio_region(fpga_handle handle, uint32_t mmio_num)
+STATIC fpga_result map_mmio_region(fpga_handle handle, uint32_t mmio_num)
 {
 	struct _fpga_handle *_handle = (struct _fpga_handle *)handle;
 	void     *addr  = NULL;
@@ -186,7 +186,7 @@ static fpga_result map_mmio_region(fpga_handle handle, uint32_t mmio_num)
 }
 
 /* Lazy mapping of MMIO region (only map if not already mapped) */
-static fpga_result find_or_map_wm(fpga_handle handle, uint32_t mmio_num,
+STATIC fpga_result find_or_map_wm(fpga_handle handle, uint32_t mmio_num,
 				struct wsid_map **wm_out)
 {
 	struct _fpga_handle *_handle = (struct _fpga_handle *)handle;

--- a/libopae/plugins/xfpga/plugin.c
+++ b/libopae/plugins/xfpga/plugin.c
@@ -48,19 +48,21 @@ int __FPGA_API__ xfpga_plugin_finalize(void)
 
 bool __FPGA_API__ xfpga_plugin_supports_device(const char *device_type)
 {
-
+	UNUSED_PARAM(device_type);
 	return true;
 }
 
 bool __FPGA_API__ xfpga_plugin_supports_host(const char *hostname)
 {
-
+	UNUSED_PARAM(hostname);
 	return true;
 }
 
 int __FPGA_API__ opae_plugin_configure(opae_api_adapter_table *adapter,
 				       const char *jsonConfig)
 {
+	UNUSED_PARAM(jsonConfig);
+
 	adapter->fpgaOpen = dlsym(adapter->plugin.dl_handle, "xfpga_fpgaOpen");
 	adapter->fpgaClose = dlsym(adapter->plugin.dl_handle, "xfpga_fpgaClose");
 	adapter->fpgaReset = dlsym(adapter->plugin.dl_handle, "xfpga_fpgaReset");

--- a/libopae/plugins/xfpga/reconf.c
+++ b/libopae/plugins/xfpga/reconf.c
@@ -82,7 +82,7 @@ struct reconf_error {
 };
 
 
-static fpga_result validate_bitstream(fpga_handle handle,
+STATIC fpga_result validate_bitstream(fpga_handle handle,
 			const uint8_t *bitstream, size_t bitstream_len,
 			int *header_len)
 {
@@ -118,7 +118,7 @@ static fpga_result validate_bitstream(fpga_handle handle,
 
 
 // open child accelerator exclusively - it not, it's busy!
-static fpga_result open_accel(fpga_handle handle, fpga_handle *accel)
+STATIC fpga_result open_accel(fpga_handle handle, fpga_handle *accel)
 {
 	fpga_result result                = FPGA_OK;
 	fpga_result destroy_result        = FPGA_OK;
@@ -186,7 +186,7 @@ free_props:
 
 
 // clears port errors
-static fpga_result clear_port_errors(fpga_handle handle)
+STATIC fpga_result clear_port_errors(fpga_handle handle)
 {
 	char syfs_path[SYSFS_PATH_MAX]    = {0};
 	char syfs_errpath[SYSFS_PATH_MAX] = {0};

--- a/libopae/plugins/xfpga/usrclk/user_clk_pgm_uclock.c
+++ b/libopae/plugins/xfpga/usrclk/user_clk_pgm_uclock.c
@@ -27,6 +27,9 @@
 // Arthur.Sheiman@Intel.com   Created: 09-08-16
 // Revision: 10-18-16  18:06
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
 
 #include <errno.h>
 #include <malloc.h>    /* malloc */
@@ -68,7 +71,7 @@
 
 struct  QUCPU_Uclock   gQUCPU_Uclock;
 
-static int using_iopll(char* sysfs_usrpath, const char* sysfs_path);
+STATIC int using_iopll(char* sysfs_usrpath, const char* sysfs_path);
 
 //Get fpga user clock
 fpga_result __FIXME_MAKE_VISIBLE__ get_userclock(const char* sysfs_path,
@@ -886,7 +889,7 @@ int fi_WaitCalDone(void)
 
 // Determine whether or not the IOPLL is serving as the source of
 // the user clock.
-static int using_iopll(char* sysfs_usrpath, const char* sysfs_path)
+STATIC int using_iopll(char* sysfs_usrpath, const char* sysfs_path)
 {
 	glob_t iopll_glob;
 

--- a/testing/mock/ioctl_handlers.cpp
+++ b/testing/mock/ioctl_handlers.cpp
@@ -37,6 +37,8 @@ namespace testing {
 
 template <typename T>
 static int validate_argp(mock_object* mock, int request, va_list argp) {
+  UNUSED_PARAM(mock);
+  UNUSED_PARAM(request);
   T* ptr = va_arg(argp, T*);
   if (ptr->argsz != sizeof(*ptr)) {
     return -1;

--- a/testing/mock/test_system.h
+++ b/testing/mock/test_system.h
@@ -41,15 +41,20 @@ namespace testing {
 constexpr size_t KiB(size_t n) { return n * 1024; }
 constexpr size_t MiB(size_t n) { return n * 1024 * KiB(1); }
 
+#ifndef UNUSED_PARAM
+#define UNUSED_PARAM(x) ((void)x)
+#endif // UNUSED_PARAM
+
 class mock_object {
  public:
   enum type_t { sysfs_attr = 0, fme, afu };
   mock_object(const std::string &devpath, const std::string &sysclass,
               uint32_t device_id, type_t type = sysfs_attr);
+  virtual ~mock_object() {}
 
   virtual int ioctl(int request, va_list arg) {
-    (void)request;
-    (void)arg;
+    UNUSED_PARAM(request);
+    UNUSED_PARAM(arg);
     throw std::logic_error("not implemented");
     return 0;
   }

--- a/testing/xfpga/test_mmio_c.cpp
+++ b/testing/xfpga/test_mmio_c.cpp
@@ -47,6 +47,8 @@ using namespace opae::testing;
 int mmio_ioctl(mock_object * m, int request, va_list argp){
     int retval = -1;
     errno = EINVAL;
+    UNUSED_PARAM(m);
+    UNUSED_PARAM(request);
     struct fpga_port_region_info *rinfo = va_arg(argp, struct fpga_port_region_info *);
     if (!rinfo) {
       FPGA_MSG("rinfo is NULL");

--- a/testing/xfpga/test_properties_c.cpp
+++ b/testing/xfpga/test_properties_c.cpp
@@ -1819,7 +1819,8 @@ TEST(properties, get_capabilities01) {
  *          expected result is FPGA_INVALID_PARAM.<br>
  */
 TEST(properties, fpga_get_properties01) {
-  fpga_token token;
+  char buf[sizeof(_fpga_token)];
+  fpga_token token = buf;
   ((_fpga_token*)token)->magic = 0xbeef;
   fpga_properties prop;
   EXPECT_EQ(xfpga_fpgaGetProperties(token, &prop), FPGA_INVALID_PARAM);
@@ -3127,6 +3128,7 @@ TEST(properties, get_num_errors01)
 {
   fpga_properties prop;
   fpga_result result = xfpga_fpgaGetProperties(NULL, &prop);
+  EXPECT_EQ(result, FPGA_OK);
   auto _prop = (_fpga_properties*)prop;
   SET_FIELD_VALID(_prop, FPGA_PROPERTY_NUM_ERRORS);
   _prop->num_errors = 9;

--- a/testing/xfpga/test_umsg_c.cpp
+++ b/testing/xfpga/test_umsg_c.cpp
@@ -42,7 +42,8 @@ int umsg_port_info(mock_object * m, int request, va_list argp){
     int retval = -1;
     errno = EINVAL;
     static bool gEnableIRQ = false;
-
+    UNUSED_PARAM(m);
+    UNUSED_PARAM(request);
     struct fpga_port_info *pinfo = va_arg(argp, struct fpga_port_info *);
     if (!pinfo) {
         FPGA_MSG("pinfo is NULL");
@@ -77,7 +78,8 @@ out_EINVAL:
 int umsg_set_mode(mock_object * m, int request, va_list argp){
     int retval = -1;
     errno = EINVAL;
-
+    UNUSED_PARAM(m);
+    UNUSED_PARAM(request);
     struct fpga_port_umsg_cfg *ucfg = va_arg(argp, struct fpga_port_umsg_cfg *);
     if (!ucfg) {
     	FPGA_MSG("ucfg is NULL");
@@ -281,7 +283,7 @@ TEST_P(umsg_c_p, test_umsg_drv_04) {
  */
 TEST_P(umsg_c_p, test_umsg_drv_05) {
   uint64_t Umsghit_Disble = 0;
-  int fddev = -1;
+//  int fddev = -1;
 
   system_->register_ioctl_handler(FPGA_PORT_UMSG_SET_MODE,umsg_set_mode);
   // NULL Driver hnadle
@@ -346,7 +348,7 @@ TEST_P(umsg_c_p, test_umsg_drv_06) {
  */
 TEST_P(umsg_c_p, test_umsg_drv_07) {
   uint64_t* umsg_ptr = NULL;
-  int fddev = -1;
+//  int fddev = -1;
 
   // NULL Driver hnadle
   EXPECT_NE(FPGA_OK, xfpga_fpgaGetUmsgPtr(NULL, &umsg_ptr));

--- a/tools/base/fpgad/log.h
+++ b/tools/base/fpgad/log.h
@@ -27,14 +27,15 @@
 #ifndef __FPGAD_LOG_H__
 #define __FPGAD_LOG_H__
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif // _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <pthread.h>
 #include <string.h>
 #include <errno.h>
-#undef _GNU_SOURCE
 
 extern FILE *fLog;
 int open_log(const char *);


### PR DESCRIPTION
Switch static function specifier to STATIC, and define STATIC
in config.h to allow turning it off for the test cases.
Re-enable unused parameter warnings, and fix them.
Fix warnings resulting from g++ > 4.8.4