### PR TITLE
fpgad: harden the workspace

### DIFF
--- a/testing/fpgad/test_ap6_c.cpp
+++ b/testing/fpgad/test_ap6_c.cpp
@@ -103,15 +103,16 @@ class fpgad_ap6_c_p : public ::testing::TestWithParam<std::string> {
       .verbosity = 0,
       .poll_interval_usec = 1000 * 1000,
       .daemon = 0,
-      .directory = ".",
-      .logfile = tmpfpgad_log_,
-      .pidfile = "",
+      .directory = { 0, },
+      .logfile = { 0, },
+      .pidfile = { 0, },
       .filemode = 0,
       .running = true,
       .socket = "/tmp/fpga_event_socket",
       .null_gbs = { "junk.gbs", tmpnull_gbs_ },
       .num_null_gbs = 2,
     };
+    strcpy(config_.logfile, tmpfpgad_log_);
 
     context_.config = &config_;
     context_.socket = 0;

--- a/testing/fpgad/test_ap_event_c.cpp
+++ b/testing/fpgad/test_ap_event_c.cpp
@@ -74,15 +74,16 @@ class fpgad_ap_event_c_p : public ::testing::TestWithParam<std::string> {
       .verbosity = 0,
       .poll_interval_usec = 100 * 1000,
       .daemon = 0,
-      .directory = ".",
-      .logfile = tmpfpgad_log_,
-      .pidfile = "",
+      .directory = { 0, },
+      .logfile = { 0, },
+      .pidfile = { 0, },
       .filemode = 0,
       .running = true,
       .socket = "/tmp/fpga_event_socket",
       .null_gbs = {0},
       .num_null_gbs = 0,
     };
+    strcpy(config_.logfile, tmpfpgad_log_);
 
     ap_thread_ = std::thread(apevent_thread, &config_);
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));

--- a/testing/fpgad/test_errtable_c.cpp
+++ b/testing/fpgad/test_errtable_c.cpp
@@ -96,15 +96,17 @@ class fpgad_errtable_c_p : public ::testing::TestWithParam<std::string> {
       .verbosity = 0,
       .poll_interval_usec = 1000 * 1000,
       .daemon = 0,
-      .directory = ".",
-      .logfile = tmpfpgad_log_,
-      .pidfile = tmpfpgad_pid_,
+      .directory = { 0, },
+      .logfile = { 0, },
+      .pidfile = { 0, },
       .filemode = 0,
       .running = true,
       .socket = "/tmp/fpga_event_socket",
       .null_gbs = {0},
       .num_null_gbs = 0,
     };
+    strcpy(config_.logfile, tmpfpgad_log_);
+    strcpy(config_.pidfile, tmpfpgad_pid_);
 
     logger_thread_ = std::thread(logger_thread, &config_);
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));

--- a/testing/hello_events/test_hello_events_c.cpp
+++ b/testing/hello_events/test_hello_events_c.cpp
@@ -299,15 +299,17 @@ class mock_hello_events_c_fpgad_p : public ::testing::TestWithParam<std::string>
       .verbosity = 0,
       .poll_interval_usec = 100 * 1000,
       .daemon = 0,
-      .directory = ".",
-      .logfile = tmpfpgad_log_,
-      .pidfile = tmpfpgad_pid_,
+      .directory = { 0, },
+      .logfile = { 0, },
+      .pidfile = { 0, },
       .filemode = 0,
       .running = true,
       .socket = "/tmp/fpga_event_socket",
       .null_gbs = {0},
       .num_null_gbs = 0,
     };
+    strcpy(config_.logfile, tmpfpgad_log_);
+    strcpy(config_.pidfile, tmpfpgad_pid_);
 
     open_log(tmpfpgad_log_);
     fpgad_log_ = std::thread(logger_thread, &config_);

--- a/testing/opae-c/test_event_c.cpp
+++ b/testing/opae-c/test_event_c.cpp
@@ -84,15 +84,18 @@ class event_c_p : public ::testing::TestWithParam<std::string> {
         .verbosity = 0,
         .poll_interval_usec = 100 * 1000,
         .daemon = 0,
-        .directory = ".",
-        .logfile = tmpfpgad_log_,
-        .pidfile = tmpfpgad_pid_,
+        .directory = { 0, },
+        .logfile = { 0, },
+        .pidfile = { 0, },
         .filemode = 0,
         .running = true,
         .socket = "/tmp/fpga_event_socket",
         .null_gbs = {0},
         .num_null_gbs = 0,
     };
