### PR TITLE
object api: remove FPGA_OBJECT_TEXT flag

### DIFF
--- a/common/include/opae/sysobject.h
+++ b/common/include/opae/sysobject.h
@@ -157,14 +157,16 @@ fpga_result fpgaObjectRead(fpga_object obj, uint8_t *buffer, size_t offset,
 			   size_t len, int flags);
 
 /**
- * @brief Read a 64-bit value from an FPGA object
+ * @brief Read a 64-bit value from an FPGA object.
+ * The value is assumed to be in string format and will be parsed. See flags
+ * below for changing that behavior.
  *
  * @param[in] obj An fpga_object instance
  * @param[out] value Pointer to a 64-bit variable to store the value in
  * @param[in] flags Flags that control how the object is read
  * If FPGA_OBJECT_SYNC is used then object will update its buffered copy before
- * retrieving the data. If FPGA_OBJECT_TEXT is used, then the data will be read
- * as an ASCII string and converted to a uint64_t.
+ * retrieving the data. If FPGA_OBJECT_RAW is used, then the data will be read
+ * as raw bytes into the uint64_t pointer variable.
  *
  * @return FPGA_OK on success, FPGA_INVALID_PARAM if any of the supplied
  * parameters is invalid
@@ -172,13 +174,14 @@ fpga_result fpgaObjectRead(fpga_object obj, uint8_t *buffer, size_t offset,
 fpga_result fpgaObjectRead64(fpga_object obj, uint64_t *value, int flags);
 
 /**
- * @brief Write 64-bit value to an FPGA object
+ * @brief Write 64-bit value to an FPGA object.
+ * The value will be converted to string before writing. See flags below for
+ * changing that behavior.
  *
  * @param[in] obj An fpga_object instance.
  * @param[in] value The value to write to the object
  * @param[in] flags Flags that control how the object is written
- * If FPGA_OBJECT_TEXT is used, then the value will be converted to an ASCII
- * string before writing it to the object.
+ * If FPGA_OBJECT_RAW is used, then the value will be written as raw bytes.
  *
  * @return FPGA_OK on success, FPGA_INVALID_PARAM if any of the supplied
  * parameters is invalid

--- a/common/include/opae/types_enum.h
+++ b/common/include/opae/types_enum.h
@@ -147,7 +147,7 @@ enum fpga_reconf_flags {
 enum fpga_object_read_flags {
   FPGA_OBJECT_SYNC = (1u << 0), /**< Synchronize data from driver */
   FPGA_OBJECT_GLOB = (1u << 1), /**< Treat names as glob expressions */
-  FPGA_OBJECT_TEXT = (1u << 2), /**< Parse or convert numeric data as text */
+  FPGA_OBJECT_RAW  = (1u << 2), /**< Read or write object data as raw bytes */
   FPGA_OBJECT_RECURSE_ONE = (1u << 3), /**< Create subobjects one level down from containers */
   FPGA_OBJECT_RECURSE_ALL = (1u << 4) /**< Create subobjects all levels from from containers */
 };

--- a/libopae/plugins/xfpga/sysobject.c
+++ b/libopae/plugins/xfpga/sysobject.c
@@ -159,10 +159,10 @@ fpga_result xfpga_fpgaObjectRead64(fpga_object obj, uint64_t *value, int flags)
 	if (res) {
 		return res;
 	}
-	if (flags & FPGA_OBJECT_TEXT) {
-		*value = strtoull((char *)_obj->buffer, NULL, 0);
-	} else {
+	if (flags & FPGA_OBJECT_RAW) {
 		*value = *(uint64_t *)_obj->buffer;
+	} else {
+		*value = strtoull((char *)_obj->buffer, NULL, 0);
 	}
 	return FPGA_OK;
 }
@@ -209,13 +209,13 @@ fpga_result xfpga_fpgaObjectWrite64(fpga_object obj, uint64_t value, int flags)
 	if (_obj->max_size) {
 		memset_s(_obj->buffer, _obj->max_size, 0);
 	}
