### PR TITLE
Add Python bindings for sysobject API

### DIFF
--- a/common/include/opae/cxx/core/sysobject.h
+++ b/common/include/opae/cxx/core/sysobject.h
@@ -166,7 +166,6 @@ class sysobject {
    */
   fpga_object c_type() const { return sysobject_; }
 
-
   /** Retrieve the underlying fpga_object primitive.
    */
   operator fpga_object() const { return sysobject_; }

--- a/common/include/opae/cxx/core/sysobject.h
+++ b/common/include/opae/cxx/core/sysobject.h
@@ -103,6 +103,13 @@ class sysobject {
   virtual ~sysobject();
 
   /**
+   * @brief Get the size (in bytes) of the object.
+   *
+   * @return The number of bytes that the object occupies in memory.
+   */
+  uint32_t size() const;
+
+  /**
    * @brief Read a 64-bit value from an FPGA object.
    * The value is assumed to be in string format and will be parsed. See flags
    * below for changing that behavior.
@@ -126,8 +133,11 @@ class sysobject {
    * @param[in] flags Flags that control how the object is written
    * If FPGA_OBJECT_RAW is used, then the value will be written as raw bytes.
    * Flags are defaulted to 0 meaning no flags.
+   *
+   * @note This operation will force a sync operation to update its cached
+   * buffer
    */
-  void write64(uint64_t value, int flags = 0);
+  void write64(uint64_t value, int flags = 0) const;
 
   /**
    * @brief Get all raw bytes from the object.
@@ -156,13 +166,13 @@ class sysobject {
    */
   fpga_object c_type() const { return sysobject_; }
 
+
   /** Retrieve the underlying fpga_object primitive.
    */
   operator fpga_object() const { return sysobject_; }
 
  private:
   sysobject();
-
   fpga_object sysobject_;
   token::ptr_t token_;
   handle::ptr_t handle_;

--- a/common/include/opae/types_enum.h
+++ b/common/include/opae/types_enum.h
@@ -144,7 +144,7 @@ enum fpga_reconf_flags {
 	FPGA_RECONF_FORCE = (1u << 0)
 };
 
-enum fpga_object_read_flags {
+enum fpga_sysobject_flags {
   FPGA_OBJECT_SYNC = (1u << 0), /**< Synchronize data from driver */
   FPGA_OBJECT_GLOB = (1u << 1), /**< Treat names as glob expressions */
   FPGA_OBJECT_RAW  = (1u << 2), /**< Read or write object data as raw bytes */

--- a/pyopae/CMakeLists.txt
+++ b/pyopae/CMakeLists.txt
@@ -42,7 +42,10 @@ set(PYOPAE_SRC opae.cpp
                pyevents.h
                pyevents.cpp
                pyerrors.h
-               pyerrors.cpp)
+               pyerrors.cpp
+               pysysobject.h
+               pysysobject.cpp
+               )
 
 set(PYBIND_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/pybind11/include)
 include_directories(${PYBIND_INCLUDE_DIR}

--- a/pyopae/opae.cpp
+++ b/pyopae/opae.cpp
@@ -1,14 +1,15 @@
 #include <Python.h>
-
-#include <opae/fpga.h>
 #include <opae/cxx/core/token.h>
+#include <opae/fpga.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <exception>
 #include "pyerrors.h"
 #include "pyevents.h"
 #include "pyhandle.h"
 #include "pyproperties.h"
 #include "pyshared_buffer.h"
+#include "pysysobject.h"
 #include "pytoken.h"
 
 namespace py = pybind11;
@@ -18,6 +19,7 @@ using opae::fpga::types::handle;
 using opae::fpga::types::shared_buffer;
 using opae::fpga::types::event;
 using opae::fpga::types::error;
+using opae::fpga::types::sysobject;
 
 #ifdef OPAE_EMBEDDED
 #include <pybind11/embed.h>
@@ -71,6 +73,15 @@ PYBIND11_MODULE(_opae, m) {
                                     py::arithmetic(), "OPAE accelerator_state")
       .value("ACCELERATOR_ASSIGNED", FPGA_ACCELERATOR_ASSIGNED)
       .value("ACCELERATOR_UNASSIGNED", FPGA_ACCELERATOR_UNASSIGNED)
+      .export_values();
+
+  py::enum_<fpga_sysobject_flags>(m, "fpga_sysobject_flags", py::arithmetic(),
+                                  "OPAE sysobject API flags.")
+      .value("SYSOBJECT_SYNC", FPGA_OBJECT_SYNC)
+      .value("SYSOBJECT_RAW", FPGA_OBJECT_RAW)
+      .value("SYSOBJECT_GLOB", FPGA_OBJECT_GLOB)
+      .value("SYSOBJECT_RECURSE_ONE", FPGA_OBJECT_RECURSE_ONE)
+      .value("SYSOBJECT_RECURSE_ALL", FPGA_OBJECT_RECURSE_ALL)
       .export_values();
 
   py::enum_<fpga_reconf_flags>(
@@ -135,6 +146,11 @@ PYBIND11_MODULE(_opae, m) {
   m.def("enumerate", &token::enumerate, token_doc_enumerate())
       .def("enumerate", token_enumerate_kwargs, token_doc_enumerate_kwargs());
   py::class_<token, token::ptr_t> pytoken(m, "token", token_doc());
+  pytoken
+      .def("__getattr__", token_get_sysobject, sysobject_doc_token_get())
+      .def("__getitem__", token_get_sysobject, sysobject_doc_token_get())
+      .def("find", token_find_sysobject, sysobject_doc_token_find(),
+           py::arg("name"), py::arg("flags") = 0);
 
   // define handle class
   m.def("open", handle_open, handle_doc_open(), py::arg("tok"),
@@ -154,7 +170,11 @@ PYBIND11_MODULE(_opae, m) {
       .def("write_csr32", &handle::write_csr32, handle_doc_write_csr32(),
            py::arg("offset"), py::arg("value"), py::arg("csr_space") = 0)
       .def("write_csr64", &handle::write_csr64, handle_doc_write_csr64(),
-           py::arg("offset"), py::arg("value"), py::arg("csr_space") = 0);
+           py::arg("offset"), py::arg("value"), py::arg("csr_space") = 0)
+      .def("__getattr__", handle_get_sysobject, sysobject_doc_handle_get())
+      .def("__getitem__", handle_get_sysobject, sysobject_doc_handle_get())
+      .def("find", token_find_sysobject, sysobject_doc_handle_find(),
+           py::arg("name"), py::arg("flags") = 0);
 
   // define shared_buffer class
   m.def("allocate_shared_buffer", shared_buffer_allocate,
@@ -191,4 +211,19 @@ PYBIND11_MODULE(_opae, m) {
 
   m.def("errors", error_errors, error_doc_errors());
 
+  // define object class
+  py::class_<sysobject, sysobject::ptr_t> pysysobject(m, "sysobject",
+                                                      sysobject_doc());
+  pysysobject
+      .def("__getattr__", sysobject_get_sysobject, sysobject_doc_object_get())
+      .def("__getitem__", sysobject_get_sysobject, sysobject_doc_object_get())
+      .def("find", sysobject_find_sysobject, sysobject_doc_object_find(),
+           py::arg("name"), py::arg("flags") = 0)
+      .def("read64",
+           [](sysobject::ptr_t obj) { return obj->read64(FPGA_OBJECT_SYNC); })
+      .def("write64", &sysobject::write64)
+      .def("size", &sysobject::size)
+      .def("bytes", sysobject_bytes, sysobject_doc_bytes())
+      .def("__getitem__", sysobject_getitem, sysobject_doc_getitem())
+      .def("__getitem__", sysobject_getslice, sysobject_doc_getslice());
 }

--- a/pyopae/pysysobject.cpp
+++ b/pyopae/pysysobject.cpp
@@ -1,0 +1,148 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTOR."AS ."
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include "pysysobject.h"
+
+using namespace opae::fpga::types;
+namespace py = pybind11;
+
+const char *sysobject_doc() {
+  return R"doc(
+    Wraps the OPAE fpga_object primitive as a Python object.
+  )doc";
+}
+
+const char *sysobject_doc_token_get() {
+  return R"doc(
+    Get a sysobject instance from a valid token object.
+  )doc";
+}
+
+const char *sysobject_doc_handle_get() {
+  return R"doc(
+    Get a sysobject instance from a valid handle object.
+  )doc";
+}
+
+const char *sysobject_doc_object_get() {
+  return R"doc(
+    Get a sysobject instance from a valid sysobject.
+    The parent sysobject must be a container type object.
+  )doc";
+}
+
+const char *sysobject_doc_token_find() {
+  return R"doc(
+    Find a sysobject instance from a valid token object.
+    Args:
+      flags: Flags that control behavior of finding sub-objects.
+      SYSOBJECT_GLOB is used to indicate that wildcard patterns (*) are allowed.
+      SYSOBJECT_RECURSE_ONE is used to indicate that the find routine should recurse one level.
+      SYSOBJECT_RECURSE_ALL is used to indicate that the find routine should recurse to all children.
+  )doc";
+}
+
+const char *sysobject_doc_handle_find() {
+  return R"doc(
+    Find a sysobject instance from a valid handle object.
+  )doc";
+}
+
+const char *sysobject_doc_object_find() {
+  return R"doc(
+    Find a sysobject instance from a valid sysobject.
+    The parent sysobject must be a container type object.
+  )doc";
+}
+
+const char *sysobject_doc_bytes() {
+  return R"doc(
+    Get bytes from the sysobject.
+    Raises `RuntimeError` if the sysobject instance is a container type.
+  )doc";
+}
+
+const char *sysobject_doc_getitem() {
+  return R"doc(
+    Get a byte from the sysobject at a given index.
+    Raises `RuntimeError` if the sysobject instance is a container type.
+  )doc";
+}
+
+const char *sysobject_doc_getslice() {
+  return R"doc(
+    Get a slice of bytes from the sysobject at a given offset.
+    Raises `RuntimeError` if the sysobject instance is a container type.
+  )doc";
+}
+
+sysobject::ptr_t token_get_sysobject(token::ptr_t tok, const std::string &name) {
+  return sysobject::get(tok, name, 0);
+}
+
+sysobject::ptr_t handle_get_sysobject(handle::ptr_t h, const std::string &name) {
+  return sysobject::get(h, name, 0);
+}
+
+sysobject::ptr_t sysobject_get_sysobject(sysobject::ptr_t o, const std::string &name) {
+  return o->get(name, 0);
+}
+
+sysobject::ptr_t token_find_sysobject(token::ptr_t tok, const std::string &name,
+                                     int flags) {
+  return sysobject::get(tok, name, flags);
+}
+
+sysobject::ptr_t handle_find_sysobject(handle::ptr_t h, const std::string &name,
+                                      int flags) {
+  return sysobject::get(h, name, flags);
+}
+
+sysobject::ptr_t sysobject_find_sysobject(sysobject::ptr_t o, const std::string &name,
+                                      int flags) {
+  return o->get(name, flags);
+}
+
+std::string sysobject_bytes(sysobject::ptr_t obj) {
+  auto bytes = obj->bytes(FPGA_OBJECT_SYNC);
+  return std::string(bytes.begin(), bytes.end());
+}
+
+uint8_t sysobject_getitem(sysobject::ptr_t obj, uint32_t offset) {
+  auto bytes = obj->bytes(offset, 1, FPGA_OBJECT_SYNC);
+  return bytes[0];
+}
+
+std::string sysobject_getslice(sysobject::ptr_t obj, py::slice slice) {
+  size_t start, stop, step, length;
+  if (!slice.compute(obj->size(), &start, &stop, &step, &length))
+    throw py::error_already_set();
+  auto bytes = obj->bytes(FPGA_OBJECT_SYNC);
+  std::string buf('\0', bytes.size());
+  for (size_t i = start, j = 0; i < stop; i += step, ++j) {
+    buf[j] = bytes[i];
+  }
+  return buf;
+}

