### PR TITLE
travis: Check if changes require Python tests

### DIFF
--- a/scripts/cover-py.sh
+++ b/scripts/cover-py.sh
@@ -2,6 +2,20 @@
 
 set -o xtrace
 
+FILES=$(find ./tools/extra/pyfpgadiag)
+if [ "$TRAVIS_COMMIT_RANGE" != "" ]; then
+    CHANGED_FILES=$(git diff --name-only $TRAVIS_COMMIT_RANGE)
+    printf "Looking at changed files:\n${CHANGED_FILES}"
+    FILES=$(comm -12 <(sort <(for f in $FILES; do printf "$f\n"; done)) <(sort <(for f in $CHANGED_FILES; do printf "./$f\n"; done)))
+fi
+
+echo "$FILES"
+
+if [ "$FILES" == "" ]; then
+	echo "No applicable files changed, skipping tests"
+	exit 0
+fi
+
 mkdir -p pytests
 cd pytests
 


### PR DESCRIPTION
Change cover-py.sh script to look at the files changed in the commit and
if that intersects with the files under Python tools, then run the
tests, otherwise, skip test execution.