### PR TITLE
Move valid Mock_errinj test to mock only

### DIFF
--- a/testing/xfpga/test_mock_errinj_c.cpp
+++ b/testing/xfpga/test_mock_errinj_c.cpp
@@ -175,6 +175,27 @@ TEST_P(err_inj_c_p, fpga_mock_errinj_03) {
 }
 
 /**
+* @test    fpga_mock_errinj_02
+* @brief   Tests:fpgaAssignPortToInterface
+* @details fpgaAssignPortToInterface Assign and Release port
+*          Then the return FPGA_OK 
+*/
+TEST_P(err_inj_c_p, fpga_mock_errinj_02) {
+  fpga_result res;
+   
+  res = xfpga_fpgaAssignPortToInterface(handle_, 2, 0, 0);
+  EXPECT_EQ(FPGA_INVALID_PARAM, res);
+
+  system_->register_ioctl_handler(FPGA_FME_PORT_RELEASE, port_release_ioctl);
+  res = xfpga_fpgaAssignPortToInterface(handle_, 1, 0, 0);
+  EXPECT_EQ(FPGA_OK, res);
+
+  system_->register_ioctl_handler(FPGA_FME_PORT_ASSIGN, port_assign_ioctl);
+  res = xfpga_fpgaAssignPortToInterface(handle_, 0, 0, 0);
+  EXPECT_EQ(FPGA_OK, res);
+}
+
+/**
  * @test       invalid_max_interface_num
  *
  * @brief      When the interface_num parameter to fpgaAssignPortToInterface
@@ -211,27 +232,6 @@ TEST_P(err_inj_c_mock_p, fpga_mock_errinj_01) {
   
   // Release buffer
   EXPECT_EQ(FPGA_OK, xfpga_fpgaReleaseBuffer(handle_, wsid));
-}
-
-/**
-* @test    fpga_mock_errinj_02
-* @brief   Tests:fpgaAssignPortToInterface
-* @details fpgaAssignPortToInterface Assign and Release port
-*          Then the return FPGA_OK 
-*/
-TEST_P(err_inj_c_mock_p, fpga_mock_errinj_02) {
-  fpga_result res;
-   
-  res = xfpga_fpgaAssignPortToInterface(handle_, 2, 0, 0);
-  EXPECT_EQ(FPGA_INVALID_PARAM, res);
-
-  system_->register_ioctl_handler(FPGA_FME_PORT_RELEASE, port_release_ioctl);
-  res = xfpga_fpgaAssignPortToInterface(handle_, 1, 0, 0);
-  EXPECT_EQ(FPGA_OK, res);
-
-  system_->register_ioctl_handler(FPGA_FME_PORT_ASSIGN, port_assign_ioctl);
-  res = xfpga_fpgaAssignPortToInterface(handle_, 0, 0, 0);
-  EXPECT_EQ(FPGA_OK, res);
 }
 
 /**

--- a/testing/xfpga/test_mock_errinj_c.cpp
+++ b/testing/xfpga/test_mock_errinj_c.cpp
@@ -100,8 +100,8 @@ int port_assign_ioctl(mock_object * m, int request, va_list argp){
       FPGA_MSG("unexpected port ID %u", port_assign->port_id);
       goto out_EINVAL;
   }
-retval = 0;
-errno = 0;
+  retval = 0;
+  errno = 0;
 out:
   va_end(argp);
   return retval;
@@ -154,26 +154,6 @@ class err_inj_c_p : public ::testing::TestWithParam<std::string> {
   test_system *system_;
 };
 
-/**
-* @test    fpga_mock_errinj_02
-* @brief   Tests:fpgaAssignPortToInterface
-* @details fpgaAssignPortToInterface Assign and Release port
-*          Then the return FPGA_OK 
-*/
-TEST_P(err_inj_c_p, fpga_mock_errinj_02) {
-  fpga_result res;
-   
-  res = xfpga_fpgaAssignPortToInterface(handle_, 2, 0, 0);
-  EXPECT_EQ(FPGA_INVALID_PARAM, res);
-
-  system_->register_ioctl_handler(FPGA_FME_PORT_RELEASE, port_release_ioctl);
-  res = xfpga_fpgaAssignPortToInterface(handle_, 0, 0, 0);
-  EXPECT_EQ(FPGA_OK, res);
-
-  system_->register_ioctl_handler(FPGA_FME_PORT_ASSIGN, port_assign_ioctl);
-  res = xfpga_fpgaAssignPortToInterface(handle_, 1, 0, 0);
-  EXPECT_EQ(FPGA_OK, res);
-}
 
 /**
 * @test    fpga_mock_errinj_03
@@ -231,6 +211,27 @@ TEST_P(err_inj_c_mock_p, fpga_mock_errinj_01) {
   
   // Release buffer
   EXPECT_EQ(FPGA_OK, xfpga_fpgaReleaseBuffer(handle_, wsid));
+}
+
+/**
+* @test    fpga_mock_errinj_02
+* @brief   Tests:fpgaAssignPortToInterface
+* @details fpgaAssignPortToInterface Assign and Release port
+*          Then the return FPGA_OK 
+*/
+TEST_P(err_inj_c_mock_p, fpga_mock_errinj_02) {
+  fpga_result res;
+   
+  res = xfpga_fpgaAssignPortToInterface(handle_, 2, 0, 0);
+  EXPECT_EQ(FPGA_INVALID_PARAM, res);
+
+  system_->register_ioctl_handler(FPGA_FME_PORT_RELEASE, port_release_ioctl);
+  res = xfpga_fpgaAssignPortToInterface(handle_, 1, 0, 0);
+  EXPECT_EQ(FPGA_OK, res);
+
+  system_->register_ioctl_handler(FPGA_FME_PORT_ASSIGN, port_assign_ioctl);
+  res = xfpga_fpgaAssignPortToInterface(handle_, 0, 0, 0);
+  EXPECT_EQ(FPGA_OK, res);
 }
 
 /**


### PR DESCRIPTION
When running fpgaAssignPortToInterface on hw, the test releases a port (/dev/intel-fpga-port1) and re-assigns it. However, the file permission is set to root rw only. This causes the rest of the hw tests to fail/segfaults. This PR moves that test to mock platform only. 