### PR TITLE
plugin-api: fix enumeration test cases

### DIFF
--- a/testing/opae-c/test_enum_c.cpp
+++ b/testing/opae-c/test_enum_c.cpp
@@ -529,7 +529,7 @@ TEST_P(enum_c_p, num_interrupts) {
       FPGA_OK);
   EXPECT_EQ(num_matches, 1);
 
-  ASSERT_EQ(fpgaPropertiesSetNumInterrupts(filter, invalid_device_.num_interrupts), FPGA_INVALID_PARAM);
+  ASSERT_EQ(fpgaPropertiesSetNumInterrupts(filter, invalid_device_.num_interrupts), FPGA_OK);
   EXPECT_EQ(
       fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
       FPGA_OK);

--- a/testing/xfpga/test_enum_c.cpp
+++ b/testing/xfpga/test_enum_c.cpp
@@ -522,7 +522,7 @@ TEST_P(enum_c_p, num_interrupts) {
       FPGA_OK);
   EXPECT_EQ(num_matches, 1);
 
-  ASSERT_EQ(fpgaPropertiesSetNumInterrupts(filter, invalid_device_.num_interrupts), FPGA_INVALID_PARAM);
+  ASSERT_EQ(fpgaPropertiesSetNumInterrupts(filter, invalid_device_.num_interrupts), FPGA_OK);
   EXPECT_EQ(
       xfpga_fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
       FPGA_OK);


### PR DESCRIPTION
We expect fpgaPropertiesSetNumInterrupts() to return FPGA_OK, irrespective of
whether the input num_interrupts parameter makes sense.