--- a/pyopae/pysysobject.h
+++ b/pyopae/pysysobject.h
@@ -1,0 +1,63 @@
+// Copyright(c) 2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+#include <Python.h>
+#include <opae/cxx/core/handle.h>
+#include <opae/cxx/core/sysobject.h>
+#include <opae/cxx/core/token.h>
+#include <pybind11/pybind11.h>
+
+const char *sysobject_doc();
+const char *sysobject_doc_token_get();
+const char *sysobject_doc_handle_get();
+const char *sysobject_doc_object_get();
+const char *sysobject_doc_token_find();
+const char *sysobject_doc_handle_find();
+const char *sysobject_doc_object_find();
+const char *sysobject_doc_bytes();
+const char *sysobject_doc_getitem();
+const char *sysobject_doc_getslice();
+
+opae::fpga::types::sysobject::ptr_t token_get_sysobject(
+    opae::fpga::types::token::ptr_t tok, const std::string &name);
+opae::fpga::types::sysobject::ptr_t handle_get_sysobject(
+    opae::fpga::types::handle::ptr_t tok, const std::string &name);
+opae::fpga::types::sysobject::ptr_t sysobject_get_sysobject(
+    opae::fpga::types::sysobject::ptr_t tok, const std::string &name);
+opae::fpga::types::sysobject::ptr_t token_find_sysobject(
+    opae::fpga::types::token::ptr_t tok, const std::string &name,
+    int flags = 0);
+opae::fpga::types::sysobject::ptr_t handle_find_sysobject(
+    opae::fpga::types::handle::ptr_t tok, const std::string &name,
+    int flags = 0);
+opae::fpga::types::sysobject::ptr_t sysobject_find_sysobject(
+    opae::fpga::types::sysobject::ptr_t tok, const std::string &name,
+    int flags = 0);
+std::string sysobject_bytes(opae::fpga::types::sysobject::ptr_t obj);
+uint8_t sysobject_getitem(opae::fpga::types::sysobject::ptr_t obj,
+                          uint32_t offset);
+std::string sysobject_getslice(opae::fpga::types::sysobject::ptr_t obj,
+                                    pybind11::slice slice);

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -539,7 +539,9 @@ if (PYTHONLIBS_VERSION_STRING GREATER "2.7.14")
      ${OPAE_SDK_SOURCE}/pyopae/pyevents.h
      ${OPAE_SDK_SOURCE}/pyopae/pyevents.cpp
      ${OPAE_SDK_SOURCE}/pyopae/pyerrors.h
