### PR TITLE
tests: scrub opae properties tests for leaks

### DIFF
--- a/libopae/api-shell.c
+++ b/libopae/api-shell.c
@@ -273,7 +273,6 @@ fpga_result fpgaGetProperties(fpga_token token, fpga_properties *prop)
 		*prop = pr;
 
 	} else {
-		fpga_token parent = NULL;
 		struct _fpga_properties *p;
 		int err;
 
@@ -328,7 +327,6 @@ fpga_result fpgaGetProperties(fpga_token token, fpga_properties *prop)
 fpga_result fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 {
 	fpga_result res;
-	fpga_token parent = NULL;
 	struct _fpga_properties *p;
 	int err;
 	opae_wrapped_token *wrapped_token = opae_validate_wrapped_token(token);

--- a/libopae/api-shell.c
+++ b/libopae/api-shell.c
@@ -462,6 +462,9 @@ static int opae_enumerate(const opae_api_adapter_table *adapter, void *context)
 		return OPAE_ENUM_CONTINUE;
 	}
 
+	if (space_remaining > num_matches)
+		space_remaining = num_matches;
+
 	for (i = 0; i < space_remaining; ++i) {
 		opae_wrapped_token *wt = opae_allocate_wrapped_token(
 			ctx->adapter_tokens[i], adapter);


### PR DESCRIPTION
Used valgrind memcheck to reveal resource leaks in the
properties tests for opae-c. Fixed 3..
1) fpgaEnumerate was leaking wrapped tokens.
2) the gcov instrumentation causes test_system::opae_create_ to
return duplicate fd's somehow. This was leaking mock_object *'s.
3) A couple of the properties tests were overwriting tokens_[i],
leaking tokens.