### PR TITLE
fixup generic object api

### DIFF
--- a/libopae/plugins/xfpga/sysfs.c
+++ b/libopae/plugins/xfpga/sysfs.c
@@ -922,8 +922,6 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 	struct _fpga_object *obj = NULL;
 	struct stat objstat;
 	int statres;
-	int fd = -1;
-	ssize_t bytes_read = 0;
 	fpga_result res = FPGA_OK;
 	if (flags & FPGA_OBJECT_GLOB) {
 		res = opae_glob_path(sysfspath);

--- a/libopae/plugins/xfpga/sysfs.c
+++ b/libopae/plugins/xfpga/sysfs.c
@@ -82,7 +82,7 @@ fpga_result sysfs_read_int(const char *path, int *i)
 	b = 0;
 
 	do {
-		res = read(fd, buf+b, sizeof(buf)-b);
+		res = read(fd, buf + b, sizeof(buf) - b);
 		if (res <= 0) {
 			FPGA_MSG("Read from %s failed", path);
 			goto out_close;
@@ -92,10 +92,11 @@ fpga_result sysfs_read_int(const char *path, int *i)
 			FPGA_MSG("Unexpected size reading from %s", path);
 			goto out_close;
 		}
-	} while (buf[b-1] != '\n' && buf[b-1] != '\0' && (unsigned)b < sizeof(buf));
+	} while (buf[b - 1] != '\n' && buf[b - 1] != '\0'
+		 && (unsigned)b < sizeof(buf));
 
 	// erase \n
-	buf[b-1] = 0;
+	buf[b - 1] = 0;
 
 	*i = atoi(buf);
 
@@ -133,7 +134,7 @@ fpga_result sysfs_read_u32(const char *path, uint32_t *u)
 	b = 0;
 
 	do {
-		res = read(fd, buf+b, sizeof(buf)-b);
+		res = read(fd, buf + b, sizeof(buf) - b);
 		if (res <= 0) {
 			FPGA_MSG("Read from %s failed", path);
 			goto out_close;
@@ -143,10 +144,11 @@ fpga_result sysfs_read_u32(const char *path, uint32_t *u)
 			FPGA_MSG("Unexpected size reading from %s", path);
 			goto out_close;
 		}
-	} while (buf[b-1] != '\n' && buf[b-1] != '\0' && (unsigned)b < sizeof(buf));
+	} while (buf[b - 1] != '\n' && buf[b - 1] != '\0'
+		 && (unsigned)b < sizeof(buf));
 
 	// erase \n
-	buf[b-1] = 0;
+	buf[b - 1] = 0;
 
 	*u = strtoul(buf, NULL, 0);
 
