### PR TITLE
libopae: fix metric api invalid input index and name

### DIFF
--- a/libopae/plugins/xfpga/metrics/afu_metrics.c
+++ b/libopae/plugins/xfpga/metrics/afu_metrics.c
@@ -199,7 +199,7 @@ fpga_result add_afu_metrics_vector(fpga_metric_vector *vector,
 	snprintf_s_i(group_name, sizeof(group_name), "%x", group_csr.group_id);
 	snprintf_s_i(metric_name, sizeof(metric_name), "%x", metric_csr.counter_id);
 
-	sprintf(qualifier_name, "%s:%x", "AFU", group_csr.group_id);
+	snprintf_s_si(qualifier_name, sizeof(qualifier_name), "%s:%x", "AFU", group_csr.group_id);
 	snprintf_s_i(metric_units, sizeof(metric_units), "%x", group_csr.units);
 
 	*metric_id = *metric_id + 1;

--- a/libopae/plugins/xfpga/metrics/metrics.c
+++ b/libopae/plugins/xfpga/metrics/metrics.c
@@ -178,6 +178,7 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByIndex(fpga_handle handle,
 						fpga_metric *metrics)
 {
 	fpga_result result                      = FPGA_OK;
+	uint64_t found                          = 0;
 	struct _fpga_handle *_handle            = (struct _fpga_handle *)handle;
 	int err                                 = 0;
 	uint64_t i                              = 0;
@@ -228,10 +229,23 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByIndex(fpga_handle handle,
 						metric_num[i],
 						&metrics[i]);
 			if (result != FPGA_OK) {
-				FPGA_ERR("Failed to get metric value");
+				FPGA_ERR("Failed to get metric value  at Index = %ld", metric_num[i]);
+				metrics[i].metric_num = metric_num[i];
 				continue;
+			} else {
+				// found metrics num
+				found++;
 			}
 		}
+
+		// API returns not found if doesnot found any metric
+		if (found == 0 || num_metric_indexes == 0) {
+			result = FPGA_NOT_FOUND;
+		}
+		else {
+			result = FPGA_OK;
+		}
+
 	} else if (objtype == FPGA_DEVICE) {
 		// get FME metrics
 		for (i = 0; i < num_metric_indexes; i++) {
@@ -241,10 +255,23 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByIndex(fpga_handle handle,
 							metric_num[i],
 							&metrics[i]);
 			if (result != FPGA_OK) {
-				FPGA_ERR("Failed to get metric value");
+				FPGA_ERR("Failed to get metric value  at Index = %ld", metric_num[i]);
+				metrics[i].metric_num = metric_num[i];
 				continue;
 			}
+			else {
+				// found metrics num
+				found++;
+			}
 		}
+
+		// API returns not found if doesnot found any metric
+		if (found == 0 || num_metric_indexes == 0) {
+			result = FPGA_NOT_FOUND;
+		} else {
+			result = FPGA_OK;
+		}
+
 	} else {
 		result = FPGA_INVALID_PARAM;
 	}
