### PR TITLE
tests: Add test coverage for opae-c properties

### DIFF
--- a/libopae/api-shell.c
+++ b/libopae/api-shell.c
@@ -327,8 +327,9 @@ fpga_result fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 
 	if (FIELD_VALID(p, FPGA_PROPERTY_PARENT) &&
 	    (p->flags & OPAE_PROPERTIES_FLAG_PARENT_ALLOC)) {
-		wrapped_parent = (opae_wrapped_token *) p->parent;
-		p->parent = wrapped_parent->opae_token;
+		wrapped_parent = opae_validate_wrapped_token(p->parent);
+		if (wrapped_parent)
+			p->parent = wrapped_parent->opae_token;
 	}
 
 	res = wrapped_token->adapter_table->fpgaUpdateProperties(
@@ -361,8 +362,10 @@ fpga_result fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 			wrapped_parent->opae_token = p->parent;
 			wrapped_parent->adapter_table = wrapped_token->adapter_table;
 			p->parent = wrapped_parent;
+			p->flags |= OPAE_PROPERTIES_FLAG_PARENT_ALLOC;
 		}
-	}
+	} else if (wrapped_parent)
+		opae_destroy_wrapped_token(wrapped_parent);
 
 	opae_mutex_unlock(err, &p->lock);
 

