### PR TITLE
Use a hash to track the wsid space.

### DIFF
--- a/libopae/src/buffer.c
+++ b/libopae/src/buffer.c
@@ -255,7 +255,7 @@ fpga_result __FPGA_API__ fpgaPrepareBuffer(fpga_handle handle, uint64_t len,
 	*wsid = wsid_gen();
 
 	/* Add to workspace id in order to store buffer length */
-	if (!wsid_add(&_handle->wsid_root,
+	if (!wsid_add(_handle->wsid_root,
 		      *wsid,
 		      dma_map.user_addr,
 		      dma_map.iova,
@@ -348,7 +348,7 @@ fpga_result __FPGA_API__ fpgaReleaseBuffer(fpga_handle handle, uint64_t wsid)
 
 ws_free:
 	/* Remove workspace */
-	wsid_del(&_handle->wsid_root, wsid);
+	wsid_del(_handle->wsid_root, wsid);
 
 out_unlock:
 	err = pthread_mutex_unlock(&_handle->lock);

--- a/libopae/src/close.c
+++ b/libopae/src/close.c
@@ -63,8 +63,8 @@ fpga_result __FPGA_API__ fpgaClose(fpga_handle handle)
 		return FPGA_INVALID_PARAM;
 	}
 
-	wsid_cleanup(&_handle->wsid_root, NULL);
-	wsid_cleanup(&_handle->mmio_root, unmap_mmio_region);
+	wsid_tracker_cleanup(_handle->wsid_root, NULL);
+	wsid_tracker_cleanup(_handle->mmio_root, unmap_mmio_region);
 	free_umsg_buffer(handle);
 	close(_handle->fddev);
 	if (_handle->fdfpgad >= 0)

--- a/libopae/src/mmio.c
+++ b/libopae/src/mmio.c
@@ -164,7 +164,7 @@ static fpga_result map_mmio_region(fpga_handle handle, uint32_t mmio_num)
 
 	/* Add to MMIO list */
 	wsid = wsid_gen();
-	if (!wsid_add(&_handle->mmio_root,
+	if (!wsid_add(_handle->mmio_root,
 		      wsid,
 		      (uint64_t) addr,
 		      (uint64_t) NULL,
@@ -423,7 +423,7 @@ fpga_result __FPGA_API__ fpgaUnmapMMIO(fpga_handle handle,
 	}
 
 	/* Remove MMIO */
-	wsid_del(&_handle->mmio_root, wm->wsid);
+	wsid_del(_handle->mmio_root, wm->wsid);
 
 out_unlock:
 	err = pthread_mutex_unlock(&_handle->lock);

--- a/libopae/src/open.c
+++ b/libopae/src/open.c
@@ -87,10 +87,10 @@ fpga_result __FPGA_API__ fpgaOpen(fpga_token token, fpga_handle *handle, int fla
 	_handle->fdfpgad = -1;
 
 	// Init MMIO table
-	_handle->mmio_root = NULL;
+	_handle->mmio_root = wsid_tracker_init(4);
 
 	// Init workspace table
-	_handle->wsid_root = NULL;
+	_handle->wsid_root = wsid_tracker_init(16384);
 
 	// Open resources in exclusive mode unless FPGA_OPEN_SHARED is given
 	open_flags = O_RDWR | ((flags & FPGA_OPEN_SHARED) ? 0 : O_EXCL);

--- a/libopae/src/types_int.h
+++ b/libopae/src/types_int.h
@@ -111,13 +111,13 @@ struct _fpga_handle {
 	pthread_mutex_t lock;
 	uint64_t magic;
 	fpga_token token;
-	int fddev;                  // file descriptor for the device.
-	int fdfpgad;                // file descriptor for the event daemon.
-	struct wsid_map *wsid_root; // wsid information (list)
-	struct wsid_map *mmio_root; // MMIO information (list)
-	void *umsg_virt;	    // umsg Virtual Memory pointer
-	uint64_t umsg_size;	    // umsg Virtual Memory Size
-	uint64_t *umsg_iova;	    // umsg IOVA from driver
+	int fddev;                      // file descriptor for the device.
+	int fdfpgad;                    // file descriptor for the event daemon.
+	struct wsid_tracker *wsid_root; // wsid information (list)
+	struct wsid_tracker *mmio_root; // MMIO information (list)
+	void *umsg_virt;	        // umsg Virtual Memory pointer
+	uint64_t umsg_size;	        // umsg Virtual Memory Size
+	uint64_t *umsg_iova;	        // umsg IOVA from driver
 };
 
 /** Object property struct
@@ -198,6 +198,14 @@ struct wsid_map {
 	uint32_t         index;
 	int              flags;
 	struct wsid_map *next;
+};
+
+/*
+ * Hash table to store wsid_maps
+ */
+struct wsid_tracker {
+	uint64_t          n_hash_buckets;
+	struct wsid_map **table;
 };
 
 /*

--- a/libopae/src/wsid_list.c
+++ b/libopae/src/wsid_list.c
@@ -33,12 +33,54 @@
 #include <pthread.h>
 #include "wsid_list_int.h"
 
-/* mutex to protect global data structures */
-extern pthread_mutex_t global_lock;
+/*
+ * The code here assumes the caller handles any required mutexes.
+ * The logic here is not thread safe on its own.
+ */
 
 /**
- * @brief Add entry to linked list for WSIDs
- *        Will allocate memory (which is freed by wsid_del() or wsid_cleanup())
+ * @brief Initialize a wsid tracker hash table
+ * @param n_hash_buckets
+ *
+ * @return
+ */
+struct wsid_tracker *wsid_tracker_init(uint32_t n_hash_buckets)
+{
+	if (!n_hash_buckets || (n_hash_buckets > 16384))
+		return NULL;
+
+	struct wsid_tracker *root = malloc(sizeof(struct wsid_tracker));
+	if (!root)
+		return NULL;
+
+	root->n_hash_buckets = n_hash_buckets;
+	root->table = calloc(n_hash_buckets, sizeof(struct wsid_map*));
+	if (!root->table) {
+		free(root);
+		return NULL;
+	}
+
+	return root;
+}
+
+/**
+ * @brief Map WSID to hash bucket index
+ * @param root
+ * @param wsid
+ *
+ * @return bucket index
+ */
+static inline uint32_t wsid_hash(struct wsid_tracker *root, uint64_t wsid)
+{
+	uint64_t h = wsid % 17659;
+	return h % root->n_hash_buckets;
+}
+
+
+/**
+ * @brief Add entry to WSID tracker
+ *        Will allocate memory (which is freed by wsid_del() or
+ *        wsid_tracker_cleanup())
  * @param root
  * @param wsid
  * @param addr
@@ -48,7 +90,7 @@ extern pthread_mutex_t global_lock;
  *
  * @return true if success, false otherwise
  */
-bool wsid_add(struct wsid_map **root,
+bool wsid_add(struct wsid_tracker *root,
 	      uint64_t wsid,
 	      uint64_t addr,
 	      uint64_t phys,
@@ -57,6 +99,7 @@ bool wsid_add(struct wsid_map **root,
 	      uint64_t index,
 	      int flags)
 {
+	uint32_t idx = wsid_hash(root, wsid);
 	struct wsid_map *tmp = malloc(sizeof(struct wsid_map));
 
 	if (!tmp)
@@ -69,29 +112,30 @@ bool wsid_add(struct wsid_map **root,
 	tmp->offset = offset;
 	tmp->index  = index;
 	tmp->flags  = flags;
-	tmp->next   = *root;
+	tmp->next   = root->table[idx];
 
-	*root = tmp;
+	root->table[idx] = tmp;
 	return true;
 }
 
 /**
- * @brief Remove entry from linked list
+ * @brief Remove entry from tracker
  *
  * @param root
  * @param wsid
  *
  * @return true if success, false otherwise
  */
-bool wsid_del(struct wsid_map **root, uint64_t wsid)
+bool wsid_del(struct wsid_tracker *root, uint64_t wsid)
 {
-	struct wsid_map *tmp = *root;
+	uint32_t idx = wsid_hash(root, wsid);
+	struct wsid_map *tmp = root->table[idx];
 
-	if (!*root)
+	if (!tmp)
 		return false; /* empty list */
 
-	if ((*root)->wsid == wsid) { /* first entry */
-		*root = (*root)->next;
+	if (tmp->wsid == wsid) { /* first entry */
+		root->table[idx] = root->table[idx]->next;
 		free(tmp);
 		return true;
 	}
@@ -116,23 +160,25 @@ bool wsid_del(struct wsid_map **root, uint64_t wsid)
  *
  * @param root
  */
-void wsid_cleanup(struct wsid_map **root, void (*clean)(struct wsid_map *))
+void wsid_tracker_cleanup(struct wsid_tracker *root,
+                          void (*clean)(struct wsid_map *))
 {
-	if (!*root)
+	if (!root)
 		return;
 
-	while ((*root)->next) {
-		struct wsid_map *tmp = *root;
-		*root = (*root)->next;
-		if (clean)
-			clean(tmp);
-		free(tmp);
+	for (uint32_t idx = 0; idx < root->n_hash_buckets; idx += 1) {
+		struct wsid_map *tmp = root->table[idx];
+
+		while (tmp) {
+			struct wsid_map *tmp2 = tmp->next;
+			if (clean)
+				clean(tmp);
+			free(tmp);
+			tmp = tmp2;
+		}
 	}
 
-	if (clean)
-		clean(*root);
-	free(*root);
-	*root = NULL;
+	free(root);
 }
 
 /**
@@ -143,9 +189,10 @@ void wsid_cleanup(struct wsid_map **root, void (*clean)(struct wsid_map *))
  *
  * @return
  */
-struct wsid_map *wsid_find(struct wsid_map *root, uint64_t wsid)
+struct wsid_map *wsid_find(struct wsid_tracker *root, uint64_t wsid)
 {
-	struct wsid_map *tmp = root;
+	uint32_t idx = wsid_hash(root, wsid);
+	struct wsid_map *tmp = root->table[idx];
 
 	while (tmp && tmp->wsid != wsid)
 		tmp = tmp->next;
@@ -161,13 +208,22 @@ struct wsid_map *wsid_find(struct wsid_map *root, uint64_t wsid)
  *
  * @return
  */
-struct wsid_map *wsid_find_by_index(struct wsid_map *root, uint32_t index)
+struct wsid_map *wsid_find_by_index(struct wsid_tracker *root, uint32_t index)
 {
-	struct wsid_map *tmp = root;
+    /*
+     * The hash table isn't set up for finding by index, but this search is
+     * used only for MMIO spaces, which should have a small number of entries.
+     */
+	for (uint32_t idx = 0; idx < root->n_hash_buckets; idx += 1) {
+		struct wsid_map *tmp = root->table[idx];
 
-	while (tmp && tmp->index != index)
-		tmp = tmp->next;
+		while (tmp && tmp->index != index)
+			tmp = tmp->next;
 
-	return tmp;
+		if (tmp)
+			return tmp;
+	}
+
+	return NULL;
 }
 

--- a/libopae/src/wsid_list.c
+++ b/libopae/src/wsid_list.c
@@ -180,6 +180,7 @@ void wsid_tracker_cleanup(struct wsid_tracker *root,
 		}
 	}
 
+	free(root->table);
 	free(root);
 }
 

--- a/libopae/src/wsid_list.c
+++ b/libopae/src/wsid_list.c
@@ -54,7 +54,7 @@ struct wsid_tracker *wsid_tracker_init(uint32_t n_hash_buckets)
 		return NULL;
 
 	root->n_hash_buckets = n_hash_buckets;
-	root->table = calloc(n_hash_buckets, sizeof(struct wsid_map*));
+	root->table = calloc(n_hash_buckets, sizeof(struct wsid_map *));
 	if (!root->table) {
 		free(root);
 		return NULL;
@@ -161,7 +161,7 @@ bool wsid_del(struct wsid_tracker *root, uint64_t wsid)
  * @param root
  */
 void wsid_tracker_cleanup(struct wsid_tracker *root,
-                          void (*clean)(struct wsid_map *))
+			  void (*clean)(struct wsid_map *))
 {
 	if (!root)
 		return;

--- a/libopae/src/wsid_list.c
+++ b/libopae/src/wsid_list.c
@@ -163,10 +163,12 @@ bool wsid_del(struct wsid_tracker *root, uint64_t wsid)
 void wsid_tracker_cleanup(struct wsid_tracker *root,
 			  void (*clean)(struct wsid_map *))
 {
+	uint32_t idx;
+
 	if (!root)
 		return;
 
-	for (uint32_t idx = 0; idx < root->n_hash_buckets; idx += 1) {
+	for (idx = 0; idx < root->n_hash_buckets; idx += 1) {
 		struct wsid_map *tmp = root->table[idx];
 
 		while (tmp) {
@@ -214,7 +216,8 @@ struct wsid_map *wsid_find_by_index(struct wsid_tracker *root, uint32_t index)
      * The hash table isn't set up for finding by index, but this search is
      * used only for MMIO spaces, which should have a small number of entries.
      */
-	for (uint32_t idx = 0; idx < root->n_hash_buckets; idx += 1) {
+	uint32_t idx;
+	for (idx = 0; idx < root->n_hash_buckets; idx += 1) {
 		struct wsid_map *tmp = root->table[idx];
 
 		while (tmp && tmp->index != index)

--- a/libopae/src/wsid_list_int.h
+++ b/libopae/src/wsid_list_int.h
@@ -31,9 +31,12 @@
 #include "types_int.h"
 
 /*
- * WSID list structure manipulation functions
+ * WSID tracking structure manipulation functions
  */
-bool wsid_add(struct wsid_map **root,
+struct wsid_tracker *wsid_tracker_init(uint32_t n_hash_buckets);
+void wsid_tracker_cleanup(struct wsid_tracker *root, void (*clean)(struct wsid_map *));
+
+bool wsid_add(struct wsid_tracker *root,
 	      uint64_t wsid,
 	      uint64_t addr,
 	      uint64_t phys,
@@ -41,11 +44,10 @@ bool wsid_add(struct wsid_map **root,
 	      uint64_t offset,
 	      uint64_t index,
 	      int      flags);
-bool wsid_del(struct wsid_map **root, uint64_t wsid);
-void wsid_cleanup(struct wsid_map **root, void (*clean)(struct wsid_map *));
+bool wsid_del(struct wsid_tracker *root, uint64_t wsid);
 uint64_t wsid_gen(void);
 
-struct wsid_map *wsid_find(struct wsid_map *root, uint64_t wsid);
-struct wsid_map *wsid_find_by_index(struct wsid_map *root, uint32_t index);
+struct wsid_map *wsid_find(struct wsid_tracker *root, uint64_t wsid);
+struct wsid_map *wsid_find_by_index(struct wsid_tracker *root, uint32_t index);
 
 #endif // ___FPGA_COMMON_INT_H__

--- a/tests/function/gtMMIO.cpp
+++ b/tests/function/gtMMIO.cpp
@@ -41,6 +41,35 @@
 using namespace common_test;
 
 
+#ifndef BUILD_ASE
+
+/*
+ * On hardware, the mmio map is a hash table.
+ */
+static bool mmio_map_is_empty(struct wsid_tracker *root) {
+  if (!root || (root->n_hash_buckets == 0))
+    return true;
+
+  for (uint32_t i = 0; i < root->n_hash_buckets; i += 1) {
+    if (root->table[i])
+      return false;
+  }
+
+  return true;
+}
+
+#else
+
+/*
+ * In ASE, the mmio map is a list.
+ */
+static bool mmio_map_is_empty(struct wsid_map *root) {
+  return !root;
+}
+
+#endif
+
+
 /**
  * @test       mmio_drv_init_01
  *
@@ -56,7 +85,12 @@ TEST(LibopaecMmioCommonALL, mmio_drv_positive_init_01) {
   // Open  port device
   token_for_afu0(&_tok);
   ASSERT_EQ(FPGA_OK, fpgaOpen(tok, &h, 0));
-  EXPECT_TRUE(((struct _fpga_handle*)h)->mmio_root == NULL);
+#ifndef BUILD_ASE
+  // On HW we build a hash table
+  EXPECT_FALSE(((struct _fpga_handle*)h)->mmio_root == NULL);
+  EXPECT_FALSE(((struct _fpga_handle*)h)->mmio_root->n_hash_buckets == 0);
+#endif
+  EXPECT_TRUE(mmio_map_is_empty(((struct _fpga_handle*)h)->mmio_root));
   ASSERT_EQ(FPGA_OK, fpgaClose(h));
 }
 
@@ -79,7 +113,7 @@ TEST(LibopaecMmioCommonALL, mmio_drv_positive_map_mmio_01) {
 #ifndef BUILD_ASE
   ASSERT_EQ(FPGA_OK, fpgaMapMMIO(h, 0, &mmio_ptr));
   EXPECT_FALSE(mmio_ptr == NULL);
-  EXPECT_FALSE(((struct _fpga_handle *)h)->mmio_root == NULL);
+  EXPECT_FALSE(mmio_map_is_empty(((struct _fpga_handle*)h)->mmio_root));
 #else
   // ASE
   ASSERT_EQ(FPGA_NOT_SUPPORTED, fpgaMapMMIO(h, 0, &mmio_ptr));
@@ -119,7 +153,7 @@ TEST(LibopaecMmioCommonALL, mmio_drv_negative_map_mmio_02) {
 
   // Do not modify mmio_ptr and mmio_root
   EXPECT_TRUE(mmio_ptr == NULL);
-  EXPECT_TRUE(((struct _fpga_handle*)h)->mmio_root == NULL);
+  EXPECT_TRUE(mmio_map_is_empty(((struct _fpga_handle*)h)->mmio_root));
 
 // Unmap memory range otherwise, will not accept open from same process
 #ifndef BUILD_ASE


### PR DESCRIPTION
Unique workspace IDs are assigned to each allocated shared buffer. The IDs are used
for discovering the PA of a buffer and for passing the buffer size to the kernel when a page
is deallocated.  The data structure was a list, which didn't scale.  A million allocated
pages took over 1.5 hours to free.  The new code accomplishes the same in about 4 seconds.