### PR TITLE
add test_pyopae binary and some tests

### DIFF
--- a/pyopae/CMakeLists.txt
+++ b/pyopae/CMakeLists.txt
@@ -27,6 +27,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(pyopae)
 set(PYOPAE_PYBIND11_VERSION "2.2")
+
 set(PYOPAE_SRC opae.cpp
                pycontext.h
                pycontext.cpp
@@ -53,7 +54,6 @@ target_include_directories(_opae
 target_link_libraries(_opae PUBLIC opae-c opae-cxx-core)
 set_target_properties(_opae PROPERTIES PREFIX ""
                        CXX_VISIBILITY_PRESET "hidden"
-                       COMPILE_FLAGS "-std=c++11"
                        LINK_FLAGS "-std=c++11"
                        LIBRARY_OUTPUT_DIRECTORY
                        ${LIBRARY_OUTPUT_PATH}/python${OPAE_PYTHON_VERSION}/opae/fpga
@@ -74,7 +74,6 @@ add_custom_command(TARGET _opae
     ${CMAKE_CURRENT_SOURCE_DIR}/test_pyopae.py
     ${LIBRARY_OUTPUT_PATH}/python${OPAE_PYTHON_VERSION}
     COMMENT "Copying Python test files")
-
 
 if (BUILD_PYTHON_DIST)
     set(SETUP_INCLUDE_DIRS "${OPAE_INCLUDE_DIR}:${PYBIND_INCLUDE_DIR}")

--- a/pyopae/opae.cpp
+++ b/pyopae/opae.cpp
@@ -1,5 +1,6 @@
 #include <Python.h>
 
+#include <opae/fpga.h>
 #include <opae/cxx/core/token.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -18,7 +19,15 @@ using opae::fpga::types::shared_buffer;
 using opae::fpga::types::event;
 using opae::fpga::types::error;
 
+#ifdef OPAE_EMBEDDED
+#include <pybind11/embed.h>
+PYBIND11_EMBEDDED_MODULE(_opae, m) {
+  m.def("initialize", &fpgaInitialize);
+#else
 PYBIND11_MODULE(_opae, m) {
+  fpgaInitialize(nullptr);
+#endif
+
   py::options opts;
   // opts.disable_function_signatures();
 
@@ -181,4 +190,5 @@ PYBIND11_MODULE(_opae, m) {
       .def("read_value", &error::read_value, error_doc_read_value());
 
   m.def("errors", error_errors, error_doc_errors());
+
 }

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -170,7 +170,7 @@ target_include_directories(hello_events-static PUBLIC
 set(CMAKE_C_FLAGS "-DSTATIC='' -DHAVE_CONFIG_H ${CMAKE_C_FLAGS} -pthread")
 
 add_custom_target(test_unit)
-
+add_dependencies(test_unit xfpga)
 if (ENABLE_MOCK)
     set(MOCK_C mock/mock.c)
 endif(ENABLE_MOCK)
@@ -214,8 +214,8 @@ include_directories(
     ${OPAE_SDK_SOURCE}/tools/base
     mock
     ${GTEST_INCLUDE_DIRS}
-    {CMAKE_CURRENT_SOURCE_DIR}
-    {CMAKE_CURRENT_SOURCE_DIR}/mock
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/mock
     )
 
 ############################################################################
@@ -515,3 +515,55 @@ add_custom_command(TARGET test_unit
     ${CMAKE_CURRENT_SOURCE_DIR}/mock_sys_tmp-dcp-rc-nlb3.tar.gz
     ${CMAKE_BINARY_DIR}
     )
+
+
+
+ ############################################################################
+ # pyopae tests #############################################################
+ ############################################################################
+ add_executable(test_pyopae
+     ${MOCK_C}
+     pyopae/test_pyopae.cpp
+     ${OPAE_SDK_SOURCE}/pyopae/opae.cpp
+     ${OPAE_SDK_SOURCE}/pyopae/pycontext.h
+     ${OPAE_SDK_SOURCE}/pyopae/pycontext.cpp
+     ${OPAE_SDK_SOURCE}/pyopae/pyproperties.h
+     ${OPAE_SDK_SOURCE}/pyopae/pyproperties.cpp
+     ${OPAE_SDK_SOURCE}/pyopae/pyhandle.h
+     ${OPAE_SDK_SOURCE}/pyopae/pyhandle.cpp
+     ${OPAE_SDK_SOURCE}/pyopae/pytoken.h
+     ${OPAE_SDK_SOURCE}/pyopae/pytoken.cpp
+     ${OPAE_SDK_SOURCE}/pyopae/pyshared_buffer.h
+     ${OPAE_SDK_SOURCE}/pyopae/pyshared_buffer.cpp
+     ${OPAE_SDK_SOURCE}/pyopae/pyevents.h
+     ${OPAE_SDK_SOURCE}/pyopae/pyevents.cpp
+     ${OPAE_SDK_SOURCE}/pyopae/pyerrors.h
+     ${OPAE_SDK_SOURCE}/pyopae/pyerrors.cpp)
+target_compile_definitions(test_pyopae PRIVATE
+    OPAE_EMBEDDED)
+target_include_directories(test_pyopae
+     PRIVATE ${CMAKE_SOURCE_DIR}/pyopae/pybind11/include
+     PRIVATE ${PYTHON_INCLUDE_DIRS}
+     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+add_library(embed INTERFACE)
+target_link_libraries(test_pyopae PUBLIC opae-c opae-cxx-core
+     test_system ${PYTHON_LIBRARIES}
+     PRIVATE embed)
+ add_dependencies(test_unit test_pyopae)
+
+macro(add_pyopae_test pytest)
+    add_custom_command(TARGET test_pyopae
+       POST_BUILD
+       COMMAND ${CMAKE_COMMAND} -E copy
+       ${CMAKE_CURRENT_SOURCE_DIR}/pyopae/${pytest}
+       ${CMAKE_BINARY_DIR}
+       )
+    add_test(
+        NAME ${pytest}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMAND $<TARGET_FILE:test_pyopae> test ${pytest}
+    )
+endmacro(add_pyopae_test pytest)
+
+add_pyopae_test(test_properties.py)
+add_pyopae_test(test_shared_buffers.py)

--- a/testing/mock/test_system.h
+++ b/testing/mock/test_system.h
@@ -38,6 +38,7 @@
 #include <json-c/json.h>
 #include <thread>
 #include <mutex>
+#include <atomic>
 #include "platform/fpga_hw.h"
 
 extern "C" {
@@ -158,6 +159,7 @@ class test_system {
  private:
   test_system();
   std::mutex fds_mutex_;
+  std::atomic_bool initialized_;
   std::string root_;
   std::map<int, mock_object *> fds_;
   std::map<int, ioctl_handler_t> default_ioctl_handlers_;

--- a/testing/pyopae/test_properties.py
+++ b/testing/pyopae/test_properties.py
@@ -27,6 +27,8 @@ import uuid
 import unittest
 NLB0 = "d8424dc4-a4a3-c413-f89e-433683f9040b"
 
+# pylint: disable=E0602, E0603
+
 class TestProperties(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/testing/pyopae/test_properties.py
+++ b/testing/pyopae/test_properties.py
@@ -1,0 +1,197 @@
+# Copyright(c) 2018, Intel Corporation
+#
+# Redistribution  and  use  in source  and  binary  forms,  with  or  without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of  source code  must retain the  above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name  of Intel Corporation  nor the names of its contributors
+#   may be used to  endorse or promote  products derived  from this  software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+# IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+# LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+# CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+# SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+# INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+# CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import uuid
+import unittest
+NLB0 = "d8424dc4-a4a3-c413-f89e-433683f9040b"
+
+class TestProperties(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.system = mockopae.test_system()
+        cls.platform = mockopae.test_platform.get("skx-p")
+        cls.system.initialize()
+        cls.system.prepare_sysfs(cls.platform)
+        opae.fpga.initialize(None)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.system.finalize()
+
+    def test_set_parent(self):
+        props = opae.fpga.properties(type=opae.fpga.DEVICE)
+        toks = opae.fpga.enumerate([props])
+        assert len(toks) > 0
+        props2 = opae.fpga.properties(type=opae.fpga.ACCELERATOR,
+                                      parent=toks[0])
+        assert props2.parent
+        props2 = opae.fpga.properties(type=opae.fpga.ACCELERATOR)
+        props2.parent = toks[0]
+        assert props2.parent
+
+    def test_guid(self):
+        props = opae.fpga.properties(guid=NLB0)
+        guid_str = props.guid
+        guid = uuid.UUID(guid_str)
+        assert str(guid).lower() == NLB0
+        props = opae.fpga.properties()
+        props.guid = NLB0
+        guid_str = props.guid
+        guid = uuid.UUID(guid_str)
+        assert str(guid).lower() == NLB0
+
+    def test_set_objtype_accelerator(self):
+        props = opae.fpga.properties(type=opae.fpga.ACCELERATOR)
+        assert props.type == opae.fpga.ACCELERATOR
+        props = opae.fpga.properties(type=opae.fpga.DEVICE)
+        props.type = opae.fpga.ACCELERATOR
+        assert props.type == opae.fpga.ACCELERATOR
+
+    def test_set_objtype_device(self):
+        props = opae.fpga.properties(type=opae.fpga.DEVICE)
+        assert props.type == opae.fpga.DEVICE
+        props = opae.fpga.properties(type=opae.fpga.ACCELERATOR)
+        props.type = opae.fpga.DEVICE
+        assert props.type == opae.fpga.DEVICE
+
+    def test_set_segment(self):
+        props = opae.fpga.properties(segment=0x9090)
+        assert props.segment == 0x9090
+        props.segment = 0xA1A1
+        assert props.segment == 0xA1A1
+
+    def test_set_bus(self):
+        props = opae.fpga.properties(bus=0x5e)
+        assert props.bus == 0x5e
+        props.bus = 0xbe
+        assert props.bus == 0xbe
+
+    def test_set_device(self):
+        props = opae.fpga.properties(device=0xe)
+        assert props.device == 0xe
+        props.device = 0xf
+        assert props.device == 0xf
+
+    def test_set_function(self):
+        props = opae.fpga.properties(function=0x7)
+        assert props.function == 0x7
+        props.function = 0x6
+        assert props.function == 0x6
+
+    def test_set_socket_id(self):
+        props = opae.fpga.properties(socket_id=1)
+        assert props.socket_id == 1
+        props.socket_id = 0
+        assert props.socket_id == 0
+
+    def test_set_object_id(self):
+        props = opae.fpga.properties(object_id=0xcafe)
+        assert props.object_id == 0xcafe
+        props.object_id = 0xfade
+        assert props.object_id == 0xfade
+
+    def test_set_num_errors(self):
+        props = opae.fpga.properties(num_errors=8)
+        assert props.num_errors == 8
+        props.num_errors = 4
+        assert props.num_errors == 4
+
+    def test_set_num_slots(self):
+        props = opae.fpga.properties(type=opae.fpga.DEVICE,
+                                     num_slots=3)
+        assert props.num_slots == 3
+        props.num_slots = 2
+        assert props.num_slots == 2
+
+    def test_set_bbs_id(self):
+        props = opae.fpga.properties(type=opae.fpga.DEVICE,
+                                     bbs_id=0xc0c0cafe)
+        assert props.bbs_id == 0xc0c0cafe
+        props.bbs_id = 0xb0b0fade
+        assert props.bbs_id == 0xb0b0fade
+
+    def test_set_bbs_version(self):
+        props = opae.fpga.properties(type=opae.fpga.DEVICE,
+                                     bbs_version=(0, 1, 2))
+        assert props.bbs_version == (0, 1, 2)
+        props.bbs_version = (1, 2, 3)
+        assert props.bbs_version == (1, 2, 3)
+
+    def test_set_vendor_id(self):
+        props = opae.fpga.properties(vendor_id=0xfafa)
+        assert props.vendor_id == 0xfafa
+        props.vendor_id = 0xdada
+        assert props.vendor_id == 0xdada
+
+    def test_set_device_id(self):
+        props = opae.fpga.properties(device_id=0xfa)
+        assert props.device_id == 0xfa
+        props.device_id = 0xda
+        assert props.device_id == 0xda
+
+    @unittest.skip("model not implemented yet")
+    def test_set_model(self):
+        props = opae.fpga.properties(model="intel skxp")
+        assert props.model == "intel skxp"
+        props.model = "intel skxp 2"
+        assert props.model == "intel skxp 2"
+
+    @unittest.skip("local_memory_size not implemented yet")
+    def test_set_local_memory_size(self):
+        props = opae.fpga.properties(local_memory_size=0xffff)
+        assert props.local_memory_size == 0xffff
+        props.local_memory_size = 0xaaaa
+        assert props.local_memory_size == 0xaaaa
+
+    @unittest.skip("capabilities not implemented yet")
+    def test_set_capabilities(self):
+        props = opae.fpga.properties(capabilities=0xdeadbeef)
+        assert props.capabilities == 0xdeadbeef
+        props.capabilities = 0xfeebdaed
+        assert props.capabilities == 0xfeebdaed
+
+    def test_set_num_mmio(self):
+        props = opae.fpga.properties(type=opae.fpga.ACCELERATOR,
+                                     num_mmio=4)
+        assert props.num_mmio == 4
+        props.num_mmio = 5
+        assert props.num_mmio == 5
+
+    def test_set_num_interrupts(self):
+        props = opae.fpga.properties(type=opae.fpga.ACCELERATOR,
+                                     num_interrupts=9)
+        assert props.num_interrupts == 9
+        props.num_interrupts = 8
+        assert props.num_interrupts == 8
+
+    def test_set_accelerator_state(self):
+        props = opae.fpga.properties(
+            type=opae.fpga.ACCELERATOR,
+            accelerator_state=opae.fpga.ACCELERATOR_ASSIGNED)
+        assert props.accelerator_state == opae.fpga.ACCELERATOR_ASSIGNED
+        props.accelerator_state = opae.fpga.ACCELERATOR_UNASSIGNED
+        assert props.accelerator_state == opae.fpga.ACCELERATOR_UNASSIGNED
+
+

--- a/testing/pyopae/test_pyopae.cpp
+++ b/testing/pyopae/test_pyopae.cpp
@@ -1,0 +1,81 @@
+#include <Python.h>
+
+#include <pybind11/embed.h>
+#include <pybind11/pybind11.h>
+#include <fstream>
+#include <iostream>
+#include "mock/test_system.h"
+#include "platform/fpga_hw.h"
+
+namespace py = pybind11;
+using namespace opae::testing;
+
+PYBIND11_EMBEDDED_MODULE(mopae, m) {
+  m.doc() = "Open Programmable Acceleration Engine";
+}
+
+PYBIND11_EMBEDDED_MODULE(mockopae, m) {
+  py::class_<test_platform> pytp(m, "test_platform");
+  pytp.def_static("platforms", &test_platform::platforms);
+  pytp.def_static("get", &test_platform::get);
+
+  py::class_<test_device> pytd(m, "test_device");
+  py::class_<test_system> pyts(m, "test_system");
+
+  pyts.def(py::init(&test_system::instance))
+      .def("initialize", &test_system::initialize)
+      .def("finalize", &test_system::finalize)
+      .def("prepare_sysfs", &test_system::prepare_syfs)
+      .def("remove_sysfs", &test_system::remove_sysfs);
+}
+
+int run_unittest(const char *testpy, py::module pymain) {
+  auto globals = py::globals();
+  auto mock = py::module::import("mockopae");
+  auto unit = py::module::import("unittest");
+  auto scope = py::dict(pymain.attr("__dict__"));
+  globals["mockopae"] = mock;
+  globals["unittest"] = unit;
+  try {
+    py::eval_file(testpy, scope);
+    auto suite = unit.attr("TestLoader")().attr("loadTestsFromModule")(pymain);
+    py::dict kwargs;
+    kwargs["verbosity"] = 2;
+    auto runner = unit.attr("TextTestRunner")(**kwargs);
+    auto result = runner.attr("run")(suite);
+    return result.attr("wasSuccessful")().cast<bool>() ? 0 : 1;
+  } catch (const py::error_already_set &ex) {
+    std::cerr << "error executing: " << testpy << " - " << ex.what() << "\n";
+  }
+  return EXIT_FAILURE;
+}
+
+int main(int argc, char *argv[]) {
+  py::scoped_interpreter guard{};
+  auto locals = py::dict();
+  auto globals = py::globals();
+  auto mopae = py::module::import("mopae");
+  auto _opae = py::module::import("_opae");
+  mopae.attr("fpga") = _opae;
+  globals["opae"] = mopae;
+  if (argc > 1) {
+    auto pymain = py::module::import("__main__");
+    if (argc > 2 && std::string(argv[1]) == "test") {
+      return run_unittest(argv[2], pymain);
+    }
+    py::list pyargv;
+    auto sys = py::module::import("sys");
+    for (int i = 1; i < argc; ++i) {
+      pyargv.append(argv[i]);
+    }
+    sys.attr("argv") = pyargv;
+    try {
+      py::eval_file(argv[1], pymain.attr("__dict__"));
+    } catch (py::error_already_set &pyerr) {
+      if (!pyerr.matches(PyExc_SystemExit)) {
+        pyerr.restore();
+      }
+    }
+  }
+  return 0;
+}

--- a/testing/pyopae/test_shared_buffers.py
+++ b/testing/pyopae/test_shared_buffers.py
@@ -26,6 +26,8 @@
 import struct
 import sys
 
+# pylint: disable=E0602, E0603
+
 class TestSharedBuffer(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/testing/pyopae/test_shared_buffers.py
+++ b/testing/pyopae/test_shared_buffers.py
@@ -1,0 +1,84 @@
+# Copyright(c) 2018, Intel Corporation
+#
+# Redistribution  and  use  in source  and  binary  forms,  with  or  without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of  source code  must retain the  above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name  of Intel Corporation  nor the names of its contributors
+#   may be used to  endorse or promote  products derived  from this  software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+# IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+# LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+# CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+# SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+# INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+# CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import struct
+import sys
+
+class TestSharedBuffer(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.system = mockopae.test_system()
+        cls.platform = mockopae.test_platform.get("skx-p")
+        cls.system.initialize()
+        cls.system.prepare_sysfs(cls.platform)
+        opae.fpga.initialize(None)
+        cls.props = opae.fpga.properties(type=opae.fpga.ACCELERATOR)
+        cls.toks = opae.fpga.enumerate([cls.props])
+        assert cls.toks
+        cls.handle = opae.fpga.open(cls.toks[0])
+        assert cls.handle
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.system.finalize()
+
+    def test_allocate(self):
+        buff1 = opae.fpga.allocate_shared_buffer(self.handle, 4096)
+        buff2 = opae.fpga.allocate_shared_buffer(self.handle, 4096)
+        assert buff1
+        assert buff2
+        assert buff1.size() == 4096
+        assert buff1.wsid() != 0
+        # TODO: look into wsid in new mock system
+        # assert buff1.io_address() != 0
+        mv = memoryview(buff1)
+        assert mv
+        assert not buff1.compare(buff2, 4096)
+        buff1.fill(0xAA)
+        buff2.fill(0xEE)
+        assert buff1.compare(buff2, 4096)
+        if sys.version_info[0] == 2:
+            assert mv[0] == '\xaa'
+            assert mv[-1] == '\xaa'
+        else:
+            assert mv[0] == 0xaa
+            assert mv[-1] == 0xaa
+        ba = bytearray(buff1)
+        assert ba[0] == 0xaa
+        buff1[42] = int(65536)
+        assert struct.unpack('<L', (bytearray(buff1[42:46])))[0] == 65536
+
+    def test_conext_release(self):
+        assert self.handle
+        self.handle.close()
+        with opae.fpga.open(self.toks[0]) as h:
+            buff = opae.fpga.allocate_shared_buffer(h, 4096)
+            assert buff
+            assert buff.size() == 4096
+            assert buff.wsid() != 0
+        assert not h
+        assert buff.size() == 0
+        assert buff.wsid() == 0
+

--- a/testing/ras/test_main_c.cpp
+++ b/testing/ras/test_main_c.cpp
@@ -456,7 +456,6 @@ TEST_P(ras_c_p, test_page_fault_errors){
  *             FPGA_INVALID_PARAM.<br>
  */
 TEST_P(ras_c_p, invalid_print_token_errors){
-  uint32_t num_matches = 0;
   fpga_token tok = nullptr;
   const std::string sysfs_port = "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-port.0/errors/errors";
 


### PR DESCRIPTION
test_pyopae binary uses pybind11 to embed the python interpreter and to
create opae.fpga as an embedded module along with test_system,
test_platform, and test_device.

test_pyopae uses the first argument to determine if it should run unit
tests defined in an external file. If the first command line argument is
`test`, it evaluates the script identified by the next argument.
This script is assumed to contain tests compatible with the Python
unittest module.

If the first argument is not `test`, the script will be simply evaluated within the context of the embedded interpreter.

In order to embed the opae.fpga module, a preprocessor definition was
added to control how the pybind11 module is defnined (embedded or not).
It also exposes fpgaInitailize as a module method, `initialize` when it
is embedded. This allows calling initialize when running on mock
devices.

This commit also adds two Python test scripts, test_properties.py and
test_shared_buffers.py and adds CMake tests for running them with
test_pyopae.

test_system is changed to include an atomic bool variable to indicate if
it has been initialized. If it hasn't, it will pass through to glibc
calls open and close.
TODO: Add similar logic to the other mocked calls.