### PR TITLE
Updated xfpga sysfs tests to work on hw.

### DIFF
--- a/testing/xfpga/test_sysfs_c.cpp
+++ b/testing/xfpga/test_sysfs_c.cpp
@@ -553,7 +553,6 @@ TEST_P(sysfs_c_mock_p, make_sysfs) {
   EXPECT_EQ(res, FPGA_NOT_FOUND);
 
   res = make_sysfs_group(tok->sysfspath, "errors", &obj,
-//                         0, handle_);
                          FPGA_OBJECT_RECURSE_ONE, handle_);
   EXPECT_EQ(res, FPGA_OK);
 

--- a/testing/xfpga/test_sysfs_c.cpp
+++ b/testing/xfpga/test_sysfs_c.cpp
@@ -497,6 +497,7 @@ TEST_P(sysfs_c_hw_p, make_sysfs) {
   res = make_sysfs_group(tok->sysfspath, "errors", &obj, FPGA_OBJECT_GLOB,
                          handle_);
   EXPECT_EQ(res, FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&obj), FPGA_OK);
 
   res = make_sysfs_group(const_cast<char *>(invalid_path.c_str()), "errors",
                          &obj, 0, handle_);

--- a/testing/xfpga/test_sysfs_c.cpp
+++ b/testing/xfpga/test_sysfs_c.cpp
@@ -77,6 +77,8 @@ class sysfs_c_p : public ::testing::TestWithParam<std::string> {
     system_->prepare_syfs(platform_);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
+    ASSERT_EQ(fpgaPropertiesSetDeviceID(filter_, 
+                                        platform_.devices[0].device_id), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
     ASSERT_EQ(xfpga_fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
                                   &num_matches_),
@@ -242,31 +244,6 @@ TEST(sysfs_c, cat_handle_sysfs_path) {
 }
 
 /**
-* @test    make_sysfs_group
-* @details
-*/
-TEST_P(sysfs_c_p, make_sysfs) {
-  const std::string invalid_path =
-      "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme";
-  _fpga_token *tok = static_cast<_fpga_token *>(tokens_[0]);
-  fpga_object obj;
-  auto res = make_sysfs_group(tok->sysfspath, "errors", &obj, 0, handle_);
-  EXPECT_EQ(res, FPGA_OK);
-
-  res = make_sysfs_group(tok->sysfspath, "errors", &obj, FPGA_OBJECT_GLOB,
-                         handle_);
-  EXPECT_NE(res, FPGA_OK);
-
-  res = make_sysfs_group(const_cast<char *>(invalid_path.c_str()), "errors",
-                         &obj, 0, handle_);
-  EXPECT_EQ(res, FPGA_NOT_FOUND);
-
-  res = make_sysfs_group(tok->sysfspath, "errors", &obj,
-                         FPGA_OBJECT_RECURSE_ONE, handle_);
-  EXPECT_EQ(res, FPGA_OK);
-}
-
-/**
 * @test    make_object
 * @details
 */
@@ -276,19 +253,6 @@ TEST_P(sysfs_c_p, make_object) {
   // errors is a sysfs directory - this should call make_sysfs_group()
   ASSERT_EQ(make_sysfs_object(tok->sysfspath, "errors", &object, 0, 0),
             FPGA_OK);
-}
-
-/**
-* @test   make_object_glob
-* @details
-*/
-TEST_P(sysfs_c_p, make_object_glob) {
-  _fpga_token *tok = static_cast<_fpga_token *>(tokens_[0]);
-  fpga_object object;
-  // errors is a sysfs directory - this should call make_sysfs_group()
-  ASSERT_NE(
-      make_sysfs_object(tok->sysfspath, "errors", &object, FPGA_OBJECT_GLOB, 0),
-      FPGA_OK);
 }
 
 /**
@@ -446,11 +410,6 @@ TEST_P(sysfs_c_p, fpga_sysfs_02) {
                            0x100);
   EXPECT_NE(result, FPGA_OK);
 
-  // valid path
-  result = sysfs_write_u64(
-      "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0/socket_id", 0);
-  EXPECT_EQ(result, FPGA_OK);
-
   // Invalid input parameters
   fpga_guid guid;
   result = sysfs_read_guid(NULL, NULL);
@@ -473,45 +432,6 @@ TEST_P(sysfs_c_p, fpga_sysfs_02) {
   // NULL handle
   result = get_fpga_deviceid(NULL, NULL);
   EXPECT_NE(result, FPGA_OK);
-}
-
-/**
-* @test    sysfs_get_pr_id
-* @details sysfs_get_pr_id given a valid bitstream
-*          return FPGA_NOT_FOUND from sysfs_read_guid
-*/
-TEST(sysfs_c, sysfs_get_pr_id) {
-  int dev = 0;
-  int subdev = 0;
-  fpga_guid guid;
-  auto res = sysfs_get_pr_id(dev, subdev, guid);
-  EXPECT_NE(res, FPGA_OK);
-}
-
-/**
-* @test    sysfs_get_slots
-* @details sysfs_get_slots given a valid parameters
-*          return FPGA_NOT_FOUND from sysfs_read_u32
-*/
-TEST(sysfs_c, sysfs_get_slots) {
-  int dev = 0;
-  int subdev = 0;
-  uint32_t u32;
-  auto res = sysfs_get_slots(dev, subdev, &u32);
-  EXPECT_NE(res, FPGA_OK);
-}
-
-/**
-* @test    sysfs_get_bitstream_id
-* @details sysfs_get_bitstream_id given a valid parameters
-*          return FPGA_NOT_FOUND from sysfs_read_u64
-*/
-TEST(sysfs_c, sysfs_get_bitstream_id) {
-  int dev = 0;
-  int subdev = 0;
-  uint64_t u64;
-  auto res = sysfs_get_bitstream_id(dev, subdev, &u64);
-  EXPECT_NE(res, FPGA_OK);
 }
 
 /**
@@ -554,3 +474,154 @@ TEST(sysfs_c, cstr_dup) {
 
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_p,
                         ::testing::ValuesIn(test_platform::keys(true)));
+
+class sysfs_c_hw_p : public sysfs_c_p {
+ protected:
+  sysfs_c_hw_p() {}
+};
+
+/**
+ * @test    make_sysfs_group
+ * @details
+ */
+TEST_P(sysfs_c_hw_p, make_sysfs) {
+  const std::string invalid_path =
+      "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme";
+  _fpga_token *tok = static_cast<_fpga_token *>(tokens_[0]);
+  fpga_object obj;
+  auto res = make_sysfs_group(tok->sysfspath, "errors", &obj, 0, handle_);
+  EXPECT_EQ(res, FPGA_OK);
+
+  res = make_sysfs_group(tok->sysfspath, "errors", &obj, FPGA_OBJECT_GLOB,
+                         handle_);
+  EXPECT_EQ(res, FPGA_OK);
+
+  res = make_sysfs_group(const_cast<char *>(invalid_path.c_str()), "errors",
+                         &obj, 0, handle_);
+  EXPECT_EQ(res, FPGA_NOT_FOUND);
+
+  res = make_sysfs_group(tok->sysfspath, "errors", &obj,
+                         FPGA_OBJECT_RECURSE_ONE, handle_);
+  EXPECT_EQ(res, FPGA_OK);
+}
+
+/**
+ * @test   make_object_glob
+ * @details
+ */
+TEST_P(sysfs_c_hw_p, make_object_glob) {
+  _fpga_token *tok = static_cast<_fpga_token *>(tokens_[0]);
+  fpga_object object;
+  // errors is a sysfs directory - this should call make_sysfs_group()
+  ASSERT_EQ(make_sysfs_object(tok->sysfspath, "errors", &object,
+                              FPGA_OBJECT_GLOB, 0),
+            FPGA_OK);
+}
+
+INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_hw_p,
+                        ::testing::ValuesIn(test_platform::hw_platforms()));
+
+class sysfs_c_mock_p : public sysfs_c_p {
+ protected:
+  sysfs_c_mock_p() {}
+};
+
+/**
+ * @test    make_sysfs_group
+ * @details
+ */
+TEST_P(sysfs_c_mock_p, make_sysfs) {
+  const std::string invalid_path =
+      "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme";
+  _fpga_token *tok = static_cast<_fpga_token *>(tokens_[0]);
+  fpga_object obj;
+  auto res = make_sysfs_group(tok->sysfspath, "errors", &obj, 0, handle_);
+  EXPECT_EQ(res, FPGA_OK);
+
+  res = make_sysfs_group(tok->sysfspath, "errors", &obj, FPGA_OBJECT_GLOB,
+                         handle_);
+  EXPECT_NE(res, FPGA_OK);
+
+  res = make_sysfs_group(const_cast<char *>(invalid_path.c_str()), "errors",
+                         &obj, 0, handle_);
+  EXPECT_EQ(res, FPGA_NOT_FOUND);
+
+  res = make_sysfs_group(tok->sysfspath, "errors", &obj,
+                         FPGA_OBJECT_RECURSE_ONE, handle_);
+  EXPECT_EQ(res, FPGA_OK);
+}
+
+/**
+ * @test   make_object_glob
+ * @details
+ */
+TEST_P(sysfs_c_mock_p, make_object_glob) {
+  _fpga_token *tok = static_cast<_fpga_token *>(tokens_[0]);
+  fpga_object object;
+  // errors is a sysfs directory - this should call make_sysfs_group()
+  ASSERT_NE(make_sysfs_object(tok->sysfspath, "errors", &object, 
+                              FPGA_OBJECT_GLOB, 0),
+            FPGA_OK);
+}
+
+/**
+ * @test    fpga_sysfs_02
+ *          sysfs_write_u64
+ */
+TEST_P(sysfs_c_mock_p, fpga_sysfs_02) {
+  fpga_result result;
+  // valid path
+  result = sysfs_write_u64(
+           "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0/socket_id", 0);
+  EXPECT_EQ(result, FPGA_OK);
+}
+
+INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_mock_p,
+                        ::testing::ValuesIn(test_platform::mock_platforms()));
+
+class sysfs_c_mock_no_drv_p : public ::testing::TestWithParam<std::string> {
+ protected:
+  sysfs_c_mock_no_drv_p() {}
+};
+
+/**
+ * @test    sysfs_get_pr_id
+ * @details sysfs_get_pr_id given a valid bitstream
+ *          return FPGA_NOT_FOUND from sysfs_read_guid
+ */
+TEST_P(sysfs_c_mock_no_drv_p, sysfs_get_pr_id) {
+  int dev = 0;
+  int subdev = 0;
+  fpga_guid guid;
+  auto res = sysfs_get_pr_id(dev, subdev, guid);
+  EXPECT_NE(res, FPGA_OK);
+}
+
+/**
+ * @test    sysfs_get_slots
+ * @details sysfs_get_slots given a valid parameters
+ *          return FPGA_NOT_FOUND from sysfs_read_u32
+ */
+TEST_P(sysfs_c_mock_no_drv_p, sysfs_get_slots) {
+  int dev = 0;
+  int subdev = 0;
+  uint32_t u32;
+  auto res = sysfs_get_slots(dev, subdev, &u32);
+  EXPECT_NE(res, FPGA_OK);
+}
+
+/**
+ * @test    sysfs_get_bitstream_id
+ * @details sysfs_get_bitstream_id given a valid parameters
+ *          return FPGA_NOT_FOUND from sysfs_read_u64
+ */
+TEST_P(sysfs_c_mock_no_drv_p, sysfs_get_bitstream_id) {
+  int dev = 0;
+  int subdev = 0;
+  uint64_t u64;
+  auto res = sysfs_get_bitstream_id(dev, subdev, &u64);
+  EXPECT_NE(res, FPGA_OK);
+}
+
+INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_mock_no_drv_p,
+                        ::testing::ValuesIn(test_platform::mock_platforms()));