@@ -266,6 +293,7 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByName(fpga_handle handle,
 						fpga_metric *metrics)
 {
 	fpga_result result                     = FPGA_OK;
+	uint64_t found                         = 0;
 	struct _fpga_handle *_handle           = (struct _fpga_handle *)handle;
 	int err                                = 0;
 	uint64_t i                             = 0;
@@ -300,6 +328,14 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByName(fpga_handle handle,
 		goto out_unlock;
 	}
 
+	result = enum_fpga_metrics(handle);
+	if (result != FPGA_OK) {
+		FPGA_ERR("Failed to Discover Metrics");
+		result = FPGA_NOT_FOUND;
+		goto out_unlock;
+	}
+
+
 	result = get_fpga_object_type(handle, &objtype);
 	if (result != FPGA_OK) {
 		FPGA_ERR("Failed to init vector");
@@ -310,12 +346,12 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByName(fpga_handle handle,
 	if (objtype == FPGA_ACCELERATOR) {
 		// get AFU metrics
 		for (i = 0; i < num_metric_names; i++) {
-
 			result = parse_metric_num_name(metrics_names[i],
 							&(_handle->fpga_enum_metric_vector),
 							&metric_num);
 			if (result != FPGA_OK) {
-				FPGA_ERR("Invalid Input Metrics string");
+				FPGA_ERR("Invalid input metrics string= %s", metrics_names[i]);
+				metrics[i].metric_num = 0xFFFF;
 				continue;
 			}
 
@@ -323,10 +359,22 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByName(fpga_handle handle,
 				metric_num,
 				&metrics[i]);
 			if (result != FPGA_OK) {
-				FPGA_ERR("Failed to get metric value");
+				FPGA_ERR("Failed to get metric value  for metric = %s", metrics_names[i]);
+				metrics[i].metric_num = 0xFFFF;
 				continue;
 			}
+			else {
+				// found metrics num
+				found++;
+			}
+		}
 
+		// API returns not found if doesnot found any metric
+		if (found == 0 || num_metric_names == 0) {
+			result = FPGA_NOT_FOUND;
+		}
+		else {
+			result = FPGA_OK;
 		}
 	} else	if (objtype == FPGA_DEVICE) {
 		// get FME metrics
@@ -336,7 +384,8 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByName(fpga_handle handle,
 							&(_handle->fpga_enum_metric_vector),
 							&metric_num);
 			if (result != FPGA_OK) {
-				FPGA_ERR("Invalid Input Metrics string");
+				FPGA_ERR("Invalid input metrics string= %s", metrics_names[i]);
+				metrics[i].metric_num = 0xFFFF;
 				continue;
 			}
 
@@ -345,10 +394,22 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByName(fpga_handle handle,
 							metric_num,
 							&metrics[i]);
 			if (result != FPGA_OK) {
-				FPGA_ERR("Failed to get metric value");
-				goto out_unlock;
+				FPGA_ERR("Failed to get metric value  for metric = %s \n", metrics_names[i]);
+				metrics[i].metric_num = 0xFFFF;
+				continue;
 			}
+			else {
+				// found metrics num
+				found++;
+			}
+		}
 
+		// API returns not found if doesnot found any metric
+		if (found == 0 || num_metric_names == 0) {
+			result = FPGA_NOT_FOUND;
+		}
+		else {
+			result = FPGA_OK;
 		}
 	} else {
 		result = FPGA_INVALID_PARAM;

--- a/libopae/plugins/xfpga/metrics/metrics.c
+++ b/libopae/plugins/xfpga/metrics/metrics.c
@@ -43,6 +43,9 @@
 #include "metrics/vector.h"
 #include "metrics/metrics_int.h"
 
+//Wrong search string invalid array index
+#define METRIC_ARRAY_INVALID_INDEX     0xFFFFFF
+
 fpga_result __FPGA_API__ xfpga_fpgaGetNumMetrics(fpga_handle handle,
 					uint64_t *num_metrics)
 {
@@ -349,7 +352,7 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByName(fpga_handle handle,
 							&metric_num);
 			if (result != FPGA_OK) {
 				FPGA_ERR("Invalid input metrics string= %s", metrics_names[i]);
-				metrics[i].metric_num = 0xFFFF;
+				metrics[i].metric_num = METRIC_ARRAY_INVALID_INDEX;
 				continue;
 			}
 
@@ -358,7 +361,7 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByName(fpga_handle handle,
 				&metrics[i]);
 			if (result != FPGA_OK) {
 				FPGA_ERR("Failed to get metric value  for metric = %s", metrics_names[i]);
-				metrics[i].metric_num = 0xFFFF;
+				metrics[i].metric_num = METRIC_ARRAY_INVALID_INDEX;
 				continue;
 			} else {
 				// found metrics num
@@ -381,7 +384,7 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByName(fpga_handle handle,
 							&metric_num);
 			if (result != FPGA_OK) {
 				FPGA_ERR("Invalid input metrics string= %s", metrics_names[i]);
-				metrics[i].metric_num = 0xFFFF;
+				metrics[i].metric_num = METRIC_ARRAY_INVALID_INDEX;
 				continue;
 			}
 
@@ -391,7 +394,7 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByName(fpga_handle handle,
 							&metrics[i]);
 			if (result != FPGA_OK) {
 				FPGA_ERR("Failed to get metric value  for metric = %s \n", metrics_names[i]);
-				metrics[i].metric_num = 0xFFFF;
+				metrics[i].metric_num = METRIC_ARRAY_INVALID_INDEX;
 				continue;
 			} else {
 				// found metrics num

--- a/libopae/plugins/xfpga/metrics/metrics.c
+++ b/libopae/plugins/xfpga/metrics/metrics.c
@@ -241,8 +241,7 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByIndex(fpga_handle handle,
 		// API returns not found if doesnot found any metric
 		if (found == 0 || num_metric_indexes == 0) {
 			result = FPGA_NOT_FOUND;
-		}
-		else {
+		} else {
 			result = FPGA_OK;
 		}
 
@@ -258,8 +257,7 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByIndex(fpga_handle handle,
 				FPGA_ERR("Failed to get metric value  at Index = %ld", metric_num[i]);
 				metrics[i].metric_num = metric_num[i];
 				continue;
-			}
-			else {
+			} else {
 				// found metrics num
 				found++;
 			}
@@ -362,8 +360,7 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByName(fpga_handle handle,
 				FPGA_ERR("Failed to get metric value  for metric = %s", metrics_names[i]);
 				metrics[i].metric_num = 0xFFFF;
 				continue;
-			}
-			else {
+			} else {
 				// found metrics num
 				found++;
 			}
@@ -372,8 +369,7 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByName(fpga_handle handle,
 		// API returns not found if doesnot found any metric
 		if (found == 0 || num_metric_names == 0) {
 			result = FPGA_NOT_FOUND;
-		}
-		else {
+		} else {
 			result = FPGA_OK;
 		}
 	} else	if (objtype == FPGA_DEVICE) {
@@ -397,8 +393,7 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByName(fpga_handle handle,
 				FPGA_ERR("Failed to get metric value  for metric = %s \n", metrics_names[i]);
 				metrics[i].metric_num = 0xFFFF;
 				continue;
-			}
-			else {
+			} else {
 				// found metrics num
 				found++;
 			}
@@ -407,8 +402,7 @@ fpga_result __FPGA_API__ xfpga_fpgaGetMetricsByName(fpga_handle handle,
 		// API returns not found if doesnot found any metric
 		if (found == 0 || num_metric_names == 0) {
 			result = FPGA_NOT_FOUND;
-		}
-		else {
+		} else {
 			result = FPGA_OK;
 		}
 	} else {

--- a/libopae/plugins/xfpga/metrics/metrics_utils.c
+++ b/libopae/plugins/xfpga/metrics/metrics_utils.c
@@ -1011,6 +1011,11 @@ fpga_result get_bmc_metrics_values(fpga_handle handle,
 		snprintf_s_s(_handle->_bmc_metric_cache_value[x].metric_name, sizeof(_handle->_bmc_metric_cache_value[x].metric_name), "%s", details.name);
 		_handle->_bmc_metric_cache_value[x].fpga_metric.value.dvalue = tmp;
 
+		strcasecmp_s(details.name, sizeof(details.name), _fpga_enum_metric->metric_name, &metric_indicator);
+		if (metric_indicator == 0) {
+			fpga_metric->value.dvalue = tmp;
+		}
+
 	}
 
 

--- a/libopae/plugins/xfpga/metrics/metrics_utils.c
+++ b/libopae/plugins/xfpga/metrics/metrics_utils.c
@@ -1170,6 +1170,7 @@ fpga_result  get_fme_metric_value(fpga_handle handle,
 		return FPGA_NOT_FOUND;
 	}
 
+	result = FPGA_NOT_FOUND;
 	for (index = 0; index < num_enun_metrics ; index++) {
 
 		_fpga_enum_metric = (struct _fpga_enum_metric *)	fpga_vector_get(enum_vector, index);

--- a/testing/xfpga/test_afu_metrics_c.cpp
+++ b/testing/xfpga/test_afu_metrics_c.cpp
@@ -127,33 +127,32 @@ protected:
 		system_->initialize();
 		system_->prepare_syfs(platform_);
 
-		ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
-		ASSERT_EQ(fpgaGetProperties(nullptr, &filter_), FPGA_OK);
+		ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
 		ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
 		num_matches_ = 0;
-		ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
+		ASSERT_EQ(xfpga_fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
 			&num_matches_),
 			FPGA_OK);
 		ASSERT_GT(num_matches_, 0);
 		handle_ = nullptr;
-		ASSERT_EQ(fpgaOpen(tokens_[0], &handle_, 0), FPGA_OK);
+		ASSERT_EQ(xfpga_fpgaOpen(tokens_[0], &handle_, 0), FPGA_OK);
 		system_->register_ioctl_handler(FPGA_PORT_GET_REGION_INFO, mmio_ioctl);
 		which_mmio_ = 0;
 		uint64_t *mmio_ptr = nullptr;
-		EXPECT_EQ(fpgaMapMMIO(handle_, which_mmio_, &mmio_ptr), FPGA_OK);
+		EXPECT_EQ(xfpga_fpgaMapMMIO(handle_, which_mmio_, &mmio_ptr), FPGA_OK);
 		EXPECT_NE(mmio_ptr, nullptr);
 	}
 
 	virtual void TearDown() override {
-		EXPECT_EQ(fpgaUnmapMMIO(handle_, which_mmio_), FPGA_OK);
+		EXPECT_EQ(xfpga_fpgaUnmapMMIO(handle_, which_mmio_), FPGA_OK);
 		EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
 		if (handle_) {
-			EXPECT_EQ(fpgaClose(handle_), FPGA_OK);
+			EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
 			handle_ = nullptr;
 		}
 		for (auto &t : tokens_) {
 			if (t) {
-				EXPECT_EQ(fpgaDestroyToken(&t), FPGA_OK);
+				EXPECT_EQ(xfpga_fpgaDestroyToken(&t), FPGA_OK);
 				t = nullptr;
 			}
 		}
@@ -181,10 +180,10 @@ void afu_metrics_c_p::create_metric_bbb_dfh() {
 
 
 	printf("------dfh.csr = %lx \n", dfh.csr);
-	EXPECT_EQ(FPGA_OK, fpgaWriteMMIO64(handle_, 0, 0x0, dfh.csr));
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x0, dfh.csr));
 
-	EXPECT_EQ(FPGA_OK, fpgaWriteMMIO64(handle_, 0, 0x8, 0xf89e433683f9040b));
-	EXPECT_EQ(FPGA_OK, fpgaWriteMMIO64(handle_, 0, 0x10, 0xd8424dc4a4a3c413));
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x8, 0xf89e433683f9040b));
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x10, 0xd8424dc4a4a3c413));
 
 
 	struct DFH dfh_bbb = { 0 };
@@ -198,10 +197,10 @@ void afu_metrics_c_p::create_metric_bbb_dfh() {
 	printf("------dfh_bbb.csr = %lx \n", dfh_bbb.csr);
 
 
-	EXPECT_EQ(FPGA_OK, fpgaWriteMMIO64(handle_, 0, 0x100, dfh_bbb.csr));
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x100, dfh_bbb.csr));
 
-	EXPECT_EQ(FPGA_OK, fpgaWriteMMIO64(handle_, 0, 0x108, 0x9D73E8F258E9E3D7));
-	EXPECT_EQ(FPGA_OK, fpgaWriteMMIO64(handle_, 0, 0x110, 0x87816958C1484CD0));
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x108, 0x9D73E8F258E9E3D7));
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x110, 0x87816958C1484CD0));
 }
 
 void afu_metrics_c_p::create_metric_bbb_csr() {
@@ -215,21 +214,21 @@ void afu_metrics_c_p::create_metric_bbb_csr() {
 	group_csr.units = 0x2;
 	group_csr.next_group_offset = 0x30;
 
-	EXPECT_EQ(FPGA_OK, fpgaWriteMMIO64(handle_, 0, 0x120, group_csr.csr));
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x120, group_csr.csr));
 	printf("------group_csr.csr = %lx \n", group_csr.csr);
 
 	value_csr.eol = 0x0;
 	value_csr.counter_id = 0xa;
 	value_csr.value = 0x99;
 
