### PR TITLE
Fix compilation of the tests (gcc-warnings in feature/plugin-api)

### DIFF
--- a/testing/mock/test_system.cpp
+++ b/testing/mock/test_system.cpp
@@ -248,6 +248,7 @@ test_system *test_system::instance() {
 }
 
 void test_system::prepare_syfs(const test_platform &platform) {
+  int result = 0;
   char tmpsysfs[]{ "tmpsysfs-XXXXXX" };
   if (platform.mock_sysfs != nullptr) {
     char* tmp = mkdtemp(tmpsysfs);
@@ -257,11 +258,13 @@ void test_system::prepare_syfs(const test_platform &platform) {
     root_ = std::string(tmp);
     std::string cmd = "tar xzf " + std::string(platform.mock_sysfs) + " -C " +
                       root_ + " --strip 1";
-    std::system(cmd.c_str());
+    result = std::system(cmd.c_str());
   }
+  return (void) result;
 }
 
 void test_system::remove_sysfs() {
+  int result = 0;
   if (root_.find("tmpsysfs") != std::string::npos) {
     struct stat st;
     if (stat(root_.c_str(), &st)) {
@@ -270,11 +273,11 @@ void test_system::remove_sysfs() {
     }
     if (S_ISDIR(st.st_mode)){
       auto cmd = "rm -rf " + root_;
-      std::system(cmd.c_str());
+      result = std::system(cmd.c_str());
     }
   }
+  return (void) result;
 }
-
 
 void test_system::set_root(const char *root) { root_ = root; }
 std::string test_system::get_root() { return root_; }
@@ -386,7 +389,7 @@ int test_system::open(const std::string &path, int flags, mode_t mode) {
   if (syspath.find(root_) == 0) {
     std::map<int, mock_object *>::iterator it = fds_.find(fd);
     if (it != fds_.end())
-        delete it->second;          
+        delete it->second;
     fds_[fd] = new mock_object(path, "", 0);
   }
   return fd;

--- a/testing/xfpga/test_buffer_c.cpp
+++ b/testing/xfpga/test_buffer_c.cpp
@@ -164,13 +164,13 @@ class buffer_prepare
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
 
-    for (auto &t : tokens_){
+    for (auto &t : tokens_) {
         if (t) {
             EXPECT_EQ(FPGA_OK,xfpga_fpgaDestroyToken(&t));
         }
     }
 
-    if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
+    if (handle_ != nullptr) { EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK); }
     system_->finalize();
   }
 
@@ -188,10 +188,10 @@ class buffer_prepare
 //  int flags = 0;
 //
 //  auto res = buffer_allocate(buf_addr, 3 * MB, flags);
-//  EXPECT_EQ(res, FPGA_INVALID_PARAM); 
+//  EXPECT_EQ(res, FPGA_INVALID_PARAM);
 //
 //  res = buffer_release(&buf_addr, 3 * MB);
-//  EXPECT_EQ(res, FPGA_INVALID_PARAM); 
+//  EXPECT_EQ(res, FPGA_INVALID_PARAM);
 //}
 
 /**
@@ -229,17 +229,17 @@ TEST_P(buffer_prepare, prepare_buf_err) {
   int flags = 0;
   uint64_t *ioaddr = NULL;
   uint64_t* invalid_buf_addr = NULL;
-  
+
   // NULL Handle
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaPrepareBuffer(NULL, 0, (void**) &buf_addr, &wsid, 0));
 
-  // NULL wsid 
+  // NULL wsid
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaPrepareBuffer(handle_, 0, (void**) &buf_addr, NULL, flags));
 
   // Invlaid Flags
   flags = 0x100;
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaPrepareBuffer(handle_, buf_len, (void**) &buf_addr, &wsid, flags));
-  
+
   // Buffer lenth is zero
   flags = FPGA_BUF_PREALLOCATED;
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaPrepareBuffer(handle_, 0, (void**) &buf_addr, &wsid, flags));
@@ -248,26 +248,26 @@ TEST_P(buffer_prepare, prepare_buf_err) {
   buf_len = 11247;
   flags = FPGA_BUF_PREALLOCATED;
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaPrepareBuffer(handle_, buf_len, (void**) &buf_addr, &wsid, flags));
-  
+
   // Invalid input buffer pointer
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaPrepareBuffer(handle_, buf_len, (void**) &invalid_buf_addr, &wsid, flags));
 
   // special test case
   EXPECT_EQ(FPGA_OK, xfpga_fpgaPrepareBuffer(handle_, 0, (void**) NULL, &wsid, flags));
-  
+
   // Buffer lenth is zero
   flags = FPGA_BUF_QUIET;
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaPrepareBuffer(handle_, 0, (void**) NULL, &wsid, flags));
-  
+
   // Invalid Handle
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaGetIOAddress(NULL, wsid, ioaddr));
-  
+
   // Invalid workspace id
   EXPECT_NE(FPGA_OK, xfpga_fpgaGetIOAddress(handle_, 0x10000, ioaddr));
-  
+
   // NULL Handle
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaReleaseBuffer(NULL, wsid));
-  
+
   // Invalid workspace id
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaReleaseBuffer(handle_, 0x10001));
 
@@ -292,7 +292,6 @@ TEST_P(buffer_prepare, xfpga_fpgaPrepareBuffer) {
 TEST_P(buffer_prepare, port_dma_unmap) {
   void *buf_addr = 0;
   uint64_t wsid = 0;
-  uint64_t ioaddr = 0;
   uint64_t buf_len = KiB(1);
   auto res = xfpga_fpgaPrepareBuffer(handle_, buf_len, &buf_addr, &wsid, 0);
   EXPECT_EQ(res, FPGA_OK);
@@ -305,7 +304,6 @@ TEST_P(buffer_prepare, port_dma_unmap) {
 TEST_P(buffer_prepare, port_dma_map) {
   void *buf_addr = 0;
   uint64_t wsid = 0;
-  uint64_t ioaddr = 0;
   uint64_t buf_len = KiB(1);
 
   system_->register_ioctl_handler(FPGA_PORT_DMA_MAP,dummy_ioctl<-1,EINVAL>);

--- a/testing/xfpga/test_common_c.cpp
+++ b/testing/xfpga/test_common_c.cpp
@@ -75,7 +75,7 @@ class common_c_p
     }
 
     EXPECT_EQ(xfpga_fpgaDestroyEventHandle(&eh_), FPGA_OK);
-    if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
+    if (handle_ != nullptr) { EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK); }
     system_->finalize();
   }
 
@@ -109,10 +109,10 @@ TEST(common, fpgaErrStr) {
 }
 
 /**
- * @test       prop_check_and_lock 
+ * @test       prop_check_and_lock
  *
  * @brief      When fpga_properties magic is invalid
- *             fpga_result returns FPGA_INVALID_PARAM 
+ *             fpga_result returns FPGA_INVALID_PARAM
  */
 
 TEST(common, prop_check_and_lock) {
@@ -128,10 +128,10 @@ TEST(common, prop_check_and_lock) {
 }
 
 /**
- * @test       handle_check_and_lock 
+ * @test       handle_check_and_lock
  *
  * @brief      When fpga_handle magic is invalid
- *             fpga_result returns FPGA_INVALID_PARAM 
+ *             fpga_result returns FPGA_INVALID_PARAM
  */
 TEST_P(common_c_p, handle_check_and_lock) {
   struct _fpga_handle *h = (struct _fpga_handle*)handle_;
@@ -144,10 +144,10 @@ TEST_P(common_c_p, handle_check_and_lock) {
 }
 
 /**
- * @test       event_handle_check_and_lock 
+ * @test       event_handle_check_and_lock
  *
  * @brief      When event_fpga_handle magic is invalid
- *             fpga_result returns FPGA_INVALID_PARAM 
+ *             fpga_result returns FPGA_INVALID_PARAM
  */
 
 TEST_P(common_c_p, event_handle_check_and_lock) {

--- a/testing/xfpga/test_error_c.cpp
+++ b/testing/xfpga/test_error_c.cpp
@@ -46,8 +46,8 @@ const std::string sysfs_fme = "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0
 const std::string dev_fme = "/dev/intel-fpga-fme.0";
 const std::string sysfs_port = "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-port.0";
 const std::string dev_port = "/dev/intel-fpga-port.0";
- 
-class error_c_p 
+
+class error_c_p
     : public ::testing::TestWithParam<std::string> {
  public:
   int delete_errors(std::string,std::string);
@@ -71,7 +71,7 @@ class error_c_p
     strncpy_s(fake_fme_token_.devpath,sizeof(fake_fme_token_.devpath),dev_fme.c_str(),dev_fme.size());
     fake_fme_token_.magic = FPGA_TOKEN_MAGIC;
     fake_fme_token_.errors = nullptr;
- 
+
   }
 
   virtual void TearDown() override {
@@ -88,15 +88,18 @@ class error_c_p
 };
 
 int error_c_p::delete_errors(std::string fpga_type, std::string filename) {
+  int result;
   std::string fme_sysfspath = tmpsysfs_ + "/" + sysfs_fme + "/" + filename;
   std::string port_sysfspath = tmpsysfs_ + "/" + sysfs_port + "/" + filename;
   if (fpga_type.compare("fme") == 0){
     auto cmd = "rm -rf " + fme_sysfspath;
-    std::system(cmd.c_str());
+    result = std::system(cmd.c_str());
+    (void) result;
     return 1;
   } else if (fpga_type.compare("port") == 0){
     auto cmd = "rm -rf " + port_sysfspath;
-    std::system(cmd.c_str());
+    result = std::system(cmd.c_str());
+    (void) result;
     return 1;
   }
   else {return -1;}
@@ -117,7 +120,7 @@ TEST_P(error_c_p, error_01) {
   unsigned int i = 0;
   uint64_t val = 0;
   fpga_token t = &fake_port_token_;
-  
+
   std::string errpath = sysfs_port + "/errors";
   build_error_list(errpath.c_str(), &fake_port_token_.errors);
 
@@ -137,7 +140,8 @@ TEST_P(error_c_p, error_01) {
     printf("[%u] %s: 0x%016lX%s\n", i, info.name, val, info.can_clear ? " (can clear)" : "");
   }
 
-  auto ret = delete_errors("port","errors");
+  auto result = delete_errors("port","errors");
+  (void) result;
   // for each error register, get info and read the current value
   for (i = 0; i < n; i++) {
     // get info struct for error register
@@ -164,7 +168,7 @@ TEST_P(error_c_p, error_02) {
   unsigned int i = 0;
   uint64_t val = 0;
   fpga_token t = &fake_fme_token_;
-  
+
   std::string errpath = sysfs_fme + "/errors";
   build_error_list(errpath.c_str(), &fake_fme_token_.errors);
 
@@ -184,7 +188,8 @@ TEST_P(error_c_p, error_02) {
     printf("[%u] %s: 0x%016lX%s\n", i, info.name, val, info.can_clear ? " (can clear)" : "");
   }
 
-  auto ret = delete_errors("fme","errors");
+  auto result = delete_errors("fme","errors");
+  (void) result;
   for (i = 0; i < n; i++) {
     // get info struct for error register
     ASSERT_EQ(FPGA_OK, xfpga_fpgaGetErrorInfo(t, i, &info));
@@ -214,7 +219,7 @@ TEST_P(error_c_p, error_03) {
   unsigned int i = 0;
   uint64_t val = 0;
   fpga_token t = &fake_port_token_;
-  
+
   std::string errpath = sysfs_port + "/errors";
   build_error_list(errpath.c_str(), &fake_port_token_.errors);
 
@@ -292,7 +297,7 @@ TEST_P(error_c_p, error_04) {
   unsigned int i = 0;
   uint64_t val = 0;
   fpga_token t = &fake_port_token_;
-  
+
   std::string errpath = sysfs_port + "/errors";
   build_error_list(errpath.c_str(), &fake_port_token_.errors);
 
@@ -361,10 +366,8 @@ TEST_P(error_c_p, error_04) {
  */
 TEST_P(error_c_p, error_05) {
   unsigned int n = 0;
-  unsigned int i = 0;
-  uint64_t val = 0;
   fpga_token t = &fake_port_token_;
-  
+
   std::string errpath = sysfs_port + "/errors";
   build_error_list(errpath.c_str(), &fake_port_token_.errors);
 
@@ -393,9 +396,8 @@ TEST_P(error_c_p, error_06) {
   fpga_error_info info;
   unsigned int n = 0;
   unsigned int i = 0;
-  uint64_t val = 0;
   fpga_token t = &fake_fme_token_;
-  
+
   std::string errpath = sysfs_fme + "/errors";
   build_error_list(errpath.c_str(), &fake_fme_token_.errors);
 
@@ -416,7 +418,7 @@ TEST_P(error_c_p, error_06) {
       EXPECT_EQ(FPGA_OK, xfpga_fpgaClearError(t, i));
     }
   }
-  
+
   // set error list to null
   fake_fme_token_.errors = nullptr;
   EXPECT_EQ(FPGA_NOT_FOUND, xfpga_fpgaClearError(t, 0));
@@ -426,24 +428,21 @@ TEST_P(error_c_p, error_06) {
  *
  * @brief      When passed a valid FME token,
  *             and delete error removes errors dir
- *             fpgaReadError() and fpgaClearError will 
+ *             fpgaReadError() and fpgaClearError will
  *             returns FPGA_EXCEPTION
  *
  */
 TEST_P(error_c_p, error_07) {
-  fpga_error_info info;
-  unsigned int n = 0;
-  unsigned int i = 0;
-  uint64_t val = 0;
   fpga_token t = &fake_fme_token_;
-  
+
   std::string errpath = sysfs_fme + "/errors";
   ASSERT_EQ(FPGA_OK, xfpga_fpgaGetProperties(t, &filter_));
 
   // build errors and immediately remove errors dir
   build_error_list(errpath.c_str(), &fake_fme_token_.errors);
-  auto ret = delete_errors("fme","errors");
-  if (ret) { EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaClearError(t, 0)); }
+  auto result = delete_errors("fme","errors");
+  (void) result;
+  if (result) { EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaClearError(t, 0)); }
 }
 
 /**
@@ -455,10 +454,8 @@ TEST_P(error_c_p, error_07) {
  */
 TEST_P(error_c_p, error_08) {
   unsigned int n = 0;
-  unsigned int i = 0;
-  uint64_t val = 0;
   fpga_token t = &fake_port_token_;
-  
+
   std::string errpath = sysfs_port + "/errors";
   build_error_list(errpath.c_str(), &fake_port_token_.errors);
 
@@ -483,10 +480,8 @@ TEST_P(error_c_p, error_08) {
  */
 TEST_P(error_c_p, error_09) {
   unsigned int n = 0;
-  unsigned int i = 0;
-  uint64_t val = 0;
   fpga_token t = &fake_fme_token_;
-  
+
   std::string errpath = sysfs_fme + "/errors";
   build_error_list(errpath.c_str(), &fake_fme_token_.errors);
 
@@ -567,7 +562,6 @@ TEST(error_c, error_03) {
   EXPECT_EQ(parent, fme);
   auto tok = (struct _fpga_token*)parent;
 
-  uint64_t val = 0;
   EXPECT_EQ(FPGA_NOT_FOUND, xfpga_fpgaClearError(parent, 10));
   tok->magic = 0x123;
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaClearError(parent, 0));
@@ -621,7 +615,7 @@ TEST(error_c, error_05) {
 /**
  * @test       error_06
  *
- * @brief      
+ * @brief
  *
  */
 TEST(error_c, error_06) {
@@ -630,10 +624,10 @@ TEST(error_c, error_06) {
   strncpy_s(_t.devpath,sizeof(_t.devpath),dev_port.c_str(),dev_port.size());
   _t.magic = FPGA_TOKEN_MAGIC;
   _t.errors = nullptr;
- 
+
   std::string invalid_errpath = sysfs_port + "/errorss";
   auto result = build_error_list(invalid_errpath.c_str(), &_t.errors);
-  EXPECT_EQ(result,0); 
+  EXPECT_EQ(result,0);
 }
 
 INSTANTIATE_TEST_CASE_P(error_c, error_c_p, ::testing::ValuesIn(test_platform::keys(true)));

--- a/testing/xfpga/test_events_c.cpp
+++ b/testing/xfpga/test_events_c.cpp
@@ -90,7 +90,7 @@ class events_p : public ::testing::TestWithParam<std::string> {
     config_.running = false;
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
     EXPECT_EQ(xfpga_fpgaDestroyEventHandle(&eh_), FPGA_OK);
-    if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
+    if (handle_ != nullptr) { EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK); }
     system_->finalize();
     fpgad_.join();
   }

--- a/testing/xfpga/test_metadata_c.cpp
+++ b/testing/xfpga/test_metadata_c.cpp
@@ -52,7 +52,7 @@ class metadata_c
 
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-    if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
+    if (handle_ != nullptr) { EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK); }
     system_->finalize();
   }
 
@@ -149,7 +149,7 @@ uint8_t bitstream_invalid_json[] = "XeonFPGA·GBSv001\53\02\00\00{\"version\": \"
 
 /**
 * @test    read_gbs_metadata
-* @brief   Tests: read_gbs_metadata 
+* @brief   Tests: read_gbs_metadata
 * @details read_gbs_metadata returns BS metadata
 *          Then the return value is FPGA_OK
 */
@@ -180,7 +180,7 @@ TEST_P(metadata_c, read_gbs_metadata) {
   result = read_gbs_metadata(bitstream_empty, &gbs_metadata);
   EXPECT_NE(result, FPGA_OK);
 
-  // Invalid metadata length 
+  // Invalid metadata length
   result = read_gbs_metadata(bitstream_metadata_length, &gbs_metadata);
   EXPECT_NE(result, FPGA_OK);
 
@@ -197,19 +197,19 @@ TEST_P(metadata_c, read_gbs_metadata) {
   // Valid metadata - malloc fail
   result = read_gbs_metadata(bitstream_valid, &gbs_metadata);
   EXPECT_EQ(result, FPGA_NO_MEMORY);
-  
+
   // Invalid metadata afu-image node
   result = read_gbs_metadata(bitstream_no_afu_image, &gbs_metadata);
   EXPECT_NE(result, FPGA_OK);
-  
+
   // Invalid metadata interface-uuid
   result = read_gbs_metadata(bitstream_no_interface_id, &gbs_metadata);
   EXPECT_NE(result, FPGA_OK);
-  
+
   // Invalid metadata afu-uuid
   result = read_gbs_metadata(bitstream_no_accelerator_id, &gbs_metadata);
   EXPECT_NE(result, FPGA_OK);
-  
+
   // Invalid input bitstream
   result = read_gbs_metadata(bitstream_invalid_length, &gbs_metadata);
   EXPECT_NE(result, FPGA_OK);

--- a/testing/xfpga/test_mmio_c.cpp
+++ b/testing/xfpga/test_mmio_c.cpp
@@ -103,7 +103,7 @@ class mmio_c_p
 
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-    if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
+    if (handle_ != nullptr) { EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK); }
     system_->finalize();
   }
 
@@ -142,7 +142,7 @@ TEST_P (mmio_c_p, test_pos_map_mmio) {
   ASSERT_EQ(FPGA_NOT_SUPPORTED, xfpga_fpgaMapMMIO(handle_, 0, &mmio_ptr));
   EXPECT_EQ(((struct _fpga_handle *)handle_)->mmio_root,nullptr);
   EXPECT_EQ(mmio_ptr,nullptr);
-#endif 
+#endif
 }
 
 
@@ -191,25 +191,25 @@ TEST_P (mmio_c_p, test_port_map_region_err) {
 
   system_->register_ioctl_handler(FPGA_PORT_GET_REGION_INFO, dummy_ioctl<-1,EFAULT>);
   EXPECT_EQ(FPGA_NO_ACCESS, xfpga_fpgaMapMMIO(handle_,-1,&mmio_ptr));
-  
+
   system_->register_ioctl_handler(FPGA_PORT_GET_REGION_INFO, dummy_ioctl<-1,ENOTSUP>);
   EXPECT_EQ(FPGA_NO_ACCESS, xfpga_fpgaMapMMIO(handle_,-1,&mmio_ptr));
- 
+
 }
 
 
 TEST_P (mmio_c_p, test_port_unmap_region_err) {
   uint64_t * mmio_ptr = NULL;
   EXPECT_NE(FPGA_OK, xfpga_fpgaMapMMIO(handle_,-1,&mmio_ptr));
-  
+
   system_->register_ioctl_handler(FPGA_PORT_GET_REGION_INFO, dummy_ioctl<-1,EINVAL>);
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaUnmapMMIO(handle_, 0));
 
   system_->register_ioctl_handler(FPGA_PORT_GET_REGION_INFO, dummy_ioctl<-1,EFAULT>);
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaUnmapMMIO(handle_, 0));
- 
+
   system_->register_ioctl_handler(FPGA_PORT_GET_REGION_INFO, dummy_ioctl<-1,ENOTSUP>);
-  EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaUnmapMMIO(handle_, 0)); 
+  EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaUnmapMMIO(handle_, 0));
 }
 
 
@@ -288,8 +288,8 @@ TEST_P (mmio_c_p, test_neg_read_write_32) {
 }
 
 
-/** 
-*  @test      mmio_c_p 
+/**
+*  @test      mmio_c_p
 *  @brief     Test: test_pos_read_write_64
 *  @details   When the parameters are valid and the drivers are loaded:
 *             xfpga_fpgaWriteMMIO64 must write correct value at given MMIO
@@ -325,7 +325,7 @@ TEST_P (mmio_c_p, test_mmio_read_write_64) {
 #ifndef BUILD_ASE
   EXPECT_EQ(FPGA_OK, xfpga_fpgaUnmapMMIO(handle_, 0));
 #endif
-} 
+}
 
 /**
 * @test       mmio_c_p

--- a/testing/xfpga/test_object_c.cpp
+++ b/testing/xfpga/test_object_c.cpp
@@ -160,7 +160,7 @@ TEST_P(sysobject_p, xfpga_fpgaObjectRead) {
   std::vector<uint8_t> buffer(DATA.size());
   EXPECT_EQ(xfpga_fpgaObjectRead(object, buffer.data(), 0, DATA.size() + 1, 0),
             FPGA_INVALID_PARAM);
-  EXPECT_EQ(xfpga_fpgaObjectRead(object, buffer.data(), 0, 10, FPGA_OBJECT_SYNC), 
+  EXPECT_EQ(xfpga_fpgaObjectRead(object, buffer.data(), 0, 10, FPGA_OBJECT_SYNC),
             FPGA_OK);
   buffer[10] = '\0';
   EXPECT_STREQ(reinterpret_cast<const char *>(buffer.data()),
@@ -212,7 +212,8 @@ TEST_P(sysobject_p, xfpga_fpgaObjectWrite64) {
 
   rewind(fp);
   std::vector<char> buffer(256);
-  fread(buffer.data(), buffer.size(), 1, fp);
+  auto result = fread(buffer.data(), buffer.size(), 1, fp);
+  (void) result;
   EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
 }
 

--- a/testing/xfpga/test_reconf_c.cpp
+++ b/testing/xfpga/test_reconf_c.cpp
@@ -70,7 +70,7 @@ class reconf_c
       }
     }
 
-    if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
+    if (handle_ != nullptr) { EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK); }
     system_->finalize();
   }
 
@@ -89,7 +89,7 @@ class reconf_c
 * @brief   Tests: set_afu_userclock
 * @details set_afu_userclock sets afu user clock
 *          Returns FPGA_OK if parameters are valid. Returns
-*          error code if invalid user clock or handle. 
+*          error code if invalid user clock or handle.
 */
 TEST_P(reconf_c, set_afu_userclock) {
   fpga_result result;
@@ -114,7 +114,7 @@ TEST_P(reconf_c, set_afu_userclock) {
 * @test    set_fpga_pwr_threshold
 * @brief   Tests: set_fpga_pwr_threshold
 * @details set_fpga_pwr_threshold sets power threshold
-*          Returns FPGA_OK if parameters are valid. Returns 
+*          Returns FPGA_OK if parameters are valid. Returns
 *          error code if invalid power threshold or handle.
 */
 TEST_P(reconf_c, set_fpga_pwr_threshold) {
@@ -198,22 +198,22 @@ TEST_P(reconf_c, fpga_reconf_slot) {
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 
   // Invalid bitstream - invalid json
-  result = xfpga_fpgaReconfigureSlot(handle_, slot, bitstream_invalid_json, 
+  result = xfpga_fpgaReconfigureSlot(handle_, slot, bitstream_invalid_json,
                                      bitstream_valid_len, flags);
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 
   // Null handle
-  result = xfpga_fpgaReconfigureSlot(NULL, slot, bitstream_valid, 
+  result = xfpga_fpgaReconfigureSlot(NULL, slot, bitstream_valid,
                                      bitstream_valid_len, flags);
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 
   // Valid bitstream - clk
-  result = xfpga_fpgaReconfigureSlot(handle_, slot, bitstream_valid, 
+  result = xfpga_fpgaReconfigureSlot(handle_, slot, bitstream_valid,
                                      bitstream_valid_len, flags);
   EXPECT_EQ(result, FPGA_NOT_SUPPORTED);
 
   // Valid bitstream - no clk
-  result = xfpga_fpgaReconfigureSlot(handle_, slot, bitstream_valid_no_clk, 
+  result = xfpga_fpgaReconfigureSlot(handle_, slot, bitstream_valid_no_clk,
                                      bitstream_valid_len, flags);
   EXPECT_EQ(result, FPGA_OK);
 
@@ -279,7 +279,6 @@ TEST_P(reconf_c, open_accel) {
   std::array<fpga_token, 2> tokens_accel = {};
   fpga_handle handle_accel;
   uint32_t num_matches_accel;
-  uint32_t i;
 
   ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_accel), FPGA_OK);
   ASSERT_EQ(fpgaPropertiesSetObjectType(filter_accel, FPGA_ACCELERATOR), FPGA_OK);

--- a/testing/xfpga/test_reset_c.cpp
+++ b/testing/xfpga/test_reset_c.cpp
@@ -55,7 +55,7 @@ class reset_c_p
 
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-    if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
+    if (handle_ != nullptr) { EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK); }
     system_->finalize();
   }
 
@@ -102,11 +102,10 @@ TEST_P(reset_c_p, test_port_drv_reset_01) {
  *
  */
 TEST_P(reset_c_p, test_port_drv_reset_02) {
-  int fddev = -1;
 
   // Reset slot
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaReset(NULL));
-  
+
   struct _fpga_handle* _handle = (struct _fpga_handle*)handle_;
   _handle->magic = 0x123;
 

--- a/testing/xfpga/test_sysfs_c.cpp
+++ b/testing/xfpga/test_sysfs_c.cpp
@@ -86,10 +86,10 @@ class sysfs_c_p : public ::testing::TestWithParam<std::string> {
     {
         if (i) {
             EXPECT_EQ(FPGA_OK,xfpga_fpgaDestroyToken(&i));
-        } 
+        }
     }
 
-    if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
+    if (handle_ != nullptr) { EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK); }
     system_->finalize();
   }
 
@@ -104,12 +104,12 @@ class sysfs_c_p : public ::testing::TestWithParam<std::string> {
 
 /**
 * @test    eintr_write_tests
-* @details 
+* @details
 */
 TEST(sysfs_c, eintr_write_tests){
   int fd = 0;
   size_t count = 1024;
-  EXPECT_NE(0,eintr_write(fd,NULL,count)); 
+  EXPECT_NE(0,eintr_write(fd,NULL,count));
 }
 
 
@@ -142,7 +142,7 @@ TEST_P(sysfs_c_p, sysfs_invalid_tests){
 
 /**
 * @test    device_invalid_test
-* @details 
+* @details
 */
 TEST_P(sysfs_c_p, deviceid_invalid_tests){
   const std::string sysfs_port = "/sys/class/fpga/intel-fpga-dev/intel-fpga-port";
@@ -150,7 +150,7 @@ TEST_P(sysfs_c_p, deviceid_invalid_tests){
   auto t = (struct _fpga_token*)h->token;
   uint64_t device_id;
   fpga_token tok;
- 
+
   auto res = get_fpga_deviceid(handle_,NULL);
   EXPECT_EQ(FPGA_INVALID_PARAM,res);
 
@@ -171,10 +171,9 @@ TEST_P(sysfs_c_p, deviceid_invalid_tests){
 
 /**
 * @test    glob_test
-* @details 
+* @details
 */
 TEST_P(sysfs_c_p, glob_tests){
-  _fpga_token *tok = static_cast<_fpga_token*>(tokens_[0]);
   std::string invalid_filename = "opae";
 
   auto res = opae_glob_path(nullptr);
@@ -187,7 +186,7 @@ TEST_P(sysfs_c_p, glob_tests){
 
 /**
 * @test    cat_sysfs_path_errors
-* @details 
+* @details
 */
 TEST(sysfs_c, cat_sysfs_path_errors)
 {
@@ -200,8 +199,8 @@ TEST(sysfs_c, cat_sysfs_path_errors)
 }
 
 /**
-* @test   cat_token_sysfs_path 
-* @details 
+* @test   cat_token_sysfs_path
+* @details
 */
 TEST(sysfs_c, cat_token_sysfs_path)
 {
@@ -220,7 +219,7 @@ TEST(sysfs_c, cat_token_sysfs_path)
 
 /**
 * @test    cat_handle_sysfs_path
-* @details 
+* @details
 */
 TEST(sysfs_c, cat_handle_sysfs_path)
 {
@@ -242,7 +241,7 @@ TEST(sysfs_c, cat_handle_sysfs_path)
 
 /**
 * @test    make_sysfs_group
-* @details 
+* @details
 */
 TEST_P(sysfs_c_p, make_sysfs)
 {
@@ -266,7 +265,7 @@ TEST_P(sysfs_c_p, make_sysfs)
 
 /**
 * @test    make_object
-* @details 
+* @details
 */
 TEST_P(sysfs_c_p, make_object)
 {
@@ -277,8 +276,8 @@ TEST_P(sysfs_c_p, make_object)
 }
 
 /**
-* @test   make_object_glob 
-* @details 
+* @test   make_object_glob
+* @details
 */
 TEST_P(sysfs_c_p, make_object_glob)
 {
@@ -298,29 +297,29 @@ TEST_P(sysfs_c_p, make_object_glob)
 TEST_P(sysfs_c_p,fpga_sysfs_01){
   uint64_t deviceid;
   fpga_result result;
-  
+
   //Valid path
   result = sysfs_deviceid_from_path("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0", &deviceid);
   ASSERT_EQ(result, FPGA_OK);
-  
+
   //NULL input
   result = sysfs_deviceid_from_path("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0", NULL);
   ASSERT_NE(result, FPGA_OK);
-  
+
   //NULL input path
   result = sysfs_deviceid_from_path(NULL, NULL);
   ASSERT_NE(result, FPGA_OK);
-  
+
   //Invalid path to get device id
   result = sysfs_deviceid_from_path("/sys/class/fpga/intel-fpga-dev.0/intel-fpga.0", &deviceid);
   ASSERT_NE(result, FPGA_OK);
-  
+
   result = sysfs_deviceid_from_path("/sys/class/fpga/intel-fpga-dev.20/intel-fpga-fme", &deviceid);
   ASSERT_NE(result, FPGA_OK);
-  
+
   result = sysfs_deviceid_from_path("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.20", &deviceid);
   ASSERT_NE(result, FPGA_OK);
-  
+
   result = sysfs_deviceid_from_path("/sys/class/fpga/intel-fpga-dev/intel-fpga-fme", &deviceid);
   ASSERT_NE(result, FPGA_OK);
 
@@ -341,118 +340,118 @@ TEST_P(sysfs_c_p, fpga_sysfs_02){
   uint32_t u1;
   uint32_t u2;
   uint64_t u64;
-  
-  
+
+
   //Empty input path string
   result = sysfs_read_int("", NULL);
   EXPECT_NE(result, FPGA_OK);
-  
+
   //NULL input parameters
   result = sysfs_read_int(NULL, NULL);
   EXPECT_NE(result, FPGA_OK);
-  
+
   //Invalid input path
   result = sysfs_read_int("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.10", NULL);
   EXPECT_NE(result, FPGA_OK);
-  
+
   result = sysfs_read_int("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0", NULL);
   EXPECT_NE(result, FPGA_OK);
-  
+
   // Valid input path
   result = sysfs_read_int("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0/socket_id", &i);
   EXPECT_EQ(result, FPGA_OK);
-  
+
   //Empty input path string
   result = sysfs_read_int("", NULL);
   EXPECT_NE(result, FPGA_OK);
-  
-  //Invalid input parameters 
+
+  //Invalid input parameters
   result = sysfs_read_u32(NULL, NULL);
   EXPECT_NE(result, FPGA_OK);
-  
+
   //Invalid input path
   result = sysfs_read_u32("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.10", NULL);
   EXPECT_NE(result, FPGA_OK);
-  
+
   result = sysfs_read_u32("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0", NULL);
   EXPECT_NE(result, FPGA_OK);
-  
+
   // Valid input path
   result = sysfs_read_u32("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0/socket_id", &u32);
   EXPECT_EQ(result, FPGA_OK);
-  
+
   //Invalid input parameters
   result = sysfs_read_u32_pair(NULL, NULL, NULL, '\0');
   EXPECT_NE(result, FPGA_OK);
-  
+
   //Invalid input parameters
   result = sysfs_read_u32_pair(NULL, NULL, NULL, 'a');
   EXPECT_NE(result, FPGA_OK);
-  
+
   //Invalid input 'sep' character
   result = sysfs_read_u32_pair("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0/socket_id", &u1, &u2, '\0');
   EXPECT_NE(result, FPGA_OK);
-  
+
   //Invalid input path value
   result = sysfs_read_u32_pair("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0/socket_id", &u1, &u2, 'a');
   EXPECT_NE(result, FPGA_OK);
-  
+
   //Invalid input path type
   result = sysfs_read_u32_pair("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0", &u1, &u2, 'a');
   EXPECT_NE(result, FPGA_OK);
-  
-  //Invalid input path 
+
+  //Invalid input path
   result = sysfs_read_u32_pair("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.10", &u1, &u2, 'a');
   EXPECT_NE(result, FPGA_OK);
-  
+
   //Empty input path string
   result = sysfs_read_u64("", NULL);
   EXPECT_NE(result, FPGA_OK);
-  
+
   //NULL input parameters
   result = sysfs_read_u64(NULL, NULL);
   EXPECT_NE(result, FPGA_OK);
-  
+
   //Invalid input path
   result = sysfs_read_u64("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.10", NULL);
   EXPECT_NE(result, FPGA_OK);
-  
+
   // Valid input path
   result = sysfs_read_u64("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0/socket_id", &u64);
   EXPECT_EQ(result, FPGA_OK);
-  
+
   //Invalid input parameters
   result = sysfs_write_u64(NULL, 0);
   EXPECT_NE(result, FPGA_OK);
-  
+
   result = sysfs_write_u64("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0", 0x100);
   EXPECT_NE(result, FPGA_OK);
-  
-  //valid path 
+
+  //valid path
   result = sysfs_write_u64("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0/socket_id", 0);
   EXPECT_EQ(result, FPGA_OK);
-  
+
   //Invalid input parameters
   fpga_guid guid;
   result = sysfs_read_guid(NULL, NULL);
   EXPECT_NE(result, FPGA_OK);
-  
+
   result = sysfs_read_guid("/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.10/", guid);
   EXPECT_NE(result, FPGA_OK);
-  
+
   //NULL input parameters
   result = get_port_sysfs(NULL, NULL);
   EXPECT_NE(result, FPGA_OK);
-  
+
   //NULL handle
   result = get_port_sysfs(NULL, (char*) "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0/socket_id");
   EXPECT_NE(result, FPGA_OK);
-  
+
   //NULL handle
   result = get_fpga_deviceid(NULL, NULL);
   EXPECT_NE(result, FPGA_OK);
-  
-} 
+
+}
 
 /**
 * @test    sysfs_get_pr_id
@@ -505,7 +504,7 @@ TEST(sysfs_c, sysfs_get_bitstream_id)
 TEST(sysfs_c, sysfs_sbdf_invalid_tests){
   std::string sysfs_dev = "/sys/devices/pci0000:5e/0000:5e:00.0/fpga/intel-fpga-dev.0";
 
-  int s = 0, b = 0, d = 0, f = 0; 
+  int s = 0, b = 0, d = 0, f = 0;
   auto res = sysfs_sbdf_from_path(sysfs_dev.c_str(),&s,&b,&d,&f);
   EXPECT_EQ(FPGA_NO_DRIVER,res);
 }
@@ -515,7 +514,7 @@ TEST(sysfs_c, sysfs_sbdf_invalid_tests){
 /**
 * @test    get_fpga_deviceid
 * @details get_fpga_device given a valid parameters
-*          return FPGA_OK 
+*          return FPGA_OK
 */
 TEST_P(sysfs_c_p, get_fpga_deviceid)
 {
@@ -528,4 +527,3 @@ TEST_P(sysfs_c_p, get_fpga_deviceid)
 }
 
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_p, ::testing::ValuesIn(test_platform::keys(true)));
-

--- a/testing/xfpga/test_umsg_c.cpp
+++ b/testing/xfpga/test_umsg_c.cpp
@@ -170,7 +170,7 @@ class umsg_c_p
       }
     }
 
-    if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
+    if (handle_ != nullptr) { EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK); }
     system_->finalize();
   }
 
@@ -282,7 +282,6 @@ TEST_P(umsg_c_p, get_umsg_ptr_ioctl_err_03) {
  */
 TEST_P (umsg_c_p, test_umsg_drv_02) {
   uint64_t Umsg_num = 0;
-  int fddev = -1;
 
   // NULL Driver hnadle
   EXPECT_NE(FPGA_OK, xfpga_fpgaGetNumUmsg(NULL, &Umsg_num));
@@ -451,7 +450,7 @@ TEST_P(umsg_c_p, test_umsg_drv_07) {
 TEST_P(umsg_c_p, test_umsg_drv_08) {
   int fddev = -1;
   auto _handle = (struct _fpga_handle*)handle_;
- 
+
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaTriggerUmsg(NULL, 0));
 
   fddev = _handle->fddev;
@@ -459,7 +458,7 @@ TEST_P(umsg_c_p, test_umsg_drv_08) {
 
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaTriggerUmsg(handle_, 0));
   _handle->fddev = fddev;
- 
+
   EXPECT_EQ(FPGA_OK, xfpga_fpgaTriggerUmsg(handle_, 0));
 
 }

--- a/testing/xfpga/test_usrclk_c.cpp
+++ b/testing/xfpga/test_usrclk_c.cpp
@@ -59,7 +59,7 @@ class usrclk_c
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_dev_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_dev_, FPGA_DEVICE), FPGA_OK);
-    ASSERT_EQ(xfpga_fpgaEnumerate(&filter_dev_, 1, tokens_dev_.data(), 
+    ASSERT_EQ(xfpga_fpgaEnumerate(&filter_dev_, 1, tokens_dev_.data(),
               tokens_dev_.size(), &num_matches_), FPGA_OK);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_accel_), FPGA_OK);
@@ -84,8 +84,8 @@ class usrclk_c
       }
     }
 
-    if (handle_dev_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_dev_), FPGA_OK);
-    if (handle_accel_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_accel_), FPGA_OK);
+    if (handle_dev_ != nullptr) { EXPECT_EQ(xfpga_fpgaClose(handle_dev_), FPGA_OK); }
+    if (handle_accel_ != nullptr) { EXPECT_EQ(xfpga_fpgaClose(handle_accel_), FPGA_OK); }
     system_->finalize();
   }
 
@@ -110,27 +110,27 @@ TEST(usrclk_c, afu_usrclk_01) {
   //Get error string
   const char * pmsg = fpac_GetErrMsg(1);
   EXPECT_EQ(NULL, !pmsg);
-  
+
   //Get error string
   pmsg = fpac_GetErrMsg(5);
   EXPECT_EQ(NULL, !pmsg);
-  
+
   //Get error string
   pmsg = fpac_GetErrMsg(16);
   EXPECT_EQ(NULL, !pmsg);
-  
+
   //Get error string for invlaid index
   pmsg = NULL;
   pmsg = fpac_GetErrMsg(17);
   EXPECT_STREQ("ERROR: MSG INDEX OUT OF RANGE", pmsg);
-  
+
   //Get error string for invlaid index
   pmsg = NULL;
   pmsg = fpac_GetErrMsg(-1);
   EXPECT_STREQ("ERROR: MSG INDEX OUT OF RANGE", pmsg);
-  
+
   fv_BugLog(1);
-  
+
   fv_BugLog(2);
 
 }
@@ -191,7 +191,7 @@ TEST_P(usrclk_c, fpga_set_user_clock) {
 
   // Invalid clk
   result = xfpga_fpgaSetUserClock(handle_dev_, 0, 0, flags);
-  EXPECT_EQ(result, FPGA_INVALID_PARAM);  
+  EXPECT_EQ(result, FPGA_INVALID_PARAM);
 
   // Valid clk
   result = xfpga_fpgaSetUserClock(handle_dev_, 312, 156, flags);

--- a/testing/xfpga/test_wsid_list_c.cpp
+++ b/testing/xfpga/test_wsid_list_c.cpp
@@ -50,7 +50,7 @@ constexpr uint64_t index_to_flags(uint64_t i) { return i * i; }
 
 static uint64_t stress_count = 0;
 
-void cleanup_cb(wsid_map *ws) { stress_count--; }
+void cleanup_cb(wsid_map *ws) { (void) ws; stress_count--; }
 
 class wsid_list_f : public ::testing::Test {
  protected:
@@ -151,7 +151,7 @@ TEST_F(wsid_list_f, wsid_find_by_index) {
 }
 
 TEST_F(wsid_list_f, stress) {
-  int count = count_;
+  uint64_t count = count_;
   // FIXME: wsid_add can result in process being killed (out of memory) if it's
   // called too many times.
   uint64_t count_max = 1024;


### PR DESCRIPTION
When using gcc-6 or gcc-7 there are several warnings that are marked as errors and thus compilation cannot succeed.

Main causes:
* unused variables
* gcc also complains about dangling 'if' without 'else' unless you surround 'if' positive branch with { .. }

i think people (me) will need this to build their branches ...