### PR TITLE
Remove "handle" parameter from fpgaObjectGetObject

### DIFF
--- a/common/include/opae/sysobject.h
+++ b/common/include/opae/sysobject.h
@@ -90,12 +90,11 @@ fpga_result fpgaHandleGetObject(fpga_handle handle, const char *name,
 /**
  * @brief Create an `fpga_object` data structure from a parent object.
  * An `fpga_object` is a handle to an FPGA resource which can be an attribute
- * or a register. If the handle parameter is NULL then the object is created
- * with read-only access. If the handle is a valid handle, then it will be
- * created with read-write access.
+ * or a register. If the parent object was created with a handle, then the new
+ * object will inherit the handle allowing it to have read-write access to the
+ * object data.
  *
  * @param[in] parent A parent container `fpga_object`.
- * @param[in] handle Handle identifying a resource (accelerator or device).
  * @param[in] name A key identifying a sub-object of the parent container.
  * @param[out] object Pointer to memory to store the object in.
  * @param[in] flags Control behavior of object identification and creation.
@@ -111,9 +110,8 @@ fpga_result fpgaHandleGetObject(fpga_handle handle, const char *name,
  * key. FPGA_NOT_SUPPORTED if this function is not supported by the current
  * implementation of this API.
  */
-fpga_result fpgaObjectGetObject(fpga_object parent, fpga_handle handle,
-				const char *name, fpga_object *object,
-				int flags);
+fpga_result fpgaObjectGetObject(fpga_object parent, const char *name,
+				fpga_object *object, int flags);
 /**
  * @brief Free memory used for the fpga_object data structure
  *

--- a/libopae/adapter.h
+++ b/libopae/adapter.h
@@ -161,8 +161,7 @@ typedef struct _opae_api_adapter_table {
 	fpga_result (*fpgaHandleGetObject)(fpga_handle handle, const char *name,
 					   fpga_object *object, int flags);
 
-	fpga_result (*fpgaObjectGetObject)(fpga_object parent,
-					   fpga_handle handle, const char *name,
+	fpga_result (*fpgaObjectGetObject)(fpga_object parent, const char *name,
 					   fpga_object *object, int flags);
 
 	fpga_result (*fpgaDestroyObject)(fpga_object *obj);

--- a/libopae/api-shell.c
+++ b/libopae/api-shell.c
@@ -287,7 +287,8 @@ fpga_result fpgaGetProperties(fpga_token token, fpga_properties *prop)
 		if (FIELD_VALID(p, FPGA_PROPERTY_PARENT)) {
 			opae_wrapped_token *wrapped_parent =
 				opae_allocate_wrapped_token(
-					p->parent, wrapped_token->adapter_table);
+					p->parent,
+					wrapped_token->adapter_table);
 
 			if (wrapped_parent) {
 				p->parent = wrapped_parent;
@@ -325,8 +326,8 @@ fpga_result fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 
 	ASSERT_NOT_NULL(p);
 
-	if (FIELD_VALID(p, FPGA_PROPERTY_PARENT) &&
-	    (p->flags & OPAE_PROPERTIES_FLAG_PARENT_ALLOC)) {
+	if (FIELD_VALID(p, FPGA_PROPERTY_PARENT)
+	    && (p->flags & OPAE_PROPERTIES_FLAG_PARENT_ALLOC)) {
 		wrapped_parent = opae_validate_wrapped_token(p->parent);
 		if (wrapped_parent)
 			p->parent = wrapped_parent->opae_token;
@@ -346,8 +347,7 @@ fpga_result fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 	if (FIELD_VALID(p, FPGA_PROPERTY_PARENT)) {
 		if (!wrapped_parent) {
 			// We need to allocate a wrapper.
-			wrapped_parent =
-			opae_allocate_wrapped_token(
+			wrapped_parent = opae_allocate_wrapped_token(
 				p->parent, wrapped_token->adapter_table);
 
 			if (wrapped_parent) {
@@ -360,7 +360,8 @@ fpga_result fpgaUpdateProperties(fpga_token token, fpga_properties prop)
 		} else {
 			// We are re-using the wrapper from above.
 			wrapped_parent->opae_token = p->parent;
-			wrapped_parent->adapter_table = wrapped_token->adapter_table;
+			wrapped_parent->adapter_table =
+				wrapped_token->adapter_table;
 			p->parent = wrapped_parent;
 			p->flags |= OPAE_PROPERTIES_FLAG_PARENT_ALLOC;
 		}
@@ -592,7 +593,7 @@ fpga_result fpgaEnumerate(const fpga_properties *filters, uint32_t num_filters,
 	// If any of the input filters has a parent token set,
 	// then it will be wrapped. We need to unwrap it here,
 	// then re-wrap below.
-	for (i = 0 ; i < num_filters ; ++i) {
+	for (i = 0; i < num_filters; ++i) {
 		int err;
 		struct _fpga_properties *p =
 			opae_validate_and_lock_properties(filters[i]);
@@ -615,8 +616,8 @@ fpga_result fpgaEnumerate(const fpga_properties *filters, uint32_t num_filters,
 				goto out_free_tokens;
 			}
 
-			fixup = (parent_token_fixup *)
-				malloc(sizeof(parent_token_fixup));
+			fixup = (parent_token_fixup *)malloc(
+				sizeof(parent_token_fixup));
 
 			if (!fixup) {
 				OPAE_ERR("malloc failed");
@@ -1309,9 +1310,8 @@ fpga_result fpgaHandleGetObject(fpga_handle handle, const char *name,
 	return res != FPGA_OK ? res : dres;
 }
 
-fpga_result fpgaObjectGetObject(fpga_object parent, fpga_handle handle,
-				const char *name, fpga_object *object,
-				int flags)
+fpga_result fpgaObjectGetObject(fpga_object parent, const char *name,
+				fpga_object *object, int flags)
 {
 	fpga_result res;
 	fpga_result dres = FPGA_OK;
@@ -1319,11 +1319,8 @@ fpga_result fpgaObjectGetObject(fpga_object parent, fpga_handle handle,
 	opae_wrapped_object *wrapped_child_object;
 	opae_wrapped_object *wrapped_object =
 		opae_validate_wrapped_object(parent);
-	opae_wrapped_handle *wrapped_handle =
-		opae_validate_wrapped_handle(handle);
 
 	ASSERT_NOT_NULL(wrapped_object);
-	ASSERT_NOT_NULL(wrapped_handle);
 	ASSERT_NOT_NULL(name);
 	ASSERT_NOT_NULL(object);
 	ASSERT_NOT_NULL_RESULT(
@@ -1333,8 +1330,7 @@ fpga_result fpgaObjectGetObject(fpga_object parent, fpga_handle handle,
 			       FPGA_NOT_SUPPORTED);
 
 	res = wrapped_object->adapter_table->fpgaObjectGetObject(
-		wrapped_object->opae_object, wrapped_handle->opae_handle,
-		name, &obj, flags);
+		wrapped_object->opae_object, name, &obj, flags);
 
 	ASSERT_RESULT(res);
 

--- a/libopae/plugins/xfpga/sysfs.c
+++ b/libopae/plugins/xfpga/sysfs.c
@@ -880,6 +880,7 @@ fpga_result make_sysfs_group(char *sysfspath, const char *name,
 		return FPGA_EXCEPTION;
 	}
 	struct _fpga_object *group = alloc_fpga_object(sysfspath, name);
+	group->handle = handle;
 	group->type = FPGA_SYSFS_DIR;
 	if (flags & FPGA_OBJECT_RECURSE_ONE
 	    || flags & FPGA_OBJECT_RECURSE_ALL) {

--- a/libopae/plugins/xfpga/sysobject.c
+++ b/libopae/plugins/xfpga/sysobject.c
@@ -64,7 +64,6 @@ fpga_result xfpga_fpgaTokenGetObject(fpga_token token, const char *name,
 	return make_sysfs_object(objpath, name, object, flags, NULL);
 }
 
-
 fpga_result xfpga_fpgaHandleGetObject(fpga_token handle, const char *name,
 				      fpga_object *object, int flags)
 {
@@ -81,9 +80,8 @@ fpga_result xfpga_fpgaHandleGetObject(fpga_token handle, const char *name,
 	return make_sysfs_object(objpath, name, object, flags, handle);
 }
 
-fpga_result xfpga_fpgaObjectGetObject(fpga_object parent, fpga_handle handle,
-				      const char *name, fpga_object *object,
-				      int flags)
+fpga_result xfpga_fpgaObjectGetObject(fpga_object parent, const char *name,
+				      fpga_object *object, int flags)
 {
 	char objpath[SYSFS_PATH_MAX] = {0};
 	fpga_result res = FPGA_EXCEPTION;
@@ -108,7 +106,7 @@ fpga_result xfpga_fpgaObjectGetObject(fpga_object parent, fpga_handle handle,
 	}
 
 
-	return make_sysfs_object(objpath, name, object, flags, handle);
+	return make_sysfs_object(objpath, name, object, flags, _obj->handle);
 }
 
 fpga_result xfpga_fpgaDestroyObject(fpga_object *obj)

--- a/libopae/plugins/xfpga/xfpga.h
+++ b/libopae/plugins/xfpga/xfpga.h
@@ -102,11 +102,11 @@ fpga_result xfpga_fpgaTokenGetObject(fpga_token token, const char *name,
 				     fpga_object *object, int flags);
 fpga_result xfpga_fpgaHandleGetObject(fpga_token handle, const char *name,
 				      fpga_object *object, int flags);
-fpga_result xfpga_fpgaObjectGetObject(fpga_object parent, fpga_handle handle,
-				      const char *name, fpga_object *object,
-				      int flags);
+fpga_result xfpga_fpgaObjectGetObject(fpga_object parent, const char *name,
+				      fpga_object *object, int flags);
 fpga_result xfpga_fpgaDestroyObject(fpga_object *obj);
-fpga_result xfpga_fpgaObjectGetSize(fpga_object obj, uint32_t *value, int flags);
+fpga_result xfpga_fpgaObjectGetSize(fpga_object obj, uint32_t *value,
+				    int flags);
 fpga_result xfpga_fpgaObjectRead(fpga_object obj, uint8_t *buffer,
 				 size_t offset, size_t len, int flags);
 fpga_result xfpga_fpgaObjectRead64(fpga_object obj, uint64_t *value, int flags);

--- a/samples/object_api.c
+++ b/samples/object_api.c
@@ -79,8 +79,8 @@ typedef struct {
 	fpga_token token;
 	fpga_object object;
 	uint8_t bus;
-        uint8_t device;
-        uint8_t function;
+	uint8_t device;
+	uint8_t function;
 	named_object objects[MAX_GROUP_OBJECTS];
 	size_t count;
 } metric_group;
@@ -93,12 +93,12 @@ typedef struct {
 } token_group;
 
 struct {
-	bool freeze;
 	int bus;
 	float interval_sec;
-} options = { false, -1, 1.0 };
+} options = { -1, 1.0};
 
-metric_group *init_metric_group(fpga_token token, const char *name, metric_group *group)
+metric_group *init_metric_group(fpga_token token, const char *name,
+				metric_group *group)
 {
 	fpga_properties props;
 	fpga_result res;
@@ -107,54 +107,32 @@ metric_group *init_metric_group(fpga_token token, const char *name, metric_group
 	group->name = name;
 	group->count = 0;
 	if (fpgaGetProperties(token, &props) == FPGA_OK) {
-		if ((res = fpgaPropertiesGetBus(props, &group->bus)) != FPGA_OK) {
+		if ((res = fpgaPropertiesGetBus(props, &group->bus))
+		    != FPGA_OK) {
 			print_err("error reading bus", res);
 		}
-		if ((res = fpgaPropertiesGetDevice(props, &group->device)) != FPGA_OK) {
+		if ((res = fpgaPropertiesGetDevice(props, &group->device))
+		    != FPGA_OK) {
 			print_err("error reading device", res);
 		}
-		if ((res = fpgaPropertiesGetFunction(props, &group->function)) != FPGA_OK) {
+		if ((res = fpgaPropertiesGetFunction(props, &group->function))
+		    != FPGA_OK) {
 			print_err("error reading function", res);
 		}
 	}
 
-	if (fpgaTokenGetObject(token, name, &group->object, FPGA_OBJECT_GLOB) == FPGA_OK) {
+	if (fpgaTokenGetObject(token, name, &group->object, FPGA_OBJECT_GLOB)
+	    == FPGA_OK) {
 		return group;
 	}
 	return NULL;
 }
 
-fpga_result freeze_group(metric_group *group, uint64_t value)
-{
-	if (!options.freeze) return FPGA_OK;
-	fpga_handle handle = NULL;
-	fpga_object object = NULL;
-	fpga_result other_res;
-	fpga_result res = fpgaOpen(group->token, &handle, FPGA_OPEN_SHARED);
-	if (res != FPGA_OK) {
-		goto out;
-	}
-	res = fpgaObjectGetObject(group->object, handle, "freeze", &object, 0);
-	if (res != FPGA_OK) {
-		goto out_close;
-	}
-	res = fpgaObjectWrite64(object, value, FPGA_OBJECT_TEXT);
-	if ((other_res = fpgaDestroyObject(&object)) != FPGA_OK) {
-		print_err("error destorying object", other_res);
-	}
-
-out_close:
-	if ((other_res = fpgaClose(handle)) != FPGA_OK) {
-		print_err("error closing handle", other_res);
-	}
-out:
-	return res;
-}
 
 fpga_result add_clock(token_group *t_group)
 {
-	fpga_result res =
-		fpgaTokenGetObject(t_group->token, "*perf/clock", &t_group->clock, FPGA_OBJECT_GLOB);
+	fpga_result res = fpgaTokenGetObject(t_group->token, "*perf/clock",
+					     &t_group->clock, FPGA_OBJECT_GLOB);
 
 	return res;
 }
@@ -163,8 +141,9 @@ fpga_result add_counter(metric_group *group, const char *name)
 {
 	fpga_result res = FPGA_EXCEPTION;
 	size_t count = group->count;
-	res = fpgaObjectGetObject(group->object, NULL, name,
-				  &group->objects[count].object, FPGA_OBJECT_GLOB);
+	res = fpgaObjectGetObject(group->object, name,
+				  &group->objects[count].object,
+				  FPGA_OBJECT_GLOB);
 	if (res == FPGA_OK) {
 		group->objects[count].value = 0;
 		group->objects[count].name = name;
@@ -180,7 +159,8 @@ void print_counters(fpga_object clock, metric_group *group)
 	size_t count = group->count;
 	size_t i;
 	uint64_t value = 0, clock_value = 0;
-	fpga_result res = fpgaObjectRead64(clock, &clock_value, FPGA_OBJECT_SYNC | FPGA_OBJECT_TEXT);
+	fpga_result res = fpgaObjectRead64(clock, &clock_value,
+					   FPGA_OBJECT_SYNC | FPGA_OBJECT_TEXT);
 	if (res != FPGA_OK) {
 		print_err("Error reading clock", res);
 		return;
@@ -189,16 +169,19 @@ void print_counters(fpga_object clock, metric_group *group)
 		res = fpgaObjectRead64(group->objects[i].object, &value,
 				       FPGA_OBJECT_SYNC | FPGA_OBJECT_TEXT);
 		if (res == FPGA_OK) {
-			group->objects[i].delta = value - group->objects[i].value;
+			group->objects[i].delta =
+				value - group->objects[i].value;
 			group->objects[i].value = value;
 		} else {
 			print_err("error reading counter", res);
 		}
 	}
-	printf("device: %02x:%02x.%1d clock %lu: \n\t", group->bus, group->device, group->function, clock_value);
+	printf("device: %02x:%02x.%1d clock %lu: \n\t", group->bus,
+	       group->device, group->function, clock_value);
 	for (i = 0; i < count; ++i) {
 		if (group->objects[i].delta > 0)
-			printf("%16s : %10lu, ", group->objects[i].name, group->objects[i].delta);
+			printf("%16s : %10lu, ", group->objects[i].name,
+			       group->objects[i].delta);
 	}
 
 	printf("\n");
@@ -209,36 +192,34 @@ void print_counters(fpga_object clock, metric_group *group)
 fpga_result parse_args(int argc, char *argv[])
 {
 	struct option longopts[] = {
-		{ "bus", required_argument, NULL, 'B'},
-		{ "freeze", no_argument, NULL, 'f'},
-		{ NULL,	0, NULL, 0},
+		{"bus", required_argument, NULL, 'B'},
+		{NULL, 0, NULL, 0},
 	};
 	int getopt_ret;
 	int option_index;
 	char *endptr = NULL;
 
 	while (-1 != (getopt_ret = getopt_long(argc, argv, GETOPT_STRING,
-						longopts, &option_index))) {
+					       longopts, &option_index))) {
 		const char *tmp_optarg = optarg;
-		/* Checks to see if optarg is null and if not it goes to value of optarg */
-		if ((optarg) && ('=' == *tmp_optarg)){
+		/* Checks to see if optarg is null and if not it goes to value
+		 * of optarg */
+		if ((optarg) && ('=' == *tmp_optarg)) {
 			++tmp_optarg;
 		}
 
-		switch (getopt_ret){
+		switch (getopt_ret) {
 		case 'B': /* bus */
-			if (NULL == tmp_optarg){
+			if (NULL == tmp_optarg) {
 				return FPGA_EXCEPTION;
 			}
 			endptr = NULL;
-			options.bus = (int) strtoul(tmp_optarg, &endptr, 0);
+			options.bus = (int)strtoul(tmp_optarg, &endptr, 0);
 			if (endptr != tmp_optarg + strnlen(tmp_optarg, 100)) {
-				fprintf(stderr, "invalid bus: %s\n", tmp_optarg);
+				fprintf(stderr, "invalid bus: %s\n",
+					tmp_optarg);
 				return FPGA_EXCEPTION;
 			}
-			break;
-		case 'f':
-			options.freeze = true;
 			break;
 		default: /* invalid option */
 			fprintf(stderr, "Invalid cmdline option \n");
@@ -288,22 +269,22 @@ int main(int argc, char *argv[])
 
 	for (i = 0; i < num_matches; ++i) {
 		metrics[i].token = tokens[i];
-                add_clock(&metrics[i]);
+		add_clock(&metrics[i]);
 		metrics[i].groups = calloc(3, sizeof(metric_group));
 		metrics[i].count = 3;
-		metric_group *g_cache =
-			init_metric_group(tokens[i], "*perf/cache", &metrics[i].groups[0]);
+		metric_group *g_cache = init_metric_group(
+			tokens[i], "*perf/cache", &metrics[i].groups[0]);
 		add_counter(g_cache, "read_hit");
 		add_counter(g_cache, "read_miss");
 		add_counter(g_cache, "write_hit");
 		add_counter(g_cache, "write_miss");
 		add_counter(g_cache, "hold_request");
-		metric_group *g_fabric =
-			init_metric_group(tokens[i], "*perf/fabric", &metrics[i].groups[1]);
+		metric_group *g_fabric = init_metric_group(
+			tokens[i], "*perf/fabric", &metrics[i].groups[1]);
 		add_counter(g_fabric, "mmio_write");
 		add_counter(g_fabric, "mmio_read");
-		metric_group *g_iommu =
-			init_metric_group(tokens[i], "*perf/iommu", &metrics[i].groups[2]);
+		metric_group *g_iommu = init_metric_group(
+			tokens[i], "*perf/iommu", &metrics[i].groups[2]);
 		add_counter(g_iommu, "iotlb_4k_hit");
 		add_counter(g_iommu, "iotlb_4k_miss");
 		add_counter(g_iommu, "iotlb_2m_hit");
@@ -315,19 +296,20 @@ int main(int argc, char *argv[])
 	while (--count > 0) {
 		for (i = 0; i < num_matches; ++i) {
 			for (j = 0; j < metrics[i].count; ++j) {
-				freeze_group(&metrics[i].groups[j], 1);
-				print_counters(metrics[i].clock, &metrics[i].groups[j]);
-				freeze_group(&metrics[i].groups[j], 0);
+				print_counters(metrics[i].clock,
+					       &metrics[i].groups[j]);
 			}
-			usleep((useconds_t)(options.interval_sec * USEC_TO_SEC));
+			usleep((useconds_t)(options.interval_sec
+					    * USEC_TO_SEC));
 		}
 	}
 
 
 out_free:
 	while (--cleanup_size > 0) {
-		if ((res = cleanup[cleanup_size].fn(cleanup[cleanup_size].param))
-			  != FPGA_OK) {
+		if ((res = cleanup[cleanup_size].fn(
+			     cleanup[cleanup_size].param))
+		    != FPGA_OK) {
 			print_err("Error destroying structure: ", res);
 		}
 	}

--- a/testing/fpgad/test_errtable_c.cpp
+++ b/testing/fpgad/test_errtable_c.cpp
@@ -55,7 +55,6 @@ int poll_error(struct fpga_err *e);
 #include <array>
 #include <fstream>
 #include <thread>
-#include <future>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -209,12 +208,8 @@ TEST_P(fpgad_errtable_c_p, logger_ap6_ktilinkfatal) {
   ASSERT_TRUE(do_poll(evt_fds[0]));
   clear_errors_port0();
 
-  auto fv = std::async(std::launch::async, [this](){
-      cause_ktilinkfatal_fme0();
-      return true;
-      });
+  cause_ktilinkfatal_fme0();
   ASSERT_TRUE(do_poll(evt_fds[1]));
-  fv.wait();
   clear_errors_fme0();
 
   close(evt_fds[0]);

--- a/testing/opae-c/test_object_c.cpp
+++ b/testing/opae-c/test_object_c.cpp
@@ -219,7 +219,7 @@ TEST_P(object_c_p, obj_get_obj) {
 
   ASSERT_EQ(fpgaHandleGetObject(accel_, "errors", &errors_obj, 0),
 		    FPGA_OK);
-  ASSERT_EQ(fpgaObjectGetObject(errors_obj, accel_, "clear",
+  ASSERT_EQ(fpgaObjectGetObject(errors_obj, "clear",
                                 &clear_obj, 0), FPGA_OK);
   ASSERT_EQ(fpgaObjectWrite64(clear_obj, 0, FPGA_OBJECT_TEXT), FPGA_OK);
   EXPECT_EQ(fpgaDestroyObject(&clear_obj), FPGA_OK);
@@ -255,7 +255,7 @@ TEST_P(object_c_p, obj_get_obj_err) {
 		    FPGA_OK);
 
   system_->invalidate_malloc(0, "opae_allocate_wrapped_object");
-  ASSERT_EQ(fpgaObjectGetObject(errors_obj, accel_, "clear",
+  ASSERT_EQ(fpgaObjectGetObject(errors_obj, "clear",
                                 &clear_obj, 0), FPGA_NO_MEMORY);
 
   EXPECT_EQ(fpgaDestroyObject(&errors_obj), FPGA_OK);

--- a/testing/xfpga/test_object_c.cpp
+++ b/testing/xfpga/test_object_c.cpp
@@ -128,7 +128,7 @@ TEST_P(sysobject_p, xfpga_fpgaObjectGetObject) {
   const char *name = "errors";
   EXPECT_EQ(xfpga_fpgaTokenGetObject(tokens_[0], name, &err_object, flags),
             FPGA_OK);
-  ASSERT_EQ(xfpga_fpgaObjectGetObject(err_object, nullptr, "revision", &object,
+  ASSERT_EQ(xfpga_fpgaObjectGetObject(err_object, "revision", &object,
                                       flags),
             FPGA_OK);
   uint64_t bbs_errors = 0;


### PR DESCRIPTION
This change simplifies the fpgaObjectGetObject API by eliminating the
optional handle parameter and instead changing the behavior so that any
object created from a handle will inherit the handle.

The object api sample is updated to not use the handle and may be
updated later to allow freezing of objects.