-     ${OPAE_SDK_SOURCE}/pyopae/pyerrors.cpp)
+     ${OPAE_SDK_SOURCE}/pyopae/pyerrors.cpp
+     ${OPAE_SDK_SOURCE}/pyopae/pysysobject.h
+     ${OPAE_SDK_SOURCE}/pyopae/pysysobject.cpp)
 target_compile_definitions(test_pyopae PRIVATE
     OPAE_EMBEDDED)
 target_include_directories(test_pyopae
@@ -568,5 +570,6 @@ endmacro(add_pyopae_test pytest)
 
 add_pyopae_test(test_properties.py)
 add_pyopae_test(test_shared_buffers.py)
+add_pyopae_test(test_sysobject.py)
 
 endif(PYTHONLIBS_VERSION_STRING GREATER "2.7.14")

--- a/testing/pyopae/test_sysobject.py
+++ b/testing/pyopae/test_sysobject.py
@@ -1,0 +1,90 @@
+# Copyright(c) 2018, Intel Corporation
+#
+# Redistribution  and  use  in source  and  binary  forms,  with  or  without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of  source code  must retain the  above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name  of Intel Corporation  nor the names of its contributors
+#   may be used to  endorse or promote  products derived  from this  software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+# IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+# LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+# CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+# SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+# INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+# CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import sys
+import uuid
+
+# pylint: disable=E0602, E0603
+
+class TestSysObject(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.system = mockopae.test_system()
+        cls.platform = mockopae.test_platform.get("skx-p")
+        cls.system.initialize()
+        cls.system.prepare_sysfs(cls.platform)
+        opae.fpga.initialize(None)
+        props = opae.fpga.properties(type=opae.fpga.ACCELERATOR)
+        cls.afu_toks = opae.fpga.enumerate([props])
+        assert cls.afu_toks
+        cls.afu_handle = opae.fpga.open(cls.afu_toks[0])
+        assert cls.afu_handle
+        props = opae.fpga.properties(type=opae.fpga.DEVICE)
+        cls.fme_toks = opae.fpga.enumerate([props])
+        assert cls.fme_toks
+        cls.fme_handle = opae.fpga.open(cls.fme_toks[0], opae.fpga.OPEN_SHARED)
+        assert cls.fme_handle
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.system.finalize()
+
+    def test_token_object(self):
+        afuid = self.afu_toks[0].afu_id.bytes()[:-1]
+        afu_guid = self.platform.devices[0].afu_guid
+        u1 = uuid.UUID(afuid)
+        u2 = uuid.UUID(afu_guid)
+        assert u1 == u2
+        afuid2 = self.afu_toks[0]["afu_id"].bytes()[:-1]
+        assert afuid == afuid2
+        with self.assertRaises(RuntimeError):
+            print(self.afu_toks[0].wrong)
+
+    def test_handle_object(self):
+        afuid = self.afu_handle.afu_id.bytes()[:-1]
+        afu_guid = self.platform.devices[0].afu_guid
+        u1 = uuid.UUID(afuid)
+        u2 = uuid.UUID(afu_guid)
+        assert u1 == u2
+
+    def test_object_object(self):
+        pr = self.fme_handle.pr
+        interface_id = pr.interface_id
+        u1 = uuid.UUID(interface_id.bytes()[:-1])
+        u2 = uuid.UUID(self.platform.devices[0].fme_guid)
+        assert u1 == u2
+
+    def test_object_read64(self):
+        errors = self.afu_handle.errors
+        rev = errors.revision
+        n1 = rev.read64()
+        assert n1 is not None
+        n2 = int(rev)
+
+        assert n1 == n2, "{} != {}".format(n1, n2)
+        with self.assertRaises(RuntimeError):
+            print(errors.read64())
+
+


### PR DESCRIPTION
* Update cxx/sysobject to
  * Include `size` function
  * Make functions `const`
* Expose more test_system/test_platform structures to Python for
  comparing against in tests
* Add pysysobject.h|cpp files that define Python bindings for
cxx/sysobject
* Add unit tests for Python versions of sysobject APIs