### PR TITLE
api: change sysobject cxx to return null

### DIFF
--- a/common/include/opae/cxx/core/sysobject.h
+++ b/common/include/opae/cxx/core/sysobject.h
@@ -43,6 +43,8 @@ class sysobject {
  public:
   typedef std::shared_ptr<sysobject> ptr_t;
 
+  sysobject() = delete;
+
   sysobject(const sysobject &o) = delete;
 
   sysobject &operator=(const sysobject &o) = delete;
@@ -171,7 +173,7 @@ class sysobject {
   operator fpga_object() const { return sysobject_; }
 
  private:
-  sysobject();
+  sysobject(fpga_object sysobj, token::ptr_t token, handle::ptr_t hnd);
   fpga_object sysobject_;
   token::ptr_t token_;
   handle::ptr_t handle_;

--- a/testing/opae-cxx/test_object_cxx_core.cpp
+++ b/testing/opae-cxx/test_object_cxx_core.cpp
@@ -160,6 +160,8 @@ TEST_P(sysobject_cxx_p, object_object) {
   ASSERT_NE(h_obj.get(), nullptr);
   auto h_value = h_obj->get("errors")->read64();
   EXPECT_EQ(t_value, h_value);
+  EXPECT_EQ(t_obj->get("abc").get(), nullptr);
+  EXPECT_EQ(h_obj->get("abc").get(), nullptr);
 }
 
 /**


### PR DESCRIPTION
Change behavior of sysobject cxx find functions to return nullptr when
FPGA_NOT_FOUND is returned from the C functions (instead of throwing
exceptions)