### PR TITLE
prog_guide: update Functions table for Umsg

### DIFF
--- a/doc/src/fpga_api/prog_guide/readme.md
+++ b/doc/src/fpga_api/prog_guide/readme.md
@@ -166,7 +166,7 @@ The table below groups important API calls by their functionality. For more info
 |Access: Reset      | ```fpgaReset()``` |Yes| Yes| Reset an accelerator |
 |Access: Event handling | ```fpga[Register, Unregister]Event()``` |Yes| Yes| Register/unregister an event to be notified about |
 |               | ```fpga[Create, Destroy]EventHandle()```|Yes| Yes| Manage ```fpga_event_handle``` life cycle |
-|Access: UMsg           | ```fpgaGetNumUmsg()```, ```fpgaSetUmsgAttributes()```, ```fpgaTriggerUmsg()```, ```fpgaGetUmsgPtr()``` |Yes| No| Low-latency accelerator notification mechanism.|
+|Access: UMsg           | ```fpgaGetNumUmsg()```, ```fpgaSetUmsgAttributes()```, ```fpgaTriggerUmsg()```, ```fpgaGetUmsgPtr()``` | No|Yes| Low-latency accelerator notification mechanism.|
 |Access: MMIO       | ```fpgaMapMMIO()```, ```fpgaUnMapMMIO()``` |Yes| Yes| Map/unmap MMIO space |
 |           | ```fpgaGetMMIOInfo()``` |Yes| Yes| Get information about the specified MMIO space |
 |           | ```fpgaReadMMIO[32, 64]()``` | Yes| Yes|Read a 32-bit or 64-bit value from MMIO space |

--- a/testing/opae-c/test_umsg_c.cpp
+++ b/testing/opae-c/test_umsg_c.cpp
@@ -132,7 +132,7 @@ class umsg_c_p : public ::testing::TestWithParam<std::string> {
     filter_ = nullptr;
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
     ASSERT_EQ(fpgaGetProperties(nullptr, &filter_), FPGA_OK);
-    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
+    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
     num_matches_ = 0;
     ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
                             &num_matches_), FPGA_OK);


### PR DESCRIPTION
Update the table to reflect that the Umsg API requires a handle of type
FPGA_ACCELERATOR.