-	EXPECT_EQ(FPGA_OK, fpgaWriteMMIO64(handle_, 0, 0x128, value_csr.csr));
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x128, value_csr.csr));
 	printf("------value_csr.csr = %lx \n", value_csr.csr);
 
 	value_csr.eol = 0x1;
 	value_csr.counter_id = 0xb;
 	value_csr.value = 0x89;
 
-	EXPECT_EQ(FPGA_OK, fpgaWriteMMIO64(handle_, 0, 0x130, value_csr.csr));
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x130, value_csr.csr));
 	printf("------value_csr.csr = %lx \n", value_csr.csr);
 
 
@@ -239,21 +238,21 @@ void afu_metrics_c_p::create_metric_bbb_csr() {
 	group_csr.units = 0x3;
 	group_csr.next_group_offset = 0x0;
 
-	EXPECT_EQ(FPGA_OK, fpgaWriteMMIO64(handle_, 0, 0x120 + 0x30, group_csr.csr));
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x120 + 0x30, group_csr.csr));
 	printf("------group_csr.csr = %lx \n", group_csr.csr);
 	// second value
 	value_csr.eol = 0x0;
 	value_csr.counter_id = 0xc;
 	value_csr.value = 0x79;
 
-	EXPECT_EQ(FPGA_OK, fpgaWriteMMIO64(handle_, 0, 0x120 + 0x38, value_csr.csr));
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x120 + 0x38, value_csr.csr));
 	printf("------value_csr.csr = %lx \n", value_csr.csr);
 
 	value_csr.eol = 0x1;
 	value_csr.counter_id = 0xd;
 	value_csr.value = 0x69;
 
-	EXPECT_EQ(FPGA_OK, fpgaWriteMMIO64(handle_, 0, 0x120 + 0x40, value_csr.csr));
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x120 + 0x40, value_csr.csr));
 	printf("------value_csr.csr = %lx \n", value_csr.csr);
 
 }
@@ -344,7 +343,7 @@ TEST_P(afu_metrics_c_p, test_afu_metrics_04) {
 	EXPECT_EQ(FPGA_OK, discover_afu_metrics_feature(handle_, &offset));
 
 	EXPECT_EQ(FPGA_OK, fpga_vector_init(&vector));
-	EXPECT_EQ(FPGA_OK, get_afu_metric_value(handle_, &vector,0x1, &fpga_metric));
+	EXPECT_NE(FPGA_OK, get_afu_metric_value(handle_, &vector,0x1, &fpga_metric));
 
 
 	// NULL input

--- a/testing/xfpga/test_afu_metrics_c.cpp
+++ b/testing/xfpga/test_afu_metrics_c.cpp
@@ -178,10 +178,10 @@ void afu_metrics_c_p::create_metric_bbb_dfh() {
 	dfh.reserved = 0;
 	dfh.type = 0x1;
 
-
 	printf("------dfh.csr = %lx \n", dfh.csr);
+	// AFU DFH
 	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x0, dfh.csr));
