### PR TITLE
Added symlink tests to the existing tool tests

### DIFF
--- a/testing/coreidle/test_main_c.cpp
+++ b/testing/coreidle/test_main_c.cpp
@@ -228,6 +228,29 @@ TEST_P(coreidle_main_c_p, main0) {
 }
 
 /**
+ * @test       main_symlink
+ * @brief      Test: coreidle_main
+ * @details    When called with parameters that specify<br>
+ *             a device that is found,<br>
+ *             but the input bitstream file is a symlink<br>
+ *             to a bitstream, coreidle returns non-zero.<br>
+ */
+TEST_P(coreidle_main_c_p, main_symlink) {
+  char zero[20];
+  char one[20];
+  char two[20];
+  strcpy(zero, "coreidle");
+  strcpy(one, "-G");
+  strcpy(two, "test_symlink");
+
+  char *argv[] = { zero, one, two };
+
+  ASSERT_EQ(symlink(tmp_gbs_, "test_symlink"), 0);
+  EXPECT_NE(coreidle_main(3, argv), 0);
+  EXPECT_EQ(unlink("test_symlink"), 0);
+}
+
+/**
  * @test       parse0
  * @brief      Test: ParseCmds
  * @details    When given "-h",<br>

--- a/testing/fpgaconf/test_fpgaconf_c.cpp
+++ b/testing/fpgaconf/test_fpgaconf_c.cpp
@@ -594,7 +594,6 @@ TEST_P(fpgaconf_c_p, main_symlink) {
   char *argv[] = { zero, one, two, three, four, five };
 
   ASSERT_EQ(symlink(tmp_gbs_, "test_symlink"), 0);
-
   EXPECT_NE(fpgaconf_main(6, argv), 0);
   EXPECT_EQ(unlink("test_symlink"), 0);
 }

--- a/testing/fpgaconf/test_fpgaconf_c.cpp
+++ b/testing/fpgaconf/test_fpgaconf_c.cpp
@@ -571,6 +571,35 @@ TEST_P(fpgaconf_c_p, main2) {
 }
 
 /**
+ * @test       main_symlink
+ * @brief      Test: fpgaconf_main
+ * @details    When the command params are valid,<br>
+ *             but the input bitstream file is a symlink<br>
+ *             to a bitstream, fpgaconf returns non-zero.<br>
+ */
+TEST_P(fpgaconf_c_p, main_symlink) {
+  char zero[20];
+  char one[20];
+  char two[20];
+  char three[20];
+  char four[20];
+  char five[20];
+  strcpy(zero, "fpgaconf");
+  strcpy(one, "-v");
+  strcpy(two, "-n");
+  strcpy(three, "-B");
+  sprintf(four, "%d", platform_.devices[0].bus);
+  strcpy(five, "test_symlink");
+
+  char *argv[] = { zero, one, two, three, four, five };
+
+  ASSERT_EQ(symlink(tmp_gbs_, "test_symlink"), 0);
+
+  EXPECT_NE(fpgaconf_main(6, argv), 0);
+  EXPECT_EQ(unlink("test_symlink"), 0);
+}
+
+/**
  * @test       str_to_guid
  * @brief      Test: string_to_guid
  * @details    When the given string does not represent a valid GUID,<br>

--- a/testing/fpgad/test_fpgad_c.cpp
+++ b/testing/fpgad/test_fpgad_c.cpp
@@ -266,10 +266,6 @@ TEST_P(fpgad_fpgad_c_p, main_symlink_log) {
     ASSERT_EQ(mkdir(dir.c_str(), 0770), 0);
   }
 
-  if (stat(test_symlink.c_str(), &buffer) == 0) {
-    ASSERT_EQ(unlink(test_symlink.c_str()), 0);
-  }
-
   ASSERT_EQ(symlink("/tmp/fpgad.log", test_symlink.c_str()), 0);
   EXPECT_NE(fpgad_main(4, argv), 0);
   EXPECT_EQ(unlink(test_symlink.c_str()), 0);
@@ -310,10 +306,6 @@ TEST_P(fpgad_fpgad_c_p, main_symlink_pid) {
 
   if (stat(dir.c_str(), &buffer)) {
     ASSERT_EQ(mkdir(dir.c_str(), 0770), 0);
-  }
-
-  if (stat(test_symlink.c_str(), &buffer) == 0) {
-    ASSERT_EQ(unlink(test_symlink.c_str()), 0);
   }
 
   ASSERT_EQ(symlink("/tmp/fpgad.pid", test_symlink.c_str()), 0);

--- a/testing/fpgad/test_fpgad_c.cpp
+++ b/testing/fpgad/test_fpgad_c.cpp
@@ -206,13 +206,13 @@ TEST_P(fpgad_fpgad_c_p, main_invalid) {
 }
 
 /**
- * @test       main_symlink
+ * @test       main_symlink_gbs
  * @brief      Test: fpgad_main
  * @details    When fpgad_main is called with valid params<br>
  *             but the input bitstream file is a symlink<br>
  *             to a bitstream, fpgad returns non-zero.<br>
  */
