### PR TITLE
fix compilation of ASE gtase because missing sysfs

### DIFF
--- a/cmake/modules/test_config_ase.cmake
+++ b/cmake/modules/test_config_ase.cmake
@@ -32,9 +32,9 @@ set(COMMON_SRC gtmain.cpp jsonParser.cpp
   unit/gtEnumerate.cpp
   unit/gtOptionParser.cpp
   unit/gtAnyValue.cpp
-  unit/gtsysfs.cpp
+  # unit/gtsysfs.cpp
   function/gtCxxEnumerate.cpp
-  function/gtCxxEvents.cpp
+  # function/gtCxxEvents.cpp
   function/gtCxxOpenClose.cpp
   function/gtCxxProperties.cpp
   function/gtCxxExcept.cpp


### PR DESCRIPTION
fix compilation of ASE gtase because missing sysfs