### PR TITLE
cover.sh: don't copy coverage files

### DIFF
--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -8,11 +8,8 @@ function finish {
 	find testing -iname "*.gcda" -exec chmod 664 '{}' \;
 	find testing -iname "*.gcno" -exec chmod 664 '{}' \;
 
+	lcov --directory testing --capture --output-file coverage.info
 
-	find testing -iname "*.gcda" | xargs -i cp {} coverage_files
-	find testing -iname "*.gcno" | xargs -i cp {} coverage_files
-
-	lcov --directory coverage_files --capture --output-file coverage.info
 	lcov -a coverage.base -a coverage.info --output-file coverage.total
 	lcov --remove coverage.total '/usr/**' 'tests/**' '*/**/CMakeFiles*' '/usr/*' 'safe_string/**' 'pybind11/*' 'testing/**' --output-file coverage.info.cleaned
 	genhtml --function-coverage -o coverage_report coverage.info.cleaned
@@ -26,17 +23,14 @@ if [ ! -f CMakeCache.txt ]; then
 	cmake .. -DCMAKE_BUILD_TYPE=Coverage -DBUILD_TESTS=ON -DNEW_UNITS=ON -DBUILD_LIBOPAE_PY=OFF
 fi
 
-
 mkdir -p coverage_files
 rm -rf coverage_files/*
 
 echo "Making tests"
-make -j4 test_unit xfpga
-
+make -j 4 test_unit xfpga
 
 lcov --directory . --zerocounters
 lcov -c -i -d . -o coverage.base
-
 
 LD_LIBRARY_PATH=${PWD}/lib \
 CTEST_OUTPUT_ON_FAILURE=1 \


### PR DESCRIPTION
cover.sh was previously copying each of the .gcda and .gcno files
to a directory, squashing the original directory hierarchy. This
resulted in some of the coverage data files being lost, eg both
userclk and coreidle have a main.c file. The change captures the
coverage data from the files in the directory hierarchy where they
are generated.