### PR TITLE
Resolved fpgaGetUmsgPtr test and added free_umsg_buffer tests

### DIFF
--- a/testing/xfpga/test_umsg_c.cpp
+++ b/testing/xfpga/test_umsg_c.cpp
@@ -23,7 +23,12 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+
+extern "C"{
 #include "types_int.h"
+fpga_result free_umsg_buffer(fpga_handle);
+}
+
 #include "xfpga.h"
 #include "intel-fpga.h"
 #include <cstdarg>
@@ -164,13 +169,13 @@ class umsg_c_p
   virtual void TearDown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
 
-    for (auto t : tokens_) {
-      if (t != nullptr) {
+    for (auto &t : tokens_) {
+      if (t) {
         EXPECT_EQ(FPGA_OK, xfpga_fpgaDestroyToken(&t));
       }
     }
 
-    if (handle_ != nullptr) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
+    if (handle_) EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
     system_->finalize();
   }
 
@@ -199,6 +204,14 @@ TEST_P (umsg_c_p, test_umsg_drv_01) {
   EXPECT_GT(Umsg_num, 0);
 }
 
+/**
+ * @test       umsg_c_p
+ * @brief      get_num_umsg_ioctl_err
+ * @details    When the parameters are valid and the drivers are loaded,
+ *             but the ioctl fails,
+ *             fpgaGetNumUmsg returns FPGA_INVALID_PARAM/FPGA_EXCEPTION
+ *
+ */
 TEST_P(umsg_c_p, get_num_umsg_ioctl_err) {
   uint64_t num = 0;
   // register an ioctl handler that will return -1 and set errno to EINVAL
@@ -215,6 +228,14 @@ TEST_P(umsg_c_p, get_num_umsg_ioctl_err) {
   EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaGetNumUmsg(handle_, &num));
 }
 
+/**
+ * @test       umsg_c_p
+ * @brief      set_umsg_attr_ioctl_err
+ * @details    When the parameters are valid and the drivers are loaded,
+ *             but the ioctl fails,
+ *             fpgaSetUmsgAttributes returns FPGA_INVALID_PARAM/FPGA_EXCEPTION
+ *
+ */
 TEST_P(umsg_c_p, set_umsg_attr_ioctl_err) {
   uint64_t value = 0;
   // register an ioctl handler that will return -1 and set errno to EINVAL
@@ -232,7 +253,14 @@ TEST_P(umsg_c_p, set_umsg_attr_ioctl_err) {
   EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaSetUmsgAttributes(handle_, value));
 }
 
-
+/**
+ * @test       umsg_c_p
+ * @brief      get_umsg_ptr_ioctl_err
+ * @details    When the parameters are valid and the drivers are loaded,
+ *             but the ioctl fails on FPGA_PORT_UMSG_ENABLE and FPGA_PORT_DMA_UNMAP
+ *             fpgaGetUmsgPtr returns FPGA_INVALID_PARAM/FPGA_EXCEPTION
+ *
+ */
 TEST_P(umsg_c_p, get_umsg_ptr_ioctl_err) {
   uint64_t *value = 0;
 
@@ -252,6 +280,15 @@ TEST_P(umsg_c_p, get_umsg_ptr_ioctl_err) {
   EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaGetUmsgPtr(handle_, &value));
 }
 
+/**
+ * @test       umsg_c_p
+ * @brief      get_umsg_ptr_ioctl_err_02
+ * @details    When the parameters are valid and the drivers are loaded,
+ *             but the ioctl fails on FPGA_PORT_UMSG_SET_BASE_ADDR
+ *             and FPGA_PORT_DMA_UNMAP. fpgaGetUmsgPtr returns 
+ *             FPGA_INVALID_PARAM/FPGA_EXCEPTION
+ *
+ */
 TEST_P(umsg_c_p, get_umsg_ptr_ioctl_err_02) {
   uint64_t *value = 0;
 
@@ -266,13 +303,76 @@ TEST_P(umsg_c_p, get_umsg_ptr_ioctl_err_02) {
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaGetUmsgPtr(handle_, &value));
 }
 
+/**
+ * @test       umsg_c_p
+ * @brief      get_umsg_ptr_ioctl_err_03
+ * @details    When the parameters are valid and the drivers are loaded,
+ *             but the ioctl fails on FPGA_PORT_DMA_MAP. fpgaGetUmsgPtr returns 
+ *             FPGA_INVALID_PARAM/FPGA_EXCEPTION
+ *
+ */
 TEST_P(umsg_c_p, get_umsg_ptr_ioctl_err_03) {
   uint64_t *value = 0;
-  system_->register_ioctl_handler(FPGA_PORT_UMSG_DISABLE, dummy_ioctl<0,EINVAL>);
+
+  // register an ioctl handler that will return -1 and set errno to EINVAL
+  system_->register_ioctl_handler(FPGA_PORT_DMA_MAP, dummy_ioctl<-1,EINVAL>);
+  EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaGetUmsgPtr(handle_, &value));
+
+  // register an ioctl handler that will return -1 and set errno to EFAULT
+  system_->register_ioctl_handler(FPGA_PORT_DMA_MAP, dummy_ioctl<-1,EFAULT>);
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaGetUmsgPtr(handle_, &value));
 }
 
