### PR TITLE
Fixed potential memory leak in fpgaconf.

### DIFF
--- a/tools/base/fpgaconf/fpgaconf.c
+++ b/tools/base/fpgaconf/fpgaconf.c
@@ -749,7 +749,7 @@ int main(int argc, char *argv[])
 	res = program_bitstream(token, slot_num, &info, config.flags);
 	if (res < 0) {
 		retval = 5;
-		goto out_free;
+		goto out_destroy;
 	}
 	print_msg(1, "Done");
 


### PR DESCRIPTION
In the case that program_bitstream() failed, the token would not be destroyed. This fixes the potential leak.