### PR TITLE
pyfpgadiag: mock `time.sleep`, fix coverage

### DIFF
--- a/scripts/cover-py.sh
+++ b/scripts/cover-py.sh
@@ -17,7 +17,7 @@ if [ "$FILES" == "" ]; then
 fi
 
 mkdir -p pytests
-cd pytests
+pushd pytests
 
 if [ ! -f CMakeCache.txt ]; then
 	cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF -DBUILD_LIBOPAE_PY=ON -DBUILD_PYTHON_DIST=ON
@@ -27,5 +27,6 @@ echo "Making pyopae"
 make -j4 opae-c opae-cxx-core pyopae-dist
 
 python -m pip install pyopae/stage/dist/opae.fpga*.whl --user
-LD_LIBRARY_PATH=$PWD/lib python -m nose2 -F -C --coverage-report term-missing test_fpgadiag -s tools/extra/pyfpgadiag/stage --coverage tools/extra/pyfpgadiag/stage
+popd
+LD_LIBRARY_PATH=$PWD/pytests/lib python -m nose2 -C --coverage-report term-missing test_fpgadiag -s pytests/tools/extra/pyfpgadiag/stage --coverage pytests/tools/extra/pyfpgadiag/stage
 pip uninstall opae.fpga -y

--- a/tools/extra/pyfpgadiag/test_fpgadiag.py
+++ b/tools/extra/pyfpgadiag/test_fpgadiag.py
@@ -335,8 +335,9 @@ class NLBTest(unittest.TestCase):
         self.assertTrue(nlb.setup(cmdline_args))
         output = ''
         with mock.patch('sys.stdout', new=StringIO()) as fake_stdout:
-            nlb.run(h, mock_fmehandle())
-            output = fake_stdout.getvalue().strip()
+            with mock.patch('time.sleep', new=lambda x: None):
+                nlb.run(h, mock_fmehandle())
+                output = fake_stdout.getvalue().strip()
         self.assertFalse(output == '')
         if not csv:
             m = NORMAL_OUTPUT.match(output)
@@ -376,8 +377,9 @@ class NLBTest(unittest.TestCase):
         self.assertTrue(nlb.setup(cmdline_args))
         output = ''
         with mock.patch('sys.stdout', new=StringIO()) as fake_stdout:
-            nlb.run(h, mock_fmehandle())
-            output = fake_stdout.getvalue().strip()
+            with mock.patch('time.sleep', new=lambda x: None):
+                nlb.run(h, mock_fmehandle())
+                output = fake_stdout.getvalue().strip()
         self.assertFalse(output == '')
         if not csv:
             m = NORMAL_OUTPUT.match(output)


### PR DESCRIPTION
Mocking time.sleep to essentially a NOOP reduces execution time to 26ish
seconds.
Change cover-py.sh script to run tests from root of repo