### PR TITLE
Check if the target path already exists in filecopy

### DIFF
--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -389,8 +389,8 @@ def config_qsys_sources(filelist, vlog_srcs):
             try:
                 shutil.copytree(src_dir, tgt_dir, symlinks=False, ignore=None)
             except Exception as e:
-                errorExit("""Failed to copy tree {0} to
-                          {1}: Exception {2}""".
+                errorExit("Failed to copy tree {0} to "
+                          "{1}: Exception {2}".
                           format(src_dir, tgt_dir, e))
 
         # Point to the copy
@@ -416,8 +416,8 @@ def config_qsys_sources(filelist, vlog_srcs):
                     shutil.copytree(src_dir, tgt_dir,
                                     symlinks=False, ignore=None)
             except Exception as e:
-                errorExit("""Failed to copy tree {0} to
-                          {1}: Exception = {2}""".format(src_dir, tgt_dir, e))
+                errorExit("Failed to copy tree {0} to "
+                          "{1}: Exception = {2}".format(src_dir, tgt_dir, e))
         tcl_srcs_copy.append(tgt_dir + q[len(src_dir):])
 
     # Second step: now that the trees are copied, update the paths in

--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -387,10 +387,11 @@ def config_qsys_sources(filelist, vlog_srcs):
             print("Preparing {0}:".format(q))
             print("  Copying {0} to {1}...".format(src_dir, tgt_dir))
             try:
-                shutil.copytree(src_dir, tgt_dir)
-            except Exception:
-                errorExit("Failed to copy tree {0} to {1}".format(src_dir,
-                                                                  tgt_dir))
+                if not os.path.exists(tgt_dir):
+                    shutil.copytree(src_dir, tgt_dir, symlinks=False, ignore=None)
+            except Exception as e:
+                errorExit("Failed to copy tree {0} to {1}: Exception {2}".format(src_dir,
+                                                                  tgt_dir, e))
 
         # Point to the copy
         qsys_srcs_copy.append(tgt_dir + q[len(src_dir):])
@@ -411,10 +412,11 @@ def config_qsys_sources(filelist, vlog_srcs):
             print("Preparing {0}:".format(t))
             print("  Copying {0} to {1}...".format(src_dir, tgt_dir))
             try:
-                shutil.copytree(src_dir, tgt_dir)
-            except Exception:
-                errorExit("Failed to copy tree {0} to {1}".format(src_dir,
-                                                                  tgt_dir))
+                if not os.path.exists(tgt_dir):
+                    shutil.copytree(src_dir, tgt_dir, symlinks=False, ignore=None)
+            except Exception as e:
+                errorExit("Failed to copy tree {0} to {1}: Exception = {2}".format(src_dir,
+                                                                  tgt_dir, e))
         tcl_srcs_copy.append(tgt_dir + q[len(src_dir):])
 
     # Second step: now that the trees are copied, update the paths in

--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -387,8 +387,7 @@ def config_qsys_sources(filelist, vlog_srcs):
             print("Preparing {0}:".format(q))
             print("  Copying {0} to {1}...".format(src_dir, tgt_dir))
             try:
-                if not os.path.exists(tgt_dir):
-                    shutil.copytree(src_dir, tgt_dir, symlinks=False, ignore=None)
+                shutil.copytree(src_dir, tgt_dir, symlinks=False, ignore=None)
             except Exception as e:
                 errorExit("Failed to copy tree {0} to {1}: Exception {2}".format(src_dir,
                                                                   tgt_dir, e))

--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -389,9 +389,9 @@ def config_qsys_sources(filelist, vlog_srcs):
             try:
                 shutil.copytree(src_dir, tgt_dir, symlinks=False, ignore=None)
             except Exception as e:
-                errorExit("""Failed to copy tree {0} to \
-                        {1}: Exception {2}""".
-                        format(src_dir, tgt_dir, e))
+                errorExit("""Failed to copy tree {0} to
+                          {1}: Exception {2}""".
+                          format(src_dir, tgt_dir, e))
 
         # Point to the copy
         qsys_srcs_copy.append(tgt_dir + q[len(src_dir):])
@@ -414,10 +414,10 @@ def config_qsys_sources(filelist, vlog_srcs):
             try:
                 if not os.path.exists(tgt_dir):
                     shutil.copytree(src_dir, tgt_dir,
-                            symlinks=False, ignore=None)
+                                    symlinks=False, ignore=None)
             except Exception as e:
-                errorExit("""Failed to copy tree {0} to \
-                        {1}: Exception = {2}""".format(src_dir, tgt_dir, e))
+                errorExit("""Failed to copy tree {0} to
+                          {1}: Exception = {2}""".format(src_dir, tgt_dir, e))
         tcl_srcs_copy.append(tgt_dir + q[len(src_dir):])
 
     # Second step: now that the trees are copied, update the paths in

--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -389,8 +389,9 @@ def config_qsys_sources(filelist, vlog_srcs):
             try:
                 shutil.copytree(src_dir, tgt_dir, symlinks=False, ignore=None)
             except Exception as e:
-                errorExit("Failed to copy tree {0} to {1}: Exception {2}".format(src_dir,
-                                                                  tgt_dir, e))
+                errorExit("""Failed to copy tree {0} to \
+                        {1}: Exception {2}""".
+                        format(src_dir, tgt_dir, e))
 
         # Point to the copy
         qsys_srcs_copy.append(tgt_dir + q[len(src_dir):])
@@ -412,10 +413,11 @@ def config_qsys_sources(filelist, vlog_srcs):
             print("  Copying {0} to {1}...".format(src_dir, tgt_dir))
             try:
                 if not os.path.exists(tgt_dir):
-                    shutil.copytree(src_dir, tgt_dir, symlinks=False, ignore=None)
+                    shutil.copytree(src_dir, tgt_dir,
+                            symlinks=False, ignore=None)
             except Exception as e:
-                errorExit("Failed to copy tree {0} to {1}: Exception = {2}".format(src_dir,
-                                                                  tgt_dir, e))
+                errorExit("""Failed to copy tree {0} to \
+                        {1}: Exception = {2}""".format(src_dir, tgt_dir, e))
         tcl_srcs_copy.append(tgt_dir + q[len(src_dir):])
 
     # Second step: now that the trees are copied, update the paths in


### PR DESCRIPTION
Check if the target path already exists in filecopy

Fixes a corner case where the source folder contains
a qsys system and subdirectories contain TCL sources.
copytree recursively copies all dirs under the src.
Later, an attempt to copy subdirectories
with TCL sources fails because files already exist.