### PR TITLE
tests: fix opae-c event test leak

### DIFF
--- a/testing/opae-c/test_event_c.cpp
+++ b/testing/opae-c/test_event_c.cpp
@@ -110,6 +110,7 @@ class event_c_p : public ::testing::TestWithParam<std::string> {
     }
     system_->finalize();
     fpgad_.join();
+    close_log();
   }
 
   std::string tmpfpgad_log_;


### PR DESCRIPTION
Identified by valgrind memcheck.