### PR TITLE
tests: increase poll timeout to 2 seconds

### DIFF
--- a/testing/fpgad/test_errtable_c.cpp
+++ b/testing/fpgad/test_errtable_c.cpp
@@ -143,10 +143,9 @@ class fpgad_errtable_c_p : public ::testing::TestWithParam<std::string> {
   void cause_ktilinkfatal_fme0()
   {
     std::string fname = fme0_ + "/errors/fatal_errors";
-    uint64_t ktilinkfatal_bit = 1;
     FILE *fp = fopen(fname.c_str(), "w");    
     ASSERT_NE(nullptr, fp);
-    EXPECT_GT(fprintf(fp, "0x%" PRIx64 "\n", ktilinkfatal_bit), 0);
+    EXPECT_GT(fprintf(fp, "0x1\n"), 0);
     fclose(fp);
   }
 

--- a/testing/fpgad/test_errtable_c.cpp
+++ b/testing/fpgad/test_errtable_c.cpp
@@ -113,7 +113,7 @@ class fpgad_errtable_c_p : public ::testing::TestWithParam<std::string> {
     pollfd.fd = fd;
     pollfd.events = POLLIN;
 
-    int res = poll(&pollfd, 1, 1000);
+    int res = poll(&pollfd, 1, 2000);
 
     return (res == 1) && ((pollfd.revents & POLLIN) != 0);
   }

--- a/testing/fpgad/test_errtable_c.cpp
+++ b/testing/fpgad/test_errtable_c.cpp
@@ -116,7 +116,7 @@ class fpgad_errtable_c_p : public ::testing::TestWithParam<std::string> {
     pollfd.fd = fd;
     pollfd.events = POLLIN;
 
-    int res = poll(&pollfd, 1, 1000);
+    int res = poll(&pollfd, 1, 3000);
 
     return (res == 1) && ((pollfd.revents & POLLIN) != 0);
   }

--- a/testing/fpgad/test_errtable_c.cpp
+++ b/testing/fpgad/test_errtable_c.cpp
@@ -24,6 +24,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#define __STDC_FORMAT_MACROS
+
 extern "C" {
 
 #include <json-c/json.h>
@@ -57,6 +59,7 @@ int poll_error(struct fpga_err *e);
 #include <cstdlib>
 #include <cstring>
 #include <unistd.h>
+#include <inttypes.h>
 #include <sys/eventfd.h>
 #include <poll.h>
 #include <dlfcn.h>

--- a/testing/fpgad/test_errtable_c.cpp
+++ b/testing/fpgad/test_errtable_c.cpp
@@ -116,7 +116,7 @@ class fpgad_errtable_c_p : public ::testing::TestWithParam<std::string> {
     pollfd.fd = fd;
     pollfd.events = POLLIN;
 
-    int res = poll(&pollfd, 1, 2000);
+    int res = poll(&pollfd, 1, 1000);
 
     return (res == 1) && ((pollfd.revents & POLLIN) != 0);
   }


### PR DESCRIPTION
In an effort to stabalize fpgad_errtable_c_p.logger_ap6_ktilinkfatal
test.