### PR TITLE
pluginmgr: add code to reset platforms detected

### DIFF
--- a/libopae/pluginmgr.c
+++ b/libopae/pluginmgr.c
@@ -159,6 +159,7 @@ int opae_plugin_mgr_finalize_all(void)
 	int res;
 	opae_api_adapter_table *aptr;
 	int errors = 0;
+	int i = 0;
 
 	opae_mutex_lock(res, &adapter_list_lock);
 
@@ -182,6 +183,13 @@ int opae_plugin_mgr_finalize_all(void)
 	}
 
 	adapter_list = NULL;
+
+	// reset platforms detected to 0
+	for (i = 0 ; platform_data_table[i].native_plugin ; ++i) {
+		platform_data_table[i].flags = 0;
+
+	}
+
 	initialized = 0;
 
 	opae_mutex_unlock(res, &adapter_list_lock);

--- a/libopae/pluginmgr.c
+++ b/libopae/pluginmgr.c
@@ -187,7 +187,6 @@ int opae_plugin_mgr_finalize_all(void)
 	// reset platforms detected to 0
 	for (i = 0 ; platform_data_table[i].native_plugin ; ++i) {
 		platform_data_table[i].flags = 0;
-
 	}
 
 	initialized = 0;

--- a/testing/opae-c/test_enum_c.cpp
+++ b/testing/opae-c/test_enum_c.cpp
@@ -84,6 +84,7 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
     if (filter_ != nullptr) {
       EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
     }
+    fpgaFinalize();
     system_->finalize();
   }
 


### PR DESCRIPTION
in opae_plugin_mgr_finalize_all, reset the flags member to 0 to
inidicate that the platform hasn't been detected.

This adds the call for fpgaFinalize in one test. Other tests need to be updated to call it too.