### PR TITLE
Add token_list tests, malloc override

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -102,10 +102,14 @@ include_directories(
     {CMAKE_CURRENT_SOURCE_DIR}/mock
     )
 
-
 add_mock_test(test_opae_enum_c opae-c-static
     opae-c/test_enum_c.cpp
 )
+
+add_mock_test(test_xfpga_token_list_c xfpga-static
+    xfpga/test_token_list_c.cpp
+)
+
 
 add_mock_test(test_xfpga_properties_c xfpga-static
     xfpga/test_properties_c.cpp

--- a/testing/mock/test_system.cpp
+++ b/testing/mock/test_system.cpp
@@ -35,6 +35,18 @@
 #include "c_test_system.h"
 #include "test_utils.h"
 
+// hijack malloc
+static bool _invalidate_malloc = false;
+void *malloc(size_t size)
+{
+  if (_invalidate_malloc) {
+    _invalidate_malloc = false;
+    return nullptr;
+  }
+  return __libc_malloc(size);
+}
+
+
 namespace opae {
 namespace testing {
 
@@ -298,6 +310,10 @@ int test_system::lstat(int ver, const char *path, struct stat *buf) {
   return lstat_(ver, syspath.c_str(), buf);
 }
 
+void test_system::invalidate_malloc() {
+  _invalidate_malloc = true;
+}
+
 }  // end of namespace testing
 }  // end of namespace opae
 
@@ -334,3 +350,4 @@ int opae_test_xstat(int ver, const char *path, struct stat *buf) {
 int opae_test_lstat(int ver, const char *path, struct stat *buf) {
   return opae::testing::test_system::instance()->lstat(ver, path, buf);
 }
+

--- a/testing/mock/test_system.h
+++ b/testing/mock/test_system.h
@@ -27,12 +27,15 @@
 #define _TEST_SYSTEM_H
 
 #include <dirent.h>
+#include <opae/fpga.h>
+#include <stddef.h>
 #include <map>
 #include <string>
 #include <vector>
-#include <stddef.h>
-#include <opae/fpga.h>
 
+extern "C" {
+extern void *__libc_malloc(size_t size);
+}
 typedef struct stat stat_t;
 
 namespace opae {
@@ -111,16 +114,15 @@ struct test_platform {
   static std::vector<std::string> keys(bool sorted = false);
 };
 
-template<int _R, long _E>
-static int dummy_ioctl(mock_object *, int, va_list)
-{
+template <int _R, long _E>
+static int dummy_ioctl(mock_object *, int, va_list) {
   errno = _E;
   return _R;
 }
 
 class test_system {
  public:
-  typedef int (*ioctl_handler_t)(mock_object*, int, va_list);
+  typedef int (*ioctl_handler_t)(mock_object *, int, va_list);
   static test_system *instance();
 
   void set_root(const char *root);
@@ -140,6 +142,7 @@ class test_system {
   ssize_t readlink(const char *path, char *buf, size_t bufsize);
   int xstat(int ver, const char *path, stat_t *buf);
   int lstat(int ver, const char *path, stat_t *buf);
+  void invalidate_malloc();
 
   bool register_ioctl_handler(int request, ioctl_handler_t);
 

--- a/testing/xfpga/test_token_list_c.cpp
+++ b/testing/xfpga/test_token_list_c.cpp
@@ -1,0 +1,100 @@
+
+// Copyright(c) 2017-2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifdef __cplusplus
+
+extern "C" {
+#endif
+#include "token_list_int.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "test_system.h"
+#include "gtest/gtest.h"
+
+using namespace opae::testing;
+
+TEST(token_list_c, simple_case)
+{
+  const char *sysfs_fme = "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0";
+  const char *dev_fme = "/dev/intel-fpga-fme.0";
+  const char *sysfs_port = "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-port.0";
+  const char *dev_port = "/dev/intel-fpga-port.0";
+  auto fme = token_add(sysfs_fme, dev_fme);
+  ASSERT_NE(fme, nullptr);
+  auto port = token_add(sysfs_port, dev_port);
+  ASSERT_NE(port, nullptr);
+  auto parent = token_get_parent(port);
+  EXPECT_EQ(parent, fme);
+
+  parent = token_get_parent(fme);
+  EXPECT_EQ(nullptr, parent);
+
+  token_cleanup();
+
+  parent = token_get_parent(port);
+  EXPECT_EQ(nullptr, parent);
+}
+
+
+TEST(token_list_c, invalid_paths)
+{
+  // paths missing dot
+  std::string sysfs_fme = "/sys/class/fpga/intel-fpga-dev/intel-fpga-fme";
+  std::string dev_fme = "/dev/intel-fpga-fme";
+  std::string sysfs_port = "/sys/class/fpga/intel-fpga-dev/intel-fpga-port";
+  std::string dev_port = "/dev/intel-fpga-port";
+  auto fme = token_add(sysfs_fme.c_str(), dev_fme.c_str());
+  EXPECT_EQ(fme, nullptr);
+
+  // paths with dot, but non-decimal character afterwards
+  sysfs_fme += ".z";
+  sysfs_port += ".z";
+  fme = token_add(sysfs_fme.c_str(), dev_fme.c_str());
+  EXPECT_EQ(fme, nullptr);
+
+  // get a parent of a bogus token
+  auto port = new _fpga_token;
+  std::copy(sysfs_port.begin(), sysfs_port.end(), &port->sysfspath[0]);
+  auto parent = token_get_parent(port);
+  EXPECT_EQ(parent, nullptr);
+
+  // invalidate malloc
+
+  sysfs_fme = "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0";
+  dev_fme = "/dev/intel-fpga-fme.0";
+
+  test_system::instance()->invalidate_malloc();
+  fme = token_add(sysfs_fme.c_str(), dev_fme.c_str());
+  ASSERT_EQ(fme, nullptr);
+
+
+
+  token_cleanup();
+}


### PR DESCRIPTION
Add token_list unit tests in xfpga testing.

Implement malloc in test_system.cpp  to check for a flag for returning
null. If the flag is set to true, it will reset it to false and return
null. The expected use case is calling test_system::invalidate_malloc()
to set the flag to true before calling a function that calls malloc.
This allows for negative testing of code that handles malloc failures.