### PR TITLE
add default_ioctl_handler function in test_system

### DIFF
--- a/testing/mock/ioctl_handlers.cpp
+++ b/testing/mock/ioctl_handlers.cpp
@@ -47,10 +47,10 @@ static int validate_argp(mock_object* mock, int request, va_list argp) {
   return 0;
 }
 
-#define DEFAULT_IOCTL_HANDLER(_REQ, _S)                               \
-  namespace {                                                          \
-  static bool r##_S = test_system::instance()->register_ioctl_handler( \
-      _REQ, validate_argp<_S>);                                        \
+#define DEFAULT_IOCTL_HANDLER(_REQ, _S)                                        \
+  namespace {                                                                  \
+  static bool r##_S =                                                          \
+      test_system::instance()->default_ioctl_handler(_REQ, validate_argp<_S>); \
   }
 
 // FPGA DEVICE
@@ -63,15 +63,15 @@ DEFAULT_IOCTL_HANDLER(FPGA_FME_ERR_SET_IRQ, fpga_fme_err_irq_set);
 // FPGA ACCELERATOR
 DEFAULT_IOCTL_HANDLER(FPGA_PORT_DMA_MAP, fpga_port_dma_map);
 DEFAULT_IOCTL_HANDLER(FPGA_PORT_DMA_UNMAP, fpga_port_dma_unmap);
-//DEFAULT_IOCTL_HANDLER(FPGA_PORT_RESET);
+// DEFAULT_IOCTL_HANDLER(FPGA_PORT_RESET);
 DEFAULT_IOCTL_HANDLER(FPGA_PORT_GET_REGION_INFO, fpga_port_region_info);
 DEFAULT_IOCTL_HANDLER(FPGA_PORT_GET_INFO, fpga_port_info);
 DEFAULT_IOCTL_HANDLER(FPGA_PORT_ERR_SET_IRQ, fpga_port_err_irq_set);
 DEFAULT_IOCTL_HANDLER(FPGA_PORT_UAFU_SET_IRQ, fpga_port_uafu_irq_set);
 DEFAULT_IOCTL_HANDLER(FPGA_PORT_UMSG_SET_MODE, fpga_port_umsg_cfg);
 DEFAULT_IOCTL_HANDLER(FPGA_PORT_UMSG_SET_BASE_ADDR, fpga_port_umsg_base_addr);
-//DEFAULT_IOCTL_HANDLER(FPGA_PORT_UMSG_ENABLE);
-//DEFAULT_IOCTL_HANDLER(FPGA_PORT_UMSG_DISABLE);
+// DEFAULT_IOCTL_HANDLER(FPGA_PORT_UMSG_ENABLE);
+// DEFAULT_IOCTL_HANDLER(FPGA_PORT_UMSG_DISABLE);
 
 }  // end of namespace testing
 }  // end of namespace opae

--- a/testing/mock/test_system.cpp
+++ b/testing/mock/test_system.cpp
@@ -302,6 +302,9 @@ void test_system::initialize() {
   ASSERT_FN(xstat_);
   ASSERT_FN(lstat_);
   ASSERT_FN(scandir_);
+  for (const auto &kv : default_ioctl_handlers_) {
+    register_ioctl_handler(kv.first, kv.second);
+  }
 }
 
 void test_system::finalize() {
@@ -317,13 +320,21 @@ void test_system::finalize() {
   for (auto kv : registered_files_) {
     unlink(kv.second.c_str());
   }
+  ioctl_handlers_.clear();
+}
+
+bool test_system::default_ioctl_handler(int request, ioctl_handler_t h) {
+  bool already_registered =
+      default_ioctl_handlers_.find(request) != default_ioctl_handlers_.end();
+  default_ioctl_handlers_[request] = h;
+  return already_registered;
 }
 
 bool test_system::register_ioctl_handler(int request, ioctl_handler_t h) {
-  bool alhready_registered =
+  bool already_registered =
       ioctl_handlers_.find(request) != ioctl_handlers_.end();
   ioctl_handlers_[request] = h;
-  return alhready_registered;
+  return already_registered;
 }
 
 FILE *test_system::register_file(const std::string &path) {

--- a/testing/mock/test_system.h
+++ b/testing/mock/test_system.h
@@ -160,6 +160,7 @@ class test_system {
   void invalidate_malloc(uint32_t after=0, const char *when_called_from=nullptr);
   void invalidate_calloc(uint32_t after=0, const char *when_called_from=nullptr);
 
+  bool default_ioctl_handler(int request, ioctl_handler_t);
   bool register_ioctl_handler(int request, ioctl_handler_t);
 
   FILE *register_file(const std::string &path);
@@ -168,6 +169,7 @@ class test_system {
   test_system();
   std::string root_;
   std::map<int, mock_object *> fds_;
+  std::map<int, ioctl_handler_t> default_ioctl_handlers_;
   std::map<int, ioctl_handler_t> ioctl_handlers_;
   std::map<std::string, std::string> registered_files_;
   static test_system *instance_;


### PR DESCRIPTION
Using default_ioctl_handler registers a handler as a default.
ioctl handlers are cleared in the finalize routine and the default
handlers are registered in the initialize routine.
This allows for starting with the default handlers earch time a test
fixture calls test_system::initialize()