--- a/libopae/api-shell.c
+++ b/libopae/api-shell.c
@@ -285,7 +285,7 @@ fpga_result fpgaGetProperties(fpga_token token, fpga_properties *prop)
 		ASSERT_NOT_NULL(p);
 
 		if (FIELD_VALID(p, FPGA_PROPERTY_PARENT)) {
-			opae_wrapped_token *wrapped_parent = 
+			opae_wrapped_token *wrapped_parent =
 				opae_allocate_wrapped_token(
 					p->parent, wrapped_token->adapter_table);
 

--- a/libopae/api-shell.c
+++ b/libopae/api-shell.c
@@ -201,14 +201,18 @@ fpga_result fpgaGetPropertiesFromHandle(fpga_handle handle,
 					fpga_properties *prop)
 {
 	fpga_result res;
-	fpga_token parent = NULL;
 	opae_wrapped_handle *wrapped_handle =
 		opae_validate_wrapped_handle(handle);
+	struct _fpga_properties *p;
+	int err;
 
 	ASSERT_NOT_NULL(wrapped_handle);
 	ASSERT_NOT_NULL(prop);
 	ASSERT_NOT_NULL_RESULT(
 		wrapped_handle->adapter_table->fpgaGetPropertiesFromHandle,
+		FPGA_NOT_SUPPORTED);
+	ASSERT_NOT_NULL_RESULT(
+		wrapped_handle->adapter_table->fpgaCloneToken,
 		FPGA_NOT_SUPPORTED);
 
 	res = wrapped_handle->adapter_table->fpgaGetPropertiesFromHandle(
@@ -218,18 +222,33 @@ fpga_result fpgaGetPropertiesFromHandle(fpga_handle handle,
 
 	// If the output properties has a parent token set,
 	// then it will be a raw token. We need to wrap it.
-	if (fpgaPropertiesGetParent(*prop, &parent) == FPGA_OK) {
-		opae_wrapped_token *wrapped_parent =
-			opae_allocate_wrapped_token(
-				parent, wrapped_handle->adapter_table);
 
-		if (!wrapped_parent) {
-			OPAE_ERR("malloc failed");
-			return FPGA_NO_MEMORY;
+	p = opae_validate_and_lock_properties(*prop);
+
+	ASSERT_NOT_NULL(p);
+
+	if (FIELD_VALID(p, FPGA_PROPERTY_PARENT)) {
+		fpga_token parent = NULL;
+
+		res = wrapped_handle->adapter_table->fpgaCloneToken(
+			p->parent, &parent);
+
+		if (res == FPGA_OK) {
+			opae_wrapped_token *wrapped_parent =
+				opae_allocate_wrapped_token(
+					parent, wrapped_handle->adapter_table);
+
+			if (wrapped_parent) {
+				p->parent = wrapped_parent;
+			} else {
+				OPAE_ERR("malloc failed");
+				res = FPGA_NO_MEMORY;
+			}
+
 		}
-
-		return fpgaPropertiesSetParent(*prop, wrapped_parent);
 	}
+
+	opae_mutex_unlock(err, &p->lock);
 
 	return res;
 }
@@ -254,12 +273,16 @@ fpga_result fpgaGetProperties(fpga_token token, fpga_properties *prop)
 		*prop = pr;
 
 	} else {
-		fpga_token parent = NULL;
+		struct _fpga_properties *p;
+		int err;
 
 		ASSERT_NOT_NULL(wrapped_token);
 
 		ASSERT_NOT_NULL_RESULT(
 			wrapped_token->adapter_table->fpgaGetProperties,
+			FPGA_NOT_SUPPORTED);
+		ASSERT_NOT_NULL_RESULT(
+			wrapped_token->adapter_table->fpgaCloneToken,
 			FPGA_NOT_SUPPORTED);
 
 		res = wrapped_token->adapter_table->fpgaGetProperties(
@@ -269,18 +292,33 @@ fpga_result fpgaGetProperties(fpga_token token, fpga_properties *prop)
 
 		// If the output properties has a parent token set,
 		// then it will be a raw token. We need to wrap it.
-		if (fpgaPropertiesGetParent(*prop, &parent) == FPGA_OK) {
-			opae_wrapped_token *wrapped_parent =
-				opae_allocate_wrapped_token(
-					parent, wrapped_token->adapter_table);
 
-			if (!wrapped_parent) {
-				OPAE_ERR("malloc failed");
-				return FPGA_NO_MEMORY;
+		p = opae_validate_and_lock_properties(*prop);
+
+		ASSERT_NOT_NULL(p);
+
+		if (FIELD_VALID(p, FPGA_PROPERTY_PARENT)) {
+			fpga_token parent = NULL;
+
+			res = wrapped_token->adapter_table->fpgaCloneToken(
+				p->parent, &parent);
+
+			if (res == FPGA_OK) {
+				opae_wrapped_token *wrapped_parent =
+					opae_allocate_wrapped_token(
+						parent, wrapped_token->adapter_table);
+
+				if (wrapped_parent) {
+					p->parent = wrapped_parent;
+				} else {
+					OPAE_ERR("malloc failed");
+					res = FPGA_NO_MEMORY;
+				}
+
 			}
-
-			return fpgaPropertiesSetParent(*prop, wrapped_parent);
 		}
+
+		opae_mutex_unlock(err, &p->lock);
 	}
 
 	return res;
@@ -289,12 +327,16 @@ fpga_result fpgaGetProperties(fpga_token token, fpga_properties *prop)
 fpga_result fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 {
 	fpga_result res;
-	fpga_token parent = NULL;
+	struct _fpga_properties *p;
+	int err;
 	opae_wrapped_token *wrapped_token = opae_validate_wrapped_token(token);
 
 	ASSERT_NOT_NULL(wrapped_token);
 	ASSERT_NOT_NULL_RESULT(
 		wrapped_token->adapter_table->fpgaUpdateProperties,
+		FPGA_NOT_SUPPORTED);
+	ASSERT_NOT_NULL_RESULT(
+		wrapped_token->adapter_table->fpgaCloneToken,
 		FPGA_NOT_SUPPORTED);
 
 	res = wrapped_token->adapter_table->fpgaUpdateProperties(
@@ -304,18 +346,33 @@ fpga_result fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 
 	// If the output properties has a parent token set,
 	// then it will be a raw token. We need to wrap it.
-	if (fpgaPropertiesGetParent(prop, &parent) == FPGA_OK) {
-		opae_wrapped_token *wrapped_parent =
-			opae_allocate_wrapped_token(
-				parent, wrapped_token->adapter_table);
 
-		if (!wrapped_parent) {
-			OPAE_ERR("malloc failed");
-			return FPGA_NO_MEMORY;
+	p = opae_validate_and_lock_properties(prop);
+
+	ASSERT_NOT_NULL(p);
+
+	if (FIELD_VALID(p, FPGA_PROPERTY_PARENT)) {
+		fpga_token parent = NULL;
+
+		res = wrapped_token->adapter_table->fpgaCloneToken(
+			p->parent, &parent);
+
+		if (res == FPGA_OK) {
+			opae_wrapped_token *wrapped_parent =
+				opae_allocate_wrapped_token(
+					parent, wrapped_token->adapter_table);
+
+			if (wrapped_parent) {
+				p->parent = wrapped_parent;
+			} else {
+				OPAE_ERR("malloc failed");
+				res = FPGA_NO_MEMORY;
+			}
+
 		}
-
-		return fpgaPropertiesSetParent(prop, wrapped_parent);
 	}
+
+	opae_mutex_unlock(err, &p->lock);
 
 	return res;
 }
@@ -461,6 +518,9 @@ static int opae_enumerate(const opae_api_adapter_table *adapter, void *context)
 		// requesting token count, only.
 		return OPAE_ENUM_CONTINUE;
 	}
+
+	if (space_remaining > num_matches)
+		space_remaining = num_matches;
 
 	for (i = 0; i < space_remaining; ++i) {
 		opae_wrapped_token *wt = opae_allocate_wrapped_token(

--- a/libopae/api-shell.c
+++ b/libopae/api-shell.c
@@ -211,12 +211,6 @@ fpga_result fpgaGetPropertiesFromHandle(fpga_handle handle,
 	ASSERT_NOT_NULL_RESULT(
 		wrapped_handle->adapter_table->fpgaGetPropertiesFromHandle,
 		FPGA_NOT_SUPPORTED);
-	ASSERT_NOT_NULL_RESULT(
-		wrapped_handle->adapter_table->fpgaCloneToken,
-		FPGA_NOT_SUPPORTED);
-	ASSERT_NOT_NULL_RESULT(
-		wrapped_handle->adapter_table->fpgaDestroyToken,
-		FPGA_NOT_SUPPORTED);
 
 	res = wrapped_handle->adapter_table->fpgaGetPropertiesFromHandle(
 		wrapped_handle->opae_handle, prop);
@@ -231,25 +225,16 @@ fpga_result fpgaGetPropertiesFromHandle(fpga_handle handle,
 	ASSERT_NOT_NULL(p);
 
 	if (FIELD_VALID(p, FPGA_PROPERTY_PARENT)) {
-		fpga_token parent = NULL;
+		opae_wrapped_token *wrapped_parent =
+			opae_allocate_wrapped_token(
+				p->parent, wrapped_handle->adapter_table);
 
-		res = wrapped_handle->adapter_table->fpgaCloneToken(
-			p->parent, &parent);
-
-		if (res == FPGA_OK) {
-			opae_wrapped_token *wrapped_parent =
-				opae_allocate_wrapped_token(
-					parent, wrapped_handle->adapter_table);
-
-			if (wrapped_parent) {
-				p->parent = wrapped_parent;
-			} else {
-				wrapped_handle->adapter_table->fpgaDestroyToken(
-						&parent);
-				OPAE_ERR("malloc failed");
-				res = FPGA_NO_MEMORY;
-			}
-
+		if (wrapped_parent) {
+			p->parent = wrapped_parent;
+			p->flags |= OPAE_PROPERTIES_FLAG_PARENT_ALLOC;
+		} else {
+			OPAE_ERR("malloc failed");
+			res = FPGA_NO_MEMORY;
 		}
 	}
 
@@ -286,12 +271,6 @@ fpga_result fpgaGetProperties(fpga_token token, fpga_properties *prop)
 		ASSERT_NOT_NULL_RESULT(
 			wrapped_token->adapter_table->fpgaGetProperties,
 			FPGA_NOT_SUPPORTED);
-		ASSERT_NOT_NULL_RESULT(
-			wrapped_token->adapter_table->fpgaCloneToken,
-			FPGA_NOT_SUPPORTED);
-		ASSERT_NOT_NULL_RESULT(
-			wrapped_token->adapter_table->fpgaDestroyToken,
-			FPGA_NOT_SUPPORTED);
 
 		res = wrapped_token->adapter_table->fpgaGetProperties(
 			wrapped_token->opae_token, prop);
@@ -306,25 +285,16 @@ fpga_result fpgaGetProperties(fpga_token token, fpga_properties *prop)
 		ASSERT_NOT_NULL(p);
 
 		if (FIELD_VALID(p, FPGA_PROPERTY_PARENT)) {
-			fpga_token parent = NULL;
+			opae_wrapped_token *wrapped_parent = 
+				opae_allocate_wrapped_token(
+					p->parent, wrapped_token->adapter_table);
 
-			res = wrapped_token->adapter_table->fpgaCloneToken(
-				p->parent, &parent);
-
-			if (res == FPGA_OK) {
-				opae_wrapped_token *wrapped_parent =
-					opae_allocate_wrapped_token(
-						parent, wrapped_token->adapter_table);
-
-				if (wrapped_parent) {
-					p->parent = wrapped_parent;
-				} else {
-					wrapped_token->adapter_table->fpgaDestroyToken(
-							&parent);
-					OPAE_ERR("malloc failed");
-					res = FPGA_NO_MEMORY;
-				}
-
+			if (wrapped_parent) {
+				p->parent = wrapped_parent;
+				p->flags |= OPAE_PROPERTIES_FLAG_PARENT_ALLOC;
+			} else {
+				OPAE_ERR("malloc failed");
+				res = FPGA_NO_MEMORY;
 			}
 		}
 
@@ -340,50 +310,57 @@ fpga_result fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 	struct _fpga_properties *p;
 	int err;
 	opae_wrapped_token *wrapped_token = opae_validate_wrapped_token(token);
+	opae_wrapped_token *wrapped_parent = NULL;
 
 	ASSERT_NOT_NULL(wrapped_token);
 	ASSERT_NOT_NULL_RESULT(
 		wrapped_token->adapter_table->fpgaUpdateProperties,
 		FPGA_NOT_SUPPORTED);
-	ASSERT_NOT_NULL_RESULT(
-		wrapped_token->adapter_table->fpgaCloneToken,
-		FPGA_NOT_SUPPORTED);
-	ASSERT_NOT_NULL_RESULT(
-		wrapped_token->adapter_table->fpgaDestroyToken,
-		FPGA_NOT_SUPPORTED);
 
-	res = wrapped_token->adapter_table->fpgaUpdateProperties(
-		wrapped_token->opae_token, prop);
-
-	ASSERT_RESULT(res);
-
-	// If the output properties has a parent token set,
-	// then it will be a raw token. We need to wrap it.
+	// If the input properties already has a parent token
+	// set, then it will be wrapped. If we allocated the wrapper,
+	// Save the wrapper, and reuse it below.
 
 	p = opae_validate_and_lock_properties(prop);
 
 	ASSERT_NOT_NULL(p);
 
+	if (FIELD_VALID(p, FPGA_PROPERTY_PARENT) &&
+	    (p->flags & OPAE_PROPERTIES_FLAG_PARENT_ALLOC)) {
+		wrapped_parent = (opae_wrapped_token *) p->parent;
+		p->parent = wrapped_parent->opae_token;
+	}
+
+	res = wrapped_token->adapter_table->fpgaUpdateProperties(
+		wrapped_token->opae_token, prop);
+
+	if (res != FPGA_OK) {
+		opae_mutex_unlock(err, &p->lock);
+		return res;
+	}
+
+	// If the output properties has a parent token set,
+	// then it will be a raw token. We need to wrap it.
+
 	if (FIELD_VALID(p, FPGA_PROPERTY_PARENT)) {
-		fpga_token parent = NULL;
-
-		res = wrapped_token->adapter_table->fpgaCloneToken(
-			p->parent, &parent);
-
-		if (res == FPGA_OK) {
-			opae_wrapped_token *wrapped_parent =
-				opae_allocate_wrapped_token(
-					parent, wrapped_token->adapter_table);
+		if (!wrapped_parent) {
+			// We need to allocate a wrapper.
+			wrapped_parent =
+			opae_allocate_wrapped_token(
+				p->parent, wrapped_token->adapter_table);
 
 			if (wrapped_parent) {
 				p->parent = wrapped_parent;
+				p->flags |= OPAE_PROPERTIES_FLAG_PARENT_ALLOC;
 			} else {
-				wrapped_token->adapter_table->fpgaDestroyToken(
-						&parent);
 				OPAE_ERR("malloc failed");
 				res = FPGA_NO_MEMORY;
 			}
-
+		} else {
+			// We are re-using the wrapper from above.
+			wrapped_parent->opae_token = p->parent;
+			wrapped_parent->adapter_table = wrapped_token->adapter_table;
+			p->parent = wrapped_parent;
 		}
 	}
 

--- a/libopae/api-shell.c
+++ b/libopae/api-shell.c
@@ -214,6 +214,9 @@ fpga_result fpgaGetPropertiesFromHandle(fpga_handle handle,
 	ASSERT_NOT_NULL_RESULT(
 		wrapped_handle->adapter_table->fpgaCloneToken,
 		FPGA_NOT_SUPPORTED);
+	ASSERT_NOT_NULL_RESULT(
+		wrapped_handle->adapter_table->fpgaDestroyToken,
+		FPGA_NOT_SUPPORTED);
 
 	res = wrapped_handle->adapter_table->fpgaGetPropertiesFromHandle(
 		wrapped_handle->opae_handle, prop);
@@ -241,6 +244,8 @@ fpga_result fpgaGetPropertiesFromHandle(fpga_handle handle,
 			if (wrapped_parent) {
 				p->parent = wrapped_parent;
 			} else {
+				wrapped_handle->adapter_table->fpgaDestroyToken(
+						&parent);
 				OPAE_ERR("malloc failed");
 				res = FPGA_NO_MEMORY;
 			}
@@ -284,6 +289,9 @@ fpga_result fpgaGetProperties(fpga_token token, fpga_properties *prop)
 		ASSERT_NOT_NULL_RESULT(
 			wrapped_token->adapter_table->fpgaCloneToken,
 			FPGA_NOT_SUPPORTED);
+		ASSERT_NOT_NULL_RESULT(
+			wrapped_token->adapter_table->fpgaDestroyToken,
+			FPGA_NOT_SUPPORTED);
 
 		res = wrapped_token->adapter_table->fpgaGetProperties(
 			wrapped_token->opae_token, prop);
@@ -311,6 +319,8 @@ fpga_result fpgaGetProperties(fpga_token token, fpga_properties *prop)
 				if (wrapped_parent) {
 					p->parent = wrapped_parent;
 				} else {
+					wrapped_token->adapter_table->fpgaDestroyToken(
+							&parent);
 					OPAE_ERR("malloc failed");
 					res = FPGA_NO_MEMORY;
 				}
@@ -337,6 +347,9 @@ fpga_result fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 		FPGA_NOT_SUPPORTED);
 	ASSERT_NOT_NULL_RESULT(
 		wrapped_token->adapter_table->fpgaCloneToken,
+		FPGA_NOT_SUPPORTED);
+	ASSERT_NOT_NULL_RESULT(
+		wrapped_token->adapter_table->fpgaDestroyToken,
 		FPGA_NOT_SUPPORTED);
 
 	res = wrapped_token->adapter_table->fpgaUpdateProperties(
@@ -365,6 +378,8 @@ fpga_result fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 			if (wrapped_parent) {
 				p->parent = wrapped_parent;
 			} else {
+				wrapped_token->adapter_table->fpgaDestroyToken(
+						&parent);
 				OPAE_ERR("malloc failed");
 				res = FPGA_NO_MEMORY;
 			}

--- a/libopae/props.h
+++ b/libopae/props.h
@@ -81,6 +81,8 @@
 struct _fpga_properties {
 	pthread_mutex_t lock;
 	uint64_t magic;
+	uint32_t flags;
+#define OPAE_PROPERTIES_FLAG_PARENT_ALLOC 0x00000001
 	/* Common properties */
 	uint64_t valid_fields; // bitmap of valid fields
 	// valid here means the field has been set using the API

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -115,6 +115,30 @@ add_mock_test(test_opae_props_c opae-c-static
     opae-c/test_props_c.cpp
 )
 
+add_mock_test(test_opae_reset_c opae-c-static
+    opae-c/test_reset_c.cpp
+)
+
+add_mock_test(test_opae_mmio_c opae-c-static
+    opae-c/test_mmio_c.cpp
+)
+
+add_mock_test(test_opae_umsg_c opae-c-static
+    opae-c/test_umsg_c.cpp
+)
+
+add_mock_test(test_opae_buffer_c opae-c-static
+    opae-c/test_buffer_c.cpp
+)
+
+add_mock_test(test_opae_version_c opae-c-static
+    opae-c/test_version_c.cpp
+)
+
+add_mock_test(test_opae_error_c opae-c-static
+    opae-c/test_error_c.cpp
+)
+
 add_mock_test(test_xfpga_token_list_c xfpga-static
     xfpga/test_token_list_c.cpp
 )

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -139,6 +139,20 @@ add_mock_test(test_opae_error_c opae-c-static
     opae-c/test_error_c.cpp
 )
 
+add_mock_test(test_opae_event_c opae-c-static
+    opae-c/test_event_c.cpp
+    ${OPAE_SDK_SOURCE}/tools/base/fpgad/srv.c
+    ${OPAE_SDK_SOURCE}/tools/base/fpgad/log.c
+)
+
+add_mock_test(test_opae_hostif_c opae-c-static
+    opae-c/test_hostif_c.cpp
+)
+
+add_mock_test(test_opae_reconf_c opae-c-static
+    opae-c/test_reconf_c.cpp
+)
+
 add_mock_test(test_xfpga_token_list_c xfpga-static
     xfpga/test_token_list_c.cpp
 )

--- a/testing/mock/test_system.cpp
+++ b/testing/mock/test_system.cpp
@@ -83,6 +83,46 @@ void *malloc(size_t size) {
   return __libc_malloc(size);
 }
 
+// hijack calloc
+static bool _invalidate_calloc = false;
+static uint32_t _invalidate_calloc_after = 0;
+static const char * _invalidate_calloc_when_called_from = nullptr;
+void *calloc(size_t nmemb, size_t size) {
+  if (_invalidate_calloc) {
+
+    if (!_invalidate_calloc_when_called_from) {
+
+        if (!_invalidate_calloc_after) {
+          _invalidate_calloc = false;
+          return nullptr;
+        }
+
+        --_invalidate_calloc_after;
+
+    } else {
+        void *caller = __builtin_return_address(0);
+        int res;
+        Dl_info info;
+
+        dladdr(caller, &info);
+        if (!info.dli_sname)
+            res = 1;
+        else
+            res = strcmp(info.dli_sname, _invalidate_calloc_when_called_from);
+
+        if (!_invalidate_calloc_after && !res) {
+          _invalidate_calloc = false;
+          _invalidate_calloc_when_called_from = nullptr;
+          return nullptr;
+        } else if (!res)
+            --_invalidate_calloc_after;
+
+    }
+
+  }
+  return __libc_calloc(nmemb, size);
+}
+
 namespace opae {
 namespace testing {
 
@@ -376,6 +416,12 @@ void test_system::invalidate_malloc(uint32_t after, const char *when_called_from
   _invalidate_malloc = true;
   _invalidate_malloc_after = after;
   _invalidate_malloc_when_called_from = when_called_from;
+}
+
+void test_system::invalidate_calloc(uint32_t after, const char *when_called_from) {
+  _invalidate_calloc = true;
+  _invalidate_calloc_after = after;
+  _invalidate_calloc_when_called_from = when_called_from;
 }
 
 }  // end of namespace testing

--- a/testing/mock/test_system.h
+++ b/testing/mock/test_system.h
@@ -36,6 +36,7 @@
 
 extern "C" {
 extern void *__libc_malloc(size_t size);
+extern void *__libc_calloc(size_t nmemb, size_t size);
 }
 typedef struct stat stat_t;
 typedef int (*filter_func)(const struct dirent *);
@@ -155,6 +156,7 @@ class test_system {
   int scandir(const char *dirp, struct dirent ***namelist, filter_func filter,
               compare_func cmp);
   void invalidate_malloc(uint32_t after=0, const char *when_called_from=nullptr);
+  void invalidate_calloc(uint32_t after=0, const char *when_called_from=nullptr);
 
   bool register_ioctl_handler(int request, ioctl_handler_t);
 

--- a/testing/opae-c/test_buffer_c.cpp
+++ b/testing/opae-c/test_buffer_c.cpp
@@ -82,10 +82,6 @@ class buffer_c_p : public ::testing::TestWithParam<std::string> {
     for (i = 0 ; i < num_matches_ ; ++i) {
         EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
     }
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/opae-c/test_buffer_c.cpp
+++ b/testing/opae-c/test_buffer_c.cpp
@@ -1,0 +1,138 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+extern "C" {
+
+#include <json-c/json.h>
+#include <uuid/uuid.h>
+#include "opae_int.h"
+
+}
+
+#include <opae/fpga.h>
+
+#include <array>
+#include <cstdlib>
+#include <cstdarg>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include <unistd.h>
+#include "gtest/gtest.h"
+#include "test_system.h"
+
+using namespace opae::testing;
+
+class buffer_c_p : public ::testing::TestWithParam<std::string> {
+ protected:
+  buffer_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+
+  virtual void SetUp() override {
+    ASSERT_TRUE(test_platform::exists(GetParam()));
+    platform_ = test_platform::get(GetParam());
+    system_ = test_system::instance();
+    system_->initialize();
+    tmpsysfs_ = system_->prepare_syfs(platform_);
+    invalid_device_ = test_device::unknown();
+
+    ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
+    ASSERT_EQ(fpgaGetProperties(nullptr, &filter_), FPGA_OK);
+    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
+    num_matches_ = 0;
+    ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
+                            &num_matches_),
+              FPGA_OK);
+    EXPECT_EQ(num_matches_, platform_.devices.size());
+    accel_ = nullptr;
+    ASSERT_EQ(fpgaOpen(tokens_[0], &accel_, 0), FPGA_OK);
+    pg_size_ = (size_t) sysconf(_SC_PAGE_SIZE);
+  }
+
+  virtual void TearDown() override {
+    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
+    if (accel_) {
+        EXPECT_EQ(fpgaClose(accel_), FPGA_OK);
+        accel_ = nullptr;
+    }
+    uint32_t i;
+    for (i = 0 ; i < num_matches_ ; ++i) {
+        EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
+    }
+    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
+      std::string cmd = "rm -rf " + tmpsysfs_;
+      std::system(cmd.c_str());
+    }
+    system_->finalize();
+  }
+
+  std::string tmpsysfs_;
+  fpga_properties filter_;
+  std::array<fpga_token, 2> tokens_;
+  fpga_handle accel_;
+  size_t pg_size_;
+  test_platform platform_;
+  uint32_t num_matches_;
+  test_device invalid_device_;
+  test_system *system_;
+};
+
+/**
+ * @test       prep_rel
+ * @brief      Test: fpgaPrepareBuffer, fpgaReleaseBuffer
+ * @details    When fpgaPrepareBuffer retrieves a valid buffer pointer and wsid,<br>
+ *             then a subsequent call to fpgaReleaseBuffer with the wsid,<br>
+ *             also returns FPGA_OK.<br>
+ */
+TEST_P(buffer_c_p, prep_rel) {
+  void *buf_addr = nullptr;
+  uint64_t wsid = 0;
+  ASSERT_EQ(fpgaPrepareBuffer(accel_, (uint64_t) pg_size_,
+                              &buf_addr, &wsid, 0), FPGA_OK);
+  EXPECT_NE(buf_addr, nullptr);
+  EXPECT_NE(wsid, 0);
+  EXPECT_EQ(fpgaReleaseBuffer(accel_, wsid), FPGA_OK);
+}
+
+/**
+ * @test       ioaddr
+ * @brief      Test: fpgaGetIOAddress
+ * @details    When called with a valid wsid,<br>
+ *             fpgaGetIOAddress retrieves the IO address for the wsid<br>
+ *             and returns FPGA_OK.<br>
+ */
+TEST_P(buffer_c_p, ioaddr) {
+  void *buf_addr = nullptr;
+  uint64_t wsid = 0;
+  uint64_t io = 0xdecafbadbeefdead;
+  ASSERT_EQ(fpgaPrepareBuffer(accel_, (uint64_t) pg_size_,
+                              &buf_addr, &wsid, 0), FPGA_OK);
+  EXPECT_EQ(fpgaGetIOAddress(accel_, wsid, &io), FPGA_OK);
+  EXPECT_NE(io, 0xdecafbadbeefdead);
+  EXPECT_EQ(fpgaReleaseBuffer(accel_, wsid), FPGA_OK);
+}
+
+INSTANTIATE_TEST_CASE_P(buffer_c, buffer_c_p, ::testing::ValuesIn(test_platform::keys(true)));

--- a/testing/opae-c/test_enum_c.cpp
+++ b/testing/opae-c/test_enum_c.cpp
@@ -78,10 +78,6 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
   virtual void TearDown() override {
     DestroyTokens();
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-    if (!tmpsysfs.empty() && tmpsysfs.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/opae-c/test_enum_c.cpp
+++ b/testing/opae-c/test_enum_c.cpp
@@ -59,16 +59,25 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
     system_ = test_system::instance();
     system_->initialize();
     tmpsysfs = system_->prepare_syfs(platform_);
-
-    ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
-    ASSERT_EQ(fpgaGetProperties(nullptr, &filter), FPGA_OK);
-    num_matches = 0xc01a;
     invalid_device_ = test_device::unknown();
 
+    ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
+    filter_ = nullptr;
+    ASSERT_EQ(fpgaGetProperties(nullptr, &filter_), FPGA_OK);
+    num_matches_ = 0;
+  }
+
+  void DestroyTokens() {
+    uint32_t i;
+    for (i = 0 ; i < num_matches_ ; ++i) {
+      EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
+    }
+    num_matches_ = 0;
   }
 
   virtual void TearDown() override {
-    EXPECT_EQ(fpgaDestroyProperties(&filter), FPGA_OK);
+    DestroyTokens();
+    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
     if (!tmpsysfs.empty() && tmpsysfs.size() > 1) {
       std::string cmd = "rm -rf " + tmpsysfs;
       std::system(cmd.c_str());
@@ -77,9 +86,9 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
   }
 
   std::string tmpsysfs;
-  fpga_properties filter;
-  std::array<fpga_token, 2> tokens;
-  uint32_t num_matches;
+  fpga_properties filter_;
+  std::array<fpga_token, 2> tokens_;
+  uint32_t num_matches_;
   test_platform platform_;
   test_device invalid_device_;
   test_system *system_;
@@ -145,222 +154,254 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
 //
 TEST_P(enum_c_p, nullfilter) {
   EXPECT_EQ(
-      fpgaEnumerate(nullptr, 0, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(nullptr, 0, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, platform_.devices.size()*2);
+  EXPECT_EQ(num_matches_, platform_.devices.size()*2);
 
+  uint32_t matches = 0;
   EXPECT_EQ(
-      fpgaEnumerate(nullptr, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(nullptr, 1, tokens_.data(), tokens_.size(), &matches),
       FPGA_INVALID_PARAM);
 }
 
 TEST_P(enum_c_p, nullmatches) {
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 0, tokens.data(), tokens.size(), NULL),
+      fpgaEnumerate(&filter_, 0, tokens_.data(), tokens_.size(), NULL),
       FPGA_INVALID_PARAM);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 0, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 0, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_INVALID_PARAM);
 }
 
 TEST_P(enum_c_p, nulltokens) {
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 0, NULL, tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 0, NULL, tokens_.size(), &num_matches_),
       FPGA_INVALID_PARAM);
 }
 
 
 TEST_P(enum_c_p, object_type) {
-  ASSERT_EQ(fpgaPropertiesSetObjectType(filter, FPGA_ACCELERATOR), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, platform_.devices.size());
+  EXPECT_EQ(num_matches_, platform_.devices.size());
 
-  EXPECT_EQ(fpgaPropertiesSetObjectType(filter, FPGA_DEVICE), FPGA_OK);
+  DestroyTokens();
+
+  EXPECT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, platform_.devices.size());
+  EXPECT_EQ(num_matches_, platform_.devices.size());
 }
 
 TEST_P(enum_c_p, parent) {
-  EXPECT_EQ(fpgaPropertiesSetObjectType(filter, FPGA_DEVICE), FPGA_OK);
+  EXPECT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, platform_.devices.size());
-  ASSERT_EQ(fpgaClearProperties(filter), FPGA_OK);
-  EXPECT_EQ(fpgaPropertiesSetParent(filter, tokens[0]), FPGA_OK);
+  EXPECT_EQ(num_matches_, platform_.devices.size());
+
+  fpga_token tok = nullptr;
+  ASSERT_EQ(fpgaCloneToken(tokens_[0], &tok), FPGA_OK);
+
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaClearProperties(filter_), FPGA_OK);
+  EXPECT_EQ(fpgaPropertiesSetParent(filter_, tok), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, platform_.devices.size());
+  EXPECT_EQ(num_matches_, platform_.devices.size());
+  EXPECT_EQ(fpgaDestroyToken(&tok), FPGA_OK);
 }
 
 TEST_P(enum_c_p, segment) {
   auto device = platform_.devices[0];
-  ASSERT_EQ(fpgaPropertiesSetSegment(filter, device.segment), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetSegment(filter_, device.segment), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 2);
+  EXPECT_EQ(num_matches_, 2);
 
-  ASSERT_EQ(fpgaPropertiesSetSegment(filter, invalid_device_.segment), FPGA_OK);
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetSegment(filter_, invalid_device_.segment), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
 TEST_P(enum_c_p, bus) {
   auto device = platform_.devices[0];
-  ASSERT_EQ(fpgaPropertiesSetBus(filter, device.bus), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetBus(filter_, device.bus), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 2);
+  EXPECT_EQ(num_matches_, 2);
 
-  ASSERT_EQ(fpgaPropertiesSetBus(filter, invalid_device_.bus), FPGA_OK);
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetBus(filter_, invalid_device_.bus), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
 TEST_P(enum_c_p, device) {
   auto device = platform_.devices[0];
-  ASSERT_EQ(fpgaPropertiesSetDevice(filter, device.device), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetDevice(filter_, device.device), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 2);
+  EXPECT_EQ(num_matches_, 2);
 
-  ASSERT_EQ(fpgaPropertiesSetDevice(filter, invalid_device_.device), FPGA_OK);
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetDevice(filter_, invalid_device_.device), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
 TEST_P(enum_c_p, function) {
   auto device = platform_.devices[0];
-  ASSERT_EQ(fpgaPropertiesSetFunction(filter, device.function), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetFunction(filter_, device.function), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 2);
+  EXPECT_EQ(num_matches_, 2);
 
-  ASSERT_EQ(fpgaPropertiesSetFunction(filter, invalid_device_.function),
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetFunction(filter_, invalid_device_.function),
             FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
 TEST_P(enum_c_p, socket_id) {
   auto device = platform_.devices[0];
-  ASSERT_EQ(fpgaPropertiesSetSocketID(filter, device.socket_id), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetSocketID(filter_, device.socket_id), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 2);
+  EXPECT_EQ(num_matches_, 2);
 
-  ASSERT_EQ(fpgaPropertiesSetSocketID(filter, invalid_device_.socket_id),
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetSocketID(filter_, invalid_device_.socket_id),
             FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
 TEST_P(enum_c_p, vendor_id) {
   auto device = platform_.devices[0];
-  ASSERT_EQ(fpgaPropertiesSetVendorID(filter, device.vendor_id), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetVendorID(filter_, device.vendor_id), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 2);
+  EXPECT_EQ(num_matches_, 2);
 
-  ASSERT_EQ(fpgaPropertiesSetVendorID(filter, invalid_device_.vendor_id),
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetVendorID(filter_, invalid_device_.vendor_id),
             FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
 TEST_P(enum_c_p, device_id) {
   auto device = platform_.devices[0];
-  ASSERT_EQ(fpgaPropertiesSetDeviceID(filter, device.device_id), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetDeviceID(filter_, device.device_id), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 2);
+  EXPECT_EQ(num_matches_, 2);
 
-  ASSERT_EQ(fpgaPropertiesSetDeviceID(filter, invalid_device_.device_id),
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetDeviceID(filter_, invalid_device_.device_id),
             FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
 TEST_P(enum_c_p, object_id) {
   auto device = platform_.devices[0];
   // fme object id
-  ASSERT_EQ(fpgaPropertiesSetObjectID(filter, device.fme_object_id), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetObjectID(filter_, device.fme_object_id), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 1);
+  EXPECT_EQ(num_matches_, 1);
 
-  ASSERT_EQ(fpgaPropertiesSetObjectID(filter, invalid_device_.fme_object_id),
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetObjectID(filter_, invalid_device_.fme_object_id),
             FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
   // afu object id
-  ASSERT_EQ(fpgaPropertiesSetObjectID(filter, device.port_object_id), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetObjectID(filter_, device.port_object_id), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 1);
+  EXPECT_EQ(num_matches_, 1);
 
-  ASSERT_EQ(fpgaPropertiesSetObjectID(filter, invalid_device_.port_object_id),
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetObjectID(filter_, invalid_device_.port_object_id),
             FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
 TEST_P(enum_c_p, num_errors) {
   auto device = platform_.devices[0];
   // fme num_errors
-  ASSERT_EQ(fpgaPropertiesSetNumErrors(filter, device.fme_num_errors), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetNumErrors(filter_, device.fme_num_errors), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 1);
+  EXPECT_EQ(num_matches_, 1);
+
+  DestroyTokens();
 
   // afu num_errors
-  ASSERT_EQ(fpgaPropertiesSetNumErrors(filter, device.port_num_errors),
+  ASSERT_EQ(fpgaPropertiesSetNumErrors(filter_, device.port_num_errors),
             FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 1);
+  EXPECT_EQ(num_matches_, 1);
+
+  DestroyTokens();
 
   // invalid
-  ASSERT_EQ(fpgaPropertiesSetNumErrors(filter, invalid_device_.port_num_errors),
+  ASSERT_EQ(fpgaPropertiesSetNumErrors(filter_, invalid_device_.port_num_errors),
             FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
 TEST_P(enum_c_p, guid) {
@@ -370,52 +411,67 @@ TEST_P(enum_c_p, guid) {
   ASSERT_EQ(uuid_parse(device.fme_guid, fme_guid), 0);
   ASSERT_EQ(uuid_parse(device.afu_guid, afu_guid), 0);
   ASSERT_EQ(uuid_parse(invalid_device_.afu_guid, random_guid), 0);
-  ASSERT_EQ(fpgaPropertiesSetGUID(filter, fme_guid), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetGUID(filter_, fme_guid), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 1);
+  EXPECT_EQ(num_matches_, 1);
+
+  DestroyTokens();
+
   // afu guid
-  ASSERT_EQ(fpgaPropertiesSetGUID(filter, afu_guid), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetGUID(filter_, afu_guid), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 1);
+  EXPECT_EQ(num_matches_, 1);
+
+  DestroyTokens();
+
   // random guid
-  ASSERT_EQ(fpgaPropertiesSetGUID(filter, random_guid), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetGUID(filter_, random_guid), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
-TEST_P(enum_c_p, clone_token) {
+TEST_P(enum_c_p, clone_token01) {
   EXPECT_EQ(
-      fpgaEnumerate(nullptr, 0, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(nullptr, 0, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  ASSERT_EQ(num_matches, 2);
-  fpga_token src = tokens[0];
-  fpga_token dst;
+  ASSERT_EQ(num_matches_, 2);
+  fpga_token src = tokens_[0];
+  fpga_token dst = nullptr;
   EXPECT_EQ(fpgaCloneToken(src, &dst), FPGA_OK);
+  EXPECT_EQ(fpgaDestroyToken(&dst), FPGA_OK);
+}
+
+TEST_P(enum_c_p, clone_token02) {
+  EXPECT_EQ(
+      fpgaEnumerate(nullptr, 0, tokens_.data(), tokens_.size(), &num_matches_),
+      FPGA_OK);
+  ASSERT_EQ(num_matches_, 2);
+  fpga_token src = tokens_[0];
+  fpga_token dst = nullptr;
+  // Invalidate the allocation of the wrapped token.
+  system_->invalidate_malloc(0, "opae_allocate_wrapped_token");
+  EXPECT_EQ(fpgaCloneToken(src, &dst), FPGA_NO_MEMORY);
 }
 
 TEST_P(enum_c_p, clone_wo_src_dst) {
   EXPECT_EQ(
-      fpgaEnumerate(nullptr, 0, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(nullptr, 0, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 2);
-  fpga_token src = tokens[0];
+  EXPECT_EQ(num_matches_, 2);
+  fpga_token src = tokens_[0];
   fpga_token dst;
   EXPECT_EQ(fpgaCloneToken(NULL, &dst), FPGA_INVALID_PARAM);
   EXPECT_EQ(fpgaCloneToken(&src, NULL), FPGA_INVALID_PARAM);
 }
 
 TEST_P(enum_c_p, no_token_magic) {
-  EXPECT_EQ(
-      fpgaEnumerate(nullptr, 0, tokens.data(), tokens.size(), &num_matches),
-      FPGA_OK);
-  EXPECT_EQ(num_matches, 2);
-  fpga_token src,dst;
+  fpga_token src = nullptr, dst = nullptr;
   EXPECT_NE(fpgaCloneToken(&src, &dst), FPGA_OK);
 }
 
@@ -424,118 +480,116 @@ TEST_P(enum_c_p, destroy_token) {
   opae_wrapped_token *dummy = new opae_wrapped_token;
   EXPECT_EQ(fpgaDestroyToken((fpga_token *)dummy), FPGA_INVALID_PARAM);
   delete dummy;
-  // null filter
-  uint32_t num_matches;
-  EXPECT_EQ(
-      fpgaEnumerate(nullptr, 0, tokens.data(), tokens.size(), &num_matches),
-      FPGA_OK);
-  ASSERT_EQ(num_matches, 2);
-  num_matches = 100;
-  for (auto t : tokens) {
-    if (t != nullptr) {
-      EXPECT_EQ(fpgaDestroyToken(&t), FPGA_OK);
-    }
-  }
-
   EXPECT_EQ(fpgaDestroyToken(nullptr), FPGA_INVALID_PARAM);
 }
 
 TEST_P(enum_c_p, num_slots) {
   auto device = platform_.devices[0];
-  ASSERT_EQ(fpgaPropertiesSetObjectType(filter, FPGA_DEVICE), FPGA_OK);
-  ASSERT_EQ(fpgaPropertiesSetNumSlots(filter, device.num_slots), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetNumSlots(filter_, device.num_slots), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 1);
+  EXPECT_EQ(num_matches_, 1);
 
-  ASSERT_EQ(fpgaPropertiesSetNumSlots(filter, invalid_device_.num_slots), FPGA_OK);
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetNumSlots(filter_, invalid_device_.num_slots), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
 TEST_P(enum_c_p, bbs_id) {
   auto device = platform_.devices[0];
-  ASSERT_EQ(fpgaPropertiesSetObjectType(filter, FPGA_DEVICE), FPGA_OK);
-  ASSERT_EQ(fpgaPropertiesSetBBSID(filter, device.bbs_id), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetBBSID(filter_, device.bbs_id), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 1);
+  EXPECT_EQ(num_matches_, 1);
 
-  ASSERT_EQ(fpgaPropertiesSetBBSID(filter, invalid_device_.bbs_id), FPGA_OK);
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetBBSID(filter_, invalid_device_.bbs_id), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
 TEST_P(enum_c_p, bbs_version) {
   auto device = platform_.devices[0];
-  ASSERT_EQ(fpgaPropertiesSetObjectType(filter, FPGA_DEVICE), FPGA_OK);
-  ASSERT_EQ(fpgaPropertiesSetBBSVersion(filter, device.bbs_version), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetBBSVersion(filter_, device.bbs_version), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 1);
+  EXPECT_EQ(num_matches_, 1);
 
-  ASSERT_EQ(fpgaPropertiesSetBBSVersion(filter, invalid_device_.bbs_version), FPGA_OK);
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetBBSVersion(filter_, invalid_device_.bbs_version), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
 TEST_P(enum_c_p, state) {
   auto device = platform_.devices[0];
-  ASSERT_EQ(fpgaPropertiesSetObjectType(filter, FPGA_ACCELERATOR), FPGA_OK);
-  ASSERT_EQ(fpgaPropertiesSetAcceleratorState(filter, device.state), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetAcceleratorState(filter_, device.state), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 1);
+  EXPECT_EQ(num_matches_, 1);
 
-  ASSERT_EQ(fpgaPropertiesSetAcceleratorState(filter, invalid_device_.state), FPGA_OK);
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetAcceleratorState(filter_, invalid_device_.state), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
 TEST_P(enum_c_p, num_mmio) {
   auto device = platform_.devices[0];
-  ASSERT_EQ(fpgaPropertiesSetObjectType(filter, FPGA_ACCELERATOR), FPGA_OK);
-  ASSERT_EQ(fpgaPropertiesSetNumMMIO(filter, device.num_mmio), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetNumMMIO(filter_, device.num_mmio), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 1);
+  EXPECT_EQ(num_matches_, 1);
 
-  ASSERT_EQ(fpgaPropertiesSetObjectType(filter, FPGA_DEVICE), FPGA_OK);
-  ASSERT_EQ(fpgaPropertiesSetNumMMIO(filter, invalid_device_.num_mmio), FPGA_INVALID_PARAM);
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetNumMMIO(filter_, invalid_device_.num_mmio), FPGA_INVALID_PARAM);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
 
 TEST_P(enum_c_p, num_interrupts) {
   auto device = platform_.devices[0];
-  ASSERT_EQ(fpgaPropertiesSetObjectType(filter, FPGA_ACCELERATOR), FPGA_OK);
-  ASSERT_EQ(fpgaPropertiesSetNumInterrupts(filter, device.num_interrupts), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetNumInterrupts(filter_, device.num_interrupts), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 1);
+  EXPECT_EQ(num_matches_, 1);
 
-  ASSERT_EQ(fpgaPropertiesSetNumInterrupts(filter, invalid_device_.num_interrupts), FPGA_OK);
+  DestroyTokens();
+
+  ASSERT_EQ(fpgaPropertiesSetNumInterrupts(filter_, invalid_device_.num_interrupts), FPGA_OK);
   EXPECT_EQ(
-      fpgaEnumerate(&filter, 1, tokens.data(), tokens.size(), &num_matches),
+      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
-  EXPECT_EQ(num_matches, 0);
+  EXPECT_EQ(num_matches_, 0);
 }
-
 
 INSTANTIATE_TEST_CASE_P(enum_c, enum_c_p, ::testing::ValuesIn(test_platform::keys(true)));

--- a/testing/opae-c/test_error_c.cpp
+++ b/testing/opae-c/test_error_c.cpp
@@ -1,0 +1,152 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+extern "C" {
+
+#include <json-c/json.h>
+#include <uuid/uuid.h>
+#include "opae_int.h"
+
+}
+
+#include <opae/fpga.h>
+
+#include <array>
+#include <cstdlib>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+#include "test_system.h"
+
+using namespace opae::testing;
+
+class error_c_p : public ::testing::TestWithParam<std::string> {
+ protected:
+  error_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+
+  virtual void SetUp() override {
+    ASSERT_TRUE(test_platform::exists(GetParam()));
+    platform_ = test_platform::get(GetParam());
+    system_ = test_system::instance();
+    system_->initialize();
+    tmpsysfs_ = system_->prepare_syfs(platform_);
+    invalid_device_ = test_device::unknown();
+
+    ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
+    ASSERT_EQ(fpgaGetProperties(nullptr, &filter_), FPGA_OK);
+    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
+    num_matches_ = 0;
+    ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
+                            &num_matches_),
+              FPGA_OK);
+    EXPECT_EQ(num_matches_, platform_.devices.size());
+  }
+
+  virtual void TearDown() override {
+    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
+    uint32_t i;
+    for (i = 0 ; i < num_matches_ ; ++i) {
+        EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
+    }
+    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
+      std::string cmd = "rm -rf " + tmpsysfs_;
+      std::system(cmd.c_str());
+    }
+    system_->finalize();
+  }
+
+  std::string tmpsysfs_;
+  fpga_properties filter_;
+  std::array<fpga_token, 2> tokens_;
+  test_platform platform_;
+  uint32_t num_matches_;
+  test_device invalid_device_;
+  test_system *system_;
+};
+
+/**
+ * @test       read
+ * @brief      Test: fpgaReadError
+ * @details    When fpgaReadError is called with valid params,<br>
+ *             it retrieves the value of the requested error,<br>
+ *             and the fn returns FPGA_OK.<br>
+ */
+TEST_P(error_c_p, read) {
+  uint64_t val = 0xdeadbeefdecafbad;
+  EXPECT_EQ(fpgaReadError(tokens_[0], 0, &val), FPGA_OK);
+  EXPECT_EQ(val, 0);
+}
+
+/**
+ * @test       get_info
+ * @brief      Test: fpgaGetErrorInfo
+ * @details    When fpgaGetErrorInfo is called with valid params,<br>
+ *             it retrieves the info of the requested error,<br>
+ *             and the fn returns FPGA_OK.<br>
+ */
+TEST_P(error_c_p, get_info) {
+  fpga_error_info info;
+  EXPECT_EQ(fpgaGetErrorInfo(tokens_[0], 0, &info), FPGA_OK);
+  EXPECT_STREQ(info.name, "first_error");
+  EXPECT_EQ(info.can_clear, false);
+}
+
+/**
+ * @test       clear
+ * @brief      Test: fpgaClearError
+ * @details    When fpgaClearError is called with valid params,<br>
+ *             it clears the requested error,<br>
+ *             and the fn returns FPGA_OK.<br>
+ */
+TEST_P(error_c_p, clear) {
+  fpga_error_info info;
+  uint32_t e = 0;
+  bool cleared = false;
+  while (fpgaGetErrorInfo(tokens_[0], e, &info) == FPGA_OK) {
+    if (info.can_clear) {
+      EXPECT_EQ(fpgaClearError(tokens_[0], e), FPGA_OK);
+      cleared = true;
+      break;
+    }
+    ++e;
+  }
+  EXPECT_EQ(cleared, true);
+}
+
+/**
+ * @test       clear
+ * @brief      Test: fpgaClearAllErrors
+ * @details    When fpgaClearAllErrors is called with valid params,<br>
+ *             it clears the requested errors,<br>
+ *             and the fn returns FPGA_OK.<br>
+ */
+TEST_P(error_c_p, clear_all) {
+  EXPECT_EQ(fpgaClearAllErrors(tokens_[0]), FPGA_OK);
+}
+
+INSTANTIATE_TEST_CASE_P(error_c, error_c_p, ::testing::ValuesIn(test_platform::keys(true)));

--- a/testing/opae-c/test_error_c.cpp
+++ b/testing/opae-c/test_error_c.cpp
@@ -73,10 +73,6 @@ class error_c_p : public ::testing::TestWithParam<std::string> {
     for (i = 0 ; i < num_matches_ ; ++i) {
         EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
     }
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/opae-c/test_event_c.cpp
+++ b/testing/opae-c/test_event_c.cpp
@@ -109,10 +109,6 @@ class event_c_p : public ::testing::TestWithParam<std::string> {
     for (i = 0 ; i < num_matches_ ; ++i) {
         EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
     }
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
     fpgad_.join();
   }

--- a/testing/opae-c/test_event_c.cpp
+++ b/testing/opae-c/test_event_c.cpp
@@ -1,0 +1,258 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+extern "C" {
+
+#include <json-c/json.h>
+#include <uuid/uuid.h>
+#include "opae_int.h"
+#include "fpgad/config_int.h"
+#include "fpgad/log.h"
+#include "fpgad/srv.h"
+
+}
+
+#include <opae/fpga.h>
+#include "intel-fpga.h"
+#include <linux/ioctl.h>
+
+#include <array>
+#include <cstdlib>
+#include <chrono>
+#include <thread>
+#include "gtest/gtest.h"
+#include "test_system.h"
+
+using namespace opae::testing;
+
+class event_c_p : public ::testing::TestWithParam<std::string> {
+ protected:
+  event_c_p()
+    : tmpsysfs_("mocksys-XXXXXX"),
+      tmpfpgad_log_("tmpfpgad-XXXXXX.log"),
+      tmpfpgad_pid_("tmpfpgad-XXXXXX.pid") {}
+ 
+  virtual void SetUp() override {
+    tmpfpgad_log_ = mkstemp(const_cast<char *>(tmpfpgad_log_.c_str()));
+    tmpfpgad_pid_ = mkstemp(const_cast<char *>(tmpfpgad_pid_.c_str()));
+    ASSERT_TRUE(test_platform::exists(GetParam()));
+    platform_ = test_platform::get(GetParam());
+    system_ = test_system::instance();
+    system_->initialize();
+    tmpsysfs_ = system_->prepare_syfs(platform_);
+    invalid_device_ = test_device::unknown();
+
+    ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
+    ASSERT_EQ(fpgaGetProperties(nullptr, &filter_), FPGA_OK);
+    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
+    num_matches_ = 0;
+    ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
+                            &num_matches_),
+              FPGA_OK);
+    EXPECT_EQ(num_matches_, platform_.devices.size());
+    accel_ = nullptr;
+    ASSERT_EQ(fpgaOpen(tokens_[0], &accel_, 0), FPGA_OK);
+
+    event_handle_ = nullptr;
+    EXPECT_EQ(fpgaCreateEventHandle(&event_handle_), FPGA_OK);
+
+    config_ = {
+        .verbosity = 0,
+        .poll_interval_usec = 100 * 1000,
+        .daemon = 0,
+        .directory = ".",
+        .logfile = tmpfpgad_log_.c_str(),
+        .pidfile = tmpfpgad_pid_.c_str(),
+        .filemode = 0,
+        .running = true,
+        .socket = "/tmp/fpga_event_socket",
+        .null_gbs = {0},
+        .num_null_gbs = 0,
+    };
+    open_log(tmpfpgad_log_.c_str());
+    fpgad_ = std::thread(server_thread, &config_);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  }
+
+  virtual void TearDown() override {
+    config_.running = false;
+    EXPECT_EQ(fpgaDestroyEventHandle(&event_handle_), FPGA_OK);
+    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
+    if (accel_) {
+        EXPECT_EQ(fpgaClose(accel_), FPGA_OK);
+        accel_ = nullptr;
+    }
+    uint32_t i;
+    for (i = 0 ; i < num_matches_ ; ++i) {
+        EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
+    }
+    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
+      std::string cmd = "rm -rf " + tmpsysfs_;
+      std::system(cmd.c_str());
+    }
+    system_->finalize();
+    fpgad_.join();
+  }
+
+  std::string tmpsysfs_;
+  std::string tmpfpgad_log_;
+  std::string tmpfpgad_pid_;
+  struct config config_;
+  std::thread fpgad_;
+  fpga_properties filter_;
+  std::array<fpga_token, 2> tokens_;
+  fpga_handle accel_;
+  fpga_event_handle event_handle_;
+  test_platform platform_;
+  uint32_t num_matches_;
+  test_device invalid_device_;
+  test_system *system_;
+};
+
+/**
+ * @test       get_obj_err01
+ * @brief      Test: fpgaGetOSObjectFromEventHandle
+ * @details    When fpgaGetOSObjectFromEventHandle is called prior<br>
+ *             to registering an event type,<br>
+ *             the fn returns FPGA_INVALID_PARAM.<br>
+ */
+TEST_P(event_c_p, get_obj_err01) {
+  int fd = -1;
+  EXPECT_EQ(fpgaGetOSObjectFromEventHandle(event_handle_, &fd), FPGA_INVALID_PARAM);
+}
+
+/**
+ * @test       get_obj_err02
+ * @brief      Test: fpgaGetOSObjectFromEventHandle
+ * @details    When fpgaGetOSObjectFromEventHandle is called with a wrapped<br>
+ *             event handle that has a NULL opae_event_handle,<br>
+ *             the fn returns FPGA_INVALID_PARAM.<br>
+ */
+TEST_P(event_c_p, get_obj_err02) {
+  EXPECT_EQ(fpgaRegisterEvent(accel_, FPGA_EVENT_ERROR,
+                              event_handle_, 0), FPGA_OK);
+
+  opae_wrapped_event_handle *wrapped_evt_handle =
+	  opae_validate_wrapped_event_handle(event_handle_);
+  ASSERT_NE(wrapped_evt_handle, nullptr);
+
+  fpga_event_handle eh = wrapped_evt_handle->opae_event_handle;
+  wrapped_evt_handle->opae_event_handle = nullptr;
+
+  int fd = -1;
+  EXPECT_EQ(fpgaGetOSObjectFromEventHandle(event_handle_, &fd), FPGA_INVALID_PARAM);
+
+  wrapped_evt_handle->opae_event_handle = eh;
+
+  EXPECT_EQ(fpgaUnregisterEvent(accel_, FPGA_EVENT_ERROR,
+			  event_handle_), FPGA_OK);
+}
+
+/**
+ * @test       get_obj_success
+ * @brief      Test: fpgaRegisterEvent, fpgaUnregisterEvent, fpgaGetOSObjectFromEventHandle
+ * @details    When fpgaGetOSObjectFromEventHandle is called after<br>
+ *             registering an event type,<br>
+ *             the fn returns FPGA_OK.<br>
+ */
+TEST_P(event_c_p, get_obj_success) {
+  int fd = -1;
+  EXPECT_EQ(fpgaRegisterEvent(accel_, FPGA_EVENT_ERROR,
+                              event_handle_, 0), FPGA_OK);
+  EXPECT_EQ(fpgaGetOSObjectFromEventHandle(event_handle_, &fd), FPGA_OK);
+
+  EXPECT_EQ(fpgaUnregisterEvent(accel_, FPGA_EVENT_ERROR,
+			  event_handle_), FPGA_OK);
+}
+
+/**
+ * @test       unreg_err01
+ * @brief      Test: fpgaUnregisterEvent
+ * @details    When fpgaUnregisterEvent is called before<br>
+ *             registering an event type,<br>
+ *             the fn returns FPGA_INVALID_PARAM.<br>
+ */
+TEST_P(event_c_p, unreg_err01) {
+  EXPECT_EQ(fpgaUnregisterEvent(accel_, FPGA_EVENT_ERROR,
+			  event_handle_), FPGA_INVALID_PARAM);
+}
+
+/**
+ * @test       unreg_err02
+ * @brief      Test: fpgaUnregisterEvent
+ * @details    When fpgaUnregisterEvent is called on a wrapped<br>
+ *             event handle object with a NULL opae_event_handle,<br>
+ *             the fn returns FPGA_INVALID_PARAM.<br>
+ */
+TEST_P(event_c_p, unreg_err02) {
+  EXPECT_EQ(fpgaRegisterEvent(accel_, FPGA_EVENT_ERROR,
+                              event_handle_, 0), FPGA_OK);
+
+  opae_wrapped_event_handle *wrapped_evt_handle =
+	  opae_validate_wrapped_event_handle(event_handle_);
+  ASSERT_NE(wrapped_evt_handle, nullptr);
+
+  fpga_event_handle eh = wrapped_evt_handle->opae_event_handle;
+  wrapped_evt_handle->opae_event_handle = nullptr;
+
+  EXPECT_EQ(fpgaUnregisterEvent(accel_, FPGA_EVENT_ERROR,
+			  event_handle_), FPGA_INVALID_PARAM);
+
+  wrapped_evt_handle->opae_event_handle = eh;
+
+  EXPECT_EQ(fpgaUnregisterEvent(accel_, FPGA_EVENT_ERROR,
+			  event_handle_), FPGA_OK);
+}
+
+/**
+ * @test       destroy_err
+ * @brief      Test: fpgaDestroyEventHandle
+ * @details    When fpgaDestroyEventHandle is called on a wrapped<br>
+ *             event handle object with a NULL opae_event_handle,<br>
+ *             the fn returns FPGA_INVALID_PARAM.<br>
+ */
+TEST_P(event_c_p, destroy_err) {
+  EXPECT_EQ(fpgaRegisterEvent(accel_, FPGA_EVENT_ERROR,
+                              event_handle_, 0), FPGA_OK);
+
+  opae_wrapped_event_handle *wrapped_evt_handle =
+	  opae_validate_wrapped_event_handle(event_handle_);
+  ASSERT_NE(wrapped_evt_handle, nullptr);
+
+  fpga_event_handle eh = wrapped_evt_handle->opae_event_handle;
+  wrapped_evt_handle->opae_event_handle = nullptr;
+
+  EXPECT_EQ(fpgaDestroyEventHandle(&event_handle_), FPGA_INVALID_PARAM);
+
+  wrapped_evt_handle->opae_event_handle = eh;
+
+  EXPECT_EQ(fpgaUnregisterEvent(accel_, FPGA_EVENT_ERROR,
+			  event_handle_), FPGA_OK);
+}
+
+
+
+INSTANTIATE_TEST_CASE_P(event_c, event_c_p, ::testing::ValuesIn(test_platform::keys(true)));

--- a/testing/opae-c/test_hostif_c.cpp
+++ b/testing/opae-c/test_hostif_c.cpp
@@ -1,0 +1,135 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+extern "C" {
+
+#include <json-c/json.h>
+#include <uuid/uuid.h>
+#include "opae_int.h"
+
+}
+
+#include <opae/fpga.h>
+#include "intel-fpga.h"
+#include <linux/ioctl.h>
+
+#include <array>
+#include <cstdlib>
+#include <cstdarg>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+#include "test_system.h"
+
+using namespace opae::testing;
+
+class hostif_c_p : public ::testing::TestWithParam<std::string> {
+ protected:
+  hostif_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+
+  virtual void SetUp() override {
+    ASSERT_TRUE(test_platform::exists(GetParam()));
+    platform_ = test_platform::get(GetParam());
+    system_ = test_system::instance();
+    system_->initialize();
+    tmpsysfs_ = system_->prepare_syfs(platform_);
+    invalid_device_ = test_device::unknown();
+
+    ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
+    ASSERT_EQ(fpgaGetProperties(nullptr, &filter_), FPGA_OK);
+    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
+    num_matches_ = 0;
+    ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
+                            &num_matches_),
+              FPGA_OK);
+    EXPECT_EQ(num_matches_, platform_.devices.size());
+    accel_ = nullptr;
+    ASSERT_EQ(fpgaOpen(tokens_[0], &accel_, 0), FPGA_OK);
+  }
+
+  virtual void TearDown() override {
+    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
+    if (accel_) {
+        EXPECT_EQ(fpgaClose(accel_), FPGA_OK);
+        accel_ = nullptr;
+    }
+    uint32_t i;
+    for (i = 0 ; i < num_matches_ ; ++i) {
+        EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
+    }
+    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
+      std::string cmd = "rm -rf " + tmpsysfs_;
+      std::system(cmd.c_str());
+    }
+    system_->finalize();
+  }
+
+  std::string tmpsysfs_;
+  fpga_properties filter_;
+  std::array<fpga_token, 2> tokens_;
+  fpga_handle accel_;
+  test_platform platform_;
+  uint32_t num_matches_;
+  test_device invalid_device_;
+  test_system *system_;
+};
+
+/**
+ * @test       assign_port
+ * @brief      Test: fpgaAssignPortToInterface
+ * @details    When fpgaAssignPortToInterface is called with valid params,<br>
+ *             then the fn returns FPGA_OK.<br>
+ */
+TEST_P(hostif_c_p, assign_port) {
+  EXPECT_EQ(fpgaAssignPortToInterface(accel_, 0,
+			  0, 0), FPGA_OK);
+}
+
+/**
+ * @test       assign_to_ifc
+ * @brief      Test: fpgaAssignToInterface
+ * @details    fpgaAssignToInterface is currently unsupported,<br>
+ *             and returns FPGA_NOT_SUPPORTED.<br>
+ */
+TEST_P(hostif_c_p, assign_to_ifc) {
+  EXPECT_EQ(fpgaAssignToInterface(accel_, tokens_[0],
+		    0, 0), FPGA_NOT_SUPPORTED);
+}
+
+/**
+ * @test       release_from_ifc
+ * @brief      Test: fpgaReleaseFromInterface
+ * @details    fpgaReleaseFromInterface is currently unsupported,<br>
+ *             and returns FPGA_NOT_SUPPORTED.<br>
+ */
+TEST_P(hostif_c_p, release_from_ifc) {
+  EXPECT_EQ(fpgaReleaseFromInterface(accel_, tokens_[0]),
+		     FPGA_NOT_SUPPORTED);
+}
+
+INSTANTIATE_TEST_CASE_P(hostif_c, hostif_c_p, ::testing::ValuesIn(test_platform::keys(true)));

--- a/testing/opae-c/test_hostif_c.cpp
+++ b/testing/opae-c/test_hostif_c.cpp
@@ -82,10 +82,6 @@ class hostif_c_p : public ::testing::TestWithParam<std::string> {
     for (i = 0 ; i < num_matches_ ; ++i) {
         EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
     }
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/opae-c/test_mmio_c.cpp
+++ b/testing/opae-c/test_mmio_c.cpp
@@ -1,0 +1,181 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+extern "C" {
+
+#include <json-c/json.h>
+#include <uuid/uuid.h>
+#include "opae_int.h"
+
+}
+
+#include <opae/fpga.h>
+#include "intel-fpga.h"
+#include <linux/ioctl.h>
+
+#include <array>
+#include <cstdlib>
+#include <cstdarg>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+#include "test_system.h"
+
+using namespace opae::testing;
+
+static int mmio_ioctl(mock_object * m, int request, va_list argp){
+    int retval = -1;
+    errno = EINVAL;
+    UNUSED_PARAM(m);
+    UNUSED_PARAM(request);
+    struct fpga_port_region_info *rinfo = va_arg(argp, struct fpga_port_region_info *);
+    if (!rinfo) {
+      FPGA_MSG("rinfo is NULL");
+      goto out_EINVAL;
+    }
+    if (rinfo->argsz != sizeof(*rinfo)) {
+      FPGA_MSG("wrong structure size");
+      goto out_EINVAL;
+    }
+    if (rinfo->index > 1 ) {
+      FPGA_MSG("unsupported MMIO index");
+      goto out_EINVAL;
+    }
+    if (rinfo->padding != 0) {
+      FPGA_MSG("unsupported padding");
+      goto out_EINVAL;
+    }
+    rinfo->flags = FPGA_REGION_READ | FPGA_REGION_WRITE | FPGA_REGION_MMAP;
+    rinfo->size = 0x40000;
+    rinfo->offset = 0;
+    retval = 0;
+    errno = 0;
+out:
+    return retval;
+
+out_EINVAL:
+    retval = -1;
+    errno = EINVAL;
+    goto out;
+}
+
+class mmio_c_p : public ::testing::TestWithParam<std::string> {
+ protected:
+  mmio_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+
+  virtual void SetUp() override {
+    ASSERT_TRUE(test_platform::exists(GetParam()));
+    platform_ = test_platform::get(GetParam());
+    system_ = test_system::instance();
+    system_->initialize();
+    tmpsysfs_ = system_->prepare_syfs(platform_);
+    invalid_device_ = test_device::unknown();
+
+    ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
+    ASSERT_EQ(fpgaGetProperties(nullptr, &filter_), FPGA_OK);
+    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
+    num_matches_ = 0;
+    ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
+                            &num_matches_),
+              FPGA_OK);
+    EXPECT_EQ(num_matches_, platform_.devices.size());
+    accel_ = nullptr;
+    ASSERT_EQ(fpgaOpen(tokens_[0], &accel_, 0), FPGA_OK);
+    system_->register_ioctl_handler(FPGA_PORT_GET_REGION_INFO, mmio_ioctl);
+
+    which_mmio_ = 0;
+    uint64_t *mmio_ptr = nullptr;
+    EXPECT_EQ(fpgaMapMMIO(accel_, which_mmio_, &mmio_ptr), FPGA_OK);
+    EXPECT_NE(mmio_ptr, nullptr);
+  }
+
+  virtual void TearDown() override {
+    EXPECT_EQ(fpgaUnmapMMIO(accel_, which_mmio_), FPGA_OK);
+    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
+    if (accel_) {
+        EXPECT_EQ(fpgaClose(accel_), FPGA_OK);
+        accel_ = nullptr;
+    }
+    uint32_t i;
+    for (i = 0 ; i < num_matches_ ; ++i) {
+        EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
+    }
+    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
+      std::string cmd = "rm -rf " + tmpsysfs_;
+      std::system(cmd.c_str());
+    }
+    system_->finalize();
+  }
+
+  std::string tmpsysfs_;
+  fpga_properties filter_;
+  std::array<fpga_token, 2> tokens_;
+  fpga_handle accel_;
+  uint32_t which_mmio_;
+  const uint64_t CSR_SCRATCHPAD0 = 0x100;
+  test_platform platform_;
+  uint32_t num_matches_;
+  test_device invalid_device_;
+  test_system *system_;
+};
+
+/**
+ * @test       mmio64
+ * @brief      Test: fpgaWriteMMIO64, fpgaReadMMIO64
+ * @details    Write the scratchpad register with fpgaWriteMMIO64,<br>
+ *             read the register back with fpgaReadMMIO64.<br>
+ *             Value written should equal value read.<br>
+ */
+TEST_P(mmio_c_p, mmio64) {
+  const uint64_t val_written = 0xdeadbeefdecafbad;
+  EXPECT_EQ(fpgaWriteMMIO64(accel_, which_mmio_,
+                            CSR_SCRATCHPAD0, val_written), FPGA_OK);
+  uint64_t val_read = 0;
+  EXPECT_EQ(fpgaReadMMIO64(accel_, which_mmio_,
+                           CSR_SCRATCHPAD0, &val_read), FPGA_OK);
+  EXPECT_EQ(val_written, val_read);
+}
+
+/**
+ * @test       mmio32
+ * @brief      Test: fpgaWriteMMIO32, fpgaReadMMIO32
+ * @details    Write the scratchpad register with fpgaWriteMMIO32,<br>
+ *             read the register back with fpgaReadMMIO32.<br>
+ *             Value written should equal value read.<br>
+ */
+TEST_P(mmio_c_p, mmio32) {
+  const uint32_t val_written = 0xc0cac01a;
+  EXPECT_EQ(fpgaWriteMMIO32(accel_, which_mmio_,
+                            CSR_SCRATCHPAD0, val_written), FPGA_OK);
+  uint32_t val_read = 0;
+  EXPECT_EQ(fpgaReadMMIO32(accel_, which_mmio_,
+                           CSR_SCRATCHPAD0, &val_read), FPGA_OK);
+  EXPECT_EQ(val_written, val_read);
+}
+
+INSTANTIATE_TEST_CASE_P(mmio_c, mmio_c_p, ::testing::ValuesIn(test_platform::keys(true)));

--- a/testing/opae-c/test_mmio_c.cpp
+++ b/testing/opae-c/test_mmio_c.cpp
@@ -125,10 +125,6 @@ class mmio_c_p : public ::testing::TestWithParam<std::string> {
     for (i = 0 ; i < num_matches_ ; ++i) {
         EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
     }
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/opae-c/test_props_c.cpp
+++ b/testing/opae-c/test_props_c.cpp
@@ -225,8 +225,6 @@ TEST_P(properties_p1, set_parent01) {
 TEST_P(properties_p1, from_handle01) {
   fpga_properties props = nullptr;
   EXPECT_EQ(fpgaGetPropertiesFromHandle(accel_, &props), FPGA_OK);
-  // props will have a cloned parent token.
-  EXPECT_EQ(fpgaDestroyToken(&((struct _fpga_properties *)props)->parent), FPGA_OK);
   EXPECT_EQ(fpgaDestroyProperties(&props), FPGA_OK);
 }
 
@@ -283,8 +281,6 @@ TEST_P(properties_p1, from_token02) {
 TEST_P(properties_p1, from_token03) {
   fpga_properties props = nullptr;
   EXPECT_EQ(fpgaGetProperties(tokens_accel_[0], &props), FPGA_OK);
-  // props will have a cloned parent token.
-  EXPECT_EQ(fpgaDestroyToken(&((struct _fpga_properties *)props)->parent), FPGA_OK);
   EXPECT_EQ(fpgaDestroyProperties(&props), FPGA_OK);
 }
 

--- a/testing/opae-c/test_props_c.cpp
+++ b/testing/opae-c/test_props_c.cpp
@@ -277,25 +277,10 @@ TEST_P(properties_p1, from_token02) {
  * @test    from_token03
  * @brief   Tests: fpgaGetProperties
  * @details When the input token is valid<br>
- *          and the call to opae_allocate_wrapped_token() fails,<br>
- *          fpgaGetProperties returns FPGA_NO_MEMORY<br>
- */
-TEST_P(properties_p1, from_token03) {
-  fpga_properties props = nullptr;
-  // Invalidate the allocation of the wrapped token.
-  system_->invalidate_malloc(0, "opae_allocate_wrapped_token");
-  EXPECT_EQ(fpgaGetProperties(tokens_accel_[0], &props), FPGA_NO_MEMORY);
-  EXPECT_EQ(fpgaDestroyProperties(&props), FPGA_OK);
-}
-
-/**
- * @test    from_token04
- * @brief   Tests: fpgaGetProperties
- * @details When the input token is valid<br>
  *          and the call is successful,<br>
  *          fpgaGetProperties returns FPGA_OK.<br>
  */
-TEST_P(properties_p1, from_token04) {
+TEST_P(properties_p1, from_token03) {
   fpga_properties props = nullptr;
   EXPECT_EQ(fpgaGetProperties(tokens_accel_[0], &props), FPGA_OK);
   // props will have a cloned parent token.

--- a/testing/opae-c/test_props_c.cpp
+++ b/testing/opae-c/test_props_c.cpp
@@ -222,9 +222,82 @@ TEST_P(properties_p1, set_parent01) {
   }
 }
 
-TEST_P(properties_p1, from_handle) {
+TEST_P(properties_p1, from_handle01) {
   fpga_properties props = nullptr;
   EXPECT_EQ(fpgaGetPropertiesFromHandle(accel_, &props), FPGA_OK);
+  // props will have a cloned parent token.
+  EXPECT_EQ(fpgaDestroyToken(&((struct _fpga_properties *)props)->parent), FPGA_OK);
+  EXPECT_EQ(fpgaDestroyProperties(&props), FPGA_OK);
+}
+
+/**
+ * @test    from_handle02
+ * @brief   Tests: fpgaGetPropertiesFromHandle
+ * @details When the call to opae_allocate_wrapped_token() fails<br>
+ *          fpgaGetPropertiesFromHandle returns FPGA_NO_MEMORY<br>
+ */
+TEST_P(properties_p1, from_handle02) {
+  fpga_properties props = nullptr;
+  // Invalidate the allocation of the wrapped token.
+  system_->invalidate_malloc(0, "opae_allocate_wrapped_token");
+  EXPECT_EQ(fpgaGetPropertiesFromHandle(accel_, &props), FPGA_NO_MEMORY);
+  EXPECT_EQ(fpgaDestroyProperties(&props), FPGA_OK);
+}
+
+/**
+ * @test    from_token01
+ * @brief   Tests: fpgaGetProperties
+ * @details When the input token is NULL<br>
+ *          and the call to opae_properties_create() fails,<br>
+ *          fpgaGetProperties returns FPGA_NO_MEMORY<br>
+ */
+TEST_P(properties_p1, from_token01) {
+  fpga_properties props = nullptr;
+  // Invalidate the allocation of the properties object.
+  system_->invalidate_calloc(0, "opae_properties_create");
+  EXPECT_EQ(fpgaGetProperties(NULL, &props), FPGA_NO_MEMORY);
+}
+
+/**
+ * @test    from_token02
+ * @brief   Tests: fpgaGetProperties
+ * @details When the input token is valid<br>
+ *          and the call to opae_allocate_wrapped_token() fails,<br>
+ *          fpgaGetProperties returns FPGA_NO_MEMORY<br>
+ */
+TEST_P(properties_p1, from_token02) {
+  fpga_properties props = nullptr;
+  // Invalidate the allocation of the wrapped token.
+  system_->invalidate_malloc(0, "opae_allocate_wrapped_token");
+  EXPECT_EQ(fpgaGetProperties(tokens_accel_[0], &props), FPGA_NO_MEMORY);
+  EXPECT_EQ(fpgaDestroyProperties(&props), FPGA_OK);
+}
+
+/**
+ * @test    from_token03
+ * @brief   Tests: fpgaGetProperties
+ * @details When the input token is valid<br>
+ *          and the call to opae_allocate_wrapped_token() fails,<br>
+ *          fpgaGetProperties returns FPGA_NO_MEMORY<br>
+ */
+TEST_P(properties_p1, from_token03) {
+  fpga_properties props = nullptr;
+  // Invalidate the allocation of the wrapped token.
+  system_->invalidate_malloc(0, "opae_allocate_wrapped_token");
+  EXPECT_EQ(fpgaGetProperties(tokens_accel_[0], &props), FPGA_NO_MEMORY);
+  EXPECT_EQ(fpgaDestroyProperties(&props), FPGA_OK);
+}
+
+/**
+ * @test    from_token04
+ * @brief   Tests: fpgaGetProperties
+ * @details When the input token is valid<br>
+ *          and the call is successful,<br>
+ *          fpgaGetProperties returns FPGA_OK.<br>
+ */
+TEST_P(properties_p1, from_token04) {
+  fpga_properties props = nullptr;
+  EXPECT_EQ(fpgaGetProperties(tokens_accel_[0], &props), FPGA_OK);
   // props will have a cloned parent token.
   EXPECT_EQ(fpgaDestroyToken(&((struct _fpga_properties *)props)->parent), FPGA_OK);
   EXPECT_EQ(fpgaDestroyProperties(&props), FPGA_OK);

--- a/testing/opae-c/test_props_c.cpp
+++ b/testing/opae-c/test_props_c.cpp
@@ -218,6 +218,23 @@ TEST_P(properties_p1, set_parent01) {
   }
 }
 
+/**
+ * @test    set_parent02
+ * @brief   Tests: fpgaPropertiesSetParent
+ * @details When setting the parent token in a properties object<br>
+ *          that has a wrapped parent token resulting from fpgaGetProperties[FromParent]<br>
+ *          or fpgaUpdateProperties,<br>
+ *          fpgaPropertiesSetParent will free the token wrapper.<br>
+ */
+TEST_P(properties_p1, set_parent02) {
+  fpga_properties prop = nullptr;
+  // The accelerator token will have a parent token set.
+  ASSERT_EQ(fpgaGetProperties(tokens_accel_[0], &prop), FPGA_OK);
+  // When this parent is set explicitly, the parent token wrapper is freed.
+  EXPECT_EQ(fpgaPropertiesSetParent(prop, tokens_device_[0]), FPGA_OK);
+  EXPECT_EQ(fpgaDestroyProperties(&prop), FPGA_OK);
+}
+
 TEST_P(properties_p1, from_handle01) {
   fpga_properties props = nullptr;
   EXPECT_EQ(fpgaGetPropertiesFromHandle(accel_, &props), FPGA_OK);
@@ -1110,6 +1127,18 @@ TEST(properties, set_function02) {
   EXPECT_EQ(FPGA_INVALID_PARAM, result);
 }
 
+/**
+ * @test    set_function03
+ * @brief   Tests: fpgaPropertiesSetFunction
+ * @details When fpgaPropertiesSetFunction is called with an invalid<br>
+ *          PCIe function number,<br>
+ *          Then the result is FPGA_INVALID_PARAM.<br>
+ */
+TEST_P(properties_p1, set_function03) {
+  // Call the API to set the objtype on the property
+  EXPECT_EQ(fpgaPropertiesSetFunction(filter_, 8), FPGA_INVALID_PARAM);
+}
+
 // * SocketID field tests *//
 /**
  * @test    get_socket_id01
@@ -1899,7 +1928,7 @@ TEST(properties, set_bbs_version03) {
 }
 
 /**
- * @test    fpga_clone_poperties01
+ * @test    fpga_clone_properties01
  * @brief   Tests: fpgaClonePoperties
  * @details Given a fpga_properties object cloned with
  fpgaCloneProperties<br>
@@ -1907,7 +1936,7 @@ TEST(properties, set_bbs_version03) {
  *          Then the result is FPGA_OK<br>
  *          And the properties object is destroyed appropriately<br>
  */
-TEST_P(properties_p1, fpga_clone_poperties01) {
+TEST_P(properties_p1, fpga_clone_properties01) {
   fpga_properties prop = NULL;
   fpga_properties clone = NULL;
   uint8_t s1 = 0xEF, s2 = 0;
@@ -1919,6 +1948,18 @@ TEST_P(properties_p1, fpga_clone_poperties01) {
   ASSERT_EQ(FPGA_OK, fpgaDestroyProperties(&clone));
   ASSERT_EQ(FPGA_OK, fpgaDestroyProperties(&prop));
   ASSERT_EQ(FPGA_INVALID_PARAM, fpgaCloneProperties(NULL, &clone));
+}
+
+/**
+ * @test    fpga_clone_properties02
+ * @brief   Tests: fpgaCloneProperties
+ * @details When calloc fails to allocate the new properties object,<br>
+ *          fpgaClonePropeties returns FPGA_EXCEPTION.<br>
+ */
+TEST_P(properties_p1, fpga_clone_properties02) {
+  fpga_properties clone = NULL;
+  system_->invalidate_calloc(0, "opae_properties_create");
+  ASSERT_EQ(fpgaCloneProperties(filter_, &clone), FPGA_EXCEPTION);
 }
 
 /**
@@ -1939,6 +1980,26 @@ TEST(properties, set_model01) {
  */
 TEST(properties, get_model01) {
   EXPECT_EQ(FPGA_NOT_SUPPORTED, fpgaPropertiesGetModel(NULL, NULL));
+}
+
+/**
+ * @test    get_lms01
+ * @brief   Tests: fpgaPropertiesGetLocalMemorySize
+ * @details fpgaPropertiesGetLocalMemorySize is not currently supported.
+ *
+ */
+TEST(properties, get_lms01) {
+  EXPECT_EQ(FPGA_NOT_SUPPORTED, fpgaPropertiesGetLocalMemorySize(NULL, NULL));
+}
+
+/**
+ * @test    set_lms01
+ * @brief   Tests: fpgaPropertiesSetLocalMemorySize
+ * @details fpgaPropertiesSetLocalMemorySize is not currently supported.
+ *
+ */
+TEST(properties, set_lms01) {
+  EXPECT_EQ(FPGA_NOT_SUPPORTED, fpgaPropertiesSetLocalMemorySize(NULL, 0));
 }
 
 /**
@@ -3097,6 +3158,21 @@ TEST_P(properties_p1, get_vendor_id02) {
 }
 
 /**
+ * @test    get_vendor_id03
+ * @brief   Tests: fpgaPropertiesGetVendorID
+ * @details Given a non-null fpga_properties* object<br>
+ *          And its object type is FPGA_ACCELERATOR<br>
+ *          But the vendor_id field is not set,<br>
+ *          When I call fpgaPropertiesGetVendorID with a pointer to an
+ *          16-bit integer variable<br>
+ *          Then the return value is FPGA_NOT_FOUND.<br>
+ */
+TEST_P(properties_p1, get_vendor_id03) {
+  uint16_t vendor = 0;
+  EXPECT_EQ(fpgaPropertiesGetVendorID(filter_, &vendor), FPGA_NOT_FOUND);
+}
+
+/**
  * @test    get_device_id01
  * @brief   Tests: fpgaPropertiesGetDeviceID
  * @details Given a null fpga_properties* object<br>
@@ -3170,6 +3246,21 @@ TEST_P(properties_p1, get_device_id02) {
   // now delete the properties object
   result = fpgaDestroyProperties(&prop);
   ASSERT_EQ(NULL, prop);
+}
+
+/**
+ * @test    get_device_id03
+ * @brief   Tests: fpgaPropertiesGetDeviceID
+ * @details Given a non-null fpga_properties* object<br>
+ *          And its object type is FPGA_ACCELERATOR<br>
+ *          But the device_id field is not set,<br>
+ *          When I call fpgaPropertiesGetDeviceID with a pointer to an
+ *          16-bit integer variable<br>
+ *          Then the return value is FPGA_NOT_FOUND.<br>
+ */
+TEST_P(properties_p1, get_device_id03) {
+  uint16_t devid = 0;
+  EXPECT_EQ(fpgaPropertiesGetDeviceID(filter_, &devid), FPGA_NOT_FOUND);
 }
 
 /**
@@ -3248,6 +3339,21 @@ TEST_P(properties_p1, get_object_id02) {
 }
 
 /**
+ * @test    get_object_id03
+ * @brief   Tests: fpgaPropertiesGetObjectID
+ * @details Given a non-null fpga_properties* object<br>
+ *          And its object type is FPGA_ACCELERATOR<br>
+ *          But it has no object_id field set,<br>
+ *          When I call fpgaPropertiesGetObjectID with a pointer to an
+ *          64-bit integer variable<br>
+ *          Then the return value is FPGA_NOT_FOUND.<br>
+ */
+TEST_P(properties_p1, get_object_id03) {
+  uint64_t objid = 0;
+  EXPECT_EQ(fpgaPropertiesGetObjectID(filter_, &objid), FPGA_NOT_FOUND);
+}
+
+/**
  * @test    fpga_destroy_properties01
  * @brief   Tests: fpgaDestroyProperties
  * @details When the fpga_properties* object<br>
@@ -3273,6 +3379,35 @@ TEST_P(properties_p1, get_num_errors01)
   // now get the parent token from the prop structure
   EXPECT_EQ(fpgaPropertiesGetNumErrors(prop, &num_errors), FPGA_OK);
   EXPECT_EQ(fpgaDestroyProperties(&prop), FPGA_OK);
+}
+
+/**
+ * @test    get_num_errors02
+ * @brief   Tests: fpgaPropertiesGetNumErrors
+ * @details When the number of errors field is not set<br>
+ *          in the properties object,<br>
+ *          Then fpgaPropertiesGetNumErrors returns FPGA_NOT_FOUND.<br>
+ *
+ */
+TEST_P(properties_p1, get_num_errors02) {
+  uint32_t errors = 0;
+  EXPECT_EQ(fpgaPropertiesGetNumErrors(filter_, &errors), FPGA_NOT_FOUND);
+}
+
+/**
+ * @test    validate01
+ * @brief   Tests: opae_validate_and_lock_properties
+ * @details When opae_validate_and_lock_properties is called with<br>
+ *          a properties object that has an invalid magic field,<br>
+ *          Then opae_validate_and_lock_properties returns NULL.<br>
+ *
+ */
+TEST_P(properties_p1, validate01) {
+  struct _fpga_properties *p = (struct _fpga_properties *) filter_;
+  ASSERT_EQ(p->magic, FPGA_PROPERTY_MAGIC);
+  p->magic = 0;
+  EXPECT_EQ(NULL, opae_validate_and_lock_properties(filter_));
+  p->magic = FPGA_PROPERTY_MAGIC;
 }
 
 INSTANTIATE_TEST_CASE_P(test_platforms, properties_p1,

--- a/testing/opae-c/test_props_c.cpp
+++ b/testing/opae-c/test_props_c.cpp
@@ -285,6 +285,46 @@ TEST_P(properties_p1, from_token03) {
 }
 
 /**
+ * @test    update01
+ * @brief   Tests: fpgaUpdateProperties
+ * @details When the input properties object has a parent token set,<br>
+ *          fpgaUpdateProperties re-uses the wrapper object.<br>
+ *          If a subsequent call to fpgaUpdateProperties results in a properites<br>
+ *          object without a parent token,<br>
+ *          then the wrapper object is freed.<br>
+ */
+TEST_P(properties_p1, update01) {
+  fpga_properties props = nullptr;
+  ASSERT_EQ(fpgaGetProperties(NULL, &props), FPGA_OK);
+  EXPECT_EQ(fpgaUpdateProperties(tokens_accel_[0], props), FPGA_OK);
+  // The output properties for the accelerator will have a parent token.
+
+  // Updating the properties again (accelerator) will re-use the existing token wrapper. 
+  EXPECT_EQ(fpgaUpdateProperties(tokens_accel_[0], props), FPGA_OK);
+
+  // Updating the properties for a device token will not result in
+  // a parent token. The token wrapper will be destroyed.
+  EXPECT_EQ(fpgaUpdateProperties(tokens_device_[0], props), FPGA_OK);
+
+  EXPECT_EQ(fpgaDestroyProperties(&props), FPGA_OK);
+}
+
+/**
+ * @test    update02
+ * @brief   Tests: fpgaUpdateProperties
+ * @details When the resulting properties object has a parent token set,<br>
+ *          but malloc fails during wrapper allocation,<br>
+ *          fpgaUpdateProperties returns FPGA_NO_MEMORY.<br>
+ */
+TEST_P(properties_p1, update02) {
+  fpga_properties props = nullptr;
+  ASSERT_EQ(fpgaGetProperties(NULL, &props), FPGA_OK);
+  system_->invalidate_malloc(0, "opae_allocate_wrapped_token");
+  EXPECT_EQ(fpgaUpdateProperties(tokens_accel_[0], props), FPGA_NO_MEMORY);
+  EXPECT_EQ(fpgaDestroyProperties(&props), FPGA_OK);
+}
+
+/**
  * @test    get_parent_null_props
  * @brief   Tests: fpgaPropertiesGetParent
  * @details Given a null fpga_properties* object<br>

--- a/testing/opae-c/test_props_c.cpp
+++ b/testing/opae-c/test_props_c.cpp
@@ -50,23 +50,35 @@ class properties_p1 : public ::testing::TestWithParam<std::string> {
     tmpsysfs_ = system_->prepare_syfs(platform_);
 
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
+
     ASSERT_EQ(fpgaGetProperties(nullptr, &filter_), FPGA_OK);
-    ASSERT_EQ(fpgaGetProperties(nullptr, &props_), FPGA_OK);
-    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
-    ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
-                            &num_matches_),
+    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
+    ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_device_.data(), tokens_device_.size(),
+                            &num_matches_device_),
               FPGA_OK);
-    EXPECT_EQ(num_matches_, platform_.devices.size());
-    ASSERT_EQ(fpgaOpen(tokens_[0], &accel_, 0), FPGA_OK);
+
     ASSERT_EQ(fpgaClearProperties(filter_), FPGA_OK);
-    num_matches_ = 0xc01a;
+    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
+    ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_accel_.data(), tokens_accel_.size(),
+                            &num_matches_accel_),
+              FPGA_OK);
+    ASSERT_EQ(num_matches_accel_, platform_.devices.size());
+
+    ASSERT_EQ(fpgaOpen(tokens_accel_[0], &accel_, 0), FPGA_OK);
+    ASSERT_EQ(fpgaClearProperties(filter_), FPGA_OK);
     invalid_device_ = test_device::unknown();
   }
 
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-    EXPECT_EQ(fpgaDestroyProperties(&props_), FPGA_OK);
     EXPECT_EQ(fpgaClose(accel_), FPGA_OK);
+    uint32_t i;
+    for (i = 0 ; i < num_matches_accel_ ; ++i) {
+        EXPECT_EQ(fpgaDestroyToken(&tokens_accel_[i]), FPGA_OK);
+    }
+    for (i = 0 ; i < num_matches_device_ ; ++i) {
+        EXPECT_EQ(fpgaDestroyToken(&tokens_device_[i]), FPGA_OK);
+    }
     if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
       std::string cmd = "rm -rf " + tmpsysfs_;
       std::system(cmd.c_str());
@@ -76,11 +88,11 @@ class properties_p1 : public ::testing::TestWithParam<std::string> {
 
   std::string tmpsysfs_;
   fpga_properties filter_;
-  fpga_properties props_;
-  std::array<fpga_token, 2> tokens_;
-  fpga_handle handle_;
+  std::array<fpga_token, 2> tokens_device_;
+  std::array<fpga_token, 2> tokens_accel_;
   fpga_handle accel_;
-  uint32_t num_matches_;
+  uint32_t num_matches_device_;
+  uint32_t num_matches_accel_;
   test_platform platform_;
   test_device invalid_device_;
   test_system* system_;
@@ -99,25 +111,43 @@ class properties_p1 : public ::testing::TestWithParam<std::string> {
  *          And the field in the token object is set to the known value<br>
  * */
 TEST_P(properties_p1, get_parent01) {
-  EXPECT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
+  fpga_properties prop = nullptr;
+  std::array<fpga_token, 2> toks = {};
+  fpga_token parent = nullptr;
+  uint32_t matches = 0;
+
+  ASSERT_EQ(fpgaGetProperties(NULL, &prop), FPGA_OK);
+  EXPECT_EQ(fpgaPropertiesSetObjectType(prop, FPGA_DEVICE), FPGA_OK);
   ASSERT_EQ(
-      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
+      fpgaEnumerate(&prop, 1, toks.data(), toks.size(), &matches),
       FPGA_OK);
-  EXPECT_EQ(num_matches_, platform_.devices.size());
+  EXPECT_EQ(matches, platform_.devices.size());
+
+  EXPECT_EQ(fpgaClearProperties(prop), FPGA_OK);
 
   // set the token to a known value
-  auto _prop = (_fpga_properties*)props_;
+  auto _prop = (_fpga_properties*)prop;
   SET_FIELD_VALID(_prop, FPGA_PROPERTY_PARENT);
-  _prop->parent = tokens_[0];
+  _prop->parent = toks[0];
 
   // now get the parent token from the prop structure
-  EXPECT_EQ(fpgaPropertiesGetParent(props_, &tokens_[1]), FPGA_OK);
+  EXPECT_EQ(fpgaPropertiesGetParent(prop, &parent), FPGA_OK);
   // GetParent clones the token so compare object_id of the two
-  fpga_properties p1, p2;
-  ASSERT_EQ(fpgaGetProperties(tokens_[0], &p1), FPGA_OK);
-  ASSERT_EQ(fpgaGetProperties(tokens_[1], &p2), FPGA_OK);
+  fpga_properties p1 = nullptr, p2 = nullptr;
+  ASSERT_EQ(fpgaGetProperties(toks[0], &p1), FPGA_OK);
+  ASSERT_EQ(fpgaGetProperties(parent,  &p2), FPGA_OK);
   EXPECT_EQ(((_fpga_properties*)p1)->object_id,
             ((_fpga_properties*)p2)->object_id);
+
+  EXPECT_EQ(fpgaDestroyProperties(&p1), FPGA_OK);
+  EXPECT_EQ(fpgaDestroyProperties(&p2), FPGA_OK);
+  EXPECT_EQ(fpgaDestroyProperties(&prop), FPGA_OK);
+
+  EXPECT_EQ(fpgaDestroyToken(&parent), FPGA_OK);
+  uint32_t i;
+  for (i = 0 ; i < matches ; ++i) {
+    EXPECT_EQ(fpgaDestroyToken(&toks[i]), FPGA_OK);
+  }
 }
 
 /**
@@ -130,12 +160,20 @@ TEST_P(properties_p1, get_parent01) {
  *          Then the return value is FPGA_NOT_FOUND<br>
  * */
 TEST_P(properties_p1, get_parent02) {
-  struct _fpga_properties* _prop = (struct _fpga_properties*)props_;
+  fpga_properties prop = nullptr;
+
+  ASSERT_EQ(fpgaGetProperties(NULL, &prop), FPGA_OK);
+
+  struct _fpga_properties* _prop = (struct _fpga_properties*)prop;
+  fpga_token tok = nullptr;
 
   // make sure the FPGA_PROPERTY_PARENT bit is zero
   EXPECT_EQ((_prop->valid_fields >> FPGA_PROPERTY_PARENT) & 1, 0);
 
-  EXPECT_EQ(fpgaPropertiesGetParent(_prop, &tokens_[0]), FPGA_NOT_FOUND);
+  EXPECT_EQ(fpgaPropertiesGetParent(_prop, &tok), FPGA_NOT_FOUND);
+  EXPECT_EQ(tok, nullptr);
+
+  EXPECT_EQ(fpgaDestroyProperties(&prop), FPGA_OK);
 }
 
 /**
@@ -148,29 +186,48 @@ TEST_P(properties_p1, get_parent02) {
  *          Then the parent object in the properties object is the token<br>
  */
 TEST_P(properties_p1, set_parent01) {
-  EXPECT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
+  fpga_properties prop = nullptr;
+  std::array<fpga_token, 2> toks = {};
+  uint32_t matches = 0;
+  fpga_token parent = nullptr;
+
+  ASSERT_EQ(fpgaGetProperties(NULL, &prop), FPGA_OK);
+  EXPECT_EQ(fpgaPropertiesSetObjectType(prop, FPGA_DEVICE), FPGA_OK);
   ASSERT_EQ(
-      fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
+      fpgaEnumerate(&prop, 1, toks.data(), toks.size(), &matches),
       FPGA_OK);
-  EXPECT_EQ(num_matches_, platform_.devices.size());
+  EXPECT_EQ(matches, platform_.devices.size());
+
+  EXPECT_EQ(fpgaClearProperties(prop), FPGA_OK);
 
   // now get the parent token from the prop structure
-  EXPECT_EQ(fpgaPropertiesSetParent(props_, tokens_[0]), FPGA_OK);
+  EXPECT_EQ(fpgaPropertiesSetParent(prop, toks[0]), FPGA_OK);
   // now get the parent token from the prop structure
-  EXPECT_EQ(fpgaPropertiesGetParent(props_, &tokens_[1]), FPGA_OK);
+  EXPECT_EQ(fpgaPropertiesGetParent(prop, &parent), FPGA_OK);
   // GetParent clones the token so compare object_id of the two
   fpga_properties p1 = nullptr, p2 = nullptr;
-  ASSERT_EQ(fpgaGetProperties(tokens_[0], &p1), FPGA_OK);
-  ASSERT_EQ(fpgaGetProperties(tokens_[1], &p2), FPGA_OK);
+  ASSERT_EQ(fpgaGetProperties(toks[0], &p1), FPGA_OK);
+  ASSERT_EQ(fpgaGetProperties(parent, &p2), FPGA_OK);
   EXPECT_EQ(((_fpga_properties*)p1)->object_id,
             ((_fpga_properties*)p2)->object_id);
 
   EXPECT_EQ(fpgaDestroyProperties(&p1), FPGA_OK);
   EXPECT_EQ(fpgaDestroyProperties(&p2), FPGA_OK);
+  EXPECT_EQ(fpgaDestroyProperties(&prop), FPGA_OK);
+
+  EXPECT_EQ(fpgaDestroyToken(&parent), FPGA_OK);
+  uint32_t i;
+  for (i = 0 ; i < matches ; ++i) {
+    EXPECT_EQ(fpgaDestroyToken(&toks[i]), FPGA_OK);
+  }
 }
 
 TEST_P(properties_p1, from_handle) {
-  EXPECT_EQ(fpgaGetPropertiesFromHandle(accel_, &props_), FPGA_OK);
+  fpga_properties props = nullptr;
+  EXPECT_EQ(fpgaGetPropertiesFromHandle(accel_, &props), FPGA_OK);
+  // props will have a cloned parent token.
+  EXPECT_EQ(fpgaDestroyToken(&((struct _fpga_properties *)props)->parent), FPGA_OK);
+  EXPECT_EQ(fpgaDestroyProperties(&props), FPGA_OK);
 }
 
 /**
@@ -199,7 +256,7 @@ TEST(properties, set_parent_null_token) {
   fpga_properties prop = NULL;
 
   // Call the API to set the token on the property
-  fpga_token token;
+  fpga_token token = nullptr;
   fpga_result result = fpgaPropertiesSetParent(prop, &token);
 
   EXPECT_EQ(FPGA_INVALID_PARAM, result);
@@ -2614,6 +2671,7 @@ TEST_P(properties_p1, get_accelerator_state05) {
 
   result = fpgaPropertiesGetAcceleratorState(prop, NULL);
   EXPECT_EQ(FPGA_INVALID_PARAM, result);
+  EXPECT_EQ(fpgaDestroyProperties(&prop), FPGA_OK);
 }
 
 /**
@@ -2858,6 +2916,7 @@ TEST_P(properties_p1, prop_213) {
   struct _fpga_properties* _prop = (struct _fpga_properties*)prop;
 
   EXPECT_EQ(FPGA_PROPERTY_MAGIC, _prop->magic);
+  EXPECT_EQ(fpgaDestroyProperties(&prop), FPGA_OK);
 }
 
 /**
@@ -3114,7 +3173,7 @@ TEST(properties, fpga_destroy_properties01) {
 
 TEST_P(properties_p1, get_num_errors01)
 {
-  fpga_properties prop;
+  fpga_properties prop = nullptr;
   fpga_result result = fpgaGetProperties(NULL, &prop);
   EXPECT_EQ(result, FPGA_OK);
   auto _prop = (_fpga_properties*)prop;
@@ -3123,6 +3182,7 @@ TEST_P(properties_p1, get_num_errors01)
   uint32_t num_errors = 0;
   // now get the parent token from the prop structure
   EXPECT_EQ(fpgaPropertiesGetNumErrors(prop, &num_errors), FPGA_OK);
+  EXPECT_EQ(fpgaDestroyProperties(&prop), FPGA_OK);
 }
 
 INSTANTIATE_TEST_CASE_P(test_platforms, properties_p1,

--- a/testing/opae-c/test_reconf_c.cpp
+++ b/testing/opae-c/test_reconf_c.cpp
@@ -1,0 +1,114 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+extern "C" {
+
+#include <json-c/json.h>
+#include <uuid/uuid.h>
+#include "opae_int.h"
+
+}
+
+#include <opae/fpga.h>
+#include "intel-fpga.h"
+#include <linux/ioctl.h>
+
+#include <array>
+#include <cstdlib>
+#include <cstdarg>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+#include "test_system.h"
+
+using namespace opae::testing;
+
+class reconf_c_p : public ::testing::TestWithParam<std::string> {
+ protected:
+  reconf_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+
+  virtual void SetUp() override {
+    ASSERT_TRUE(test_platform::exists(GetParam()));
+    platform_ = test_platform::get(GetParam());
+    system_ = test_system::instance();
+    system_->initialize();
+    tmpsysfs_ = system_->prepare_syfs(platform_);
+    invalid_device_ = test_device::unknown();
+
+    ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
+    ASSERT_EQ(fpgaGetProperties(nullptr, &filter_), FPGA_OK);
+    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
+    num_matches_ = 0;
+    ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
+                            &num_matches_),
+              FPGA_OK);
+    EXPECT_EQ(num_matches_, platform_.devices.size());
+    accel_ = nullptr;
+    ASSERT_EQ(fpgaOpen(tokens_[0], &accel_, 0), FPGA_OK);
+  }
+
+  virtual void TearDown() override {
+    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
+    if (accel_) {
+        EXPECT_EQ(fpgaClose(accel_), FPGA_OK);
+        accel_ = nullptr;
+    }
+    uint32_t i;
+    for (i = 0 ; i < num_matches_ ; ++i) {
+        EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
+    }
+    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
+      std::string cmd = "rm -rf " + tmpsysfs_;
+      std::system(cmd.c_str());
+    }
+    system_->finalize();
+  }
+
+  std::string tmpsysfs_;
+  fpga_properties filter_;
+  std::array<fpga_token, 2> tokens_;
+  fpga_handle accel_;
+  test_platform platform_;
+  uint32_t num_matches_;
+  test_device invalid_device_;
+  test_system *system_;
+};
+
+/**
+ * @test       pr
+ * @brief      Test: fpgaReconfigureSlot
+ * @details    When fpgaReconfigureSlot is called with invalid params,<br>
+ *             then the fn returns FPGA_INVALID_PARAM.<br>
+ */
+TEST_P(reconf_c_p, pr) {
+  uint8_t bitstream[] = { 'b', 'i', 't', 's', 0 };
+  EXPECT_EQ(fpgaReconfigureSlot(accel_, 0,
+		  bitstream, 5, 0), FPGA_INVALID_PARAM);
+}
+
+INSTANTIATE_TEST_CASE_P(reconf_c, reconf_c_p, ::testing::ValuesIn(test_platform::keys(true)));

--- a/testing/opae-c/test_reconf_c.cpp
+++ b/testing/opae-c/test_reconf_c.cpp
@@ -82,10 +82,6 @@ class reconf_c_p : public ::testing::TestWithParam<std::string> {
     for (i = 0 ; i < num_matches_ ; ++i) {
         EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
     }
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/opae-c/test_reset_c.cpp
+++ b/testing/opae-c/test_reset_c.cpp
@@ -1,0 +1,103 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+extern "C" {
+
+#include <json-c/json.h>
+#include <uuid/uuid.h>
+#include "opae_int.h"
+
+}
+
+#include <opae/fpga.h>
+
+#include <array>
+#include <cstdlib>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+#include "test_system.h"
+
+using namespace opae::testing;
+
+class reset_c_p : public ::testing::TestWithParam<std::string> {
+ protected:
+  reset_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+
+  virtual void SetUp() override {
+    ASSERT_TRUE(test_platform::exists(GetParam()));
+    platform_ = test_platform::get(GetParam());
+    system_ = test_system::instance();
+    system_->initialize();
+    tmpsysfs_ = system_->prepare_syfs(platform_);
+    invalid_device_ = test_device::unknown();
+
+    ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
+    ASSERT_EQ(fpgaGetProperties(nullptr, &filter_), FPGA_OK);
+    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
+    num_matches_ = 0;
+    ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
+                            &num_matches_),
+              FPGA_OK);
+    EXPECT_EQ(num_matches_, platform_.devices.size());
+    accel_ = nullptr;
+    ASSERT_EQ(fpgaOpen(tokens_[0], &accel_, 0), FPGA_OK);
+  }
+
+  virtual void TearDown() override {
+    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
+    if (accel_) {
+        EXPECT_EQ(fpgaClose(accel_), FPGA_OK);
+        accel_ = nullptr;
+    }
+    uint32_t i;
+    for (i = 0 ; i < num_matches_ ; ++i) {
+        EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
+    }
+    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
+      std::string cmd = "rm -rf " + tmpsysfs_;
+      std::system(cmd.c_str());
+    }
+    system_->finalize();
+  }
+
+  std::string tmpsysfs_;
+  fpga_properties filter_;
+  std::array<fpga_token, 2> tokens_;
+  fpga_handle accel_;
+  test_platform platform_;
+  uint32_t num_matches_;
+  test_device invalid_device_;
+  test_system *system_;
+};
+
+TEST_P(reset_c_p, success) {
+    EXPECT_EQ(fpgaReset(accel_), FPGA_OK);
+}
+
+INSTANTIATE_TEST_CASE_P(reset_c, reset_c_p, ::testing::ValuesIn(test_platform::keys(true)));

--- a/testing/opae-c/test_reset_c.cpp
+++ b/testing/opae-c/test_reset_c.cpp
@@ -79,10 +79,6 @@ class reset_c_p : public ::testing::TestWithParam<std::string> {
     for (i = 0 ; i < num_matches_ ; ++i) {
         EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
     }
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/opae-c/test_umsg_c.cpp
+++ b/testing/opae-c/test_umsg_c.cpp
@@ -1,0 +1,232 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+extern "C" {
+
+#include <json-c/json.h>
+#include <uuid/uuid.h>
+#include "opae_int.h"
+
+}
+
+#include <opae/fpga.h>
+#include "intel-fpga.h"
+#include <linux/ioctl.h>
+
+#include <array>
+#include <cstdlib>
+#include <cstdarg>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+#include "test_system.h"
+
+using namespace opae::testing;
+
+int umsg_port_info(mock_object * m, int request, va_list argp){
+    int retval = -1;
+    errno = EINVAL;
+    static bool gEnableIRQ = false;
+    UNUSED_PARAM(m);
+    UNUSED_PARAM(request);
+    struct fpga_port_info *pinfo = va_arg(argp, struct fpga_port_info *);
+    if (!pinfo) {
+        FPGA_MSG("pinfo is NULL");
+        goto out_EINVAL;
+    }
+    if (pinfo->argsz != sizeof(*pinfo)) {
+        FPGA_MSG("wrong structure size");
+        goto out_EINVAL;
+    }
+    pinfo->flags = 0;
+    pinfo->num_regions = 1;
+    pinfo->num_umsgs = 8;
+    if (gEnableIRQ) {
+        pinfo->capability = FPGA_PORT_CAP_ERR_IRQ | FPGA_PORT_CAP_UAFU_IRQ;
+        pinfo->num_uafu_irqs = 1;
+    } else {
+        pinfo->capability = 0;
+        pinfo->num_uafu_irqs = 0;
+    }
+    retval = 0;
+    errno = 0;
+out:
+    return retval;
+
+out_EINVAL:
+    retval = -1;
+    errno = EINVAL;
+    goto out;
+}
+
+int umsg_set_mode(mock_object * m, int request, va_list argp){
+    int retval = -1;
+    errno = EINVAL;
+    UNUSED_PARAM(m);
+    UNUSED_PARAM(request);
+    struct fpga_port_umsg_cfg *ucfg = va_arg(argp, struct fpga_port_umsg_cfg *);
+    if (!ucfg) {
+    	FPGA_MSG("ucfg is NULL");
+    	goto out_EINVAL;
+    }
+    if (ucfg->argsz != sizeof(*ucfg)) {
+    	FPGA_MSG("wrong structure size");
+    	goto out_EINVAL;
+    }
+    if (ucfg->flags != 0) {
+    	FPGA_MSG("unexpected flags %u", ucfg->flags);
+    	goto out_EINVAL;
+    }
+    /* TODO: check hint_bitmap */
+    if (ucfg->hint_bitmap >> 8) {
+    	FPGA_MSG("invalid hint_bitmap 0x%x", ucfg->hint_bitmap);
+    	goto out_EINVAL;
+    }
+    retval = 0;
+    errno = 0;
+out:
+    return retval;
+
+out_EINVAL:
+    retval = -1;
+    errno = EINVAL;
+    goto out;
+}
+
+class umsg_c_p : public ::testing::TestWithParam<std::string> {
+ protected:
+  umsg_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+
+  virtual void SetUp() override {
+    ASSERT_TRUE(test_platform::exists(GetParam()));
+    platform_ = test_platform::get(GetParam());
+    system_ = test_system::instance();
+    system_->initialize();
+    tmpsysfs_ = system_->prepare_syfs(platform_);
+    invalid_device_ = test_device::unknown();
+
+    ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
+    ASSERT_EQ(fpgaGetProperties(nullptr, &filter_), FPGA_OK);
+    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
+    num_matches_ = 0;
+    ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
+                            &num_matches_),
+              FPGA_OK);
+    EXPECT_EQ(num_matches_, platform_.devices.size());
+    accel_ = nullptr;
+    ASSERT_EQ(fpgaOpen(tokens_[0], &accel_, 0), FPGA_OK);
+    system_->register_ioctl_handler(FPGA_PORT_GET_INFO, umsg_port_info);
+    system_->register_ioctl_handler(FPGA_PORT_UMSG_SET_MODE, umsg_set_mode);
+  }
+
+  virtual void TearDown() override {
+    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
+    if (accel_) {
+        EXPECT_EQ(fpgaClose(accel_), FPGA_OK);
+        accel_ = nullptr;
+    }
+    uint32_t i;
+    for (i = 0 ; i < num_matches_ ; ++i) {
+        EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
+    }
+    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
+      std::string cmd = "rm -rf " + tmpsysfs_;
+      std::system(cmd.c_str());
+    }
+    system_->finalize();
+  }
+
+  std::string tmpsysfs_;
+  fpga_properties filter_;
+  std::array<fpga_token, 2> tokens_;
+  fpga_handle accel_;
+  test_platform platform_;
+  uint32_t num_matches_;
+  test_device invalid_device_;
+  test_system *system_;
+};
+
+/**
+ * @test       get_num
+ * @brief      Test: fpgaGetNumUmsg
+ * @details    When fpgaGetNumUmsg retrieves the number of UMsgs,<br>
+ *             the number of Umsgs is greater than 0,<br>
+ *             and the fn returns FPGA_OK.<br>
+ */
+TEST_P(umsg_c_p, get_num) {
+  uint64_t num = 0;
+  EXPECT_EQ(fpgaGetNumUmsg(accel_, &num), FPGA_OK);
+  EXPECT_GT(num, 0);
+}
+
+/**
+ * @test       set_attr
+ * @brief      Test: fpgaSetUmsgAttributes
+ * @details    When fpgaSetUmsgAttributes is called with valid values,<br>
+ *             then the fn returns FPGA_OK.<br>
+ */
+TEST_P(umsg_c_p, set_attr) {
+  uint64_t enable  = 0xff;
+  uint64_t disable = 0;
+  EXPECT_EQ(fpgaSetUmsgAttributes(accel_, enable), FPGA_OK);
+  EXPECT_EQ(fpgaSetUmsgAttributes(accel_, disable), FPGA_OK);
+}
+
+/**
+ * @test       trigger
+ * @brief      Test: fpgaTriggerUmsg
+ * @details    When Umsgs are enabled and<br>
+ *             fpgaTriggerUmsg is called with a valid value,<br>
+ *             then the fn returns FPGA_OK.<br>
+ */
+TEST_P(umsg_c_p, DISABLED_trigger) {
+  uint64_t enable  = 0xff;
+  uint64_t disable = 0;
+  EXPECT_EQ(fpgaSetUmsgAttributes(accel_, enable), FPGA_OK);
+  EXPECT_EQ(fpgaTriggerUmsg(accel_, 1), FPGA_OK);
+  EXPECT_EQ(fpgaSetUmsgAttributes(accel_, disable), FPGA_OK);
+}
+
+/**
+ * @test       get_ptr
+ * @brief      Test: fpgaGetUmsgPtr
+ * @details    When Umsgs are enabled and<br>
+ *             fpgaGetUmsgPtr is called with a valid value,<br>
+ *             then the fn returns FPGA_OK.<br>
+ */
+TEST_P(umsg_c_p, get_ptr) {
+  uint64_t enable  = 0xff;
+  uint64_t disable = 0;
+  uint64_t *umsg_ptr = nullptr;
+  EXPECT_EQ(fpgaSetUmsgAttributes(accel_, enable), FPGA_OK);
+  EXPECT_EQ(fpgaGetUmsgPtr(accel_, &umsg_ptr), FPGA_OK);
+  EXPECT_NE(umsg_ptr, nullptr);
+  EXPECT_EQ(fpgaSetUmsgAttributes(accel_, disable), FPGA_OK);
+}
+
+INSTANTIATE_TEST_CASE_P(umsg_c, umsg_c_p, ::testing::ValuesIn(test_platform::keys(true)));

--- a/testing/opae-c/test_umsg_c.cpp
+++ b/testing/opae-c/test_umsg_c.cpp
@@ -154,10 +154,6 @@ class umsg_c_p : public ::testing::TestWithParam<std::string> {
     for (i = 0 ; i < num_matches_ ; ++i) {
         EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
     }
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/opae-c/test_version_c.cpp
+++ b/testing/opae-c/test_version_c.cpp
@@ -1,0 +1,131 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+extern "C" {
+
+#include <json-c/json.h>
+#include <uuid/uuid.h>
+#include "opae_int.h"
+
+}
+
+#include <config.h>
+#include <opae/fpga.h>
+
+#include <array>
+#include <cstdlib>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+#include "test_system.h"
+
+using namespace opae::testing;
+
+/**
+ * @test       opaec
+ * @brief      Test: fpgaGetOPAECVersion
+ * @details    When fpgaGetOPAECVersion is called with a valid param,<br>
+ *             then it retrieves the INTEL_FPGA_API_VER_* constants<br>
+ *             from config.h.<br>
+ */
+TEST(version, opaec) {
+  fpga_version v;
+  EXPECT_EQ(fpgaGetOPAECVersion(&v), FPGA_OK);
+  EXPECT_EQ(v.major, INTEL_FPGA_API_VER_MAJOR);
+  EXPECT_EQ(v.minor, INTEL_FPGA_API_VER_MINOR);
+  EXPECT_EQ(v.patch, INTEL_FPGA_API_VER_REV);
+}
+
+/**
+ * @test       opaec_string
+ * @brief      Test: fpgaGetOPAECVersionString
+ * @details    When fpgaGetOPAECVersionString is called with valid params,<br>
+ *             then it retrieves the INTEL_FPGA_API_VERSION string<br>
+ *             from config.h.<br>
+ */
+TEST(version, opaec_string) {
+  char ver_str[32];
+  EXPECT_EQ(fpgaGetOPAECVersionString(ver_str, sizeof(ver_str)), FPGA_OK);
+  EXPECT_STREQ(ver_str, INTEL_FPGA_API_VERSION);
+}
+
+/**
+ * @test       opaec_string_err
+ * @brief      Test: fpgaGetOPAECVersionString
+ * @details    When fpgaGetOPAECVersionString is called with invalid params,<br>
+ *             then it returns FPGA_EXCEPTION.<br>
+ */
+TEST(version, opaec_string_err) {
+  char ver_str[4097];
+  EXPECT_EQ(fpgaGetOPAECVersionString(ver_str, sizeof(ver_str)), FPGA_EXCEPTION);
+}
+
+/**
+ * @test       opaec_build_string
+ * @brief      Test: fpgaGetOPAECBuildString
+ * @details    When fpgaGetOPAECBuildString is called with valid params,<br>
+ *             then it retrieves the INTEL_FPGA_API_HASH string<br>
+ *             from config.h.<br>
+ */
+TEST(version, opaec_build_string) {
+  char b_str[32];
+  EXPECT_EQ(fpgaGetOPAECBuildString(b_str, sizeof(b_str)), FPGA_OK);
+  EXPECT_STREQ(b_str, INTEL_FPGA_API_HASH);
+}
+
+/**
+ * @test       opaec_build_string_err
+ * @brief      Test: fpgaGetOPAECBuildString
+ * @details    When fpgaGetOPAECBuildString is called with invalid params,<br>
+ *             then it returns FPGA_EXCEPTION.<br>
+ */
+TEST(version, opaec_build_string_err) {
+  char b_str[4097];
+  EXPECT_EQ(fpgaGetOPAECBuildString(b_str, sizeof(b_str)), FPGA_EXCEPTION);
+}
+
+/**
+ * @test       str
+ * @brief      Test: fpgaErrStr
+ * @details    When fpgaErrStr is called with valid params,<br>
+ *             then it returns the corresponding const char *.<br>
+ */
+TEST(err, str) {
+  EXPECT_STREQ(fpgaErrStr(FPGA_OK),            "success");
+  EXPECT_STREQ(fpgaErrStr(FPGA_INVALID_PARAM), "invalid parameter");
+  EXPECT_STREQ(fpgaErrStr(FPGA_BUSY),          "resource busy");
+  EXPECT_STREQ(fpgaErrStr(FPGA_EXCEPTION),     "exception");
+  EXPECT_STREQ(fpgaErrStr(FPGA_NOT_FOUND),     "not found");
+  EXPECT_STREQ(fpgaErrStr(FPGA_NO_MEMORY),     "no memory");
+  EXPECT_STREQ(fpgaErrStr(FPGA_NOT_SUPPORTED), "not supported");
+  EXPECT_STREQ(fpgaErrStr(FPGA_NO_DRIVER),     "no driver available");
+  EXPECT_STREQ(fpgaErrStr(FPGA_NO_DAEMON),     "no fpga daemon running");
+  EXPECT_STREQ(fpgaErrStr(FPGA_NO_ACCESS),     "insufficient privileges");
+  EXPECT_STREQ(fpgaErrStr(FPGA_RECONF_ERROR),  "reconfiguration error");
+  EXPECT_STREQ(fpgaErrStr((fpga_result)-1),    "unknown error");
+}


### PR DESCRIPTION
Increase coverage for fpgaGetProperties[FromHandle].
Add intercept for calloc(), modeled after malloc() intercept.
Call through the adpater to destroy the cloned parent token
if the wrapped token object allocation fails (fpgaGetProperties[FromHandle]
and fpgaUpdateProperties).