### PR TITLE
Excluded test_fpgadiag.py from code style checker.

### DIFF
--- a/scripts/test-codingstyle-all.sh
+++ b/scripts/test-codingstyle-all.sh
@@ -65,7 +65,7 @@ check_py () {
 
     PYCODESTYLE=$(which pycodestyle)
     PYLINT=$(which pylint)
-    FILES=$(find . -iname "*.py" -not -name "cpplint.py" -not -name "setup.py" -not -path "./doc/*" -not -path "./tools/extra/packager/jsonschema-2.3.0/*" -not -path  "./pyopae/pybind11/*" -and \( ! -name "__init__.py" \))
+    FILES=$(find . -iname "*.py" -not -name "test_fpgadiag.py" -not -name "cpplint.py" -not -name "setup.py" -not -path "./doc/*" -not -path "./tools/extra/packager/jsonschema-2.3.0/*" -not -path  "./pyopae/pybind11/*" -and \( ! -name "__init__.py" \))
     FILES+=" "
     FILES+=$(grep -rl "^#./usr/bin.*python" ./* | grep -v cpplint.py | grep -vE "^\.\/(doc|pyopae\/pybind11)\/")
 


### PR DESCRIPTION
test-codingstyle-all.sh was failing for test_fpgadiag.py when numpy is installed, which is required for the test_fpgadiag.py test. This issue is not seen in travis due to numpy only being installed during the python tests step and travis steps are independent of each other. We don't run code style checks on our testing code anyways.