### PR TITLE
Added flags to Coverage build type to catch build warnings.

### DIFF
--- a/cmake/modules/coverage.cmake
+++ b/cmake/modules/coverage.cmake
@@ -33,7 +33,7 @@ if(NOT GCOV_EXECUTABLE)
   message(FATAL_ERROR "gcov not found! Aborting...")
 endif()
 
-set(GCOV_COMPILE_FLAGS "-g -O0 --coverage -fprofile-arcs -ftest-coverage")
+set(GCOV_COMPILE_FLAGS "-g -O0 --coverage -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror")
 set(GCOV_LINK_FLAGS "-lgcov")
 
 set(CMAKE_CXX_FLAGS_COVERAGE


### PR DESCRIPTION
Added compile flags for the Coverage build type to check for warnings in the tests. Otherwise the tests could get merged with issues that would cause a build to error out during any other build type.