### PR TITLE
Removed fpgabist compile flags definition in order to use top level compile flags.

### DIFF
--- a/tools/extra/pac/fpgabist/bist/CMakeLists.txt
+++ b/tools/extra/pac/fpgabist/bist/CMakeLists.txt
@@ -29,7 +29,6 @@ include_directories(${OPAE_INCLUDE_DIR})
 add_executable(bist_app bist_afu.c)
 set_install_rpath(bist_app)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 target_link_libraries(bist_app opae-c ${libjson-c_LIBRARIES} uuid rt ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS bist_app

--- a/tools/extra/pac/fpgabist/bist/bist_afu.c
+++ b/tools/extra/pac/fpgabist/bist/bist_afu.c
@@ -195,7 +195,7 @@ int main(int argc, char *argv[])
 
 	cache_line *cl_ptr = (cache_line *)input_ptr;
 
-        uint32_t i;
+	uint32_t i;
 
 	for (i = 0; i < LPBK1_BUFFER_SIZE / CL(1); ++i) {
 		cl_ptr[i].uint[15] = i+1; /* set the last uint in every cacheline */

--- a/tools/extra/pac/fpgabist/bist/bist_afu.c
+++ b/tools/extra/pac/fpgabist/bist/bist_afu.c
@@ -194,7 +194,10 @@ int main(int argc, char *argv[])
 	memset((void *)output_ptr, 0xBE, LPBK1_BUFFER_SIZE);
 
 	cache_line *cl_ptr = (cache_line *)input_ptr;
-	for (uint32_t i = 0; i < LPBK1_BUFFER_SIZE / CL(1); ++i) {
+
+        uint32_t i;
+
+	for (i = 0; i < LPBK1_BUFFER_SIZE / CL(1); ++i) {
 		cl_ptr[i].uint[15] = i+1; /* set the last uint in every cacheline */
 	}
 
@@ -322,7 +325,7 @@ int main(int argc, char *argv[])
 	ON_ERR_GOTO(res, out_free_output, "writing CSR_CFG");
 
 	/* Check output buffer contents */
-	for (uint32_t i = 0; i < LPBK1_BUFFER_SIZE; i++) {
+	for (i = 0; i < LPBK1_BUFFER_SIZE; i++) {
 		if (((uint8_t *)output_ptr)[i] != ((uint8_t *)input_ptr)[i]) {
 			fprintf(stderr, "Output does NOT match input "
 				"at offset %i!\n", i);


### PR DESCRIPTION
fpgabist's cmake file would overwrite the c flags set in the top level project. This change enables fpgabist to use the compile flags given at the top level of the project so we can get coverage data.