+    strcpy(config_.logfile, tmpfpgad_log_);
+    strcpy(config_.pidfile, tmpfpgad_pid_);
+
     open_log(tmpfpgad_log_);
     fpgad_ = std::thread(server_thread, &config_);
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));

--- a/testing/opae-cxx/test_events_cxx_core.cpp
+++ b/testing/opae-cxx/test_events_cxx_core.cpp
@@ -76,15 +76,18 @@ class events_cxx_core : public ::testing::TestWithParam<std::string> {
         .verbosity = 0,
         .poll_interval_usec = 100 * 1000,
         .daemon = 0,
-        .directory = ".",
-        .logfile = tmpfpgad_log_,
-        .pidfile = tmpfpgad_pid_,
+        .directory = { 0, },
+        .logfile = { 0, },
+        .pidfile = { 0, },
         .filemode = 0,
         .running = true,
         .socket = "/tmp/fpga_event_socket",
         .null_gbs = {0},
         .num_null_gbs = 0,
     };
+    strcpy(config_.logfile, tmpfpgad_log_);
+    strcpy(config_.pidfile, tmpfpgad_pid_);
+
     open_log(tmpfpgad_log_);
     fpgad_ = std::thread(server_thread, &config_);
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));

--- a/testing/xfpga/test_events_c.cpp
+++ b/testing/xfpga/test_events_c.cpp
@@ -326,15 +326,18 @@ class events_p : public ::testing::TestWithParam<std::string> {
         .verbosity = 0,
         .poll_interval_usec = 100 * 1000,
         .daemon = 0,
-        .directory = ".",
-        .logfile = tmpfpgad_log_,
-        .pidfile = tmpfpgad_pid_,
+        .directory = { 0, },
+        .logfile = { 0, },
+        .pidfile = { 0, },
         .filemode = 0,
         .running = true,
         .socket = "/tmp/fpga_event_socket",
         .null_gbs = {0},
         .num_null_gbs = 0,
     };
+    strcpy(config_.logfile, tmpfpgad_log_);
+    strcpy(config_.pidfile, tmpfpgad_pid_);
+
     open_log(tmpfpgad_log_);
     fpgad_ = std::thread(server_thread, &config_);
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
@@ -1335,15 +1338,18 @@ class events_handle_p : public ::testing::TestWithParam<std::string> {
         .verbosity = 0,
         .poll_interval_usec = 100 * 1000,
         .daemon = 0,
-        .directory = ".",
-        .logfile = tmpfpgad_log_,
-        .pidfile = tmpfpgad_pid_,
+        .directory = { 0, },
+        .logfile = { 0, },
+        .pidfile = { 0, },
         .filemode = 0,
         .running = true,
         .socket = "/tmp/fpga_event_socket",
         .null_gbs = {0},
         .num_null_gbs = 0,
     };
+    strcpy(config_.logfile, tmpfpgad_log_);
+    strcpy(config_.pidfile, tmpfpgad_pid_);
+
     open_log(tmpfpgad_log_);
     fpgad_ = std::thread(server_thread, &config_);
     logger_thread_ = std::thread(logger_thread, &config_);

--- a/tools/base/fpgad/config_int.h
+++ b/tools/base/fpgad/config_int.h
@@ -28,6 +28,7 @@
 #define __FPGAD_CONFIG_H__
 #include <fcntl.h>
 #include <stdbool.h>
+#include <linux/limits.h>
 
 #define MAX_NULL_GBS 16
 #define MAX_SOCKETS 2
@@ -43,11 +44,11 @@ struct config {
 	unsigned int verbosity;
 	useconds_t   poll_interval_usec;
 
-	int daemon;            // whether to daemonize
-	const char *directory; // working directory when daemonizing
-	const char *logfile;   // location of log file
-	const char *pidfile;   // where to write fpgad.pid
-	mode_t filemode;       // argument for umask
+	int daemon;               // whether to daemonize
+	char directory[PATH_MAX]; // working directory when daemonizing
+	char logfile[PATH_MAX];   // location of log file
+	char pidfile[PATH_MAX];   // where to write fpgad.pid
+	mode_t filemode;          // argument for umask
 
 	bool running;
 


### PR DESCRIPTION
Deprecate --directory and --umask parameters.
Restrict --logfile and --pidfile parameters to allowing file names only.
Set directory based on the current user:
* If root, then use /var/lib/opae
* Otherwise, use ${HOME}/.opae
Set the umask based on the current user:
* If root, deny world read/write and group write.
* Otherwise, deny world write and group write.