### PR TITLE
xfpga: add device_id/vendor_id and iter fn

### DIFF
--- a/libopae/plugins/xfpga/sysfs.c
+++ b/libopae/plugins/xfpga/sysfs.c
@@ -306,13 +306,16 @@ STATIC int sysfs_region_destroy(sysfs_fpga_region *region)
 
 int sysfs_region_count(void)
 {
-	int res = 0;
+	int res = 0, count = 0;
 	if (!opae_mutex_lock(res, &_sysfs_region_lock)) {
-		res = _sysfs_region_count;
+		count = _sysfs_region_count;
 	}
 
-	opae_mutex_unlock(res, &_sysfs_region_lock);
-	return res;
+	if (opae_mutex_unlock(res, &_sysfs_region_lock)) {
+		count = 0;
+	}
+
+	return count;
 }
 
 void sysfs_foreach_region(region_cb cb, void *context)

--- a/libopae/plugins/xfpga/sysfs.c
+++ b/libopae/plugins/xfpga/sysfs.c
@@ -406,6 +406,16 @@ int sysfs_finalize(void)
 	return FPGA_OK;
 }
 
+const sysfs_fpga_region *sysfs_get_region(size_t num)
+{
+	if (num >= _sysfs_region_count) {
+		FPGA_ERR("No such region with index: %d", num);
+		return NULL;
+	}
+
+	return &_regions[num];
+}
+
 int sysfs_filter(const struct dirent *de)
 {
 	return de->d_name[0] != '.';

--- a/libopae/plugins/xfpga/sysfs_int.h
+++ b/libopae/plugins/xfpga/sysfs_int.h
@@ -76,10 +76,16 @@ typedef struct _sysfs_fpga_region {
   uint8_t bus;
   uint8_t device;
   uint8_t function;
+  uint32_t device_id;
+  uint32_t vendor_id;
 } sysfs_fpga_region;
+
 int sysfs_initialize(void);
 int sysfs_finalize(void);
 int sysfs_region_count(void);
+
+typedef void (*region_cb)(sysfs_fpga_region *region, void *context);
+void sysfs_foreach_region(region_cb cb, void *context);
 
 /**
  * @brief Get BBS interface id

--- a/libopae/plugins/xfpga/sysfs_int.h
+++ b/libopae/plugins/xfpga/sysfs_int.h
@@ -56,6 +56,27 @@
 extern "C" {
 #endif
 
+
+typedef struct _sysfs_fpga_region sysfs_fpga_region;
+
+typedef struct _sysfs_fpga_resource {
+	sysfs_fpga_region *region;
+	char path[SYSFS_PATH_MAX];
+	fpga_objtype type;
+	int num;
+} sysfs_fpga_resource;
+
+#define SYSFS_MAX_RESOURCES 4
+typedef struct _sysfs_fpga_region {
+	char path[SYSFS_PATH_MAX];
+	int number;
+	sysfs_fpga_resource *fme;
+	sysfs_fpga_resource *port;
+  uint32_t segment;
+  uint8_t bus;
+  uint8_t device;
+  uint8_t function;
+} sysfs_fpga_region;
 int sysfs_initialize(void);
 int sysfs_finalize(void);
 int sysfs_region_count(void);

--- a/libopae/plugins/xfpga/sysfs_int.h
+++ b/libopae/plugins/xfpga/sysfs_int.h
@@ -87,6 +87,8 @@ int sysfs_region_count(void);
 typedef void (*region_cb)(sysfs_fpga_region *region, void *context);
 void sysfs_foreach_region(region_cb cb, void *context);
 
+const sysfs_fpga_region *sysfs_get_region(size_t num);
+
 /**
  * @brief Get BBS interface id
  *


### PR DESCRIPTION
* add `parse_device_vendor_id` function that reads device/vendor sysfs
attributes
* change `make_region` to call `parse_device_vendor_id` using region
path as the root, and `device/device` and `device/vendor` to get
device_id and vendor_id.
* add `sysfs_foreach_region` iterator function to  process regions
* add sysfs tests