### PR TITLE
fix some memory leaks

### DIFF
--- a/libopae/pluginmgr.c
+++ b/libopae/pluginmgr.c
@@ -64,7 +64,7 @@ static platform_data platform_data_table[] = {
 };
 
 static int initialized;
-static platforms_detected;
+static int platforms_detected;
 
 static opae_api_adapter_table *adapter_list = (void *)0;
 static pthread_mutex_t adapter_list_lock =

--- a/libopae/pluginmgr.c
+++ b/libopae/pluginmgr.c
@@ -182,6 +182,7 @@ int opae_plugin_mgr_finalize_all(void)
 
 	adapter_list = NULL;
 	initialized = 0;
+	platforms_detected = 0;
 
 	opae_mutex_unlock(res, &adapter_list_lock);
 

--- a/libopae/pluginmgr.c
+++ b/libopae/pluginmgr.c
@@ -64,7 +64,6 @@ static platform_data platform_data_table[] = {
 };
 
 static int initialized;
-static int platforms_detected;
 
 static opae_api_adapter_table *adapter_list = (void *)0;
 static pthread_mutex_t adapter_list_lock =
@@ -182,7 +181,6 @@ int opae_plugin_mgr_finalize_all(void)
 
 	adapter_list = NULL;
 	initialized = 0;
-	platforms_detected = 0;
 
 	opae_mutex_unlock(res, &adapter_list_lock);
 