@@ -160,7 +162,7 @@ out_close:
 
 // read tuple separated by 'sep' character
 fpga_result sysfs_read_u32_pair(const char *path, uint32_t *u1, uint32_t *u2,
-				 char sep)
+				char sep)
 {
 	int fd;
 	int res;
@@ -193,7 +195,7 @@ fpga_result sysfs_read_u32_pair(const char *path, uint32_t *u1, uint32_t *u2,
 	b = 0;
 
 	do {
-		res = read(fd, buf+b, sizeof(buf)-b);
+		res = read(fd, buf + b, sizeof(buf) - b);
 		if (res <= 0) {
 			FPGA_MSG("Read from %s failed", path);
 			goto out_close;
@@ -203,19 +205,21 @@ fpga_result sysfs_read_u32_pair(const char *path, uint32_t *u1, uint32_t *u2,
 			FPGA_MSG("Unexpected size reading from %s", path);
 			goto out_close;
 		}
-	} while (buf[b-1] != '\n' && buf[b-1] != '\0' && (unsigned)b < sizeof(buf));
+	} while (buf[b - 1] != '\n' && buf[b - 1] != '\0'
+		 && (unsigned)b < sizeof(buf));
 
 	// erase \n
-	buf[b-1] = 0;
+	buf[b - 1] = 0;
 
 	// read first value
 	x1 = strtoul(buf, &c, 0);
 	if (*c != sep) {
-		FPGA_MSG("couldn't find separation character '%c' in '%s'", sep, path);
+		FPGA_MSG("couldn't find separation character '%c' in '%s'", sep,
+			 path);
 		goto out_close;
 	}
 	// read second value
-	x2 = strtoul(c+1, &c, 0);
+	x2 = strtoul(c + 1, &c, 0);
 	if (*c != '\0') {
 		FPGA_MSG("unexpected character '%c' in '%s'", *c, path);
 		goto out_close;
@@ -234,10 +238,10 @@ out_close:
 
 fpga_result __FIXME_MAKE_VISIBLE__ sysfs_read_u64(const char *path, uint64_t *u)
 {
-	int fd                     = -1;
-	int res                    = 0;
-	char buf[SYSFS_PATH_MAX]   = {0};
-	int b                      = 0;
+	int fd = -1;
+	int res = 0;
+	char buf[SYSFS_PATH_MAX] = {0};
+	int b = 0;
 
 	if (path == NULL) {
 		FPGA_ERR("Invalid input path");
@@ -256,7 +260,7 @@ fpga_result __FIXME_MAKE_VISIBLE__ sysfs_read_u64(const char *path, uint64_t *u)
 	}
 
 	do {
-		res = read(fd, buf+b, sizeof(buf)-b);
+		res = read(fd, buf + b, sizeof(buf) - b);
 		if (res <= 0) {
 			FPGA_MSG("Read from %s failed", path);
 			goto out_close;
@@ -266,10 +270,11 @@ fpga_result __FIXME_MAKE_VISIBLE__ sysfs_read_u64(const char *path, uint64_t *u)
 			FPGA_MSG("Unexpected size reading from %s", path);
 			goto out_close;
 		}
-	} while (buf[b-1] != '\n' && buf[b-1] != '\0' && (unsigned)b < sizeof(buf));
+	} while (buf[b - 1] != '\n' && buf[b - 1] != '\0'
+		 && (unsigned)b < sizeof(buf));
 
 	// erase \n
-	buf[b-1] = 0;
+	buf[b - 1] = 0;
 
 	*u = strtoull(buf, NULL, 0);
 
@@ -283,10 +288,10 @@ out_close:
 
 fpga_result __FIXME_MAKE_VISIBLE__ sysfs_write_u64(const char *path, uint64_t u)
 {
-	int fd                     = -1;
-	int res                    = 0;
-	char buf[SYSFS_PATH_MAX]   = {0};
-	int b                      = 0;
+	int fd = -1;
+	int res = 0;
+	char buf[SYSFS_PATH_MAX] = {0};
+	int b = 0;
 
 	if (path == NULL) {
 		FPGA_ERR("Invalid input path");
@@ -307,7 +312,7 @@ fpga_result __FIXME_MAKE_VISIBLE__ sysfs_write_u64(const char *path, uint64_t u)
 	snprintf_s_l(buf, sizeof(buf), "0x%lx", u);
 
 	do {
-		res = write(fd, buf + b, sizeof(buf) -b);
+		res = write(fd, buf + b, sizeof(buf) - b);
 		if (res <= 0) {
 			FPGA_ERR("Failed to write");
 			goto out_close;
@@ -319,7 +324,8 @@ fpga_result __FIXME_MAKE_VISIBLE__ sysfs_write_u64(const char *path, uint64_t u)
 			goto out_close;
 		}
 
-	} while (buf[b - 1] != '\n' && buf[b - 1] != '\0' && (unsigned)b < sizeof(buf));
+	} while (buf[b - 1] != '\n' && buf[b - 1] != '\0'
+		 && (unsigned)b < sizeof(buf));
 
 	close(fd);
 	return FPGA_OK;
@@ -359,7 +365,7 @@ fpga_result sysfs_read_guid(const char *path, fpga_guid guid)
 	b = 0;
 
 	do {
-		res = read(fd, buf+b, sizeof(buf)-b);
+		res = read(fd, buf + b, sizeof(buf) - b);
 		if (res <= 0) {
 			FPGA_MSG("Read from %s failed", path);
 			goto out_close;
@@ -369,20 +375,21 @@ fpga_result sysfs_read_guid(const char *path, fpga_guid guid)
 			FPGA_MSG("Unexpected size reading from %s", path);
 			goto out_close;
 		}
-	} while (buf[b-1] != '\n' && buf[b-1] != '\0' && (unsigned)b < sizeof(buf));
+	} while (buf[b - 1] != '\n' && buf[b - 1] != '\0'
+		 && (unsigned)b < sizeof(buf));
 
 	// erase \n
-	buf[b-1] = 0;
+	buf[b - 1] = 0;
 
-	for (i = 0 ; i < 32 ; i += 2) {
-		tmp = buf[i+2];
-		buf[i+2] = 0;
+	for (i = 0; i < 32; i += 2) {
+		tmp = buf[i + 2];
+		buf[i + 2] = 0;
 
 		octet = 0;
 		sscanf_s_u(&buf[i], "%x", &octet);
-		guid[i/2] = (uint8_t) octet;
+		guid[i / 2] = (uint8_t)octet;
 
-		buf[i+2] = tmp;
+		buf[i + 2] = tmp;
 	}
 
 	close(fd);
@@ -405,17 +412,16 @@ fpga_result sysfs_get_socket_id(int dev, uint8_t *socket_id)
 	int i;
 
 	snprintf_s_ii(spath, SYSFS_PATH_MAX,
-		 SYSFS_FPGA_CLASS_PATH
-		 SYSFS_FME_PATH_FMT "/"
-		 FPGA_SYSFS_SOCKET_ID,
-		 dev, dev);
+		      SYSFS_FPGA_CLASS_PATH SYSFS_FME_PATH_FMT
+		      "/" FPGA_SYSFS_SOCKET_ID,
+		      dev, dev);
 
 	i = 0;
 	result = sysfs_read_int(spath, &i);
 	if (FPGA_OK != result)
 		return result;
 
-	*socket_id = (uint8_t) i;
+	*socket_id = (uint8_t)i;
 
 	return FPGA_OK;
 }
@@ -426,10 +432,9 @@ fpga_result sysfs_get_afu_id(int dev, fpga_guid guid)
 	char spath[SYSFS_PATH_MAX];
 
 	snprintf_s_ii(spath, SYSFS_PATH_MAX,
-		 SYSFS_FPGA_CLASS_PATH
-		 SYSFS_AFU_PATH_FMT "/"
-		 FPGA_SYSFS_AFU_GUID,
-		 dev, dev);
+		      SYSFS_FPGA_CLASS_PATH SYSFS_AFU_PATH_FMT
+		      "/" FPGA_SYSFS_AFU_GUID,
+		      dev, dev);
 
 	return sysfs_read_guid(spath, guid);
 }
