### PR TITLE
Add ability to query platform names

### DIFF
--- a/testing/platform/fpga_hw.h
+++ b/testing/platform/fpga_hw.h
@@ -86,6 +86,9 @@ struct test_platform {
   static test_platform get(const std::string &key);
   static bool exists(const std::string &key);
   static std::vector<std::string> keys(bool sorted = false);
+  static std::vector<std::string> platforms(std::initializer_list<std::string> names);
+  static std::vector<std::string> mock_platforms(std::initializer_list<std::string> names);
+  static std::vector<std::string> hw_platforms(std::initializer_list<std::string> names);
   template<class P>
   int count_devices(P op) {
     int count = 0;


### PR DESCRIPTION
Add static functions to query platform names based on input names and
whether or not the platform is mocked. This is meant to be used when
instantiating parametereized test fixtures that use the platform name.

Examples include something similar to the following:
```C++
INSTANTIATE_TEST_CASE_P(test, test_p,
		::testing::ValuesIn(test_platform::platforms({"skx-p"})));

INSTANTIATE_TEST_CASE_P(test, test_p,
		::testing::ValuesIn(test_platform::platforms({"skx-p", "dcp-rc"})));

INSTANTIATE_TEST_CASE_P(test, test_p,
		::testing::ValuesIn(test_platform::mock_platforms({"skx-p"})));

INSTANTIATE_TEST_CASE_P(test, test_p,
		::testing::ValuesIn(test_platform::mock_platforms({})));

INSTANTIATE_TEST_CASE_P(test, test_p,
		::testing::ValuesIn(test_platform::hw_platforms({"dcp-rc"})));
```