### PR TITLE
Fixed unused variable warning for newer compilers.

### DIFF
--- a/testing/mock/ioctl_handlers.cpp
+++ b/testing/mock/ioctl_handlers.cpp
@@ -49,7 +49,7 @@ static int validate_argp(mock_object* mock, int request, va_list argp) {
 
 #define DEFAULT_IOCTL_HANDLER(_REQ, _S)                                        \
   namespace {                                                                  \
-  static bool r##_S =                                                          \
+  static bool r##_S __attribute__((unused)) =                                  \
       test_system::instance()->default_ioctl_handler(_REQ, validate_argp<_S>); \
   }
 


### PR DESCRIPTION
I was able to reproduce the compilation issue on gcc 5.4. This should fix the warning.