-
+	// AFU GUID
 	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x8, 0xf89e433683f9040b));
 	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x10, 0xd8424dc4a4a3c413));
 
@@ -196,9 +196,9 @@ void afu_metrics_c_p::create_metric_bbb_dfh() {
 	dfh_bbb.reserved = 0;
 	printf("------dfh_bbb.csr = %lx \n", dfh_bbb.csr);
 
-
+	// Metrics DFH
 	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x100, dfh_bbb.csr));
-
+	// Metrics GUID
 	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x108, 0x9D73E8F258E9E3D7));
 	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x110, 0x87816958C1484CD0));
 }

--- a/testing/xfpga/test_metrics_c.cpp
+++ b/testing/xfpga/test_metrics_c.cpp
@@ -68,9 +68,9 @@ extern "C" {
 using namespace opae::testing;
 
 
-class metics_c_p : public ::testing::TestWithParam<std::string> {
+class metrics_c_p : public ::testing::TestWithParam<std::string> {
 protected:
-	metics_c_p()
+	metrics_c_p()
 		: tokens_{ {nullptr, nullptr} },
 		handle_(nullptr) {}
 
@@ -119,7 +119,7 @@ protected:
 *
 *
 */
-TEST_P(metics_c_p, test_metric_01) {
+TEST_P(metrics_c_p, test_metric_01) {
 
 	// get number of metrics
 	uint64_t num_metrics;
@@ -146,7 +146,7 @@ TEST_P(metics_c_p, test_metric_01) {
 *
 *
 */
-TEST_P(metics_c_p, test_metric_02) {
+TEST_P(metrics_c_p, test_metric_02) {
 
 	struct _fpga_handle *_handle = NULL;
 	uint64_t num_metrics;
@@ -179,7 +179,7 @@ TEST_P(metics_c_p, test_metric_02) {
 *
 *
 */
-TEST_P(metics_c_p, test_metric_03) {
+TEST_P(metrics_c_p, test_metric_03) {
 
 	struct _fpga_handle *_handle = NULL;
 
@@ -216,7 +216,7 @@ TEST_P(metics_c_p, test_metric_03) {
 *
 *
 */
-TEST_P(metics_c_p, test_metric_04) {
+TEST_P(metrics_c_p, test_metric_04) {
 
 	struct _fpga_handle *_handle = NULL;
 
@@ -257,4 +257,308 @@ TEST_P(metics_c_p, test_metric_04) {
 	free(metric_array_search);
 
 }
-INSTANTIATE_TEST_CASE_P(metics_c, metics_c_p, ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));
+INSTANTIATE_TEST_CASE_P(metrics_c, metrics_c_p, ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));
+
+
+int mmio_ioctl(mock_object * m, int request, va_list argp) {
+	int retval = -1;
+	errno = EINVAL;
+	UNUSED_PARAM(m);
+	UNUSED_PARAM(request);
+	struct fpga_port_region_info *rinfo = va_arg(argp, struct fpga_port_region_info *);
+	if (!rinfo) {
+		FPGA_MSG("rinfo is NULL");
+		goto out_EINVAL;
+	}
+	if (rinfo->argsz != sizeof(*rinfo)) {
+		FPGA_MSG("wrong structure size");
+		goto out_EINVAL;
+	}
+	if (rinfo->index > 1) {
+		FPGA_MSG("unsupported MMIO index");
+		goto out_EINVAL;
+	}
+	if (rinfo->padding != 0) {
+		FPGA_MSG("unsupported padding");
+		goto out_EINVAL;
+	}
+	rinfo->flags = FPGA_REGION_READ | FPGA_REGION_WRITE | FPGA_REGION_MMAP;
+	rinfo->size = 0x40000;
+	rinfo->offset = 0;
+	retval = 0;
+	errno = 0;
+
+out:
+	return retval;
+
+out_EINVAL:
+	retval = -1;
+	errno = EINVAL;
+	goto out;
+}
+
+
+
+
+/**
+* @brief metrics afu gtest fixture
+*
+*/
+class metrics_afu_c_p : public ::testing::TestWithParam<std::string> {
+protected:
+	metrics_afu_c_p()
+		: tokens_{ {nullptr, nullptr} },
+		handle_(nullptr) {}
+	void create_metric_bbb_dfh();
+	void create_metric_bbb_csr();
+	virtual void SetUp() override {
+
+		ASSERT_TRUE(test_platform::exists(GetParam()));
+		platform_ = test_platform::get(GetParam());
+		system_ = test_system::instance();
+		system_->initialize();
+		system_->prepare_syfs(platform_);
+
+		ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
+		ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
+		ASSERT_EQ(xfpga_fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
+			&num_matches_),
+			FPGA_OK);
+
+		ASSERT_EQ(xfpga_fpgaOpen(tokens_[0], &handle_, 0), FPGA_OK);
+
+
+		system_->register_ioctl_handler(FPGA_PORT_GET_REGION_INFO, mmio_ioctl);
+		which_mmio_ = 0;
+		uint64_t *mmio_ptr = nullptr;
+		EXPECT_EQ(xfpga_fpgaMapMMIO(handle_, which_mmio_, &mmio_ptr), FPGA_OK);
+		EXPECT_NE(mmio_ptr, nullptr);
+	}
+
+	virtual void TearDown() override {
+		EXPECT_EQ(xfpga_fpgaUnmapMMIO(handle_, which_mmio_), FPGA_OK);
+		EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
+		for (auto &t : tokens_) {
+			if (t) {
+				EXPECT_EQ(xfpga_fpgaDestroyToken(&t), FPGA_OK);
+				t = nullptr;
+			}
+		}
+		if (handle_) { EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK); }
+		system_->finalize();
+	}
+	uint32_t which_mmio_;
+	std::array<fpga_token, 2> tokens_;
+	fpga_handle handle_;
+	fpga_properties filter_;
+	uint32_t num_matches_;
+	test_platform platform_;
+	test_system *system_;
+
+};
+
+void metrics_afu_c_p::create_metric_bbb_dfh() {
+
+	struct DFH dfh;
+	dfh.id = 0x1;
+	dfh.revision = 0;
+	dfh.next_header_offset = 0x100;
+	dfh.eol = 1;
+	dfh.reserved = 0;
+	dfh.type = 0x1;
+
+
+	printf("------dfh.csr = %lx \n", dfh.csr);
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x0, dfh.csr));
+
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x8, 0xf89e433683f9040b));
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x10, 0xd8424dc4a4a3c413));
+
+
+	struct DFH dfh_bbb = { 0 };
+
+	dfh_bbb.type = 0x2;
+	dfh_bbb.id = 0x1;
+	dfh_bbb.revision = 0;
+	dfh_bbb.next_header_offset = 0x000;
+	dfh_bbb.eol = 1;
+	dfh_bbb.reserved = 0;
+	printf("------dfh_bbb.csr = %lx \n", dfh_bbb.csr);
+
+
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x100, dfh_bbb.csr));
+
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x108, 0x9D73E8F258E9E3D7));
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x110, 0x87816958C1484CD0));
+}
+
+void metrics_afu_c_p::create_metric_bbb_csr() {
+
+
+	struct metric_bbb_group group_csr = { 0 };
+	struct metric_bbb_value value_csr = { 0 };
+
+	group_csr.eol = 0;
+	group_csr.group_id = 0x2;
+	group_csr.units = 0x2;
+	group_csr.next_group_offset = 0x30;
+
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x120, group_csr.csr));
+	printf("------group_csr.csr = %lx \n", group_csr.csr);
+
+	value_csr.eol = 0x0;
+	value_csr.counter_id = 0xa;
+	value_csr.value = 0x99;
+
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x128, value_csr.csr));
+	printf("------value_csr.csr = %lx \n", value_csr.csr);
+
+	value_csr.eol = 0x1;
+	value_csr.counter_id = 0xb;
+	value_csr.value = 0x89;
+
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x130, value_csr.csr));
+	printf("------value_csr.csr = %lx \n", value_csr.csr);
+
+
+	// second group
+	group_csr.eol = 1;
+	group_csr.group_id = 0x3;
+	group_csr.units = 0x3;
+	group_csr.next_group_offset = 0x0;
+
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x120 + 0x30, group_csr.csr));
+	printf("------group_csr.csr = %lx \n", group_csr.csr);
+	// second value
+	value_csr.eol = 0x0;
+	value_csr.counter_id = 0xc;
+	value_csr.value = 0x79;
+
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x120 + 0x38, value_csr.csr));
+	printf("------value_csr.csr = %lx \n", value_csr.csr);
+
+	value_csr.eol = 0x1;
+	value_csr.counter_id = 0xd;
+	value_csr.value = 0x69;
+
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaWriteMMIO64(handle_, 0, 0x120 + 0x40, value_csr.csr));
+	printf("------value_csr.csr = %lx \n", value_csr.csr);
+
+}
+
+
+/**
+* @test    test_afc_metric_01
+* @brief   Tests: xfpga_fpgaGetNumMetrics
+*                 xfpga_fpgaGetNumMetrics functions
+* @details Validates AFU get number metrics & 
+* get metrics info
+*
+*
+*/
+TEST_P(metrics_afu_c_p, test_afc_metric_01) {
+
+	create_metric_bbb_dfh();
+	create_metric_bbb_csr();
+
+	uint64_t num_metrics = 0;;
+
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaGetNumMetrics(handle_, &num_metrics));
+	printf("num_metrics =%ld \n", num_metrics);
+
+	struct fpga_metric_info  *fpga_metric_info = (struct fpga_metric_info *) calloc(sizeof(struct fpga_metric_info), num_metrics);
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaGetMetricsInfo(handle_, fpga_metric_info, &num_metrics));
+
+	free(fpga_metric_info);
+}
+
+/**
+* @test    test_afc_metric_02
+* @brief   Tests: xfpga_fpgaGetNumMetrics
+*                 xfpga_fpgaGetNumMetrics
+*                 xfpga_fpgaGetMetricsByIndex functions
+* @details Validates no AFU metrics
+*
+*
+*/
+TEST_P(metrics_afu_c_p, test_afc_metric_02) {
+
+	uint64_t num_metrics = 0;;
+
+	EXPECT_NE(FPGA_OK, xfpga_fpgaGetNumMetrics(handle_, &num_metrics));
+	printf("num_metrics =%ld \n", num_metrics);
+
+	// No AFU metrics
+	struct fpga_metric_info  *fpga_metric_info = (struct fpga_metric_info *) calloc(sizeof(struct fpga_metric_info), num_metrics);
+	EXPECT_NE(FPGA_OK, xfpga_fpgaGetMetricsInfo(handle_, fpga_metric_info, &num_metrics));
+	free(fpga_metric_info);
+
+	// No AFU metrics
+	uint64_t id_array[] = { 1, 2,3 };
+	struct fpga_metric  *metric_array = (struct fpga_metric *) calloc(sizeof(struct fpga_metric), 3);
+	EXPECT_NE(FPGA_OK, xfpga_fpgaGetMetricsByIndex(handle_, id_array, 3, metric_array));
+	free(metric_array);
+}
+
+/**
+* @test    test_afc_metric_03
+* @brief   Tests: xfpga_fpgaGetMetricsByIndex functions
+* @details Validates AFU get metric value by index
+*
+*
+*/
+TEST_P(metrics_afu_c_p, test_afc_metric_03) {
+
+	create_metric_bbb_dfh();
+	create_metric_bbb_csr();
+
+	// valid index
+	uint64_t id_array[] = { 1, 2,3 };
+	struct fpga_metric  *metric_array = (struct fpga_metric *) calloc(sizeof(struct fpga_metric), 3);
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaGetMetricsByIndex(handle_, id_array, 3, metric_array));
+
+	EXPECT_NE(FPGA_OK, xfpga_fpgaGetMetricsByIndex(handle_, id_array, 0, metric_array));
+	free(metric_array);
+
+	// invalid index
+	uint64_t id_array_invalid[] = { 10, 20,30 };
+	struct fpga_metric  *metric_array_invalid = (struct fpga_metric *) calloc(sizeof(struct fpga_metric), 3);
+	EXPECT_NE(FPGA_OK, xfpga_fpgaGetMetricsByIndex(handle_, id_array_invalid, 3, metric_array_invalid));
+	free(metric_array_invalid);
+}
+
+/**
+* @test    test_afc_metric_03
+* @brief   Tests: xfpga_fpgaGetMetricsByName functions
+* @details Validates AFU get metric value by name
+*
+*
+*/
+TEST_P(metrics_afu_c_p, test_afc_metric_04) {
+
+	create_metric_bbb_dfh();
+	create_metric_bbb_csr();
+
+	// valid afu Metrics name
+	const char* metric_string[2] = { "AFU:2:a","AFU:3:b" };
+	uint64_t  array_size = 2;
+
+	struct fpga_metric *metric_array_search = (struct fpga_metric *) calloc(sizeof(struct fpga_metric), array_size);
+	EXPECT_EQ(FPGA_OK, xfpga_fpgaGetMetricsByName(handle_,
+		(char**)metric_string,
+		array_size,
+		metric_array_search));
+
+	free(metric_array_search);
+
+	// invalid afu Metrics name
+	const char* metric_string_invalid[2] = { "power_mgmt:consumed","performance:fabric:port0:mmio_read" };
+
+	metric_array_search = (struct fpga_metric *) calloc(sizeof(struct fpga_metric), array_size);
+	EXPECT_NE(FPGA_OK, xfpga_fpgaGetMetricsByName(handle_,
+		(char**)metric_string_invalid,
+		array_size,
+		metric_array_search));
+	free(metric_array_search);
+}
+INSTANTIATE_TEST_CASE_P(metrics_c, metrics_afu_c_p, ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/testing/xfpga/test_metrics_utils_c.cpp
+++ b/testing/xfpga/test_metrics_utils_c.cpp
@@ -56,9 +56,9 @@ extern "C" {
 using namespace opae::testing;
 
 
-class metrics_uitls_c_p : public ::testing::TestWithParam<std::string> {
+class metrics_utils_c_p : public ::testing::TestWithParam<std::string> {
 protected:
-	metrics_uitls_c_p()
+	metrics_utils_c_p()
 		: tokens_{ {nullptr, nullptr} },
 		handle_(nullptr) {}
 
@@ -110,7 +110,7 @@ protected:
  *
  *
  */
-TEST_P(metrics_uitls_c_p, test_metric_utils_100) {
+TEST_P(metrics_utils_c_p, test_metric_utils_100) {
 
 	char group_sysfs[FPGA_METRIC_STR_SIZE] = { 0 };
 
@@ -123,7 +123,6 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_100) {
 	EXPECT_NE(FPGA_OK, metric_sysfs_path_is_dir((const char*)"/tmp/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0/bitstream_id1"));
 
 	std::string sysclass_path = system_->get_sysfs_path(std::string("/sys/class/fpga/intel-fpga-dev.0"));
-	//printf("sysclass_path %s \n", sysclass_path.c_str());
 
 	EXPECT_EQ(FPGA_OK, metric_sysfs_path_is_dir((const char*)sysclass_path.c_str()));
 
@@ -136,7 +135,7 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_100) {
  *
  *
  */
-TEST_P(metrics_uitls_c_p, test_metric_utils_101) {
+TEST_P(metrics_utils_c_p, test_metric_utils_101) {
 
 	char metric_sysfs[FPGA_METRIC_STR_SIZE] = { 0 };
 
@@ -164,7 +163,7 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_101) {
  *
  *
  */
-TEST_P(metrics_uitls_c_p, test_metric_utils_102) {
+TEST_P(metrics_utils_c_p, test_metric_utils_102) {
 
 	char group_name[FPGA_METRIC_STR_SIZE] = { "power_mgmt" };
 	char group_sysfs[FPGA_METRIC_STR_SIZE] = { "tmp/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0/" };
@@ -215,7 +214,7 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_102) {
  *
  *
  */
-TEST_P(metrics_uitls_c_p, test_metric_utils_103) {
+TEST_P(metrics_utils_c_p, test_metric_utils_103) {
 
 	char group_sysfs[FPGA_METRIC_STR_SIZE] = { "/tmp/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0" };
 	char group_sysfs_invalid[FPGA_METRIC_STR_SIZE] = { 0 };
@@ -251,7 +250,7 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_103) {
  *
  *
  */
-TEST_P(metrics_uitls_c_p, test_metric_utils_104) {
+TEST_P(metrics_utils_c_p, test_metric_utils_104) {
 
 	char group_sysfs[FPGA_METRIC_STR_SIZE] = { "/tmp/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0" };
 	char group_sysfs_invalid[FPGA_METRIC_STR_SIZE] = { 0 };
@@ -288,7 +287,7 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_104) {
  *
  *
  */
-TEST_P(metrics_uitls_c_p, test_metric_utils_105) {
+TEST_P(metrics_utils_c_p, test_metric_utils_105) {
 
 	char qualifier_name[FPGA_METRIC_STR_SIZE] = { 0 };
 	char group_sysfs[FPGA_METRIC_STR_SIZE] = { 0 };
@@ -339,7 +338,7 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_105) {
  *
  *
  */
-TEST_P(metrics_uitls_c_p, test_metric_utils_106) {
+TEST_P(metrics_utils_c_p, test_metric_utils_106) {
 
 	char group_sysfs[FPGA_METRIC_STR_SIZE] = { 0 };
 	fpga_metric_vector vector;
@@ -374,7 +373,7 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_106) {
  *
  *
  */
-TEST_P(metrics_uitls_c_p, test_metric_utils_107) {
+TEST_P(metrics_utils_c_p, test_metric_utils_107) {
 
 	struct _fpga_enum_metric _enum_metric = {
 		 "power_mgmt",
@@ -407,7 +406,7 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_107) {
  *
  *
  */
-TEST_P(metrics_uitls_c_p, test_metric_utils_109) {
+TEST_P(metrics_utils_c_p, test_metric_utils_109) {
 
 	EXPECT_EQ(FPGA_OK, enum_fpga_metrics(handle_));
 
@@ -423,7 +422,7 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_109) {
  *
  *
  */
-TEST_P(metrics_uitls_c_p, test_metric_utils_10) {
+TEST_P(metrics_utils_c_p, test_metric_utils_10) {
 
 	struct _fpga_handle *_handle = (struct _fpga_handle *) handle_;
 
@@ -466,7 +465,7 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_10) {
  *
  *
  */
-TEST_P(metrics_uitls_c_p, test_metric_utils_11) {
+TEST_P(metrics_utils_c_p, test_metric_utils_11) {
 
 	struct _fpga_handle *_handle = (struct _fpga_handle *) handle_;
 
@@ -495,7 +494,7 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_11) {
  *
  *
  */
-TEST_P(metrics_uitls_c_p, test_metric_utils_12) {
+TEST_P(metrics_utils_c_p, test_metric_utils_12) {
 
 	EXPECT_NE(FPGA_OK, free_fpga_enum_metrics_vector(NULL));
 
@@ -512,7 +511,7 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_12) {
  *
  *
  */
-TEST_P(metrics_uitls_c_p, test_metric_utils_13) {
+TEST_P(metrics_utils_c_p, test_metric_utils_13) {
 
 	uint64_t  value;
 
@@ -538,7 +537,7 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_13) {
 	EXPECT_EQ(FPGA_OK, get_pwr_thermal_value(group_sysfs, &value));
 }
 
-TEST_P(metrics_uitls_c_p, test_metric_utils_14) {
+TEST_P(metrics_utils_c_p, test_metric_utils_14) {
 
 	uint64_t  value;
 
@@ -564,7 +563,7 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_14) {
 	EXPECT_NE(FPGA_OK, get_performance_counter_value(group_sysfs, metric_sysfs, &value));
 }
 
-TEST_P(metrics_uitls_c_p, test_metric_utils_15) {
+TEST_P(metrics_utils_c_p, test_metric_utils_15) {
 
 	fpga_objtype objtype;
 	EXPECT_NE(FPGA_OK, get_fpga_object_type(NULL, &objtype));
@@ -572,13 +571,13 @@ TEST_P(metrics_uitls_c_p, test_metric_utils_15) {
 	EXPECT_NE(FPGA_OK, get_fpga_object_type(handle_,NULL));
 }
 
-INSTANTIATE_TEST_CASE_P(metrics_uitls_c, metrics_uitls_c_p, 
+INSTANTIATE_TEST_CASE_P(metrics_utils_c, metrics_utils_c_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({"skx-p"})) );
 
 
-class metrics_uitls_dcp_c_p : public ::testing::TestWithParam<std::string> {
+class metrics_utils_dcp_c_p : public ::testing::TestWithParam<std::string> {
 protected:
-	metrics_uitls_dcp_c_p()
+	metrics_utils_dcp_c_p()
 		: tokens_{ {nullptr, nullptr} },
 		handle_(nullptr) {}
 
@@ -620,7 +619,7 @@ protected:
 
 };
 
-TEST_P(metrics_uitls_dcp_c_p, test_metric_utils_12) {
+TEST_P(metrics_utils_dcp_c_p, test_metric_utils_12) {
 
 	uint64_t metric_id;
 
@@ -641,7 +640,7 @@ TEST_P(metrics_uitls_dcp_c_p, test_metric_utils_12) {
 	EXPECT_EQ(FPGA_OK, fpga_vector_free(&vector));
 }
 
-TEST_P(metrics_uitls_dcp_c_p, test_metric_utils_13) {
+TEST_P(metrics_utils_dcp_c_p, test_metric_utils_13) {
 
 	struct _fpga_handle *_handle = (struct _fpga_handle *) handle_;
 
@@ -656,7 +655,7 @@ TEST_P(metrics_uitls_dcp_c_p, test_metric_utils_13) {
 
 }
 
-TEST_P(metrics_uitls_dcp_c_p, test_metric_utils_14) {
+TEST_P(metrics_utils_dcp_c_p, test_metric_utils_14) {
 
 	struct _fpga_handle *_handle = (struct _fpga_handle *) handle_;
 
@@ -676,6 +675,6 @@ TEST_P(metrics_uitls_dcp_c_p, test_metric_utils_14) {
 
 }
 
-INSTANTIATE_TEST_CASE_P(metrics_uitls_c, metrics_uitls_dcp_c_p, 
+INSTANTIATE_TEST_CASE_P(metrics_utils_c, metrics_utils_dcp_c_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dcp-rc" })));
 

--- a/testing/xfpga/test_metrics_utils_c.cpp
+++ b/testing/xfpga/test_metrics_utils_c.cpp
@@ -56,9 +56,9 @@ extern "C" {
 using namespace opae::testing;
 
 
-class metics_uitls_c_p : public ::testing::TestWithParam<std::string> {
+class metrics_uitls_c_p : public ::testing::TestWithParam<std::string> {
 protected:
-	metics_uitls_c_p()
+	metrics_uitls_c_p()
 		: tokens_{ {nullptr, nullptr} },
 		handle_(nullptr) {}
 
@@ -110,7 +110,7 @@ protected:
  *
  *
  */
-TEST_P(metics_uitls_c_p, test_metric_utils_100) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_100) {
 
 	char group_sysfs[FPGA_METRIC_STR_SIZE] = { 0 };
 
@@ -136,7 +136,7 @@ TEST_P(metics_uitls_c_p, test_metric_utils_100) {
  *
  *
  */
-TEST_P(metics_uitls_c_p, test_metric_utils_101) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_101) {
 
 	char metric_sysfs[FPGA_METRIC_STR_SIZE] = { 0 };
 
@@ -164,7 +164,7 @@ TEST_P(metics_uitls_c_p, test_metric_utils_101) {
  *
  *
  */
-TEST_P(metics_uitls_c_p, test_metric_utils_102) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_102) {
 
 	char group_name[FPGA_METRIC_STR_SIZE] = { "power_mgmt" };
 	char group_sysfs[FPGA_METRIC_STR_SIZE] = { "tmp/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0/" };
@@ -215,7 +215,7 @@ TEST_P(metics_uitls_c_p, test_metric_utils_102) {
  *
  *
  */
-TEST_P(metics_uitls_c_p, test_metric_utils_103) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_103) {
 
 	char group_sysfs[FPGA_METRIC_STR_SIZE] = { "/tmp/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0" };
 	char group_sysfs_invalid[FPGA_METRIC_STR_SIZE] = { 0 };
@@ -251,7 +251,7 @@ TEST_P(metics_uitls_c_p, test_metric_utils_103) {
  *
  *
  */
-TEST_P(metics_uitls_c_p, test_metric_utils_104) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_104) {
 
 	char group_sysfs[FPGA_METRIC_STR_SIZE] = { "/tmp/class/fpga/intel-fpga-dev.0/intel-fpga-fme.0" };
 	char group_sysfs_invalid[FPGA_METRIC_STR_SIZE] = { 0 };
@@ -288,7 +288,7 @@ TEST_P(metics_uitls_c_p, test_metric_utils_104) {
  *
  *
  */
-TEST_P(metics_uitls_c_p, test_metric_utils_105) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_105) {
 
 	char qualifier_name[FPGA_METRIC_STR_SIZE] = { 0 };
 	char group_sysfs[FPGA_METRIC_STR_SIZE] = { 0 };
@@ -339,7 +339,7 @@ TEST_P(metics_uitls_c_p, test_metric_utils_105) {
  *
  *
  */
-TEST_P(metics_uitls_c_p, test_metric_utils_106) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_106) {
 
 	char group_sysfs[FPGA_METRIC_STR_SIZE] = { 0 };
 	fpga_metric_vector vector;
@@ -374,7 +374,7 @@ TEST_P(metics_uitls_c_p, test_metric_utils_106) {
  *
  *
  */
-TEST_P(metics_uitls_c_p, test_metric_utils_107) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_107) {
 
 	struct _fpga_enum_metric _enum_metric = {
 		 "power_mgmt",
@@ -407,7 +407,7 @@ TEST_P(metics_uitls_c_p, test_metric_utils_107) {
  *
  *
  */
-TEST_P(metics_uitls_c_p, test_metric_utils_109) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_109) {
 
 	EXPECT_EQ(FPGA_OK, enum_fpga_metrics(handle_));
 
@@ -423,7 +423,7 @@ TEST_P(metics_uitls_c_p, test_metric_utils_109) {
  *
  *
  */
-TEST_P(metics_uitls_c_p, test_metric_utils_10) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_10) {
 
 	struct _fpga_handle *_handle = (struct _fpga_handle *) handle_;
 
@@ -466,7 +466,7 @@ TEST_P(metics_uitls_c_p, test_metric_utils_10) {
  *
  *
  */
-TEST_P(metics_uitls_c_p, test_metric_utils_11) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_11) {
 
 	struct _fpga_handle *_handle = (struct _fpga_handle *) handle_;
 
@@ -495,7 +495,7 @@ TEST_P(metics_uitls_c_p, test_metric_utils_11) {
  *
  *
  */
-TEST_P(metics_uitls_c_p, test_metric_utils_12) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_12) {
 
 	EXPECT_NE(FPGA_OK, free_fpga_enum_metrics_vector(NULL));
 
@@ -512,7 +512,7 @@ TEST_P(metics_uitls_c_p, test_metric_utils_12) {
  *
  *
  */
-TEST_P(metics_uitls_c_p, test_metric_utils_13) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_13) {
 
 	uint64_t  value;
 
@@ -538,7 +538,7 @@ TEST_P(metics_uitls_c_p, test_metric_utils_13) {
 	EXPECT_EQ(FPGA_OK, get_pwr_thermal_value(group_sysfs, &value));
 }
 
-TEST_P(metics_uitls_c_p, test_metric_utils_14) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_14) {
 
 	uint64_t  value;
 
@@ -564,7 +564,7 @@ TEST_P(metics_uitls_c_p, test_metric_utils_14) {
 	EXPECT_NE(FPGA_OK, get_performance_counter_value(group_sysfs, metric_sysfs, &value));
 }
 
-TEST_P(metics_uitls_c_p, test_metric_utils_15) {
+TEST_P(metrics_uitls_c_p, test_metric_utils_15) {
 
 	fpga_objtype objtype;
 	EXPECT_NE(FPGA_OK, get_fpga_object_type(NULL, &objtype));
@@ -572,13 +572,13 @@ TEST_P(metics_uitls_c_p, test_metric_utils_15) {
 	EXPECT_NE(FPGA_OK, get_fpga_object_type(handle_,NULL));
 }
 
-INSTANTIATE_TEST_CASE_P(metics_uitls_c, metics_uitls_c_p, 
+INSTANTIATE_TEST_CASE_P(metrics_uitls_c, metrics_uitls_c_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({"skx-p"})) );
 
 
-class metics_uitls_dcp_c_p : public ::testing::TestWithParam<std::string> {
+class metrics_uitls_dcp_c_p : public ::testing::TestWithParam<std::string> {
 protected:
-	metics_uitls_dcp_c_p()
+	metrics_uitls_dcp_c_p()
 		: tokens_{ {nullptr, nullptr} },
 		handle_(nullptr) {}
 
@@ -620,7 +620,7 @@ protected:
 
 };
 
-TEST_P(metics_uitls_dcp_c_p, test_metric_utils_12) {
+TEST_P(metrics_uitls_dcp_c_p, test_metric_utils_12) {
 
 	uint64_t metric_id;
 
@@ -641,7 +641,7 @@ TEST_P(metics_uitls_dcp_c_p, test_metric_utils_12) {
 	EXPECT_EQ(FPGA_OK, fpga_vector_free(&vector));
 }
 
-TEST_P(metics_uitls_dcp_c_p, test_metric_utils_13) {
+TEST_P(metrics_uitls_dcp_c_p, test_metric_utils_13) {
 
 	struct _fpga_handle *_handle = (struct _fpga_handle *) handle_;
 
@@ -656,7 +656,7 @@ TEST_P(metics_uitls_dcp_c_p, test_metric_utils_13) {
 
 }
 
-TEST_P(metics_uitls_dcp_c_p, test_metric_utils_14) {
+TEST_P(metrics_uitls_dcp_c_p, test_metric_utils_14) {
 
 	struct _fpga_handle *_handle = (struct _fpga_handle *) handle_;
 
@@ -676,6 +676,6 @@ TEST_P(metics_uitls_dcp_c_p, test_metric_utils_14) {
 
 }
 
-INSTANTIATE_TEST_CASE_P(metics_uitls_c, metics_uitls_dcp_c_p, 
+INSTANTIATE_TEST_CASE_P(metrics_uitls_c, metrics_uitls_dcp_c_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dcp-rc" })));
 


### PR DESCRIPTION
changes:
	-returns error not found if user passes all invlaid index
	 to getmetricbyindex()

       -returns error not found if user passes all invlaid serach
	 strings to getmetricbyname()