### PR TITLE
tests: re-enable pyopae tests

### DIFF
--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -6,7 +6,7 @@ mkdir -p unittests
 cd unittests
 
 if [ ! -f CMakeCache.txt ]; then
-	cmake .. -DOPAE_PYTHON_VERSION=$TRAVIS_PYTHON_VERSION -DCMAKE_BUILD_TYPE=Coverage -DBUILD_TESTS=ON -DBUILD_LIBOPAE_PY=ON
+	cmake .. -DOPAE_PYTHON_VERSION=2.7 -DCMAKE_BUILD_TYPE=Coverage -DBUILD_TESTS=ON -DBUILD_LIBOPAE_PY=ON
 fi
 
 mkdir -p coverage_files

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -6,7 +6,7 @@ mkdir -p unittests
 cd unittests
 
 if [ ! -f CMakeCache.txt ]; then
-	cmake .. -DCMAKE_BUILD_TYPE=Coverage -DBUILD_TESTS=ON -DBUILD_LIBOPAE_PY=ON
+	cmake .. -DOPAE_PYTHON_VERSION=$TRAVIS_PYTHON_VERSION -DCMAKE_BUILD_TYPE=Coverage -DBUILD_TESTS=ON -DBUILD_LIBOPAE_PY=ON
 fi
 
 mkdir -p coverage_files

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -631,7 +631,16 @@ add_custom_command(TARGET test_unit
 ############################################################################
 # pyopae tests #############################################################
 ############################################################################
-if (DEFINED ENV{TRAVIS_PYTHON_VERSION})
+try_compile(SUPPORTS_EMBEDDED_PYTHON
+    ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/pyopae/test_embed.cpp
+    CMAKE_FLAGS
+    "-DINCLUDE_DIRECTORIES=${PYTHON_INCLUDE_DIRS};${CMAKE_SOURCE_DIR}/pyopae/pybind11/include"
+    LINK_LIBRARIES ${PYTHON_LIBRARIES}
+    OUTPUT_VARIABLE TRY_COMPILE_OUTPUT
+    CXX_STANDARD 11
+    )
+
+if (SUPPORTS_EMBEDDED_PYTHON)
     add_executable(test_pyopae
          ${MOCK_C}
          pyopae/test_pyopae.cpp
@@ -681,5 +690,8 @@ if (DEFINED ENV{TRAVIS_PYTHON_VERSION})
     add_pyopae_test(test_properties.py)
     add_pyopae_test(test_shared_buffers.py)
     add_pyopae_test(test_sysobject.py)
-
-endif (DEFINED ENV{TRAVIS_PYTHON_VERSION})
+else(SUPPORTS_EMBEDDED_PYTHON)
+    message(WARNING
+        "Could not compile embedded Python. See errors in embed.txt")
+    file(WRITE embed.txt ${TRY_COMPILE_OUTPUT})
+endif (SUPPORTS_EMBEDDED_PYTHON)

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -631,55 +631,55 @@ add_custom_command(TARGET test_unit
 ############################################################################
 # pyopae tests #############################################################
 ############################################################################
-if (PYTHONLIBS_VERSION_STRING GREATER "2.7.14")
- add_executable(test_pyopae
-     ${MOCK_C}
-     pyopae/test_pyopae.cpp
-     ${OPAE_SDK_SOURCE}/pyopae/opae.cpp
-     ${OPAE_SDK_SOURCE}/pyopae/pycontext.h
-     ${OPAE_SDK_SOURCE}/pyopae/pycontext.cpp
-     ${OPAE_SDK_SOURCE}/pyopae/pyproperties.h
-     ${OPAE_SDK_SOURCE}/pyopae/pyproperties.cpp
-     ${OPAE_SDK_SOURCE}/pyopae/pyhandle.h
-     ${OPAE_SDK_SOURCE}/pyopae/pyhandle.cpp
-     ${OPAE_SDK_SOURCE}/pyopae/pytoken.h
-     ${OPAE_SDK_SOURCE}/pyopae/pytoken.cpp
-     ${OPAE_SDK_SOURCE}/pyopae/pyshared_buffer.h
-     ${OPAE_SDK_SOURCE}/pyopae/pyshared_buffer.cpp
-     ${OPAE_SDK_SOURCE}/pyopae/pyevents.h
-     ${OPAE_SDK_SOURCE}/pyopae/pyevents.cpp
-     ${OPAE_SDK_SOURCE}/pyopae/pyerrors.h
-     ${OPAE_SDK_SOURCE}/pyopae/pyerrors.cpp
-     ${OPAE_SDK_SOURCE}/pyopae/pysysobject.h
-     ${OPAE_SDK_SOURCE}/pyopae/pysysobject.cpp)
-target_compile_definitions(test_pyopae PRIVATE
-    OPAE_EMBEDDED)
-target_include_directories(test_pyopae
-     PRIVATE ${CMAKE_SOURCE_DIR}/pyopae/pybind11/include
-     PRIVATE ${PYTHON_INCLUDE_DIRS}
-     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-add_library(embed INTERFACE)
-target_link_libraries(test_pyopae PUBLIC opae-c opae-cxx-core
-     test_system ${PYTHON_LIBRARIES}
-     PRIVATE embed)
-add_dependencies(test_unit test_pyopae)
+if (DEFINED ENV{TRAVIS_PYTHON_VERSION})
+    add_executable(test_pyopae
+         ${MOCK_C}
+         pyopae/test_pyopae.cpp
+         ${OPAE_SDK_SOURCE}/pyopae/opae.cpp
+         ${OPAE_SDK_SOURCE}/pyopae/pycontext.h
+         ${OPAE_SDK_SOURCE}/pyopae/pycontext.cpp
+         ${OPAE_SDK_SOURCE}/pyopae/pyproperties.h
+         ${OPAE_SDK_SOURCE}/pyopae/pyproperties.cpp
+         ${OPAE_SDK_SOURCE}/pyopae/pyhandle.h
+         ${OPAE_SDK_SOURCE}/pyopae/pyhandle.cpp
+         ${OPAE_SDK_SOURCE}/pyopae/pytoken.h
+         ${OPAE_SDK_SOURCE}/pyopae/pytoken.cpp
+         ${OPAE_SDK_SOURCE}/pyopae/pyshared_buffer.h
+         ${OPAE_SDK_SOURCE}/pyopae/pyshared_buffer.cpp
+         ${OPAE_SDK_SOURCE}/pyopae/pyevents.h
+         ${OPAE_SDK_SOURCE}/pyopae/pyevents.cpp
+         ${OPAE_SDK_SOURCE}/pyopae/pyerrors.h
+         ${OPAE_SDK_SOURCE}/pyopae/pyerrors.cpp
+         ${OPAE_SDK_SOURCE}/pyopae/pysysobject.h
+         ${OPAE_SDK_SOURCE}/pyopae/pysysobject.cpp)
+    target_compile_definitions(test_pyopae PRIVATE
+        OPAE_EMBEDDED)
+    target_include_directories(test_pyopae
+         PRIVATE ${CMAKE_SOURCE_DIR}/pyopae/pybind11/include
+         PRIVATE ${PYTHON_INCLUDE_DIRS}
+         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    add_library(embed INTERFACE)
+    target_link_libraries(test_pyopae PUBLIC opae-c opae-cxx-core
+         test_system ${PYTHON_LIBRARIES}
+         PRIVATE embed)
+    add_dependencies(test_unit test_pyopae)
 
-macro(add_pyopae_test pytest)
-    add_custom_command(TARGET test_pyopae
-       POST_BUILD
-       COMMAND ${CMAKE_COMMAND} -E copy
-       ${CMAKE_CURRENT_SOURCE_DIR}/pyopae/${pytest}
-       ${CMAKE_BINARY_DIR}
-       )
-    add_test(
-        NAME ${pytest}
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        COMMAND $<TARGET_FILE:test_pyopae> test ${pytest}
-    )
-endmacro(add_pyopae_test pytest)
+    macro(add_pyopae_test pytest)
+        add_custom_command(TARGET test_pyopae
+           POST_BUILD
+           COMMAND ${CMAKE_COMMAND} -E copy
+           ${CMAKE_CURRENT_SOURCE_DIR}/pyopae/${pytest}
+           ${CMAKE_BINARY_DIR}
+           )
+        add_test(
+            NAME ${pytest}
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            COMMAND $<TARGET_FILE:test_pyopae> test ${pytest}
+        )
+    endmacro(add_pyopae_test pytest)
 
-add_pyopae_test(test_properties.py)
-add_pyopae_test(test_shared_buffers.py)
-add_pyopae_test(test_sysobject.py)
+    add_pyopae_test(test_properties.py)
+    add_pyopae_test(test_shared_buffers.py)
+    add_pyopae_test(test_sysobject.py)
 
-endif(PYTHONLIBS_VERSION_STRING GREATER "2.7.14")
+endif (DEFINED ENV{TRAVIS_PYTHON_VERSION})

--- a/testing/pyopae/test_embed.cpp
+++ b/testing/pyopae/test_embed.cpp
@@ -1,0 +1,15 @@
+
+#include <Python.h>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/embed.h>
+
+namespace py = pybind11;
+
+PYBIND11_EMBEDDED_MODULE(testembed, m) {
+  m.def("zero", []() { return 0;});
+}
+
+int main(int argc, char *argv[]) {
+  return 0;
+}

--- a/testing/pyopae/test_pyopae.cpp
+++ b/testing/pyopae/test_pyopae.cpp
@@ -1,3 +1,28 @@
+// Copyright(c) 2017-2018, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 #include <Python.h>
 
 #include <pybind11/embed.h>

--- a/testing/pyopae/test_sysobject.py
+++ b/testing/pyopae/test_sysobject.py
@@ -59,8 +59,9 @@ class TestSysObject(unittest.TestCase):
         assert u1 == u2
         afuid2 = self.afu_toks[0]["afu_id"].bytes()[:-1]
         assert afuid == afuid2
+        self.assertEquals(self.afu_toks[0].wrong, None)
         with self.assertRaises(RuntimeError):
-            print(self.afu_toks[0].wrong)
+            print(self.afu_toks[0]['../fpga'].read64())
 
     def test_handle_object(self):
         afuid = self.afu_handle.afu_id.bytes()[:-1]
@@ -80,10 +81,7 @@ class TestSysObject(unittest.TestCase):
         errors = self.afu_handle.errors
         rev = errors.revision
         n1 = rev.read64()
-        assert n1 is not None
-        n2 = int(rev)
-
-        assert n1 == n2, "{} != {}".format(n1, n2)
+        self.assertEquals(n1, 1)
         with self.assertRaises(RuntimeError):
             print(errors.read64())
 


### PR DESCRIPTION
* Use TRAVIS_PYTHON_VERSION env. variable when configuring the builld
* Check TRAVIS_PYTHON_VERSION in testing/CMakeLists.txt to determine if
  test_pyopae + tests should be built/executed
* Update sysobject Python tests to reflect latest change in the cxx API