+/**
+ * @test       umsg_c_p
+ * @brief      invalid_free_umsg_buffer
+ * @details    When the drivers are loaded and handle umsg_virt is mapped,
+ *             but ioctl fails on FPGA_PORT_UMSG_DISABLE, FPGA_ERR outputs
+ *             "Failed to disable UMSG" and returns FPGA_OK
+ *             When ioctl fails on FPGA_PORT_UMSG_SET_BASE_ADDR, FPGA_ERR outputs
+ *             "led to zero UMSG address" and returns FPGA_OK
+ *
+ */
+TEST_P(umsg_c_p, invalid_free_umsg_buffer) {
+  uint64_t* umsg_ptr = NULL;
+  uint64_t *value = 0;
+  system_->register_ioctl_handler(FPGA_PORT_UMSG_SET_BASE_ADDR, umsg_set_base_addr);
+  system_->register_ioctl_handler(FPGA_PORT_UMSG_ENABLE, dummy_ioctl<0,EINVAL>);
+  auto res = xfpga_fpgaGetUmsgPtr(handle_, &umsg_ptr);
+  EXPECT_EQ(FPGA_OK, res);
+ 
+  // register an ioctl handler that will return -1 and set errno to EINVAL
+  system_->register_ioctl_handler(FPGA_PORT_UMSG_DISABLE, dummy_ioctl<-1,EINVAL>);
+  EXPECT_EQ(FPGA_OK, free_umsg_buffer(handle_));
 
+  // register an ioctl handler that will return -1 and set errno to EINVAL
+  res = xfpga_fpgaGetUmsgPtr(handle_, &umsg_ptr);
+  EXPECT_EQ(FPGA_OK, res);
+  system_->register_ioctl_handler(FPGA_PORT_UMSG_DISABLE, dummy_ioctl<0,EINVAL>);
+  system_->register_ioctl_handler(FPGA_PORT_UMSG_SET_BASE_ADDR, dummy_ioctl<-1,EINVAL>);
+  EXPECT_EQ(FPGA_OK, free_umsg_buffer(handle_));
+}
+
+/**
+ * @test       umsg_c_p
+ * @brief      invalid_free_umsg_buffer
+ * @details    When the drivers are loaded and handle umsg_virt is mapped,
+ *             but ioctl fails on FPGA_PORT_DMA_UNMAP, FPGA_ERR outputs
+ *             "Failed to unmap UMSG Buffer" and returns FPGA_OK
+ *
+ */
+TEST_P(umsg_c_p, invalid_free_umsg_buffer_02) {
+  uint64_t* umsg_ptr = NULL;
+  uint64_t *value = 0;
+  system_->register_ioctl_handler(FPGA_PORT_UMSG_SET_BASE_ADDR, umsg_set_base_addr);
+  system_->register_ioctl_handler(FPGA_PORT_UMSG_ENABLE, dummy_ioctl<0,EINVAL>);
+  auto res = xfpga_fpgaGetUmsgPtr(handle_, &umsg_ptr);
+  EXPECT_EQ(FPGA_OK, res);
+ 
+  // register an ioctl handler that will return -1 and set errno to EINVAL
+  system_->register_ioctl_handler(FPGA_PORT_DMA_UNMAP, dummy_ioctl<-1,EINVAL>);
+  EXPECT_EQ(FPGA_OK, free_umsg_buffer(handle_));
+}
 /**
  * @test       umsg_c_p
  * @brief      test_umsg_drv_02
@@ -294,7 +394,6 @@ TEST_P (umsg_c_p, test_umsg_drv_02) {
 
   _handle->magic = FPGA_HANDLE_MAGIC;
 }
-
 
 /**
  * @test       umsg_c_p


### PR DESCRIPTION
Previous fpgaGetUmsgPtr test called an ioctl that doesn't exist, hence the failure. That test has been removed and added new tests for free_umsg_buffer.