@@ -439,10 +444,9 @@ fpga_result sysfs_get_pr_id(int dev, fpga_guid guid)
 	char spath[SYSFS_PATH_MAX];
 
 	snprintf_s_ii(spath, SYSFS_PATH_MAX,
-		 SYSFS_FPGA_CLASS_PATH
-		 SYSFS_FME_PATH_FMT "/"
-		 FPGA_SYSFS_FME_INTERFACE_ID,
-		 dev, dev);
+		      SYSFS_FPGA_CLASS_PATH SYSFS_FME_PATH_FMT
+		      "/" FPGA_SYSFS_FME_INTERFACE_ID,
+		      dev, dev);
 
 	return sysfs_read_guid(spath, guid);
 }
@@ -453,10 +457,9 @@ fpga_result sysfs_get_slots(int dev, uint32_t *slots)
 	char spath[SYSFS_PATH_MAX];
 
 	snprintf_s_ii(spath, SYSFS_PATH_MAX,
-		 SYSFS_FPGA_CLASS_PATH
-		 SYSFS_FME_PATH_FMT "/"
-		 FPGA_SYSFS_NUM_SLOTS,
-		 dev, dev);
+		      SYSFS_FPGA_CLASS_PATH SYSFS_FME_PATH_FMT
+		      "/" FPGA_SYSFS_NUM_SLOTS,
+		      dev, dev);
 
 	return sysfs_read_u32(spath, slots);
 }
@@ -467,22 +470,20 @@ fpga_result sysfs_get_bitstream_id(int dev, uint64_t *id)
 	char spath[SYSFS_PATH_MAX];
 
 	snprintf_s_ii(spath, SYSFS_PATH_MAX,
-		 SYSFS_FPGA_CLASS_PATH
-		 SYSFS_FME_PATH_FMT "/"
-		 FPGA_SYSFS_BITSTREAM_ID,
-		 dev, dev);
+		      SYSFS_FPGA_CLASS_PATH SYSFS_FME_PATH_FMT
+		      "/" FPGA_SYSFS_BITSTREAM_ID,
+		      dev, dev);
 
 	return sysfs_read_u64(spath, id);
 }
 
 // Get port syfs path
-fpga_result get_port_sysfs(fpga_handle handle,
-				char *sysfs_port)
+fpga_result get_port_sysfs(fpga_handle handle, char *sysfs_port)
 {
 
-	struct _fpga_token  *_token;
-	struct _fpga_handle *_handle  = (struct _fpga_handle *)handle;
-	char *p                       = 0;
+	struct _fpga_token *_token;
+	struct _fpga_handle *_handle = (struct _fpga_handle *)handle;
+	char *p = 0;
 
 	if (sysfs_port == NULL) {
 		FPGA_ERR("Invalid output pointer");
@@ -512,22 +513,21 @@ fpga_result get_port_sysfs(fpga_handle handle,
 	}
 
 	snprintf_s_ii(sysfs_port, SYSFS_PATH_MAX,
-		SYSFS_FPGA_CLASS_PATH SYSFS_AFU_PATH_FMT,
-		_token->instance, _token->instance);
+		      SYSFS_FPGA_CLASS_PATH SYSFS_AFU_PATH_FMT,
+		      _token->instance, _token->instance);
 
 	return FPGA_OK;
 }
 
 // get fpga device id
