### PR TITLE
Removed unused variables in test.

### DIFF
--- a/testing/xfpga/test_open_close_c.cpp
+++ b/testing/xfpga/test_open_close_c.cpp
@@ -309,11 +309,9 @@ INSTANTIATE_TEST_CASE_P(openclose_c, openclose_c_p, ::testing::ValuesIn(test_pla
  *
  */
 TEST(openclose_c, invalid_open_close) {
-  fpga_properties filter;
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
   fpga_handle h;
-  uint32_t num_matches = 0;
 
   const std::string sysfs_port = "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-port.0";
   const std::string dev_port = "/dev/intel-fpga-port.0";


### PR DESCRIPTION
Removed unused variables in test code that caused warnings in gcc version 4.8.5-16. Not sure why this is not causing warnings in other versions. Even 4.8.5-11 doesn't catch it. But unused vars is a common check.