### PR TITLE
Fix for passing Bus to fpgainfo

### DIFF
--- a/tools/extra/pac/fpgabist/fpgabist
+++ b/tools/extra/pac/fpgabist/fpgabist
@@ -61,7 +61,7 @@ def main(args):
 
     # Display data from FPGA info
     for feature in FEATURES:
-        cmd = "fpgainfo {} -B {}".format(feature, bdf['bus'])
+        cmd = "fpgainfo {} -B 0x{}".format(feature, bdf['bus'])
         subprocess.call(cmd, shell=True)
 
     gbs_paths = args.gbs_paths


### PR DESCRIPTION
Small fix to properly pass the bdf information to the command running `fpgainfo`