### PR TITLE
Use correct memset function in fpgaObjectWrite64

### DIFF
--- a/libopae/plugins/xfpga/sysobject.c
+++ b/libopae/plugins/xfpga/sysobject.c
@@ -190,7 +190,9 @@ fpga_result xfpga_fpgaObjectWrite64(fpga_object obj, uint64_t value, int flags)
 	if (res != FPGA_OK) {
 		return res;
 	}
-	memset32_s((uint32_t *)_obj->buffer, _obj->size, 0);
+	if (_obj->max_size) {
+		memset_s(_obj->buffer, _obj->max_size, 0);
+	}
 	if (flags & FPGA_OBJECT_TEXT) {
 		snprintf_s_l((char *)_obj->buffer, _obj->max_size, "0x%" PRIx64,
 			     value);


### PR DESCRIPTION
Add a check for max_size being non-zero, then it calls memset_s to zero
out the memory (instead of memset32_s). Because it was using memset32_s
but using the size, this could potentially corrupt memory when size was
the same as max_size.