### PR TITLE
wsid's bound to shared buffers must be unique

### DIFF
--- a/libopae/src/common.c
+++ b/libopae/src/common.c
@@ -34,7 +34,6 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
-#include <stdatomic.h>
 
 // Buffer Allocation constants
 #define KB 1024
@@ -180,9 +179,9 @@ const char __FPGA_API__ *fpgaErrStr(fpga_result e)
  */
 uint64_t wsid_gen(void)
 {
-	static atomic_uint_fast64_t ctr = 0;
+	static uint64_t ctr = 0;
 
-	uint64_t id = atomic_fetch_add(&ctr, 1);
+	uint64_t id = __sync_fetch_and_add(&ctr, 1);
 	id ^= ((unsigned long) getpid() % 16777216) << 40;
 	return id;
 }

--- a/libopae/src/common.c
+++ b/libopae/src/common.c
@@ -179,7 +179,7 @@ const char __FPGA_API__ *fpgaErrStr(fpga_result e)
  */
 uint64_t wsid_gen(void)
 {
-	static uint64_t ctr = 0;
+	static uint64_t ctr;
 
 	uint64_t id = __sync_fetch_and_add(&ctr, 1);
 	id ^= ((unsigned long) getpid() % 16777216) << 40;

--- a/libopae/src/common.c
+++ b/libopae/src/common.c
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
+#include <stdatomic.h>
 
 // Buffer Allocation constants
 #define KB 1024
@@ -179,10 +180,9 @@ const char __FPGA_API__ *fpgaErrStr(fpga_result e)
  */
 uint64_t wsid_gen(void)
 {
-	struct timeval t;
-	uint64_t id = 0;
-	gettimeofday(&t, NULL);
-	id = ((t.tv_sec * 1000 * 1000) + (t.tv_usec * 1000)) << 42;
-	id |= ((unsigned long) getpid() % 16777216) << 24;
+	static atomic_uint_fast64_t ctr = 0;
+
+	uint64_t id = atomic_fetch_add(&ctr, 1);
+	id ^= ((unsigned long) getpid() % 16777216) << 40;
 	return id;
 }


### PR DESCRIPTION
The hash computation was generating aliases when about 250k pages were allocated.
Use a simple atomic counter, which is also faster, instead.