-TEST_P(fpgad_fpgad_c_p, main_symlink) {
+TEST_P(fpgad_fpgad_c_p, main_symlink_gbs) {
   char zero[20];
   char one[20];
   char two[20];
@@ -227,6 +227,98 @@ TEST_P(fpgad_fpgad_c_p, main_symlink) {
   ASSERT_EQ(symlink(tmp_gbs_, "test_symlink"), 0);
   EXPECT_NE(fpgad_main(4, argv), 0);
   EXPECT_EQ(unlink("test_symlink"), 0);
+}
+
+/**
+ * @test       main_symlink_log
+ * @brief      Test: fpgad_main
+ * @details    When fpgad_main is called with valid params<br>
+ *             but the output log file is a symlink<br>
+ *             to a file, fpgad returns non-zero.<br>
+ */
+TEST_P(fpgad_fpgad_c_p, main_symlink_log) {
+  char zero[20];
+  char one[20];
+  char two[20];
+  char three[20];
+  strcpy(zero, "fpgad");
+  strcpy(one, "-l");
+  strcpy(two, "test_symlink");
+  strcpy(three, "-h");
+
+  char *argv[] = { zero, one, two, three };
+
+  std::string dir;
+  std::string test_symlink;
+
+  if (!geteuid()) {
+    dir = "/var/lib/opae";
+  } else {
+    dir = std::string(getenv("HOME")) +
+               std::string("/.opae");
+  }
+
+  test_symlink = dir + "/test_symlink";
+
+  struct stat buffer;
+
+  if (stat(dir.c_str(), &buffer)) {
+    ASSERT_EQ(mkdir(dir.c_str(), 0770), 0);
+  }
+
+  if (stat(test_symlink.c_str(), &buffer) == 0) {
+    ASSERT_EQ(unlink(test_symlink.c_str()), 0);
+  }
+
+  ASSERT_EQ(symlink("/tmp/fpgad.log", test_symlink.c_str()), 0);
+  EXPECT_NE(fpgad_main(4, argv), 0);
+  EXPECT_EQ(unlink(test_symlink.c_str()), 0);
+}
+
+/**
+ * @test       main_symlink_pid
+ * @brief      Test: fpgad_main
+ * @details    When fpgad_main is called with valid params<br>
+ *             but the output log file is a symlink<br>
+ *             to a file, fpgad returns non-zero.<br>
+ */
+TEST_P(fpgad_fpgad_c_p, main_symlink_pid) {
+  char zero[20];
+  char one[20];
+  char two[20];
+  char three[20];
+  strcpy(zero, "fpgad");
+  strcpy(one, "-p");
+  strcpy(two, "test_symlink");
+  strcpy(three, "-h");
+
+  char *argv[] = { zero, one, two, three };
+
+  std::string dir;
+  std::string test_symlink;
+
+  if (!geteuid()) {
+    dir = "/var/lib/opae";
+  } else {
+    dir = std::string(getenv("HOME")) +
+               std::string("/.opae");
+  }
+
+  test_symlink = dir + "/test_symlink";
+
+  struct stat buffer;
+
+  if (stat(dir.c_str(), &buffer)) {
+    ASSERT_EQ(mkdir(dir.c_str(), 0770), 0);
+  }
+
+  if (stat(test_symlink.c_str(), &buffer) == 0) {
+    ASSERT_EQ(unlink(test_symlink.c_str()), 0);
+  }
+
+  ASSERT_EQ(symlink("/tmp/fpgad.pid", test_symlink.c_str()), 0);
+  EXPECT_NE(fpgad_main(4, argv), 0);
+  EXPECT_EQ(unlink(test_symlink.c_str()), 0);
 }
 
 INSTANTIATE_TEST_CASE_P(fpgad_fpgad_c, fpgad_fpgad_c_p,


### PR DESCRIPTION
Added tests to verify disallowing symlinks for fpgaconf, fpgad, and coreidle for user input file paths that the applications read from and write to.

Note: These tests will fail until symlink check capability is implemented for these tools.