### PR TITLE
libopae: remove static functions in bmc module

### DIFF
--- a/libopae/plugins/xfpga/metrics/bmc/bmc.c
+++ b/libopae/plugins/xfpga/metrics/bmc/bmc.c
@@ -26,7 +26,7 @@
 
 #include "bmc.h"
 #define _TIMESPEC_DEFINED
-#include "../../types_int.h" // **HACK to get sysfs path **
+#include "../../types_int.h"
 #include "safe_string/safe_string.h"
 #include "bmcdata.h"
 #include <sys/types.h>
@@ -49,8 +49,8 @@
 		}                                                              \
 	} while (0)
 
-static fpga_result read_sysfs_file(fpga_token token, const char *file,
-				   void **buf, uint32_t *tot_bytes_ret)
+fpga_result read_sysfs_file(fpga_token token, const char *file,
+		   void **buf, uint32_t *tot_bytes_ret)
 {
 	char sysfspath[SYSFS_PATH_MAX];
 	struct stat stats;

--- a/libopae/plugins/xfpga/metrics/bmc/bmc_ioctl.c
+++ b/libopae/plugins/xfpga/metrics/bmc/bmc_ioctl.c
@@ -49,7 +49,7 @@
 		}                                                              \
 	} while (0)
 
-static fpga_result rawFromDouble(Values *details, double dbl, uint8_t *raw)
+fpga_result rawFromDouble(Values *details, double dbl, uint8_t *raw)
 {
 	fpga_result res = FPGA_OK;
 
@@ -73,8 +73,8 @@ static fpga_result rawFromDouble(Values *details, double dbl, uint8_t *raw)
 	return res;
 }
 
-static void fill_set_request(Values *vals, threshold_list *thresh,
-			     bmc_set_thresh_request *req)
+void fill_set_request(Values *vals, threshold_list *thresh,
+		     bmc_set_thresh_request *req)
 {
 	fpga_result res = FPGA_OK;
 	uint8_t mask = 0;
@@ -132,8 +132,8 @@ static void fill_set_request(Values *vals, threshold_list *thresh,
 	}
 }
 
-static fpga_result _bmcSetThreshold(int fd, uint32_t sensor,
-				    bmc_set_thresh_request *req)
+fpga_result _bmcSetThreshold(int fd, uint32_t sensor,
+		    bmc_set_thresh_request *req)
 {
 	bmc_xact xact = {0};
 	bmc_set_thresh_response resp;
@@ -165,8 +165,8 @@ out_close:
 	return res;
 }
 
-static fpga_result _bmcGetThreshold(int fd, uint32_t sensor,
-				    bmc_get_thresh_response *resp)
+fpga_result _bmcGetThreshold(int fd, uint32_t sensor,
+			    bmc_get_thresh_response *resp)
 {
 	bmc_xact xact = {0};
 	bmc_get_thresh_request req;

--- a/libopae/plugins/xfpga/metrics/bmc/bmc_ioctl.h
+++ b/libopae/plugins/xfpga/metrics/bmc/bmc_ioctl.h
@@ -33,7 +33,7 @@
 
 #include <opae/fpga.h>
 #include <wchar.h>
-
+#include "bmcdata.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -100,6 +100,20 @@ typedef enum {
 	UC_thresh = 0x10,
 	UNR_thresh = 0x20,
 } Thresh;
+
+fpga_result rawFromDouble(Values *details, double dbl, uint8_t *raw);
+
+void fill_set_request(Values *vals, threshold_list *thresh,
+	bmc_set_thresh_request *req);
+
+fpga_result _bmcSetThreshold(int fd, uint32_t sensor,
+	bmc_set_thresh_request *req);
+
+fpga_result _bmcGetThreshold(int fd, uint32_t sensor,
+	bmc_get_thresh_response *resp);
+
+fpga_result bmcSetHWThresholds(bmc_sdr_handle sdr_h, uint32_t sensor,
+	threshold_list *thresh);
 
 #ifdef __cplusplus
 }

--- a/libopae/plugins/xfpga/metrics/bmc/bmcdata.h
+++ b/libopae/plugins/xfpga/metrics/bmc/bmcdata.h
@@ -35,10 +35,6 @@
 #include <wchar.h>
 #include "bmcinfo.h"
 
-//#ifdef __cplusplus
-//extern "C" {
-//#endif
-
 typedef enum {
 	CHIP_RESET_CAUSE_POR = 0x01,
 	CHIP_RESET_CAUSE_EXTRST = 0x02,
@@ -49,26 +45,15 @@ typedef enum {
 	CHIP_RESET_CAUSE_SPIKE = 0x40,
 } ResetCauses;
 
-//extern uint8_t bcd_plus[];
-//extern uint8_t ASCII_6_bit_translation[];
-//extern wchar_t *base_units[];
-//extern size_t max_base_units;
-//extern char *sensor_type_codes[];
-//extern size_t max_sensor_type_code;
-//extern char *event_reading_type_codes[];
-//extern size_t max_event_reading_type_code;
-//extern char *entity_id_codes[];
-//extern size_t max_entity_id_code;
-//extern int bmcdata_verbose;
-
-//void bmc_print_detail(sensor_reading *reading, sdr_header *header, sdr_key *key,
-//		      sdr_body *body);
+#ifdef __cplusplus
+extern "C" {
+#endif
 void calc_params(sdr_body *body, Values *val);
 double getvalue(Values *val, uint8_t raw);
-//void print_reset_cause(reset_cause *cause);
 
-//#ifdef __cplusplus
-//}
-//#endif
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !BMCDATA_H */


### PR DESCRIPTION
Changes:
    - Remove static functions in bmc module c files
    - Add functions in bmc c files