-fpga_result get_fpga_deviceid(fpga_handle handle,
-				uint64_t *deviceid)
+fpga_result get_fpga_deviceid(fpga_handle handle, uint64_t *deviceid)
 {
-	struct _fpga_token  *_token      = NULL;
-	struct _fpga_handle  *_handle    = (struct _fpga_handle *)handle;
-	char sysfs_path[SYSFS_PATH_MAX]  = {0};
-	char *p                          = NULL;
-	fpga_result result               = FPGA_OK;
-	int err                          = 0;
+	struct _fpga_token *_token = NULL;
+	struct _fpga_handle *_handle = (struct _fpga_handle *)handle;
+	char sysfs_path[SYSFS_PATH_MAX] = {0};
+	char *p = NULL;
+	fpga_result result = FPGA_OK;
+	int err = 0;
 
 	if (_handle == NULL) {
 		FPGA_ERR("Invalid handle");
@@ -558,11 +558,9 @@ fpga_result get_fpga_deviceid(fpga_handle handle,
 		goto out_unlock;
 	}
 
-	snprintf_s_is(sysfs_path,
-		 SYSFS_PATH_MAX,
-		 SYSFS_FPGA_CLASS_PATH SYSFS_FPGA_FMT "/%s",
-		 _token->instance,
-		 FPGA_SYSFS_DEVICEID);
+	snprintf_s_is(sysfs_path, SYSFS_PATH_MAX,
+		      SYSFS_FPGA_CLASS_PATH SYSFS_FPGA_FMT "/%s",
+		      _token->instance, FPGA_SYSFS_DEVICEID);
 
 	result = sysfs_read_u64(sysfs_path, deviceid);
 	if (result != 0) {
@@ -578,13 +576,12 @@ out_unlock:
 }
 
 // get fpga device id using the sysfs path
-fpga_result sysfs_deviceid_from_path(const char *sysfspath,
-				uint64_t *deviceid)
+fpga_result sysfs_deviceid_from_path(const char *sysfspath, uint64_t *deviceid)
 {
-	char sysfs_path[SYSFS_PATH_MAX]  = {0};
-	char *p                          = NULL;
-	int device_instance              = 0;
-	fpga_result result               = FPGA_OK;
+	char sysfs_path[SYSFS_PATH_MAX] = {0};
+	char *p = NULL;
+	int device_instance = 0;
+	fpga_result result = FPGA_OK;
 
 	if (deviceid == NULL) {
 		FPGA_ERR("Invalid input Parameters");
@@ -605,11 +602,9 @@ fpga_result sysfs_deviceid_from_path(const char *sysfspath,
 
 	device_instance = atoi(p + 1);
 
-	snprintf_s_is(sysfs_path,
-		 SYSFS_PATH_MAX,
-		 SYSFS_FPGA_CLASS_PATH SYSFS_FPGA_FMT "/%s",
-		 device_instance,
-		 FPGA_SYSFS_DEVICEID);
+	snprintf_s_is(sysfs_path, SYSFS_PATH_MAX,
+		      SYSFS_FPGA_CLASS_PATH SYSFS_FPGA_FMT "/%s",
+		      device_instance, FPGA_SYSFS_DEVICEID);
 
 	result = sysfs_read_u64(sysfs_path, deviceid);
 	if (result != 0)
@@ -622,7 +617,8 @@ fpga_result sysfs_deviceid_from_path(const char *sysfspath,
  * The rlpath path is assumed to be of the form:
  * ../../devices/pci0000:5e/0000:5e:00.0/fpga/intel-fpga-dev.0
  */
-fpga_result sysfs_sbdf_from_path(const char *sysfspath, int *s, int *b, int *d, int *f)
+fpga_result sysfs_sbdf_from_path(const char *sysfspath, int *s, int *b, int *d,
+				 int *f)
 {
 	int res;
 	char rlpath[SYSFS_PATH_MAX];
@@ -658,16 +654,16 @@ fpga_result sysfs_sbdf_from_path(const char *sysfspath, int *s, int *b, int *d, 
 	//           11
 	// 012345678901
 	// ssss:bb:dd.f
-	*f = (int) strtoul(p+11, NULL, 16);
+	*f = (int)strtoul(p + 11, NULL, 16);
 	*(p + 10) = 0;
 
-	*d = (int) strtoul(p+8, NULL, 16);
+	*d = (int)strtoul(p + 8, NULL, 16);
 	*(p + 7) = 0;
 
-	*b = (int) strtoul(p+5, NULL, 16);
+	*b = (int)strtoul(p + 5, NULL, 16);
 	*(p + 4) = 0;
 
-	*s = (int) strtoul(p, NULL, 16);
+	*s = (int)strtoul(p, NULL, 16);
 
 	return FPGA_OK;
 }
@@ -787,7 +783,7 @@ struct _fpga_object *alloc_fpga_object(const char *sysfspath, const char *name)
 		obj->handle = NULL;
 		obj->path = strdup(sysfspath);
 		obj->name = strdup(name);
-		obj->fd = -1;
+		obj->perm = 0;
 		obj->size = 0;
 		obj->max_size = 0;
 		obj->buffer = NULL;
@@ -803,11 +799,9 @@ fpga_result opae_glob_path(char *path)
 	int globres = glob(path, 0, NULL, &pglob);
 	if (!globres) {
 		if (pglob.gl_pathc > 1) {
-			FPGA_MSG(
-				"Ambiguous object key - using first one");
+			FPGA_MSG("Ambiguous object key - using first one");
 		}
-		if (strcpy_s(path, FILENAME_MAX,
-			      pglob.gl_pathv[0])) {
+		if (strcpy_s(path, FILENAME_MAX, pglob.gl_pathv[0])) {
 			FPGA_ERR("Could not copy globbed path");
 			res = FPGA_EXCEPTION;
 		}
@@ -825,6 +819,30 @@ fpga_result opae_glob_path(char *path)
 		}
 	}
 	return res;
+}
+
+fpga_result sync_object(fpga_object obj)
+{
+	struct _fpga_object *_obj;
+	int fd = -1;
+	ssize_t bytes_read = 0;
+	ASSERT_NOT_NULL(obj);
+	_obj = (struct _fpga_object *)obj;
+	fd = open(_obj->path, _obj->perm);
+	if (fd < 0) {
+		FPGA_ERR("Error opening %s: %s", _obj->path, strerror(errno));
+		return FPGA_EXCEPTION;
+	}
+	bytes_read = eintr_read(fd, _obj->buffer, _obj->max_size);
+	if (bytes_read < 0) {
+		FPGA_ERR("Error reading from %s: %s", _obj->path,
+			 strerror(errno));
+		close(fd);
+		return FPGA_EXCEPTION;
+	}
+	_obj->size = bytes_read;
+	close(fd);
+	return FPGA_OK;
 }
 
 fpga_result make_sysfs_group(char *sysfspath, const char *name,
@@ -904,6 +922,8 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 	struct _fpga_object *obj = NULL;
 	struct stat objstat;
 	int statres;
+	int fd = -1;
+	ssize_t bytes_read = 0;
 	fpga_result res = FPGA_OK;
 	if (flags & FPGA_OBJECT_GLOB) {
 		res = opae_glob_path(sysfspath);
@@ -931,14 +951,21 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 	}
 	obj->handle = handle;
 	obj->type = FPGA_SYSFS_FILE;
-	obj->fd = open(sysfspath, handle == NULL ? O_RDONLY : O_RDWR);
-	if (obj->fd < 0) {
-		FPGA_ERR("Error opening %s", sysfspath);
-		return FPGA_EXCEPTION;
-	}
 	obj->buffer = calloc(pg_size, sizeof(uint8_t));
 	obj->max_size = pg_size;
-	obj->size = eintr_read(obj->fd, obj->buffer, pg_size);
+	if (handle && (objstat.st_mode & (S_IWUSR | S_IWGRP | S_IWOTH))) {
+		if ((objstat.st_mode & (S_IRUSR | S_IRGRP | S_IROTH))) {
+			obj->perm = O_RDWR;
+		} else {
+			obj->perm = O_WRONLY;
+		}
+	} else {
+		obj->perm = O_RDONLY;
+	}
 	*object = (fpga_object)obj;
+	if (obj->perm == O_RDONLY || obj->perm == O_RDWR) {
+		return sync_object((fpga_object)obj);
+	}
+
 	return FPGA_OK;
 }

--- a/libopae/plugins/xfpga/sysfs_int.h
+++ b/libopae/plugins/xfpga/sysfs_int.h
@@ -96,6 +96,7 @@ fpga_result cat_sysfs_path(char *dest, const char *path);
 fpga_result cat_handle_sysfs_path(char *dest, fpga_handle handle,
 				  const char *path);
 struct _fpga_object *alloc_fpga_object(const char *sysfspath, const char *name);
+fpga_result sync_object(fpga_object object);
 fpga_result make_sysfs_group(char *sysfspath, const char *name,
 			     fpga_object *object, int flags, fpga_handle handle);
 fpga_result make_sysfs_object(char *sysfspath, const char *name,

--- a/libopae/plugins/xfpga/sysobject.c
+++ b/libopae/plugins/xfpga/sysobject.c
@@ -200,7 +200,7 @@ fpga_result xfpga_fpgaObjectWrite64(fpga_object obj, uint64_t value, int flags)
 		*(uint64_t *)_obj->buffer = value;
 	}
 	fd = open(_obj->path, _obj->perm);
-	if (fd < 0 ) {
+	if (fd < 0) {
 		FPGA_ERR("Error opening %s: %s", _obj->path, strerror(errno));
 		return FPGA_EXCEPTION;
 	}
@@ -216,7 +216,6 @@ fpga_result xfpga_fpgaObjectWrite64(fpga_object obj, uint64_t value, int flags)
 		FPGA_ERR("pthread_mutex_unlock() failed: %s", strerror(errno));
 		res = FPGA_EXCEPTION;
 	}
-out_close:
 	close(fd);
 	return res;
 }

--- a/libopae/plugins/xfpga/sysobject.c
+++ b/libopae/plugins/xfpga/sysobject.c
@@ -128,10 +128,6 @@ fpga_result xfpga_fpgaDestroyObject(fpga_object *obj)
 		}
 	}
 	FREE_IF(_obj->objects);
-	if (_obj->fd > 0) {
-		close(_obj->fd);
-		_obj->fd = -1;
-	}
 	free(_obj);
 	*obj = NULL;
 	return FPGA_OK;
@@ -140,9 +136,12 @@ fpga_result xfpga_fpgaDestroyObject(fpga_object *obj)
 fpga_result xfpga_fpgaObjectRead64(fpga_object obj, uint64_t *value, int flags)
 {
 	struct _fpga_object *_obj = (struct _fpga_object *)obj;
+	fpga_result res = FPGA_OK;
 	if (flags & FPGA_OBJECT_SYNC) {
-		lseek(_obj->fd, 0, SEEK_SET);
-		_obj->size = eintr_read(_obj->fd, _obj->buffer, _obj->max_size);
+		res = sync_object(obj);
+	}
+	if (res) {
+		return res;
 	}
 	if (flags & FPGA_OBJECT_TEXT) {
 		*value = strtoull((char *)_obj->buffer, NULL, 0);
@@ -156,6 +155,7 @@ fpga_result xfpga_fpgaObjectRead(fpga_object obj, uint8_t *buffer,
 				 size_t offset, size_t len, int flags)
 {
 	struct _fpga_object *_obj = (struct _fpga_object *)obj;
+	fpga_result res = FPGA_OK;
 	ASSERT_NOT_NULL(obj);
 	ASSERT_NOT_NULL(buffer);
 	if (offset + len > _obj->size) {
@@ -163,8 +163,10 @@ fpga_result xfpga_fpgaObjectRead(fpga_object obj, uint8_t *buffer,
 	}
 
 	if (flags & FPGA_OBJECT_SYNC) {
-		lseek(_obj->fd, 0, SEEK_SET);
-		_obj->size = eintr_read(_obj->fd, _obj->buffer, _obj->max_size);
+		res = sync_object(obj);
+		if (res) {
+			return res;
+		}
 	}
 	if (offset + len > _obj->size) {
 		FPGA_ERR("Bytes requested exceed object size");
@@ -179,7 +181,8 @@ fpga_result xfpga_fpgaObjectWrite64(fpga_object obj, uint64_t value, int flags)
 {
 	struct _fpga_object *_obj = (struct _fpga_object *)obj;
 	size_t bytes_written = 0;
-	fpga_result res;
+	int fd = -1;
+	fpga_result res = FPGA_OK;
 	errno_t err;
 	ASSERT_NOT_NULL(obj);
 	ASSERT_NOT_NULL(_obj->handle);
@@ -196,16 +199,24 @@ fpga_result xfpga_fpgaObjectWrite64(fpga_object obj, uint64_t value, int flags)
 		_obj->size = sizeof(uint64_t);
 		*(uint64_t *)_obj->buffer = value;
 	}
-	lseek(_obj->fd, 0, SEEK_SET);
-	bytes_written = eintr_write(_obj->fd, _obj->buffer, _obj->size);
+	fd = open(_obj->path, _obj->perm);
+	if (fd < 0 ) {
+		FPGA_ERR("Error opening %s: %s", _obj->path, strerror(errno));
+		return FPGA_EXCEPTION;
+	}
+	lseek(fd, 0, SEEK_SET);
+	bytes_written = eintr_write(fd, _obj->buffer, _obj->size);
 	if (bytes_written != _obj->size) {
-		FPGA_ERR("Did not write 64-bit value");
+		FPGA_ERR("Did not write 64-bit value: %s", strerror(errno));
 		res = FPGA_EXCEPTION;
 	}
 	err = pthread_mutex_unlock(
 		&((struct _fpga_handle *)_obj->handle)->lock);
 	if (err) {
 		FPGA_ERR("pthread_mutex_unlock() failed: %s", strerror(errno));
+		res = FPGA_EXCEPTION;
 	}
+out_close:
+	close(fd);
 	return res;
 }

--- a/libopae/plugins/xfpga/types_int.h
+++ b/libopae/plugins/xfpga/types_int.h
@@ -167,7 +167,7 @@ struct _fpga_object {
 	fpga_sysfs_type type;
 	char *path;
 	char *name;
-	int fd;
+	int perm;
 	size_t size;
 	size_t max_size;
 	uint8_t *buffer;

--- a/testing/mock/test_system.h
+++ b/testing/mock/test_system.h
@@ -158,11 +158,14 @@ class test_system {
 
   bool register_ioctl_handler(int request, ioctl_handler_t);
 
+  FILE *register_file(const std::string &path);
+
  private:
   test_system();
   std::string root_;
   std::map<int, mock_object *> fds_;
   std::map<int, ioctl_handler_t> ioctl_handlers_;
+  std::map<std::string, std::string> registered_files_;
   static test_system *instance_;
 
   typedef int (*open_func)(const char *pathname, int flags);

--- a/testing/xfpga/test_object_c.cpp
+++ b/testing/xfpga/test_object_c.cpp
@@ -23,11 +23,16 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+#include <fstream>
 #include "gtest/gtest.h"
 #include "test_system.h"
+#include "types_int.h"
 #include "xfpga.h"
 
 using namespace opae::testing;
+
+const std::string DATA =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
 class sysobject_p : public ::testing::TestWithParam<std::string> {
  protected:
@@ -36,8 +41,7 @@ class sysobject_p : public ::testing::TestWithParam<std::string> {
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &dev_filter_), FPGA_OK);
-    ASSERT_EQ(fpgaPropertiesSetObjectType(dev_filter_, FPGA_DEVICE),
-              FPGA_OK);
+    ASSERT_EQ(fpgaPropertiesSetObjectType(dev_filter_, FPGA_DEVICE), FPGA_OK);
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &acc_filter_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(acc_filter_, FPGA_ACCELERATOR),
               FPGA_OK);
@@ -61,6 +65,7 @@ class sysobject_p : public ::testing::TestWithParam<std::string> {
   test_device invalid_device_;
   test_system *system_;
   std::array<fpga_token, 2> tokens_;
+  fpga_handle handle_;
   fpga_properties dev_filter_;
   fpga_properties acc_filter_;
 };
@@ -70,36 +75,61 @@ TEST_P(sysobject_p, xfpga_fpgaTokenGetObject) {
   ASSERT_EQ(xfpga_fpgaEnumerate(&dev_filter_, 1, tokens_.data(), tokens_.size(),
                                 &num_matches),
             FPGA_OK);
+  ASSERT_GT(num_matches, 0);
   const char *name = "bitstream_id";
   fpga_object object;
   int flags = 0;
   EXPECT_EQ(xfpga_fpgaTokenGetObject(tokens_[0], name, &object, flags),
             FPGA_OK);
   uint64_t bitstream_id = 0;
-  EXPECT_EQ(xfpga_fpgaObjectRead64(object, &bitstream_id, FPGA_OBJECT_TEXT), FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaObjectRead64(object, &bitstream_id, FPGA_OBJECT_TEXT),
+            FPGA_OK);
   EXPECT_EQ(bitstream_id, platform_.devices[0].bbs_id);
-  EXPECT_EQ(xfpga_fpgaTokenGetObject(tokens_[0], "invalid_name", &object, 0), FPGA_NOT_FOUND);
+  EXPECT_EQ(xfpga_fpgaTokenGetObject(tokens_[0], "invalid_name", &object, 0),
+            FPGA_NOT_FOUND);
   EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
 }
 
-// TEST_P(sysobject_p, xfpga_fpgaHandleGetObject) {
-//   fpga_token handle = 0;
-//   const char *name = 0;
-//   fpga_object *object = 0;
-//   int flags = 0;
-//   auto res = xfpga_fpgaHandleGetObject(handle, name, object, flags);
-//   EXPECT_EQ(res, FPGA_OK);
-// }
-//
-// TEST_P(sysobject_p, xfpga_fpgaObjectGetObject) {
-//   fpga_object parent = 0;
-//   fpga_handle handle = 0;
-//   const char *name = 0;
-//   fpga_object *object = 0;
-//   int flags = 0;
-//   auto res = xfpga_fpgaObjectGetObject(parent, handle, name, object, flags);
-//   EXPECT_EQ(res, FPGA_OK);
-// }
+TEST_P(sysobject_p, xfpga_fpgaHandleGetObject) {
+  uint32_t num_matches = 0;
+  ASSERT_EQ(xfpga_fpgaEnumerate(&dev_filter_, 1, tokens_.data(), tokens_.size(),
+                                &num_matches),
+            FPGA_OK);
+  ASSERT_GT(num_matches, 0);
+  ASSERT_EQ(xfpga_fpgaOpen(tokens_[0], &handle_, 0), FPGA_OK);
+  const char *name = "bitstream_id";
+  fpga_object object;
+  int flags = 0;
+  EXPECT_EQ(xfpga_fpgaHandleGetObject(handle_, name, &object, flags), FPGA_OK);
+  uint64_t bitstream_id = 0;
+  EXPECT_EQ(xfpga_fpgaObjectRead64(object, &bitstream_id, FPGA_OBJECT_TEXT),
+            FPGA_OK);
+  EXPECT_EQ(bitstream_id, platform_.devices[0].bbs_id);
+  EXPECT_EQ(xfpga_fpgaHandleGetObject(handle_, "invalid_name", &object, 0),
+            FPGA_NOT_FOUND);
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
+}
+
+TEST_P(sysobject_p, xfpga_fpgaObjectGetObject) {
+  uint32_t num_matches = 0;
+  ASSERT_EQ(xfpga_fpgaEnumerate(&dev_filter_, 1, tokens_.data(), tokens_.size(),
+                                &num_matches),
+            FPGA_OK);
+  ASSERT_GT(num_matches, 0);
+  fpga_object err_object, object;
+  int flags = 0;
+  const char *name = "errors";
+  EXPECT_EQ(xfpga_fpgaTokenGetObject(tokens_[0], name, &err_object, flags),
+            FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaObjectGetObject(err_object, nullptr, "bbs_errors",
+                                      &object, flags),
+            FPGA_OK);
+  uint64_t bbs_errors = 0;
+  EXPECT_EQ(xfpga_fpgaObjectRead64(object, &bbs_errors, FPGA_OBJECT_TEXT),
+            FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&err_object), FPGA_OK);
+}
 //
 // TEST_P(sysobject_p, xfpga_fpgaDestroyObject) {
 //   fpga_object *obj = 0;
@@ -115,15 +145,59 @@ TEST_P(sysobject_p, xfpga_fpgaTokenGetObject) {
 //   EXPECT_EQ(res, FPGA_OK);
 // }
 //
-// TEST_P(sysobject_p, xfpga_fpgaObjectRead) {
-//   fpga_object obj = 0;
-//   uint8_t *buffer = 0;
-//   int offset = 0;
-//   int len = 0;
-//   int flags = 0;
-//   auto res = xfpga_fpgaObjectRead(obj, buffer, offset, len, flags);
-//   EXPECT_EQ(res, FPGA_OK);
-// }
+TEST_P(sysobject_p, xfpga_fpgaObjectRead) {
+  uint32_t num_matches = 0;
+  ASSERT_EQ(xfpga_fpgaEnumerate(&dev_filter_, 1, tokens_.data(), tokens_.size(),
+                                &num_matches),
+            FPGA_OK);
+  ASSERT_GT(num_matches, 0);
+  _fpga_token *tk = static_cast<_fpga_token *>(tokens_[0]);
+  std::string syspath(tk->sysfspath);
+  syspath += "/testdata";
+  auto fp = system_->register_file(syspath);
+  ASSERT_NE(fp, nullptr) << strerror(errno);
+  fwrite(DATA.c_str(), DATA.size(), 1, fp);
+  fflush(fp);
+  fpga_object object;
+  int flags = 0;
+  EXPECT_EQ(xfpga_fpgaTokenGetObject(tokens_[0], "testdata", &object, flags),
+            FPGA_OK);
+  std::vector<uint8_t> buffer(DATA.size());
+  EXPECT_EQ(xfpga_fpgaObjectRead(object, buffer.data(), 0, 10, 0), FPGA_OK);
+  buffer[10] = '\0';
+  EXPECT_STREQ(reinterpret_cast<const char *>(buffer.data()),
+               DATA.substr(0, 10).c_str());
+  rewind(fp);
+  std::string c0c0str = "0xc0c0cafe\n";
+  uint64_t value = 0;
+  fwrite(c0c0str.c_str(), c0c0str.size(), 1, fp);
+  fflush(fp);
+  EXPECT_EQ(xfpga_fpgaObjectRead64(object, &value, FPGA_OBJECT_TEXT | FPGA_OBJECT_SYNC), FPGA_OK);
+  EXPECT_EQ(value, 0xc0c0cafe);
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
+}
+
+TEST_P(sysobject_p, xfpga_fpgaObjectWrite64) {
+  uint32_t num_matches = 0;
+  ASSERT_EQ(xfpga_fpgaEnumerate(&dev_filter_, 1, tokens_.data(), tokens_.size(),
+                                &num_matches),
+            FPGA_OK);
+  ASSERT_GT(num_matches, 0);
+  _fpga_handle *h = static_cast<_fpga_handle *>(handle_);
+  _fpga_token *tok = static_cast<_fpga_token *>(h->token);
+  std::string syspath(tok->sysfspath);
+  syspath += "/testdata";
+  auto fp = system_->register_file(syspath);
+  ASSERT_EQ(xfpga_fpgaOpen(tokens_[0], &handle_, 0), FPGA_OK);
+  fpga_object object;
+  EXPECT_EQ(xfpga_fpgaHandleGetObject(handle_, "testdata", &object, 0), FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaObjectWrite64(object, 0xc0c0cafe, FPGA_OBJECT_TEXT),
+            FPGA_OK);
+  rewind(fp);
+  std::vector<char> buffer(256);
+  fread(buffer.data(), buffer.size(), 1, fp);
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
+}
 //
 // TEST_P(sysobject_p, xfpga_fpgaObjectWrite64) {
 //   fpga_object obj = 0;

--- a/testing/xfpga/test_object_c.cpp
+++ b/testing/xfpga/test_object_c.cpp
@@ -36,7 +36,7 @@ const std::string DATA =
 
 class sysobject_p : public ::testing::TestWithParam<std::string> {
  protected:
-  sysobject_p() : tmpsysfs_("mocksys-XXXXXX") {}
+  sysobject_p() : tmpsysfs_("mocksys-XXXXXX"), tokens_{nullptr} {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
@@ -56,6 +56,11 @@ class sysobject_p : public ::testing::TestWithParam<std::string> {
     if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
       std::string cmd = "rm -rf " + tmpsysfs_;
       std::system(cmd.c_str());
+    }
+    for (auto t : tokens_) {
+      if (t) {
+        EXPECT_EQ(xfpga_fpgaDestroyToken(&t), FPGA_OK);
+      }
     }
     system_->finalize();
   }
@@ -108,6 +113,7 @@ TEST_P(sysobject_p, xfpga_fpgaHandleGetObject) {
   EXPECT_EQ(xfpga_fpgaHandleGetObject(handle_, "invalid_name", &object, 0),
             FPGA_NOT_FOUND);
   EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaClose(&handle_), FPGA_OK);
 }
 
 TEST_P(sysobject_p, xfpga_fpgaObjectGetObject) {
@@ -197,6 +203,7 @@ TEST_P(sysobject_p, xfpga_fpgaObjectWrite64) {
   std::vector<char> buffer(256);
   fread(buffer.data(), buffer.size(), 1, fp);
   EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaClose(&handle_), FPGA_OK);
 }
 //
 // TEST_P(sysobject_p, xfpga_fpgaObjectWrite64) {


### PR DESCRIPTION
* Remove "caching" of sysfs file descriptors
* Store permissions with file - determined dynamically from stat
* Add tests for object API functions
* Add test_system::register_file to dynamically register dummy files
  These files get routed to /tmp instead and are used for creating dummy
  files not part of the sysfs tree

I ran clang-format in the sysfs.c file so I apologize for the large diff. I've already had to undo this formatting several times in other pull request so I would just like to get this change in. 
The real diff for this starts at ~line: 787.
 
