### PR TITLE
Fix some AFU source file list parsing:

### DIFF
--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -222,12 +222,9 @@ def config_sources(fd, filelist):
         if (len(s) == 0):
             None
         elif (s[0] == '+'):
-            # + simulator commands go in both Verilog and VHDL
+            # + simulator commands go only in Verilog.  VHDL simulation
+            # doesn't support these.
             vlog_srcs.append(s)
-            # Unfortuantely, vhdlan (VCS VHDL simulator) doesn't support
-            # the same directives as the Verilog simulator.
-            if (tool_brand != 'VCS'):
-                vhdl_srcs.append(s)
         elif (s[0] == '-'):
             # For now assume - is an include directive and used only for
             # Verilog. Escape all but the first space, which likely

--- a/platforms/scripts/rtl_src_config
+++ b/platforms/scripts/rtl_src_config
@@ -100,18 +100,7 @@ def lookupTag(filename, db):
 #
 def emitCfg(opts, cfg):
     # Filtering for specific file types?
-    file_type_filter = opts.qsys or opts.ipx or opts.json
-
-    # emit tcl sources
-    # _hw.tcl sources are used to describe and package
-    # components used in a Qsys system. They must be available
-    # in the simulation dir relative to the path specified in
-    # components.ipx with Qsys system
-    if (opts.tcl):
-        for c in cfg:
-            if (lookupTag(c, tcl_tag_map)):
-                print(c)
-        return
+    file_type_filter = opts.qsys or opts.ipx or opts.json or opts.tcl
 
     if (not file_type_filter):
         # First emit all preprocessor configuration
@@ -139,11 +128,10 @@ def emitCfg(opts, cfg):
             None
         elif ("SI:" == c[:3]):
             # Simulator include
-            if (opts.sim):
-                if (lookupTag(c, tcl_tag_map)):
-                    print(c[3:])
-                else:
-                    print("-F " + c[3:])
+            if (lookupTag(c, tcl_tag_map) and (opts.sim or opts.tcl)):
+                print(c[3:])
+            elif (opts.sim):
+                print("-F " + c[3:])
         elif ("QI:" == c[:3]):
             # Quartus include
             if (not opts.sim and not file_type_filter):
@@ -164,9 +152,14 @@ def emitCfg(opts, cfg):
             elif (opts.ipx):
                 if (lookupTag(c, qsys_ipx_tag_map)):
                     print(c)
+            elif (opts.tcl):
+                if (lookupTag(c, tcl_tag_map)):
+                    print(c)
             elif (tag is not None):
-                # QII flow ignores _hw.tcl
-                if(tag is not 'SOURCE_TCL_SCRIPT_FILE'):
+                # We assume that all bare .tcl files are part of Qsys
+                # and ignore them in Quartus flows. To get a .tcl
+                # file in Quartus, use QI:<path to>.tcl.
+                if (tag is not 'SOURCE_TCL_SCRIPT_FILE'):
                     print('set_global_assignment -name {0} "{1}"'
                           .format(tag, c))
 


### PR DESCRIPTION
- VHDL simulation doesn't accept +define in the list of sources.
- QI:foo.tcl was treated as a filename when setting up Qsys simulation.