### PR TITLE
fpgad: close client connections on exit

### DIFF
--- a/tools/base/fpgad/srv.c
+++ b/tools/base/fpgad/srv.c
@@ -352,6 +352,7 @@ void *server_thread(void *thread_context)
 
 	pollfds[SRV_SOCKET].fd = server_socket;
 	pollfds[SRV_SOCKET].events = POLLIN | POLLPRI;
+	num_fds = 1;
 
 	while (c->running) {
 
@@ -401,6 +402,11 @@ void *server_thread(void *thread_context)
 	}
 
 	unregister_all_events();
+
+	// close any active client sockets
+	for (i = FIRST_CLIENT_SOCKET ; i < num_fds ; ++i) {
+		close(pollfds[i].fd);
+	}
 
 out_close_server:
 	close(server_socket);


### PR DESCRIPTION
When run repeatedly in our test environment, server_thread was always
accumulating client sockets onto the end of pollfds. Eventually, we
would hit the limit and fail when given a high iteration count. This
change causes server_thread to close all client sockets on exit, and
resets num_fds to 1 when the thread is started to ensure correctness.