### PR TITLE
Add assemble_gbs_header fn in test_system.

### DIFF
--- a/testing/mock/test_system.cpp
+++ b/testing/mock/test_system.cpp
@@ -313,7 +313,7 @@ std::string test_system::get_sysfs_path(const std::string &src) {
 std::vector<uint8_t> test_system::assemble_gbs_header(const test_device &td) {
   std::vector<uint8_t> gbs_header(20, 0);
   if (uuid_parse(td.gbs_guid, gbs_header.data())) {
-    std::string msg = "unsable to parse UUID: ";
+    std::string msg = "unable to parse UUID: ";
     msg.append(td.gbs_guid);
     throw std::runtime_error(msg);
   }

--- a/testing/mock/test_system.h
+++ b/testing/mock/test_system.h
@@ -68,6 +68,7 @@ class mock_object {
 
   std::string sysclass() const { return sysclass_; }
   uint32_t device_id() const { return device_id_; }
+  type_t type() const { return type_; }
 
  private:
   std::string devpath_;
@@ -112,6 +113,8 @@ struct test_device {
   uint32_t device_id;
   uint32_t fme_num_errors;
   uint32_t port_num_errors;
+  const char *gbs_guid;
+  const char *mdata;
   static test_device unknown();
 };
 
@@ -137,6 +140,7 @@ class test_system {
   void set_root(const char *root);
   std::string get_root();
   std::string get_sysfs_path(const std::string &src);
+  std::vector<uint8_t> assemble_gbs_header(const test_device &td);
 
   void initialize();
   void finalize();

--- a/testing/xfpga/test_metadata_c.cpp
+++ b/testing/xfpga/test_metadata_c.cpp
@@ -48,6 +48,8 @@ class metadata_c
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
     ASSERT_EQ(xfpga_fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
 						&num_matches_),  FPGA_OK);
+    bitstream_valid_ = system_->assemble_gbs_header(platform_.devices[0]);
+    mdata_ = platform_.devices[0].mdata;
   }
 
   virtual void TearDown() override {
@@ -62,14 +64,10 @@ class metadata_c
   uint32_t num_matches_;
   test_platform platform_;
   test_system *system_;
+  std::string mdata_;
+  std::vector<uint8_t> bitstream_valid_;
 };
 
-uint8_t bitstream_valid[] = "XeonFPGA·GBSv001\53\02\00\00{\"version\": 640, \"afu-image\": \
-      {\"clock-frequency-high\": 312, \"clock-frequency-low\": 156, \
-      \"power\": 50, \"interface-uuid\": \"1a422218-6dba-448e-b302-425cbcde1406\", \
-      \"magic-no\": 488605312, \"accelerator-clusters\": [{\"total-contexts\": 1,\
-      \"name\": \"nlb_400\", \"accelerator-type-uuid\":\
-      \"d8424dc4-a4a3-c413-f89e-433683f9040b\"}]}, \"platform-name\": \"MCP\"}";
 uint8_t bitstream_null[10] = "abcd";
 uint8_t bitstream_invalid_guid[] = "Xeon·GBSv001\53\02\00\00{\"version\": 640, \"afu-image\":\
       {\"clock-frequency-high\": 312, \"clock-frequency-low\": 156, \
@@ -189,13 +187,13 @@ TEST_P(metadata_c, read_gbs_metadata) {
   EXPECT_NE(result, FPGA_OK);
 
   // Valid metadata
-  result = read_gbs_metadata(bitstream_valid, &gbs_metadata);
+  result = read_gbs_metadata(bitstream_valid_.data(), &gbs_metadata);
   EXPECT_EQ(result, FPGA_OK);
 
   test_system::instance()->invalidate_malloc();
 
   // Valid metadata - malloc fail
-  result = read_gbs_metadata(bitstream_valid, &gbs_metadata);
+  result = read_gbs_metadata(bitstream_valid_.data(), &gbs_metadata);
   EXPECT_EQ(result, FPGA_NO_MEMORY);
   
   // Invalid metadata afu-image node
@@ -235,13 +233,13 @@ TEST_P(metadata_c, validate_bitstream_metadata) {
   ASSERT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_[0], &handle_, 0));
 
   // Valid metadata
-  result = validate_bitstream_metadata(handle_, bitstream_valid);
+  result = validate_bitstream_metadata(handle_, bitstream_valid_.data());
   EXPECT_EQ(result, FPGA_OK);
 
   test_system::instance()->invalidate_malloc();
 
   // Valid metadata - malloc fail
-  result = validate_bitstream_metadata(handle_, bitstream_valid);
+  result = validate_bitstream_metadata(handle_, bitstream_valid_.data());
   EXPECT_EQ(result, FPGA_NO_MEMORY);
 
   // Invalid input bitstream
@@ -290,8 +288,8 @@ TEST_P(metadata_c, get_bitstream_header_len) {
   int len;
 
   // Valid metadata
-  len = get_bitstream_header_len(bitstream_valid);
-  EXPECT_EQ(len, 575);
+  len = get_bitstream_header_len(bitstream_valid_.data());
+  EXPECT_EQ(len, mdata_.size() + sizeof(fpga_guid) + sizeof(uint32_t));
 
   // Invalid guid
   len = get_bitstream_header_len(bitstream_invalid_guid);
@@ -311,8 +309,8 @@ TEST_P(metadata_c, get_bitstream_json_len) {
   int len;
 
   // Valid metadata
-  len = get_bitstream_json_len(bitstream_valid);
-  EXPECT_EQ(len, 555);
+  len = get_bitstream_json_len(bitstream_valid_.data());
+  EXPECT_EQ(len, mdata_.size());
 
   // Invalid metadata
   len = get_bitstream_json_len(bitstream_invalid_guid);


### PR DESCRIPTION
This function can assemble a simple gbs header from data encoded in the
platform db for the given platform device.