### PR TITLE
fpgaconf: use canonicalize_file_name

### DIFF
--- a/testing/fpgaconf/test_fpgaconf_c.cpp
+++ b/testing/fpgaconf/test_fpgaconf_c.cpp
@@ -392,6 +392,8 @@ TEST_P(fpgaconf_c_p, parse_args0) {
  *             and the fn returns 0.<br>
  */
 TEST_P(fpgaconf_c_p, parse_args1) {
+  char tmpfilename[] = "tmp-empty-XXXXXX.gbs";
+  close(mkstemps(tmpfilename, 4));
   char zero[20];
   char one[20];
   char two[20];
@@ -425,7 +427,7 @@ TEST_P(fpgaconf_c_p, parse_args1) {
   strcpy(thirteen, "2");
   strcpy(fourteen, "-A");
   strcpy(fifteen, "-I");
-  strcpy(sixteen, "file.gbs");
+  strcpy(sixteen, tmpfilename);
 
   char *argv[] = { zero, one, two, three, four,
                    five, six, seven, eight, nine,
@@ -443,7 +445,8 @@ TEST_P(fpgaconf_c_p, parse_args1) {
   EXPECT_EQ(config.target.socket, 2);
   EXPECT_EQ(config.mode, 0);
   ASSERT_NE(config.filename, nullptr);
-  EXPECT_STREQ(config.filename, "file.gbs");
+  EXPECT_STREQ(basename(config.filename), tmpfilename);
+  unlink(tmpfilename);
 }
 
 /**
@@ -462,6 +465,20 @@ TEST_P(fpgaconf_c_p, parse_args2) {
 
   EXPECT_LT(parse_args(2, argv), 0);
 }
+
+/**
+ * @test       parse_args3
+ * @brief      Test: parse_args
+ * @details    When given a gbs file that does not exist<br>
+ *             parse_args fails at parsing the command line<br>
+ *             and the fn returns non-zero value
+ */
+TEST_P(fpgaconf_c_p, parse_args3) {
+  const char *argv[] = { "fpgaconf", "no-file.gbs" };
+  EXPECT_NE(parse_args(2, (char**)argv), 0);
+}
+
+
 
 /**
  * @test       ifc_id1

--- a/tools/base/fpgaconf/fpgaconf.c
+++ b/tools/base/fpgaconf/fpgaconf.c
@@ -36,7 +36,7 @@
  *   * Auto-discovery of compatible slots for supplied bitstream
  *   * Dry-run mode ("what would happen if...?")
  */
-
+#define _GNU_SOURCE
 #include <errno.h>
 #include <getopt.h>
 #include <stdio.h>
@@ -372,9 +372,13 @@ int parse_args(int argc, char *argv[])
 		fprintf(stderr, "No GBS file\n");
 		return -1;
 	}
-	config.filename = argv[optind];
-
-	return 0;
+	config.filename = canonicalize_file_name(argv[optind]);
+	if (config.filename) {
+		return 0;
+	} else {
+		fprintf(stderr, "Error locating GBS file specified: \"%s\"\n", strerror(errno));
+		return -1;
+	}
 }
 
 /*
@@ -753,5 +757,9 @@ out_destroy:
 out_free:
 	free(info.data);
 out_exit:
+	if (config.filename) {
+		free(config.filename);
+		config.filename = NULL;
+	}
 	return retval;
 }


### PR DESCRIPTION
Use canonicalize_file_name when validating the input gbs file.
Add/Update unit tests for this functionality.