-	if (flags & FPGA_OBJECT_TEXT) {
+	if (flags & FPGA_OBJECT_RAW) {
+		_obj->size = sizeof(uint64_t);
+		*(uint64_t *)_obj->buffer = value;
+	} else {
 		snprintf_s_l((char *)_obj->buffer, _obj->max_size, "0x%" PRIx64,
 			     value);
 		_obj->size = (size_t)strlen((const char *)_obj->buffer);
-	} else {
-		_obj->size = sizeof(uint64_t);
-		*(uint64_t *)_obj->buffer = value;
 	}
 	fd = open(_obj->path, _obj->perm);
 	if (fd < 0) {

--- a/samples/hello_events.c
+++ b/samples/hello_events.c
@@ -114,7 +114,7 @@ static fpga_result inject_ras_fatal_error(fpga_token fme_token, uint8_t err)
 		return result;
 	}
 
-	result = fpgaHandleGetObject(fme_handle, FME_SYSFS_INJECT_ERROR, &inj_err_object, FPGA_OBJECT_TEXT);
+	result = fpgaHandleGetObject(fme_handle, FME_SYSFS_INJECT_ERROR, &inj_err_object, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to get Handle Object");
 		goto out_close;
@@ -123,7 +123,7 @@ static fpga_result inject_ras_fatal_error(fpga_token fme_token, uint8_t err)
 	// Inject fatal error
 	inj_error.fatal_error = err;
 
-	result = fpgaObjectWrite64(inj_err_object, inj_error.csr, FPGA_OBJECT_TEXT);
+	result = fpgaObjectWrite64(inj_err_object, inj_error.csr, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Read Object ");
 		goto out_destroy_obj;

--- a/samples/object_api.c
+++ b/samples/object_api.c
@@ -138,7 +138,7 @@ fpga_result freeze_group(metric_group *group, uint64_t value)
 	if (res != FPGA_OK) {
 		goto out_close;
 	}
-	res = fpgaObjectWrite64(object, value, FPGA_OBJECT_TEXT);
+	res = fpgaObjectWrite64(object, value, 0);
 	if ((other_res = fpgaDestroyObject(&object)) != FPGA_OK) {
 		print_err("error destorying object", other_res);
 	}
@@ -180,14 +180,14 @@ void print_counters(fpga_object clock, metric_group *group)
 	size_t count = group->count;
 	size_t i;
 	uint64_t value = 0, clock_value = 0;
-	fpga_result res = fpgaObjectRead64(clock, &clock_value, FPGA_OBJECT_SYNC | FPGA_OBJECT_TEXT);
+	fpga_result res = fpgaObjectRead64(clock, &clock_value, FPGA_OBJECT_SYNC);
 	if (res != FPGA_OK) {
 		print_err("Error reading clock", res);
 		return;
 	}
 	for (i = 0; i < count; ++i) {
 		res = fpgaObjectRead64(group->objects[i].object, &value,
-				       FPGA_OBJECT_SYNC | FPGA_OBJECT_TEXT);
+				       FPGA_OBJECT_SYNC);
 		if (res == FPGA_OK) {
 			group->objects[i].delta = value - group->objects[i].value;
 			group->objects[i].value = value;

--- a/testing/opae-c/test_object_c.cpp
+++ b/testing/opae-c/test_object_c.cpp
@@ -150,7 +150,7 @@ TEST_P(object_c_p, obj_read) {
  */
 TEST_P(object_c_p, obj_read64) {
   uint64_t val = 0;
-  EXPECT_EQ(fpgaObjectRead64(token_obj_, &val, FPGA_OBJECT_TEXT), FPGA_OK);
+  EXPECT_EQ(fpgaObjectRead64(token_obj_, &val, 0), FPGA_OK);
   EXPECT_EQ(val, 1ul);
 }
 
@@ -168,13 +168,13 @@ TEST_P(object_c_p, obj_write64) {
   // read the port errors
   ASSERT_EQ(fpgaHandleGetObject(accel_, "errors/errors", &obj, 0),
 		    FPGA_OK);
-  ASSERT_EQ(fpgaObjectRead64(obj, &errors, FPGA_OBJECT_TEXT), FPGA_OK);
+  ASSERT_EQ(fpgaObjectRead64(obj, &errors, 0), FPGA_OK);
   EXPECT_EQ(fpgaDestroyObject(&obj), FPGA_OK);
 
   // clear the port errors
   ASSERT_EQ(fpgaHandleGetObject(accel_, "errors/clear", &obj, 0),
 		    FPGA_OK);
-  ASSERT_EQ(fpgaObjectWrite64(obj, errors, FPGA_OBJECT_TEXT), FPGA_OK);
+  ASSERT_EQ(fpgaObjectWrite64(obj, errors, 0), FPGA_OK);
   EXPECT_EQ(fpgaDestroyObject(&obj), FPGA_OK);
 }
 
@@ -221,7 +221,7 @@ TEST_P(object_c_p, obj_get_obj) {
 		    FPGA_OK);
   ASSERT_EQ(fpgaObjectGetObject(errors_obj, accel_, "clear",
                                 &clear_obj, 0), FPGA_OK);
-  ASSERT_EQ(fpgaObjectWrite64(clear_obj, 0, FPGA_OBJECT_TEXT), FPGA_OK);
+  ASSERT_EQ(fpgaObjectWrite64(clear_obj, 0, 0), FPGA_OK);
   EXPECT_EQ(fpgaDestroyObject(&clear_obj), FPGA_OK);
   EXPECT_EQ(fpgaDestroyObject(&errors_obj), FPGA_OK);
 }

--- a/testing/xfpga/test_object_c.cpp
+++ b/testing/xfpga/test_object_c.cpp
@@ -89,7 +89,7 @@ TEST_P(sysobject_p, xfpga_fpgaTokenGetObject) {
   EXPECT_EQ(xfpga_fpgaTokenGetObject(tokens_[0], name, &object, flags),
             FPGA_OK);
   uint64_t bitstream_id = 0;
-  EXPECT_EQ(xfpga_fpgaObjectRead64(object, &bitstream_id, FPGA_OBJECT_TEXT),
+  EXPECT_EQ(xfpga_fpgaObjectRead64(object, &bitstream_id, 0),
             FPGA_OK);
   EXPECT_EQ(bitstream_id, platform_.devices[0].bbs_id);
   EXPECT_EQ(xfpga_fpgaTokenGetObject(tokens_[0], "invalid_name", &object, 0),
@@ -109,7 +109,7 @@ TEST_P(sysobject_p, xfpga_fpgaHandleGetObject) {
   int flags = 0;
   ASSERT_EQ(xfpga_fpgaHandleGetObject(handle_, name, &object, flags), FPGA_OK);
   uint64_t bitstream_id = 0;
-  EXPECT_EQ(xfpga_fpgaObjectRead64(object, &bitstream_id, FPGA_OBJECT_TEXT),
+  EXPECT_EQ(xfpga_fpgaObjectRead64(object, &bitstream_id, 0),
             FPGA_OK);
   EXPECT_EQ(bitstream_id, platform_.devices[0].bbs_id);
   EXPECT_EQ(xfpga_fpgaHandleGetObject(handle_, "invalid_name", &object, 0),
@@ -132,7 +132,7 @@ TEST_P(sysobject_p, xfpga_fpgaObjectGetObject) {
                                       flags),
             FPGA_OK);
   uint64_t bbs_errors = 0;
-  EXPECT_EQ(xfpga_fpgaObjectRead64(object, &bbs_errors, FPGA_OBJECT_TEXT),
+  EXPECT_EQ(xfpga_fpgaObjectRead64(object, &bbs_errors, 0),
             FPGA_OK);
   EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
   EXPECT_EQ(xfpga_fpgaDestroyObject(&err_object), FPGA_OK);
@@ -172,9 +172,7 @@ TEST_P(sysobject_p, xfpga_fpgaObjectRead) {
   uint64_t value = 0;
   fwrite(c0c0str.c_str(), c0c0str.size(), 1, fp);
   fflush(fp);
-  EXPECT_EQ(xfpga_fpgaObjectRead64(object, &value,
-                                   FPGA_OBJECT_TEXT | FPGA_OBJECT_SYNC),
-            FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaObjectRead64(object, &value, FPGA_OBJECT_SYNC), FPGA_OK);
   EXPECT_EQ(value, 0xc0c0cafe);
   EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
 }
@@ -195,7 +193,7 @@ TEST_P(sysobject_p, xfpga_fpgaObjectWrite64) {
   ASSERT_EQ(xfpga_fpgaHandleGetObject(handle_, "testdata", &object, 0),
             FPGA_OK);
   EXPECT_EQ(xfpga_fpgaObjectWrite64(object, 0xc0c0cafe, 0), FPGA_OK);
-  EXPECT_EQ(xfpga_fpgaObjectWrite64(object, 0xc0c0cafe, FPGA_OBJECT_TEXT),
+  EXPECT_EQ(xfpga_fpgaObjectWrite64(object, 0xc0c0cafe, 0),
             FPGA_OK);
 
   _fpga_object *obj = static_cast<_fpga_object *>(object);

--- a/tools/extra/coreidle/coreidle.c
+++ b/tools/extra/coreidle/coreidle.c
@@ -168,13 +168,13 @@ fpga_result set_cpu_core_idle(fpga_handle handle,
 	fpga_object fpga_object;
 
 	// XEON PWR LIMIT
-	result = fpgaHandleGetObject(handle, XEON_PWR_LIMIT, &fpga_object, FPGA_OBJECT_TEXT);
+	result = fpgaHandleGetObject(handle, XEON_PWR_LIMIT, &fpga_object, 0);
 	if (result != FPGA_OK) {
 		fprintf(stderr, "Failed to get Handle Object \n");
 		return result;
 	}
 
-	result = fpgaObjectRead64(fpga_object, &value, FPGA_OBJECT_TEXT);
+	result = fpgaObjectRead64(fpga_object, &value, 0);
 	if (result != FPGA_OK) {
 		fprintf(stderr, "Failed to Read Object \n");
 		fpgaDestroyObject(&fpga_object);
@@ -190,13 +190,13 @@ fpga_result set_cpu_core_idle(fpga_handle handle,
 	}
 
 	// FPGA PWR LIMIT
-	result = fpgaHandleGetObject(handle, FPGA_PWR_LIMIT, &fpga_object, FPGA_OBJECT_TEXT);
+	result = fpgaHandleGetObject(handle, FPGA_PWR_LIMIT, &fpga_object, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to get Handle Object \n");
 		return result;
 	}
 
-	result = fpgaObjectRead64(fpga_object, &value, FPGA_OBJECT_TEXT);
+	result = fpgaObjectRead64(fpga_object, &value, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Read Object \n");
 		fpgaDestroyObject(&fpga_object);
@@ -213,13 +213,13 @@ fpga_result set_cpu_core_idle(fpga_handle handle,
 
 
 	// Socke id
-	result = fpgaHandleGetObject(handle, FPGA_SYSFS_SOCKET_ID, &fpga_object, FPGA_OBJECT_TEXT);
+	result = fpgaHandleGetObject(handle, FPGA_SYSFS_SOCKET_ID, &fpga_object, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to get Handle Object \n");
 		return result;
 	}
 
-	result = fpgaObjectRead64(fpga_object, &socketid, FPGA_OBJECT_TEXT);
+	result = fpgaObjectRead64(fpga_object, &socketid, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Read Object \n");
 		fpgaDestroyObject(&fpga_object);

--- a/tools/extra/ras/main.c
+++ b/tools/extra/ras/main.c
@@ -606,13 +606,13 @@ fpga_result print_errors(fpga_token token,
 		return FPGA_INVALID_PARAM;
 	}
 
-	result = fpgaTokenGetObject(token, err_path, &err_object, FPGA_OBJECT_TEXT);
+	result = fpgaTokenGetObject(token, err_path, &err_object, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to get Token Object");
 		return result;
 	}
 
-	result = fpgaObjectRead64(err_object, &value, FPGA_OBJECT_TEXT);
+	result = fpgaObjectRead64(err_object, &value, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Read Object ");
 		return result;
@@ -641,13 +641,13 @@ fpga_result print_ras_errors(fpga_token token)
 	uint64_t revision          = 0;
 	fpga_object rev_object;
 
-	result = fpgaTokenGetObject(token, FME_SYSFS_ERR_REVISION, &rev_object, FPGA_OBJECT_TEXT);
+	result = fpgaTokenGetObject(token, FME_SYSFS_ERR_REVISION, &rev_object, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to get Token Object");
 		return result;
 	}
 
-	result = fpgaObjectRead64(rev_object, &revision, FPGA_OBJECT_TEXT);
+	result = fpgaObjectRead64(rev_object, &revision, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Read Object ");
 		return result;
@@ -760,13 +760,13 @@ fpga_result print_port_errors(fpga_token token)
 	printf("\n ==========================================\n");
 	printf(" ----------- PRINT PORT ERROR  START--------  \n");
 
-	result = fpgaTokenGetObject(token, PORT_SYSFS_ERR, &err_object, FPGA_OBJECT_TEXT);
+	result = fpgaTokenGetObject(token, PORT_SYSFS_ERR, &err_object, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to get Token Object");
 		return result;
 	}
 
-	result = fpgaObjectRead64(err_object, &value, FPGA_OBJECT_TEXT);
+	result = fpgaObjectRead64(err_object, &value, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Read Object ");
 		return result;
@@ -801,13 +801,13 @@ fpga_result clear_port_errors(fpga_handle afu_handle)
 
 	printf(" ----------- Clear port error-------- \n \n");
 	// Power
-	result = fpgaHandleGetObject(afu_handle, PORT_SYSFS_ERR_CLEAR, &port_error_object, FPGA_OBJECT_TEXT);
+	result = fpgaHandleGetObject(afu_handle, PORT_SYSFS_ERR_CLEAR, &port_error_object, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to get Token Object");
 		return result;
 	}
 
-	result = fpgaObjectRead64(port_error_object, &value, FPGA_OBJECT_TEXT);
+	result = fpgaObjectRead64(port_error_object, &value, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Read Object ");
 		return result;
@@ -815,7 +815,7 @@ fpga_result clear_port_errors(fpga_handle afu_handle)
 
 	printf("\n \n Port error CSR : 0x%lx \n", value);
 
-	result = fpgaObjectWrite64(port_error_object, 0x0, FPGA_OBJECT_TEXT);
+	result = fpgaObjectWrite64(port_error_object, 0x0, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Read Object ");
 		return result;
@@ -841,13 +841,13 @@ fpga_result inject_ras_errors(fpga_handle fme_handle,
 
 	printf("----------- INJECT ERROR START -------- \n \n");
 	// Power
-	result = fpgaHandleGetObject(fme_handle, FME_SYSFS_INJECT_ERROR, &inj_error_object, FPGA_OBJECT_TEXT);
+	result = fpgaHandleGetObject(fme_handle, FME_SYSFS_INJECT_ERROR, &inj_error_object, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to get Token Object");
 		return result;
 	}
 
-	result = fpgaObjectRead64(inj_error_object, &inj_error.csr, FPGA_OBJECT_TEXT);
+	result = fpgaObjectRead64(inj_error_object, &inj_error.csr, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Read Object ");
 		return result;
@@ -869,7 +869,7 @@ fpga_result inject_ras_errors(fpga_handle fme_handle,
 
 	printf("Injected inj_error.csr: %ld \n", inj_error.csr);
 
-	result = fpgaObjectWrite64(inj_error_object, inj_error.csr, FPGA_OBJECT_TEXT);
+	result = fpgaObjectWrite64(inj_error_object, inj_error.csr, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Read Object ");
 		return result;
@@ -895,13 +895,13 @@ fpga_result clear_inject_ras_errors(fpga_handle fme_handle)
 
 	printf("----------- INJECT ERROR START -------- \n \n");
 	// Clear Inject error
-	result = fpgaHandleGetObject(fme_handle, FME_SYSFS_INJECT_ERROR, &error_object, FPGA_OBJECT_TEXT);
+	result = fpgaHandleGetObject(fme_handle, FME_SYSFS_INJECT_ERROR, &error_object, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to get Token Object");
 		return result;
 	}
 
-	result = fpgaObjectRead64(error_object, &inj_error.csr, FPGA_OBJECT_TEXT);
+	result = fpgaObjectRead64(error_object, &inj_error.csr, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Read Object ");
 		return result;
@@ -909,7 +909,7 @@ fpga_result clear_inject_ras_errors(fpga_handle fme_handle)
 
 	printf(" Clear inj_error.csr: 0x%lx \n", inj_error.csr);;
 
-	result = fpgaObjectWrite64(error_object, 0x0, FPGA_OBJECT_TEXT);
+	result = fpgaObjectWrite64(error_object, 0x0, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Write Object ");
 		return result;
@@ -925,13 +925,13 @@ fpga_result clear_inject_ras_errors(fpga_handle fme_handle)
 	printf("----------- FME ERROR START --------- \n \n");
 
 	// Clear FME error
-	result = fpgaHandleGetObject(fme_handle, FME_SYSFS_CLEAR_ERRORS, &error_object, FPGA_OBJECT_TEXT);
+	result = fpgaHandleGetObject(fme_handle, FME_SYSFS_CLEAR_ERRORS, &error_object, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to get handle Object");
 		return result;
 	}
 
-	result = fpgaObjectWrite64(error_object, 0x0, FPGA_OBJECT_TEXT);
+	result = fpgaObjectWrite64(error_object, 0x0, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Write Object ");
 		return result;
@@ -957,13 +957,13 @@ fpga_result print_pwr_temp(fpga_token token)
 	printf("\n ----------- POWER & THERMAL START-----------\n");
 	printf(" ========================================== \n \n");
 	// Power
-	result = fpgaTokenGetObject(token, FME_SYSFS_POWER_MGMT_CONSUMED, &pwr_temp_object, FPGA_OBJECT_TEXT);
+	result = fpgaTokenGetObject(token, FME_SYSFS_POWER_MGMT_CONSUMED, &pwr_temp_object, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to get Token Object");
 		return result;
 	}
 
-	result = fpgaObjectRead64(pwr_temp_object, &value, FPGA_OBJECT_TEXT);
+	result = fpgaObjectRead64(pwr_temp_object, &value, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Read Object ");
 		return result;
@@ -978,7 +978,7 @@ fpga_result print_pwr_temp(fpga_token token)
 	}
 
 	// Thermal
-	result = fpgaTokenGetObject(token, FME_SYSFS_THERMAL_MGMT_TEMP, &pwr_temp_object, FPGA_OBJECT_TEXT);
+	result = fpgaTokenGetObject(token, FME_SYSFS_THERMAL_MGMT_TEMP, &pwr_temp_object, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to get Token Object");
 		return result;
@@ -999,13 +999,13 @@ fpga_result print_pwr_temp(fpga_token token)
 	}
 
 
-	result = fpgaTokenGetObject(token, FME_SYSFS_THERMAL_MGMT_THRESHOLD_TRIP, &pwr_temp_object, FPGA_OBJECT_TEXT);
+	result = fpgaTokenGetObject(token, FME_SYSFS_THERMAL_MGMT_THRESHOLD_TRIP, &pwr_temp_object, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to get Token Object");
 		return result;
 	}
 
-	result = fpgaObjectRead64(pwr_temp_object, &value, FPGA_OBJECT_TEXT);
+	result = fpgaObjectRead64(pwr_temp_object, &value, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Read Object ");
 		return result;
@@ -1052,13 +1052,13 @@ fpga_result mmio_error(fpga_handle afu_handle, struct RASCommandLine *rasCmdLine
 	if ( rasCmdLine->function >0 )
 		function = rasCmdLine->bus;
 
-	result = fpgaHandleGetObject(afu_handle, FPAG_DEVICEID_PATH, &dev_object, FPGA_OBJECT_TEXT);
+	result = fpgaHandleGetObject(afu_handle, FPAG_DEVICEID_PATH, &dev_object, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to get Handle Object");
 		return result;
 	}
 
-	result = fpgaObjectRead64(dev_object, &value, FPGA_OBJECT_TEXT);
+	result = fpgaObjectRead64(dev_object, &value, 0);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Read Object ");
 		return result;


### PR DESCRIPTION
* Remvoe FPGA_OBJECT_TEXT flag and replace with its contrary,,
FPGA_OBJECT_RAW.
* Change the default behavior of fpgaObjectRead64 and fpgaObjectWrite64
to treat buffer read as string text and parse it.
* The FPGA_OBJECT_RAW can read in the raw bytes and store it in the
output variable or take the raw bytes and write them to the object.