### PR TITLE
Enabled mock tests to be run on hw with ENABLE_MOCK=ON.

### DIFF
--- a/testing/platform/CMakeLists.txt
+++ b/testing/platform/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required (VERSION 2.8)
 
+if (ENABLE_MOCK)
+  add_definitions(-DENABLE_MOCK)
+endif (ENABLE_MOCK)
+
 # Enable checking compiler flags
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)

--- a/testing/platform/fpga_hw.cpp
+++ b/testing/platform/fpga_hw.cpp
@@ -351,17 +351,19 @@ std::pair<std::string, test_platform> make_platform(uint16_t ven_id, uint16_t de
 
 void fpga_db::discover_hw() {
   platform_db db;
+#ifdef ENABLE_MOCK
+  std::cout << "Mock is enabled." << std::endl;
+  platforms_ = MOCK_PLATFORMS;
+#else
   auto sys_pci_devs = find_supported_devices();
-  if (sys_pci_devs.empty()) {
-    platforms_ = MOCK_PLATFORMS;
-  } else {
-    for (auto kv : known_devices) {
-      if (!kv.second.empty()) {
-        ven_dev_id id = kv.first;
-        platforms_.insert(make_platform(id.first, id.second, kv.second));
-      }
+
+  for (auto kv : known_devices) {
+    if (!kv.second.empty()) {
+      ven_dev_id id = kv.first;
+      platforms_.insert(make_platform(id.first, id.second, kv.second));
     }
   }
+#endif
 }
 
 std::vector<std::string> fpga_db::keys(bool sorted) {


### PR DESCRIPTION
Previously it was impossible to run mock on hw as it would populate the platforms database with found hw on the system regardless if ENABLE_MOCK was set. Now it should determine how to populate the platforms database entirely by whether or not ENABLE_MOCK is ON or OFF, regardless of whether or not there are fpgas on the system. This allows the running of all tests on mock even on a system with fpgas, if the user chooses. Also made it print the status of mock if it is enabled, to avoid confusion.