--- a/testing/xfpga/test_sysfs_c.cpp
+++ b/testing/xfpga/test_sysfs_c.cpp
@@ -253,6 +253,7 @@ TEST_P(sysfs_c_p, make_object) {
   // errors is a sysfs directory - this should call make_sysfs_group()
   ASSERT_EQ(make_sysfs_object(tok->sysfspath, "errors", &object, 0, 0),
             FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
 }
 
 /**
@@ -491,6 +492,7 @@ TEST_P(sysfs_c_hw_p, make_sysfs) {
   fpga_object obj;
   auto res = make_sysfs_group(tok->sysfspath, "errors", &obj, 0, handle_);
   EXPECT_EQ(res, FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&obj), FPGA_OK);
 
   res = make_sysfs_group(tok->sysfspath, "errors", &obj, FPGA_OBJECT_GLOB,
                          handle_);
@@ -503,6 +505,7 @@ TEST_P(sysfs_c_hw_p, make_sysfs) {
   res = make_sysfs_group(tok->sysfspath, "errors", &obj,
                          FPGA_OBJECT_RECURSE_ONE, handle_);
   EXPECT_EQ(res, FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&obj), FPGA_OK);
 }
 
 /**
@@ -516,6 +519,7 @@ TEST_P(sysfs_c_hw_p, make_object_glob) {
   ASSERT_EQ(make_sysfs_object(tok->sysfspath, "errors", &object,
                               FPGA_OBJECT_GLOB, 0),
             FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
 }
 
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_hw_p,
@@ -535,8 +539,10 @@ TEST_P(sysfs_c_mock_p, make_sysfs) {
       "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-fme";
   _fpga_token *tok = static_cast<_fpga_token *>(tokens_[0]);
   fpga_object obj;
+
   auto res = make_sysfs_group(tok->sysfspath, "errors", &obj, 0, handle_);
   EXPECT_EQ(res, FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&obj), FPGA_OK);
 
   res = make_sysfs_group(tok->sysfspath, "errors", &obj, FPGA_OBJECT_GLOB,
                          handle_);
@@ -547,8 +553,11 @@ TEST_P(sysfs_c_mock_p, make_sysfs) {
   EXPECT_EQ(res, FPGA_NOT_FOUND);
 
   res = make_sysfs_group(tok->sysfspath, "errors", &obj,
+//                         0, handle_);
                          FPGA_OBJECT_RECURSE_ONE, handle_);
   EXPECT_EQ(res, FPGA_OK);
+
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&obj), FPGA_OK);
 }
 
 /**


### PR DESCRIPTION
Updated the tests to enumerate based on the current platform's device id.
Moved sysfs_get_pr_id, sysfs_get_slots, and sysfs_get_bitstream_id tests to mock only without driver due to them expecting no driver.
Separated make_sysfs and make_object_glob tests into mock only and hw only tests.