### PR TITLE
Add test_system::remove_sysfs function

### DIFF
--- a/testing/mock/test_system.cpp
+++ b/testing/mock/test_system.cpp
@@ -40,6 +40,7 @@
 #define _GNU_SOURCE 1
 #endif
 #include <dlfcn.h>
+#include <sys/stat.h>
 
 void * __builtin_return_address(unsigned level);
 
@@ -221,6 +222,21 @@ std::string test_system::prepare_syfs(const test_platform &platform) {
   return "/";
 }
 
+void test_system::remove_sysfs() {
+  if (root_.find("tmpsysfs") != std::string::npos) {
+    struct stat st;
+    if (stat(root_.c_str(), &st)) {
+      std::cerr << "Error stat'ing root dir (" << root_ << "):" << strerror(errno) << "\n";
+      return;
+    }
+    if (S_ISDIR(st.st_mode)){
+      auto cmd = "rm -rf " + root_;
+      std::system(cmd.c_str());
+    }
+  }
+}
+
+
 void test_system::set_root(const char *root) { root_ = root; }
 
 std::string test_system::get_sysfs_path(const std::string &src) {
@@ -251,6 +267,7 @@ void test_system::finalize() {
       kv.second = nullptr;
     }
   }
+  remove_sysfs();
   root_ = "";
   fds_.clear();
 }

--- a/testing/mock/test_system.h
+++ b/testing/mock/test_system.h
@@ -139,6 +139,7 @@ class test_system {
   void initialize();
   void finalize();
   std::string prepare_syfs(const test_platform &platform);
+  void remove_sysfs();
 
   int open(const std::string &path, int flags);
   int open(const std::string &path, int flags, mode_t m);

--- a/testing/opae-c/test_enum_c.cpp
+++ b/testing/opae-c/test_enum_c.cpp
@@ -69,10 +69,6 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
 
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter), FPGA_OK);
-    if (!tmpsysfs.empty() && tmpsysfs.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/opae-c/test_open_c.cpp
+++ b/testing/opae-c/test_open_c.cpp
@@ -75,10 +75,6 @@ class open_c_p : public ::testing::TestWithParam<std::string> {
         EXPECT_EQ(fpgaDestroyToken(&tokens_[i]), FPGA_OK);
     }
 
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/opae-c/test_props_c.cpp
+++ b/testing/opae-c/test_props_c.cpp
@@ -79,10 +79,6 @@ class properties_p1 : public ::testing::TestWithParam<std::string> {
     for (i = 0 ; i < num_matches_device_ ; ++i) {
         EXPECT_EQ(fpgaDestroyToken(&tokens_device_[i]), FPGA_OK);
     }
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/xfpga/test_buffer_c.cpp
+++ b/testing/xfpga/test_buffer_c.cpp
@@ -66,10 +66,6 @@ class buffer_prepare
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
     if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/xfpga/test_common_c.cpp
+++ b/testing/xfpga/test_common_c.cpp
@@ -76,10 +76,6 @@ class common_c_p
 
     EXPECT_EQ(xfpga_fpgaDestroyEventHandle(&eh_), FPGA_OK);
     if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/xfpga/test_enum_c.cpp
+++ b/testing/xfpga/test_enum_c.cpp
@@ -61,10 +61,6 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
 
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter), FPGA_OK);
-    if (!tmpsysfs.empty() && tmpsysfs.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/xfpga/test_events_c.cpp
+++ b/testing/xfpga/test_events_c.cpp
@@ -92,10 +92,6 @@ class events_p : public ::testing::TestWithParam<std::string> {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
     EXPECT_EQ(xfpga_fpgaDestroyEventHandle(&eh_), FPGA_OK);
     if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
     fpgad_.join();
   }

--- a/testing/xfpga/test_metadata_c.cpp
+++ b/testing/xfpga/test_metadata_c.cpp
@@ -53,10 +53,6 @@ class metadata_c
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
     if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
-    if (!tmpsysfs.empty() && tmpsysfs.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/xfpga/test_mmio_c.cpp
+++ b/testing/xfpga/test_mmio_c.cpp
@@ -104,10 +104,6 @@ class mmio_c_p
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
     if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/xfpga/test_mock_errinj_c.cpp
+++ b/testing/xfpga/test_mock_errinj_c.cpp
@@ -142,10 +142,6 @@ class mock_err_inj_c_p : public ::testing::TestWithParam<std::string> {
       }
     }
 
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/xfpga/test_object_c.cpp
+++ b/testing/xfpga/test_object_c.cpp
@@ -49,10 +49,6 @@ class sysobject_p : public ::testing::TestWithParam<std::string> {
   }
 
   virtual void TearDown() override {
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/xfpga/test_open_close_c.cpp
+++ b/testing/xfpga/test_open_close_c.cpp
@@ -108,10 +108,6 @@ class openclose_c_p
       }
     }
 
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/xfpga/test_properties_c.cpp
+++ b/testing/xfpga/test_properties_c.cpp
@@ -62,10 +62,6 @@ class properties_p1 : public ::testing::TestWithParam<std::string> {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
     EXPECT_EQ(fpgaDestroyProperties(&props_), FPGA_OK);
     EXPECT_EQ(xfpga_fpgaClose(accel_), FPGA_OK);
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/xfpga/test_reconf_c.cpp
+++ b/testing/xfpga/test_reconf_c.cpp
@@ -65,10 +65,6 @@ class reconf_c
     }
 
     if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/xfpga/test_reset_c.cpp
+++ b/testing/xfpga/test_reset_c.cpp
@@ -56,10 +56,6 @@ class reset_c_p
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
     if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/xfpga/test_sysfs_c.cpp
+++ b/testing/xfpga/test_sysfs_c.cpp
@@ -69,10 +69,6 @@ class sysfs_c_p : public ::testing::TestWithParam<std::string> {
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
     if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/xfpga/test_umsg_c.cpp
+++ b/testing/xfpga/test_umsg_c.cpp
@@ -133,10 +133,6 @@ class umsg_c_p
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
     if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 

--- a/testing/xfpga/test_usrclk_c.cpp
+++ b/testing/xfpga/test_usrclk_c.cpp
@@ -86,10 +86,6 @@ class usrclk_c
 
     if (handle_dev_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_dev_), FPGA_OK);
     if (handle_accel_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_accel_), FPGA_OK);
-    if (!tmpsysfs_.empty() && tmpsysfs_.size() > 1) {
-      std::string cmd = "rm -rf " + tmpsysfs_;
-      std::system(cmd.c_str());
-    }
     system_->finalize();
   }
 


### PR DESCRIPTION
Since test_system is extracting the mock sysfs structure in the fn
test_system::prepare_syfs, it should also remove the temporary dirctory
that it creates from that step. This change adds a function
`remove_sysfs` which simply removes the directory (with some error
checking). Because this function is called in the test_system::finalize fn,
this allows the duplicate code to be removed from all the tests.