@@ -223,7 +221,6 @@ STATIC void opae_plugin_mgr_detect_platform(uint16_t vendor, uint16_t device)
 
 		if (platform_data_table[i].vendor_id == vendor &&
 		    platform_data_table[i].device_id == device) {
-			platforms_detected++;
 			OPAE_DBG("platform detected: vid=0x%04x did=0x%04x -> %s",
 					vendor, device,
 					platform_data_table[i].native_plugin);
@@ -336,6 +333,7 @@ int opae_plugin_mgr_initialize(const char *cfg_file)
 	int j;
 	int res;
 	int errors = 0;
+	int platforms_detected = 0;
 	opae_api_adapter_table *adapter;
 
 	// TODO: parse config file
@@ -363,6 +361,7 @@ int opae_plugin_mgr_initialize(const char *cfg_file)
 			continue; // This platform was not detected.
 
 		native_plugin = platform_data_table[i].native_plugin;
+		platforms_detected++;
 
 		// Iterate over the table again to prevent multiple loads
 		// of the same native plugin.

--- a/libopae/pluginmgr.c
+++ b/libopae/pluginmgr.c
@@ -64,6 +64,7 @@ static platform_data platform_data_table[] = {
 };
 
 static int initialized;
+static platforms_detected;
 
 static opae_api_adapter_table *adapter_list = (void *)0;
 static pthread_mutex_t adapter_list_lock =
@@ -221,6 +222,7 @@ STATIC void opae_plugin_mgr_detect_platform(uint16_t vendor, uint16_t device)
 
 		if (platform_data_table[i].vendor_id == vendor &&
 		    platform_data_table[i].device_id == device) {
+			platforms_detected++;
 			OPAE_DBG("platform detected: vid=0x%04x did=0x%04x -> %s",
 					vendor, device,
 					platform_data_table[i].native_plugin);
@@ -417,7 +419,7 @@ int opae_plugin_mgr_initialize(const char *cfg_file)
 	// Call each plugin's initialization routine.
 	errors += opae_plugin_mgr_initialize_all();
 
-	if (!errors)
+	if (!errors && platforms_detected)
 		initialized = 1;
 
 out_unlock:

--- a/testing/mock/test_system.cpp
+++ b/testing/mock/test_system.cpp
@@ -208,7 +208,7 @@ test_system *test_system::instance() {
 }
 
 void test_system::prepare_syfs(const test_platform &platform) {
-  char tmpsysfs[]{ "tmpsysfs-XXXXXX\0" };
+  char tmpsysfs[]{ "tmpsysfs-XXXXXX" };
   if (platform.mock_sysfs != nullptr) {
     char* tmp = mkdtemp(tmpsysfs);
     if (tmp == nullptr) {

--- a/testing/mock/test_system.cpp
+++ b/testing/mock/test_system.cpp
@@ -184,6 +184,7 @@ std::vector<std::string> test_platform::keys(bool sorted) {
   return keys;
 }
 
+
 test_system *test_system::instance_ = nullptr;
 
 test_system::test_system() : root_("") {
@@ -206,17 +207,18 @@ test_system *test_system::instance() {
   return test_system::instance_;
 }
 
-std::string test_system::prepare_syfs(const test_platform &platform) {
-  std::string tmpsysfs = "tmpsysfs-XXXXXX";
+void test_system::prepare_syfs(const test_platform &platform) {
+  char tmpsysfs[]{ "tmpsysfs-XXXXXX\0" };
   if (platform.mock_sysfs != nullptr) {
-    tmpsysfs = mkdtemp(const_cast<char *>(tmpsysfs.c_str()));
+    char* tmp = mkdtemp(tmpsysfs);
+    if (tmp == nullptr) {
+      throw std::runtime_error("error making tmpsysfs");
+    }
+    root_ = std::string(tmp);
     std::string cmd = "tar xzf " + std::string(platform.mock_sysfs) + " -C " +
-                      tmpsysfs + " --strip 1";
+                      root_ + " --strip 1";
     std::system(cmd.c_str());
-    root_ = tmpsysfs;
-    return tmpsysfs;
   }
-  return "/";
 }
 
 void test_system::remove_sysfs() {

--- a/testing/mock/test_system.h
+++ b/testing/mock/test_system.h
@@ -138,7 +138,7 @@ class test_system {
 
   void initialize();
   void finalize();
-  std::string prepare_syfs(const test_platform &platform);
+  void prepare_syfs(const test_platform &platform);
   void remove_sysfs();
 
   int open(const std::string &path, int flags);

--- a/testing/opae-c/test_buffer_c.cpp
+++ b/testing/opae-c/test_buffer_c.cpp
@@ -49,14 +49,14 @@ using namespace opae::testing;
 
 class buffer_c_p : public ::testing::TestWithParam<std::string> {
  protected:
-  buffer_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+  buffer_c_p() {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
     invalid_device_ = test_device::unknown();
 
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
@@ -85,7 +85,6 @@ class buffer_c_p : public ::testing::TestWithParam<std::string> {
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_;
   fpga_handle accel_;

--- a/testing/opae-c/test_enum_c.cpp
+++ b/testing/opae-c/test_enum_c.cpp
@@ -51,14 +51,14 @@ using namespace opae::testing;
 
 class enum_c_p : public ::testing::TestWithParam<std::string> {
  protected:
-  enum_c_p() : tmpsysfs("mocksys-XXXXXX") {}
+  enum_c_p() {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
     ASSERT_EQ(fpgaGetProperties(nullptr, &filter), FPGA_OK);
@@ -72,7 +72,6 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
     system_->finalize();
   }
 
-  std::string tmpsysfs;
   fpga_properties filter;
   std::array<fpga_token, 2> tokens;
   uint32_t num_matches;

--- a/testing/opae-c/test_error_c.cpp
+++ b/testing/opae-c/test_error_c.cpp
@@ -47,14 +47,14 @@ using namespace opae::testing;
 
 class error_c_p : public ::testing::TestWithParam<std::string> {
  protected:
-  error_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+  error_c_p() {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
     invalid_device_ = test_device::unknown();
 
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
@@ -76,7 +76,6 @@ class error_c_p : public ::testing::TestWithParam<std::string> {
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_;
   test_platform platform_;

--- a/testing/opae-c/test_event_c.cpp
+++ b/testing/opae-c/test_event_c.cpp
@@ -51,10 +51,9 @@ using namespace opae::testing;
 class event_c_p : public ::testing::TestWithParam<std::string> {
  protected:
   event_c_p()
-    : tmpsysfs_("mocksys-XXXXXX"),
-      tmpfpgad_log_("tmpfpgad-XXXXXX.log"),
+    : tmpfpgad_log_("tmpfpgad-XXXXXX.log"),
       tmpfpgad_pid_("tmpfpgad-XXXXXX.pid") {}
- 
+
   virtual void SetUp() override {
     tmpfpgad_log_ = mkstemp(const_cast<char *>(tmpfpgad_log_.c_str()));
     tmpfpgad_pid_ = mkstemp(const_cast<char *>(tmpfpgad_pid_.c_str()));
@@ -62,7 +61,7 @@ class event_c_p : public ::testing::TestWithParam<std::string> {
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
     invalid_device_ = test_device::unknown();
 
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
@@ -113,7 +112,6 @@ class event_c_p : public ::testing::TestWithParam<std::string> {
     fpgad_.join();
   }
 
-  std::string tmpsysfs_;
   std::string tmpfpgad_log_;
   std::string tmpfpgad_pid_;
   struct config config_;

--- a/testing/opae-c/test_hostif_c.cpp
+++ b/testing/opae-c/test_hostif_c.cpp
@@ -50,14 +50,14 @@ using namespace opae::testing;
 
 class hostif_c_p : public ::testing::TestWithParam<std::string> {
  protected:
-  hostif_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+  hostif_c_p() {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
     invalid_device_ = test_device::unknown();
 
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
@@ -85,7 +85,6 @@ class hostif_c_p : public ::testing::TestWithParam<std::string> {
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_;
   fpga_handle accel_;

--- a/testing/opae-c/test_mmio_c.cpp
+++ b/testing/opae-c/test_mmio_c.cpp
@@ -86,14 +86,14 @@ out_EINVAL:
 
 class mmio_c_p : public ::testing::TestWithParam<std::string> {
  protected:
-  mmio_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+  mmio_c_p() {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
     invalid_device_ = test_device::unknown();
 
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
@@ -128,7 +128,6 @@ class mmio_c_p : public ::testing::TestWithParam<std::string> {
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_;
   fpga_handle accel_;

--- a/testing/opae-c/test_open_c.cpp
+++ b/testing/opae-c/test_open_c.cpp
@@ -47,14 +47,14 @@ using namespace opae::testing;
 
 class open_c_p : public ::testing::TestWithParam<std::string> {
  protected:
-  open_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+  open_c_p() {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
     invalid_device_ = test_device::unknown();
 
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
@@ -78,7 +78,6 @@ class open_c_p : public ::testing::TestWithParam<std::string> {
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_;
   fpga_handle accel_;

--- a/testing/opae-c/test_props_c.cpp
+++ b/testing/opae-c/test_props_c.cpp
@@ -40,14 +40,14 @@ using namespace opae::testing;
 
 class properties_p1 : public ::testing::TestWithParam<std::string> {
  protected:
-  properties_p1() : tmpsysfs_("mocksys-XXXXXX") {}
+  properties_p1() {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
 
@@ -82,7 +82,6 @@ class properties_p1 : public ::testing::TestWithParam<std::string> {
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_device_;
   std::array<fpga_token, 2> tokens_accel_;

--- a/testing/opae-c/test_reconf_c.cpp
+++ b/testing/opae-c/test_reconf_c.cpp
@@ -50,14 +50,14 @@ using namespace opae::testing;
 
 class reconf_c_p : public ::testing::TestWithParam<std::string> {
  protected:
-  reconf_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+  reconf_c_p() {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
     invalid_device_ = test_device::unknown();
 
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
@@ -85,7 +85,6 @@ class reconf_c_p : public ::testing::TestWithParam<std::string> {
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_;
   fpga_handle accel_;

--- a/testing/opae-c/test_reset_c.cpp
+++ b/testing/opae-c/test_reset_c.cpp
@@ -47,14 +47,14 @@ using namespace opae::testing;
 
 class reset_c_p : public ::testing::TestWithParam<std::string> {
  protected:
-  reset_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+  reset_c_p() {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
     invalid_device_ = test_device::unknown();
 
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
@@ -82,7 +82,6 @@ class reset_c_p : public ::testing::TestWithParam<std::string> {
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_;
   fpga_handle accel_;

--- a/testing/opae-c/test_umsg_c.cpp
+++ b/testing/opae-c/test_umsg_c.cpp
@@ -120,14 +120,14 @@ out_EINVAL:
 
 class umsg_c_p : public ::testing::TestWithParam<std::string> {
  protected:
-  umsg_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+  umsg_c_p() {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
     invalid_device_ = test_device::unknown();
 
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
@@ -157,7 +157,6 @@ class umsg_c_p : public ::testing::TestWithParam<std::string> {
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_;
   fpga_handle accel_;

--- a/testing/xfpga/test_buffer_c.cpp
+++ b/testing/xfpga/test_buffer_c.cpp
@@ -44,7 +44,7 @@ using namespace opae::testing;
 class buffer_prepare
     : public ::testing::TestWithParam<std::tuple<std::string, buffer_params>> {
  protected:
-  buffer_prepare() : tmpsysfs_("mocksys-XXXXXX"), handle_(nullptr) {}
+  buffer_prepare() : handle_(nullptr) {}
 
   virtual void SetUp() override {
     auto tpl = GetParam();
@@ -53,7 +53,7 @@ class buffer_prepare
     platform_ = test_platform::get(platform_key);
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
@@ -69,7 +69,6 @@ class buffer_prepare
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_;
   fpga_handle handle_;

--- a/testing/xfpga/test_common_c.cpp
+++ b/testing/xfpga/test_common_c.cpp
@@ -47,14 +47,14 @@ using namespace opae::testing;
 class common_c_p
     : public ::testing::TestWithParam<std::string> {
  protected:
-  common_c_p() : tmpsysfs_("mocksys-XXXXXX"), handle_(nullptr) {}
+  common_c_p() : handle_(nullptr) {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
@@ -79,7 +79,6 @@ class common_c_p
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_ = {};
   fpga_handle handle_;

--- a/testing/xfpga/test_enum_c.cpp
+++ b/testing/xfpga/test_enum_c.cpp
@@ -44,7 +44,7 @@ using namespace opae::testing;
 
 class enum_c_p : public ::testing::TestWithParam<std::string> {
  protected:
-  enum_c_p() {}
+  enum_c_p() : tokens_ {nullptr} {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
@@ -66,9 +66,10 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
   }
 
   void DestroyTokens() {
-    for (auto t : tokens_) {
+    for (auto & t : tokens_) {
       if (t != nullptr) {
         EXPECT_EQ(xfpga_fpgaDestroyToken(&t), FPGA_OK);
+        t = nullptr;
       }
     }
   }
@@ -350,6 +351,7 @@ TEST_P(enum_c_p, num_errors) {
       xfpga_fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(), &num_matches_),
       FPGA_OK);
   EXPECT_EQ(num_matches_, 1);
+  SCOPED_TRACE("num_errors: DestroyTokens()");
   DestroyTokens();
 
   // invalid
@@ -427,11 +429,8 @@ TEST_P(enum_c_p, destroy_token) {
       FPGA_OK);
   EXPECT_EQ(num_matches_, 2);
   num_matches_ = 100;
-  for (auto t : tokens_) {
-    if (t != nullptr) {
-      EXPECT_EQ(xfpga_fpgaDestroyToken(&t), FPGA_OK);
-    }
-  }
+  SCOPED_TRACE("destroy_token: DestroyTokens()");
+  DestroyTokens();
 
   EXPECT_EQ(xfpga_fpgaDestroyToken(nullptr), FPGA_INVALID_PARAM);
   _fpga_token *dummy = new _fpga_token;

--- a/testing/xfpga/test_events_c.cpp
+++ b/testing/xfpga/test_events_c.cpp
@@ -47,8 +47,7 @@ using namespace opae::testing;
 class events_p : public ::testing::TestWithParam<std::string> {
  protected:
   events_p()
-      : tmpsysfs_("mocksys-XXXXXX"),
-        tmpfpgad_log_("tmpfpgad-XXXXXX.log"),
+      : tmpfpgad_log_("tmpfpgad-XXXXXX.log"),
         tmpfpgad_pid_("tmpfpgad-XXXXXX.pid"),
         handle_(nullptr) {}
 
@@ -60,12 +59,12 @@ class events_p : public ::testing::TestWithParam<std::string> {
     platform_ = test_platform::get(platform_key);
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
     ASSERT_EQ(xfpga_fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
-                            &num_matches_),
+                                  &num_matches_),
               FPGA_OK);
     ASSERT_EQ(xfpga_fpgaOpen(tokens_[0], &handle_, 0), FPGA_OK);
     ASSERT_EQ(xfpga_fpgaCreateEventHandle(&eh_), FPGA_OK);
@@ -96,7 +95,6 @@ class events_p : public ::testing::TestWithParam<std::string> {
     fpgad_.join();
   }
 
-  std::string tmpsysfs_;
   std::string tmpfpgad_log_;
   std::string tmpfpgad_pid_;
   struct config config_;
@@ -112,16 +110,20 @@ class events_p : public ::testing::TestWithParam<std::string> {
 
 TEST_P(events_p, register_event) {
   fpga_result res;
-  ASSERT_EQ(res = xfpga_fpgaRegisterEvent(handle_, FPGA_EVENT_ERROR, eh_, 0), FPGA_OK)
+  ASSERT_EQ(res = xfpga_fpgaRegisterEvent(handle_, FPGA_EVENT_ERROR, eh_, 0),
+            FPGA_OK)
       << "\tEVENT TYPE: ERROR, RESULT: " << fpgaErrStr(res);
-  EXPECT_EQ(res = xfpga_fpgaUnregisterEvent(handle_, FPGA_EVENT_ERROR, eh_), FPGA_OK)
+  EXPECT_EQ(res = xfpga_fpgaUnregisterEvent(handle_, FPGA_EVENT_ERROR, eh_),
+            FPGA_OK)
       << "\tRESULT: " << fpgaErrStr(res);
 
-  ASSERT_EQ(res = xfpga_fpgaRegisterEvent(handle_, FPGA_EVENT_POWER_THERMAL, eh_, 0),
-            FPGA_OK)
+  ASSERT_EQ(
+      res = xfpga_fpgaRegisterEvent(handle_, FPGA_EVENT_POWER_THERMAL, eh_, 0),
+      FPGA_OK)
       << "\tEVENT TYPE: ERROR, RESULT: " << fpgaErrStr(res);
-  EXPECT_EQ(res = xfpga_fpgaUnregisterEvent(handle_, FPGA_EVENT_POWER_THERMAL, eh_),
-            FPGA_OK)
+  EXPECT_EQ(
+      res = xfpga_fpgaUnregisterEvent(handle_, FPGA_EVENT_POWER_THERMAL, eh_),
+      FPGA_OK)
       << "\tRESULT: " << fpgaErrStr(res);
 }
 

--- a/testing/xfpga/test_metadata_c.cpp
+++ b/testing/xfpga/test_metadata_c.cpp
@@ -35,14 +35,14 @@ using namespace opae::testing;
 class metadata_c
     : public ::testing::TestWithParam<std::string> {
  protected:
-  metadata_c() : tmpsysfs("mocksys-XXXXXX"), handle_(nullptr) {}
+  metadata_c() : handle_(nullptr) {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
@@ -56,7 +56,6 @@ class metadata_c
     system_->finalize();
   }
 
-  std::string tmpsysfs;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_;
   fpga_handle handle_;

--- a/testing/xfpga/test_mmio_c.cpp
+++ b/testing/xfpga/test_mmio_c.cpp
@@ -83,14 +83,14 @@ out_EINVAL:
 class mmio_c_p
     : public ::testing::TestWithParam<std::string> {
  protected:
-  mmio_c_p() : tmpsysfs_("mocksys-XXXXXX"), handle_(nullptr) {}
+  mmio_c_p() : handle_(nullptr) {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
@@ -107,7 +107,6 @@ class mmio_c_p
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_;
   fpga_handle handle_;

--- a/testing/xfpga/test_mock_errinj_c.cpp
+++ b/testing/xfpga/test_mock_errinj_c.cpp
@@ -117,14 +117,14 @@ out_EINVAL:
 
 class mock_err_inj_c_p : public ::testing::TestWithParam<std::string> {
  protected:
-   mock_err_inj_c_p() : tmpsysfs_("mocksys-XXXXXX") {}
+   mock_err_inj_c_p() {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
@@ -145,7 +145,6 @@ class mock_err_inj_c_p : public ::testing::TestWithParam<std::string> {
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_ = {};
   fpga_handle handle_;

--- a/testing/xfpga/test_object_c.cpp
+++ b/testing/xfpga/test_object_c.cpp
@@ -37,7 +37,7 @@ const std::string DATA =
 class sysobject_p : public ::testing::TestWithParam<std::string> {
  protected:
   sysobject_p()
-      : tmpsysfs_("mocksys-XXXXXX"), tokens_{nullptr}, handle_(nullptr) {}
+      : tokens_{nullptr}, handle_(nullptr) {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
@@ -49,7 +49,7 @@ class sysobject_p : public ::testing::TestWithParam<std::string> {
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
     invalid_device_ = test_device::unknown();
   }
 
@@ -66,7 +66,6 @@ class sysobject_p : public ::testing::TestWithParam<std::string> {
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   test_platform platform_;
   test_device invalid_device_;
   test_system *system_;

--- a/testing/xfpga/test_open_close_c.cpp
+++ b/testing/xfpga/test_open_close_c.cpp
@@ -83,14 +83,14 @@ out_EINVAL:
 class openclose_c_p
     : public ::testing::TestWithParam<std::string> {
  protected:
-  openclose_c_p() : tmpsysfs_("mocksys-XXXXXX"), handle_(nullptr) {}
+  openclose_c_p() : handle_(nullptr) {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
@@ -101,7 +101,7 @@ class openclose_c_p
 
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-    
+
     for (auto t : tokens_){
       if (t != nullptr){
         EXPECT_EQ(FPGA_OK, xfpga_fpgaDestroyToken(&t));
@@ -111,7 +111,6 @@ class openclose_c_p
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   fpga_handle handle_;
   std::array<fpga_token, 2> tokens_ = {};

--- a/testing/xfpga/test_properties_c.cpp
+++ b/testing/xfpga/test_properties_c.cpp
@@ -36,14 +36,14 @@ using namespace opae::testing;
 
 class properties_p1 : public ::testing::TestWithParam<std::string> {
  protected:
-  properties_p1() : tmpsysfs_("mocksys-XXXXXX") {}
+  properties_p1() {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &props_), FPGA_OK);
@@ -65,7 +65,6 @@ class properties_p1 : public ::testing::TestWithParam<std::string> {
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   fpga_properties props_;
   std::array<fpga_token, 2> tokens_;

--- a/testing/xfpga/test_reconf_c.cpp
+++ b/testing/xfpga/test_reconf_c.cpp
@@ -39,14 +39,14 @@ using namespace opae::testing;
 class reconf_c
     : public ::testing::TestWithParam<std::string> {
  protected:
-  reconf_c() : tmpsysfs_("mocksys-XXXXXX"), handle_(nullptr) {}
+  reconf_c() : handle_(nullptr) {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
@@ -68,7 +68,6 @@ class reconf_c
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_ = {};
   fpga_handle handle_;

--- a/testing/xfpga/test_reset_c.cpp
+++ b/testing/xfpga/test_reset_c.cpp
@@ -36,14 +36,14 @@ using namespace opae::testing;
 class reset_c_p
     : public ::testing::TestWithParam<std::string> {
  protected:
-  reset_c_p() : tmpsysfs_("mocksys-XXXXXX"), handle_(nullptr) {}
+  reset_c_p() : handle_(nullptr) {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
@@ -59,7 +59,6 @@ class reset_c_p
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_;
   fpga_handle handle_;

--- a/testing/xfpga/test_sysfs_c.cpp
+++ b/testing/xfpga/test_sysfs_c.cpp
@@ -49,14 +49,14 @@ using namespace opae::testing;
 
 class sysfs_c_p : public ::testing::TestWithParam<std::string> {
  protected:
-  sysfs_c_p() : tmpsysfs_("mocksys-XXXXXX"), handle_(nullptr){}
+  sysfs_c_p() : handle_(nullptr){}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
@@ -72,7 +72,6 @@ class sysfs_c_p : public ::testing::TestWithParam<std::string> {
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_;
   fpga_handle handle_;

--- a/testing/xfpga/test_umsg_c.cpp
+++ b/testing/xfpga/test_umsg_c.cpp
@@ -112,14 +112,14 @@ out_EINVAL:
 class umsg_c_p
     : public ::testing::TestWithParam<std::string> {
  protected:
-  umsg_c_p() : tmpsysfs_("mocksys-XXXXXX"), handle_(nullptr) {}
+  umsg_c_p() : handle_(nullptr) {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
@@ -136,7 +136,6 @@ class umsg_c_p
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_;
   std::array<fpga_token, 2> tokens_;
   fpga_handle handle_;

--- a/testing/xfpga/test_usrclk_c.cpp
+++ b/testing/xfpga/test_usrclk_c.cpp
@@ -48,14 +48,14 @@ using namespace opae::testing;
 class usrclk_c
     : public ::testing::TestWithParam<std::string> {
  protected:
-  usrclk_c() : tmpsysfs_("mocksys-XXXXXX"), handle_dev_(nullptr), handle_accel_(nullptr) {}
+  usrclk_c() : handle_dev_(nullptr), handle_accel_(nullptr) {}
 
   virtual void SetUp() override {
     ASSERT_TRUE(test_platform::exists(GetParam()));
     platform_ = test_platform::get(GetParam());
     system_ = test_system::instance();
     system_->initialize();
-    tmpsysfs_ = system_->prepare_syfs(platform_);
+    system_->prepare_syfs(platform_);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_dev_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_dev_, FPGA_DEVICE), FPGA_OK);
@@ -89,7 +89,6 @@ class usrclk_c
     system_->finalize();
   }
 
-  std::string tmpsysfs_;
   fpga_properties filter_dev_;
   fpga_properties filter_accel_;
   std::array<fpga_token, 2> tokens_dev_ = {};


### PR DESCRIPTION
Fix memory leak related to mkdtemp
Fix other leaks from not destroying tokens in enum_c tests