### PR TITLE
pyopae: add pysysobject.cpp to setup.py

### DIFF
--- a/pyopae/MANIFEST.in
+++ b/pyopae/MANIFEST.in
@@ -13,3 +13,5 @@ include pyevents.h
 include pyevents.cpp
 include pyerrors.h
 include pyerrors.cpp
+include pysysobject.h
+include pysysobject.cpp

--- a/pyopae/setup.py
+++ b/pyopae/setup.py
@@ -40,6 +40,7 @@ extensions = [
                        "pyshared_buffer.cpp",
                        "pyevents.cpp",
                        "pyerrors.cpp",
+                       "pysysobject.cpp",
                        "opae.cpp"],
               language="c++",
               extra_compile_args=["-std=c++11"],


### PR DESCRIPTION
Add pysysobject.cpp to setup.py for compilation when building the extension module