### PR TITLE
Fix cache statistics reporting in fpgadiag.

### DIFF
--- a/tools/extra/libopae++/fpga_resource.cpp
+++ b/tools/extra/libopae++/fpga_resource.cpp
@@ -215,6 +215,7 @@ std::string fpga_resource::sysfs_path_from_token(fpga_token t)
 {
    struct _fpga_token
    {
+       uint32_t instance;
        uint64_t magic;
        char sysfspath[256];
        char devpath[256];


### PR DESCRIPTION
_fpga_token changed. A better solution here would be to expose sysfspath in
the OPAE API given a token.