### PR TITLE
Include afu_platform_info in generated rpm

### DIFF
--- a/opae.spec.in
+++ b/opae.spec.in
@@ -110,6 +110,7 @@ ldconfig
 %files devel
 %defattr(-,root,root,-)
 @CMAKE_INSTALL_PREFIX@/bin/afu_platform_config
+@CMAKE_INSTALL_PREFIX@/bin/afu_platform_info
 @CMAKE_INSTALL_PREFIX@/bin/afu_synth_setup
 @CMAKE_INSTALL_PREFIX@/bin/rtl_src_config
 %dir @CMAKE_INSTALL_PREFIX@/include/opae


### PR DESCRIPTION
The afu_platform_info file is needed to generate AFUs.  It
is included when installing from source, but not included
in the generated rpm.