### PR TITLE
Add C++ core sysobject API

### DIFF
--- a/common/include/opae/cxx/core/sysobject.h
+++ b/common/include/opae/cxx/core/sysobject.h
@@ -52,15 +52,13 @@ class sysobject {
    *
    * @param t[in] Token object representing a resource.
    * @param name[in] An identifier representing an object belonging to a
-   * resource
-   * represented by the token.
+   * resource represented by the token.
    * @param[in] flags Control behavior of object identification and creation.
    * FPGA_OBJECT_GLOB is used to indicate that the name should be treated as a
    * globbing expression.  FPGA_OBJECT_RECURSE_ONE indicates that subobjects be
    * created for objects one level down from the object identified by name.
    * FPGA_OBJECT_RECURSE_ALL indicates that subobjects be created for all
-   * objects
-   * below the current object identified by name.
+   * objects below the current object identified by name.
    *
    * @return A shared_ptr to a sysobject instance.
    */
@@ -72,15 +70,13 @@ class sysobject {
    *
    * @param h[in] Handle object representing an open resource.
    * @param name[in] An identifier representing an object belonging to a
-   * resource
-   * represented by the handle.
+   * resource represented by the handle.
    * @param[in] flags Control behavior of object identification and creation.
    * FPGA_OBJECT_GLOB is used to indicate that the name should be treated as a
    * globbing expression.  FPGA_OBJECT_RECURSE_ONE indicates that subobjects be
    * created for objects one level down from the object identified by name.
    * FPGA_OBJECT_RECURSE_ALL indicates that subobjects be created for all
-   * objects
-   * below the current object identified by name.
+   * objects below the current object identified by name.
    *
    * @return A shared_ptr to a sysobject instance.
    */
@@ -88,10 +84,10 @@ class sysobject {
                               int flags = 0);
 
   /**
-   * @brief Get a sysobject from a object. This will be read-write if its
-   * parent has created from a handle..
+   * @brief Get a sysobject froman object. This will be read-write if its
+   * parent was created from a handle..
    *
-   * @param name[in] An identifier representing an object belonging this
+   * @param name[in] An identifier representing an object belonging to this
    * object.
    * @param[in] flags Control behavior of object identification and creation.
    * FPGA_OBJECT_GLOB is used to indicate that the name should be treated as a
@@ -99,7 +95,6 @@ class sysobject {
    * created for objects one level down from the object identified by name.
    * FPGA_OBJECT_RECURSE_ALL indicates that subobjects be created for all
    * objects. Flags are defaulted to 0 meaning no flags.
-   * below the current object identified by name.
    *
    * @return A shared_ptr to a sysobject instance.
    */
@@ -128,7 +123,7 @@ class sysobject {
    * The value will be converted to string before writing. See flags below for
    * changing that behavior.
    *
-   * @param value The value to write to the object.
+   * @param[in] value The value to write to the object.
    * @param[in] flags Flags that control how the object is written
    * If FPGA_OBJECT_RAW is used, then the value will be written as raw bytes.
    * Flags are defaulted to 0 meaning no flags.

--- a/common/include/opae/cxx/core/sysobject.h
+++ b/common/include/opae/cxx/core/sysobject.h
@@ -1,0 +1,179 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+#include <memory>
+#include <vector>
+
+#include <opae/cxx/core/handle.h>
+#include <opae/cxx/core/token.h>
+#include <opae/types.h>
+
+namespace opae {
+namespace fpga {
+namespace types {
+
+/** Wraps the OPAE fpga_object primitive.
+ * sysobject's are created from a call to fpgaTokenGetObject,
+ * fpgaHandleGetObject, or fpgaObjectGetObject
+ */
+class sysobject {
+ public:
+  typedef std::shared_ptr<sysobject> ptr_t;
+
+  sysobject(const sysobject &o) = delete;
+
+  sysobject &operator=(const sysobject &o) = delete;
+
+  /**
+   * @brief Get a sysobject from a token. This will be read-only.
+   *
+   * @param t[in] Token object representing a resource.
+   * @param name[in] An identifier representing an object belonging to a
+   * resource
+   * represented by the token.
+   * @param[in] flags Control behavior of object identification and creation.
+   * FPGA_OBJECT_GLOB is used to indicate that the name should be treated as a
+   * globbing expression.  FPGA_OBJECT_RECURSE_ONE indicates that subobjects be
+   * created for objects one level down from the object identified by name.
+   * FPGA_OBJECT_RECURSE_ALL indicates that subobjects be created for all
+   * objects
+   * below the current object identified by name.
+   *
+   * @return A shared_ptr to a sysobject instance.
+   */
+  static sysobject::ptr_t get(token::ptr_t t, const std::string &name,
+                              int flags = 0);
+
+  /**
+   * @brief Get a sysobject from a handle. This will be read-write.
+   *
+   * @param h[in] Handle object representing an open resource.
+   * @param name[in] An identifier representing an object belonging to a
+   * resource
+   * represented by the handle.
+   * @param[in] flags Control behavior of object identification and creation.
+   * FPGA_OBJECT_GLOB is used to indicate that the name should be treated as a
+   * globbing expression.  FPGA_OBJECT_RECURSE_ONE indicates that subobjects be
+   * created for objects one level down from the object identified by name.
+   * FPGA_OBJECT_RECURSE_ALL indicates that subobjects be created for all
+   * objects
+   * below the current object identified by name.
+   *
+   * @return A shared_ptr to a sysobject instance.
+   */
+  static sysobject::ptr_t get(handle::ptr_t h, const std::string &name,
+                              int flags = 0);
+
+  /**
+   * @brief Get a sysobject from a object. This will be read-write if its
+   * parent has created from a handle..
+   *
+   * @param name[in] An identifier representing an object belonging this
+   * object.
+   * @param[in] flags Control behavior of object identification and creation.
+   * FPGA_OBJECT_GLOB is used to indicate that the name should be treated as a
+   * globbing expression.  FPGA_OBJECT_RECURSE_ONE indicates that subobjects be
+   * created for objects one level down from the object identified by name.
+   * FPGA_OBJECT_RECURSE_ALL indicates that subobjects be created for all
+   * objects. Flags are defaulted to 0 meaning no flags.
+   * below the current object identified by name.
+   *
+   * @return A shared_ptr to a sysobject instance.
+   */
+  sysobject::ptr_t get(const std::string &name, int flags = 0);
+
+
+  virtual ~sysobject();
+
+  /**
+   * @brief Read a 64-bit value from an FPGA object.
+   * The value is assumed to be in string format and will be parsed. See flags
+   * below for changing that behavior.
+   *
+   * @param[in] flags Flags that control how the object is read
+   * If FPGA_OBJECT_SYNC is used then object will update its buffered copy before
+   * retrieving the data. If FPGA_OBJECT_RAW is used, then the data will be read
+   * as raw bytes into the uint64_t pointer variable. Flags are defaulted to 0
+   * meaning no flags.
+   *
+   * @return A 64-bit value from the object.
+   */
+  uint64_t read64(int flags = 0) const;
+
+  /**
+   * @brief Write 64-bit value to an FPGA object.
+   * The value will be converted to string before writing. See flags below for
+   * changing that behavior.
+   *
+   * @param value The value to write to the object.
+   * @param[in] flags Flags that control how the object is written
+   * If FPGA_OBJECT_RAW is used, then the value will be written as raw bytes.
+   * Flags are defaulted to 0 meaning no flags.
+   */
+  void write64(uint64_t value, int flags = 0);
+
+  /**
+   * @brief Get all raw bytes from the object.
+   *
+   * @param[in]flags Flags that control how object is read
+   * If FPGA_OBJECT_SYNC is used then object will update its buffered copy before
+   * retrieving the data.
+   *
+   * @return A vector of all bytes in the object.
+   */
+  std::vector<uint8_t> bytes(int flags = 0) const;
+
+  /**
+   * @brief Get a subset of raw bytes from the object.
+   *
+   * @param[in]flags Flags that control how object is read
+   * If FPGA_OBJECT_SYNC is used then object will update its buffered copy before
+   * retrieving the data.
+   *
+   * @return A vector of size bytes in the object starting at offset.
+   */
+  std::vector<uint8_t> bytes(uint32_t offset, uint32_t size,
+                             int flags = 0) const;
+
+  /** Retrieve the underlying fpga_object primitive.
+   */
+  fpga_object c_type() const { return sysobject_; }
+
+  /** Retrieve the underlying fpga_object primitive.
+   */
+  operator fpga_object() const { return sysobject_; }
+
+ private:
+  sysobject();
+
+  fpga_object sysobject_;
+  token::ptr_t token_;
+  handle::ptr_t handle_;
+};
+
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/libopae/plugins/xfpga/sysobject.c
+++ b/libopae/plugins/xfpga/sysobject.c
@@ -151,6 +151,9 @@ fpga_result xfpga_fpgaObjectRead64(fpga_object obj, uint64_t *value, int flags)
 {
 	struct _fpga_object *_obj = (struct _fpga_object *)obj;
 	fpga_result res = FPGA_OK;
+	if (_obj->type != FPGA_SYSFS_FILE) {
+		return FPGA_INVALID_PARAM;
+	}
 	if (flags & FPGA_OBJECT_SYNC) {
 		res = sync_object(obj);
 	}
@@ -172,6 +175,9 @@ fpga_result xfpga_fpgaObjectRead(fpga_object obj, uint8_t *buffer,
 	fpga_result res = FPGA_OK;
 	ASSERT_NOT_NULL(obj);
 	ASSERT_NOT_NULL(buffer);
+	if (_obj->type != FPGA_SYSFS_FILE) {
+		return FPGA_INVALID_PARAM;
+	}
 	if (offset + len > _obj->size) {
 		return FPGA_INVALID_PARAM;
 	}
@@ -200,6 +206,9 @@ fpga_result xfpga_fpgaObjectWrite64(fpga_object obj, uint64_t value, int flags)
 	errno_t err;
 	ASSERT_NOT_NULL(obj);
 	ASSERT_NOT_NULL(_obj->handle);
+	if (_obj->type != FPGA_SYSFS_FILE) {
+		return FPGA_INVALID_PARAM;
+	}
 	res = handle_check_and_lock(_obj->handle);
 	if (res != FPGA_OK) {
 		return res;

--- a/libopae/plugins/xfpga/sysobject.c
+++ b/libopae/plugins/xfpga/sysobject.c
@@ -192,7 +192,7 @@ fpga_result xfpga_fpgaObjectRead(fpga_object obj, uint8_t *buffer,
 		FPGA_ERR("Bytes requested exceed object size");
 		return FPGA_INVALID_PARAM;
 	}
-	memcpy_s(buffer, _obj->max_size, _obj->buffer + offset, len);
+	memcpy_s(buffer, len, _obj->buffer + offset, len);
 
 	return FPGA_OK;
 }

--- a/libopaecxx/CMakeLists.txt
+++ b/libopaecxx/CMakeLists.txt
@@ -53,7 +53,8 @@ set(OPAECXXCORE_SRC src/properties.cpp
                     src/shared_buffer.cpp
                     src/events.cpp
                     src/except.cpp
-		    src/errors.cpp
+                    src/errors.cpp
+                    src/sysobject.cpp
                     src/version.cpp)
 
 add_library(opae-cxx-core SHARED ${OPAECXXCORE_SRC})

--- a/libopaecxx/src/sysobject.cpp
+++ b/libopaecxx/src/sysobject.cpp
@@ -89,7 +89,7 @@ std::vector<uint8_t> sysobject::bytes(int flags) const {
 
 std::vector<uint8_t> sysobject::bytes(uint32_t offset, uint32_t size,
                                       int flags) const {
-  std::vector<uint8_t> bytes(size - offset);
+  std::vector<uint8_t> bytes(size);
   ASSERT_FPGA_OK(fpgaObjectRead(sysobject_, bytes.data(), offset, size, flags));
   return bytes;
 }

--- a/libopaecxx/src/sysobject.cpp
+++ b/libopaecxx/src/sysobject.cpp
@@ -1,0 +1,99 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include <opae/cxx/core/except.h>
+#include <opae/cxx/core/sysobject.h>
+#include <opae/sysobject.h>
+
+namespace opae {
+namespace fpga {
+namespace types {
+
+sysobject::sysobject() : sysobject_(nullptr), handle_(0) {}
+sysobject::~sysobject() {
+  auto res = fpgaDestroyObject(&sysobject_);
+  if (res != FPGA_OK) {
+    std::cerr << "Error while calling fpgaDestroyObject: " << fpgaErrStr(res)
+              << "\n";
+  }
+}
+
+sysobject::ptr_t sysobject::get(token::ptr_t tok, const std::string &path,
+                                int flags) {
+  sysobject::ptr_t obj(new sysobject());
+  auto res =
+      fpgaTokenGetObject(tok->c_type(), path.c_str(), &obj->sysobject_, flags);
+  ASSERT_FPGA_OK(res);
+  obj->token_ = tok;
+  return obj;
+}
+
+sysobject::ptr_t sysobject::get(handle::ptr_t hnd, const std::string &path,
+                                int flags) {
+  sysobject::ptr_t obj(new sysobject());
+  obj->handle_ = hnd;
+  auto res =
+      fpgaHandleGetObject(hnd->c_type(), path.c_str(), &obj->sysobject_, flags);
+  ASSERT_FPGA_OK(res);
+  obj->handle_ = hnd;
+  return obj;
+}
+
+sysobject::ptr_t sysobject::get(const std::string &path, int flags) {
+  sysobject::ptr_t obj(new sysobject());
+  auto res =
+      fpgaObjectGetObject(sysobject_, path.c_str(), &obj->sysobject_, flags);
+  ASSERT_FPGA_OK(res);
+  return obj;
+}
+
+uint64_t sysobject::read64(int flags) const {
+  uint64_t value = 0;
+  ASSERT_FPGA_OK(fpgaObjectRead64(sysobject_, &value, flags));
+  return value;
+}
+
+void sysobject::write64(uint64_t value, int flags) {
+  ASSERT_FPGA_OK(fpgaObjectWrite64(sysobject_, value, flags));
+}
+
+std::vector<uint8_t> sysobject::bytes(int flags) const {
+  uint32_t size;
+  ASSERT_FPGA_OK(fpgaObjectGetSize(sysobject_, &size, flags));
+  std::vector<uint8_t> bytes(size);
+  ASSERT_FPGA_OK(fpgaObjectRead(sysobject_, bytes.data(), 0, size, flags));
+  return bytes;
+}
+
+std::vector<uint8_t> sysobject::bytes(uint32_t offset, uint32_t size,
+                                      int flags) const {
+  std::vector<uint8_t> bytes(size - offset);
+  ASSERT_FPGA_OK(fpgaObjectRead(sysobject_, bytes.data(), offset, size, flags));
+  return bytes;
+}
+
+}  // end of namespace types
+}  // end of namespace fpga
+}  // end of namespace opae

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(opae-cxx-core-static
     ${OPAE_SDK_SOURCE}/libopaecxx/src/properties.cpp
     ${OPAE_SDK_SOURCE}/libopaecxx/src/shared_buffer.cpp
     ${OPAE_SDK_SOURCE}/libopaecxx/src/token.cpp
+    ${OPAE_SDK_SOURCE}/libopaecxx/src/sysobject.cpp
     ${OPAE_SDK_SOURCE}/libopaecxx/src/version.cpp
     )
 target_include_directories(opae-cxx-core-static PUBLIC
@@ -240,6 +241,10 @@ add_mock_test(test_opae_version_cxx_core opae-cxx-core-static
 
 add_mock_test(test_opae_except_cxx_core opae-cxx-core-static
     opae-cxx/test_except_cxx_core.cpp
+)
+
+add_mock_test(test_opae_object_cxx_core opae-cxx-core-static
+    opae-cxx/test_object_cxx_core.cpp
 )
 
 ############################################################################

--- a/testing/opae-cxx/test_object_cxx_core.cpp
+++ b/testing/opae-cxx/test_object_cxx_core.cpp
@@ -1,0 +1,124 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include <opae/cxx/core/sysobject.h>
+
+#include <array>
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+#include "test_system.h"
+
+using namespace opae::testing;
+using namespace opae::fpga::types;
+
+class sysobject_cxx_p : public ::testing::TestWithParam<std::string> {
+ protected:
+  sysobject_cxx_p() {}
+
+  virtual void SetUp() override {
+    ASSERT_TRUE(test_platform::exists(GetParam()));
+    platform_ = test_platform::get(GetParam());
+    system_ = test_system::instance();
+    system_->initialize();
+    system_->prepare_syfs(platform_);
+    invalid_device_ = test_device::unknown();
+
+    ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
+    tokens_ = token::enumerate({properties::get(FPGA_ACCELERATOR)});
+    ASSERT_GT(tokens_.size(), 0);
+    handle_ = handle::open(tokens_[0], 0);
+    ASSERT_NE(handle_.get(), nullptr);
+  }
+
+  virtual void TearDown() override {
+    system_->finalize();
+    tokens_.clear();
+    handle_->close();
+    handle_.reset();
+  }
+
+  std::vector<token::ptr_t> tokens_;
+  handle::ptr_t handle_;
+  test_platform platform_;
+  test_device invalid_device_;
+  test_system *system_;
+};
+
+TEST_P(sysobject_cxx_p, token_object) {
+  auto obj = sysobject::get(tokens_[0], "afu_id");
+  ASSERT_NE(obj.get(), nullptr);
+  auto bytes = obj->bytes();
+  ASSERT_NE(bytes.size(), 0);
+  auto guid_read = std::string(bytes.begin(), bytes.end());
+  auto afu_guid = std::string(platform_.devices[0].afu_guid);
+  system_->normalize_guid(guid_read);
+  system_->normalize_guid(afu_guid);
+  ASSERT_STREQ(afu_guid.c_str(), guid_read.c_str());
+}
+
+TEST_P(sysobject_cxx_p, handle_object) {
+  auto obj = sysobject::get(handle_, "afu_id");
+  ASSERT_NE(obj.get(), nullptr);
+  auto bytes = obj->bytes();
+  ASSERT_NE(bytes.size(), 0);
+  auto guid_read = std::string(bytes.begin(), bytes.end());
+  auto afu_guid = std::string(platform_.devices[0].afu_guid);
+  system_->normalize_guid(guid_read);
+  system_->normalize_guid(afu_guid);
+  ASSERT_STREQ(afu_guid.c_str(), guid_read.c_str());
+  obj = sysobject::get(handle_, "errors/errors");
+  ASSERT_NE(obj.get(), nullptr);
+  EXPECT_NO_THROW(obj->write64((0x1UL << 50)));
+}
+
+TEST_P(sysobject_cxx_p, object_object) {
+  auto t_obj = sysobject::get(tokens_[0], "errors");
+  ASSERT_NE(t_obj.get(), nullptr);
+  auto t_value = t_obj->get("errors")->read64();
+  auto h_obj = sysobject::get(handle_, "errors");
+  ASSERT_NE(h_obj.get(), nullptr);
+  auto h_value = h_obj->get("errors")->read64();
+  EXPECT_EQ(t_value, h_value);
+  EXPECT_THROW(t_obj->get("errors")->write64(0x100),
+               opae::fpga::types::invalid_param);
+  ASSERT_NO_THROW(h_obj->get("errors")->write64(0x100));
+  h_value = h_obj->get("errors")->read64(FPGA_OBJECT_SYNC);
+  EXPECT_NE(t_value, h_value);
+}
+
+TEST_P(sysobject_cxx_p, read_bytes) {
+  auto obj = sysobject::get(tokens_[0], "afu_id");
+  auto bytes = obj->bytes(3, 4);
+  auto str1 = std::string(bytes.begin(), bytes.end());
+  auto str2 = std::string(platform_.devices[0].afu_guid, 3, 4);
+  ASSERT_TRUE(std::equal(str1.begin(), str1.end(), str2.begin(),
+                         [](char lhs, char rhs) {
+                           return std::tolower(lhs) == std::tolower(rhs);
+                         }));
+}
+
+INSTANTIATE_TEST_CASE_P(sysobject_cxx, sysobject_cxx_p,
+                        ::testing::ValuesIn(test_platform::keys(true)));


### PR DESCRIPTION
* The cxx/core/sysobject wraps the Object API
* Add tests cases for cxx sysobject class
* Add some error checking in the Object API read/write routines
  * Check if the object can be read/written (if it's not a dir object)