### PR TITLE
Fix issues with RPM generation after porting tools to distutils

### DIFF
--- a/opae.spec.in
+++ b/opae.spec.in
@@ -140,7 +140,6 @@ ldconfig
 @CMAKE_INSTALL_PREFIX@/bin/coreidle
 @CMAKE_INSTALL_PREFIX@/bin/fpga_dma_test
 @CMAKE_INSTALL_PREFIX@/bin/fpgabist
-@CMAKE_INSTALL_PREFIX@/bin/fpgaflash
 @CMAKE_INSTALL_PREFIX@/bin/hssi_config
 @CMAKE_INSTALL_PREFIX@/bin/hssi_loopback
 @CMAKE_INSTALL_PREFIX@/bin/mmlink

--- a/tools/extra/pac/fpgaflash/CMakeLists.txt
+++ b/tools/extra/pac/fpgaflash/CMakeLists.txt
@@ -36,12 +36,12 @@ configure_file(setup.py ${FLASHTOOLSDIST_STAGE_DIR}/setup.py @ONLY)
 configure_file(fpgaflash ${FLASH_DIR}/fpgaflash.py @ONLY)
 
 ##################add target to build fpgaflash distribution################
-add_custom_target(fpgaflash-dist
+add_custom_target(fpgaflash-dist ALL
                 COMMAND ${PYTHON_EXECUTABLE} setup.py sdist
                 WORKING_DIRECTORY ${FLASHTOOLSDIST_STAGE_DIR})       
 
 ################# install tool with pip  ######################## 
-install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install --user dist/*
+install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install --user dist/opae.fpgaflash-${INTEL_FPGA_API_VERSION}.tar.gz
                 WORKING_DIRECTORY ${FLASHTOOLSDIST_STAGE_DIR})"
         COMPONENT toolfpgaflash)
 

--- a/tools/extra/packager/CMakeLists.txt
+++ b/tools/extra/packager/CMakeLists.txt
@@ -62,12 +62,12 @@ file(COPY metadata DESTINATION ${PACKGER_DIR})
 file(COPY schema DESTINATION ${PACKGER_DIR})
 
 ##################add target to build packager distribution################
-add_custom_target(packager-dist
+add_custom_target(packager-dist ALL
                 COMMAND ${PYTHON_EXECUTABLE} setup.py sdist
                 WORKING_DIRECTORY ${PACKTOOLSDIST_STAGE_DIR})       
 
 ################# install tool with pip  ######################## 
-install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install --user dist/*
+install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install --user dist/opae.packager-${INTEL_FPGA_API_VERSION}.tar.gz
                 WORKING_DIRECTORY ${PACKTOOLSDIST_STAGE_DIR})"
         COMPONENT toolpackager)
 

--- a/tools/extra/pyfpgadiag/CMakeLists.txt
+++ b/tools/extra/pyfpgadiag/CMakeLists.txt
@@ -51,7 +51,7 @@ foreach(pyfile ${PYFILES})
     configure_file(${pyfile} ${PYDIST_STAGE_DIR}/${pyfile} @ONLY)
 endforeach(pyfile ${PYFILES})
 
-add_custom_target(pyfpgadiag-dist
+add_custom_target(pyfpgadiag-dist ALL
     COMMAND ${PYTHON_EXECUTABLE} setup.py sdist
     COMMAND ${PYTHON_EXECUTABLE} setup.py bdist_wheel
     DEPENDS ${PYFILES}


### PR DESCRIPTION
After porting fpgaflash, packager and fpgadiag to using distutils, there were errors in RPM package generation. This PR fixes that issue.