### PR TITLE
xfpga: add functions for getting info

### DIFF
--- a/libopae/plugins/xfpga/event.c
+++ b/libopae/plugins/xfpga/event.c
@@ -111,7 +111,8 @@ STATIC fpga_result send_fme_event_request(fpga_handle handle,
 		return FPGA_INVALID_PARAM;
 	}
 
-	if ((res = opae_get_fme_info(_handle->fddev, &fme_info))) {
+	res = opae_get_fme_info(_handle->fddev, &fme_info);
+	if (res) {
 		return res;
 	}
 
@@ -151,7 +152,8 @@ STATIC fpga_result send_port_event_request(fpga_handle handle,
 		return FPGA_INVALID_PARAM;
 	}
 
-	if ((res = opae_get_port_info(_handle->fddev, &port_info))) {
+	res = opae_get_port_info(_handle->fddev, &port_info);
+	if (res) {
 		return res;
 	}
 
@@ -196,7 +198,8 @@ STATIC fpga_result send_uafu_event_request(fpga_handle handle,
 		return FPGA_INVALID_PARAM;
 	}
 
-	if ((res = opae_get_port_info(_handle->fddev, &port_info))) {
+	res = opae_get_port_info(_handle->fddev, &port_info);
+	if (res) {
 		return res;
 	}
 
@@ -263,7 +266,8 @@ STATIC fpga_result check_interrupts_supported(fpga_handle handle,
 	}
 
 	if (*objtype == FPGA_DEVICE) {
-		if ((res = opae_get_fme_info(_handle->fddev, &fme_info))) {
+		res = opae_get_fme_info(_handle->fddev, &fme_info);
+		if (res) {
 			res = FPGA_EXCEPTION;
 			goto destroy_prop;
 		}
@@ -275,7 +279,8 @@ STATIC fpga_result check_interrupts_supported(fpga_handle handle,
 			res = FPGA_NOT_SUPPORTED;
 		}
 	} else if (*objtype == FPGA_ACCELERATOR) {
-		if ((res = opae_get_port_info(_handle->fddev, &port_info))) {
+		res = opae_get_port_info(_handle->fddev, &port_info);
+		if (res) {
 			FPGA_ERR("Could not get PORT info: %s",
 				 strerror(errno));
 			goto destroy_prop;

--- a/libopae/plugins/xfpga/opae_ioctl.c
+++ b/libopae/plugins/xfpga/opae_ioctl.c
@@ -65,6 +65,52 @@ fpga_result opae_ioctl(int fd, int request, ...)
 	return res;
 }
 
+int opae_get_fme_info(int fd, opae_fme_info *info)
+{
+	ASSERT_NOT_NULL(info);
+	struct fpga_fme_info fme_info = {.argsz = sizeof(fme_info), .flags = 0};
+	int res = opae_ioctl(fd, FPGA_FME_GET_INFO, &fme_info);
+	if (!res) {
+		info->flags = fme_info.flags;
+		info->capability = fme_info.capability;
+	}
+	return res;
+}
+
+int opae_get_port_info(int fd, opae_port_info *info)
+{
+	ASSERT_NOT_NULL(info);
+	struct fpga_port_info pinfo = {.argsz = sizeof(pinfo), .flags = 0};
+	int res = opae_ioctl(fd, FPGA_PORT_GET_INFO, &pinfo);
+	if (!res) {
+		info->flags = pinfo.flags;
+		info->capability = pinfo.capability;
+		info->num_regions = pinfo.num_regions;
+		info->num_umsgs = pinfo.num_umsgs;
+		info->num_uafu_irqs = pinfo.num_uafu_irqs;
+	}
+	return res;
+
+
+}
+
+int opae_get_port_region_info(int fd, uint32_t index,
+			      opae_port_region_info *info)
+{
+	ASSERT_NOT_NULL(info);
+	struct fpga_port_region_info rinfo = {.argsz = sizeof(rinfo),
+					      .padding = 0,
+					      .index = index};
+	int res = opae_ioctl(fd, FPGA_PORT_GET_REGION_INFO, &rinfo);
+	if (!res) {
+		info->flags = rinfo.flags;
+		info->size = rinfo.size;
+		info->offset = rinfo.offset;
+	}
+	return res;
+
+}
+
 int opae_port_map(int fd, void *addr, uint64_t len, uint64_t *io_addr)
 {
 	int res = 0;
@@ -76,7 +122,7 @@ int opae_port_map(int fd, void *addr, uint64_t len, uint64_t *io_addr)
 					    .user_addr = (__u64)addr,
 					    .length = (__u64)len,
 					    .iova = 0};
-
+	ASSERT_NOT_NULL(io_addr);
 	/* Dispatch ioctl command */
 	req = FPGA_PORT_DMA_MAP;
 	msg = &dma_map;

--- a/libopae/plugins/xfpga/opae_ioctl.h
+++ b/libopae/plugins/xfpga/opae_ioctl.h
@@ -32,7 +32,31 @@
 #define OPAE_IOCTL_H
 #include <stdint.h>
 
+typedef struct _opae_fme_info {
+	uint32_t flags;
+	uint32_t capability;
+} opae_fme_info;
+
+typedef struct _opae_port_info {
+	uint32_t flags;
+	uint32_t capability;
+	uint32_t num_regions;
+	uint32_t num_umsgs;
+	uint32_t num_uafu_irqs;
+} opae_port_info;
+
+typedef struct _opae_port_region_info {
+	uint32_t flags;
+	uint64_t size;
+	uint64_t offset;
+} opae_port_region_info;
+
+int opae_get_fme_info(int fd, opae_fme_info *info);
+int opae_get_port_info(int fd, opae_port_info *info);
+int opae_get_port_region_info(int fd, uint32_t index, opae_port_region_info *info);
+
 int opae_port_map(int fd, void *addr, uint64_t len, uint64_t *io_addr);
 int opae_port_unmap(int fd, uint64_t io_addr);
+
 
 #endif /* !OPAE_IOCTL_H */

--- a/libopae/plugins/xfpga/umsg.c
+++ b/libopae/plugins/xfpga/umsg.c
@@ -59,7 +59,8 @@ xfpga_fpgaGetNumUmsg(fpga_handle handle, uint64_t *value)
 	}
 
 
-	if (!(result = opae_get_port_info(_handle->fddev, &port_info))) {
+	result = opae_get_port_info(_handle->fddev, &port_info);
+	if (!result) {
 		*value = port_info.num_umsgs;
 	}
 

--- a/libopae/plugins/xfpga/umsg.c
+++ b/libopae/plugins/xfpga/umsg.c
@@ -28,6 +28,7 @@
 #include "opae/utils.h"
 #include "opae/umsg.h"
 #include "common_int.h"
+#include "opae_ioctl.h"
 #include "intel-fpga.h"
 
 #include <sys/types.h>
@@ -43,8 +44,8 @@ xfpga_fpgaGetNumUmsg(fpga_handle handle, uint64_t *value)
 {
 	struct _fpga_handle  *_handle = (struct _fpga_handle *)handle;
 	fpga_result result            = FPGA_OK;
-	struct fpga_port_info info    = { 0 };
 	int err                       = 0;
+	opae_port_info port_info      = { 0 };
 
 	ASSERT_NOT_NULL(value);
 	result = handle_check_and_lock(_handle);
@@ -57,25 +58,10 @@ xfpga_fpgaGetNumUmsg(fpga_handle handle, uint64_t *value)
 		goto out_unlock;
 	}
 
-	// Set ioctl port info struct parameters
-	info.argsz = sizeof(info);
-	info.flags = 0;
 
-	// ioctl
-	result = ioctl(_handle->fddev, FPGA_PORT_GET_INFO, &info);
-	if (result != 0) {
-		FPGA_MSG("FPGA_PORT_GET_INFO ioctl failed");
-		if ((errno == EINVAL) ||
-		(errno == EFAULT)) {
-			result = FPGA_INVALID_PARAM;
-		} else {
-			result = FPGA_EXCEPTION;
-		}
-		goto out_unlock;
+	if (!(result = opae_get_port_info(_handle->fddev, &port_info))) {
+		*value = port_info.num_umsgs;
 	}
-
-	// Assign number of umsgs
-	*value = info.num_umsgs;
 
 out_unlock:
 	err = pthread_mutex_unlock(&_handle->lock);

--- a/testing/xfpga/test_events_c.cpp
+++ b/testing/xfpga/test_events_c.cpp
@@ -1000,7 +1000,7 @@ TEST_P(events_mock_p, invalid_fme_event_request_01){
   system_->register_ioctl_handler(FPGA_FME_GET_INFO, dummy_ioctl<-1,EINVAL>);
 
   res = send_fme_event_request(handle_dev_,eh_,fme_op);
-  EXPECT_EQ(FPGA_EXCEPTION,res);
+  EXPECT_EQ(FPGA_INVALID_PARAM,res);
 
   gEnableIRQ = true;
   system_->register_ioctl_handler(FPGA_FME_GET_INFO, fme_info);
@@ -1025,7 +1025,7 @@ TEST_P(events_mock_p, invalid_port_event_request_01){
   system_->register_ioctl_handler(FPGA_PORT_GET_INFO, dummy_ioctl<-1,EINVAL>);
 
   res = send_port_event_request(handle_dev_,eh_,port_op);
-  EXPECT_EQ(FPGA_EXCEPTION,res);
+  EXPECT_EQ(FPGA_INVALID_PARAM,res);
 
   gEnableIRQ = true;
   system_->register_ioctl_handler(FPGA_PORT_GET_INFO, port_info);
@@ -1050,7 +1050,7 @@ TEST_P(events_mock_p, invalid_uafu_event_request_01){
   port_op = FPGA_IRQ_ASSIGN;
   system_->register_ioctl_handler(FPGA_PORT_GET_INFO, dummy_ioctl<-1,EINVAL>);
   res = send_uafu_event_request(handle_dev_,eh_,0,port_op);
-  EXPECT_EQ(FPGA_EXCEPTION,res);
+  EXPECT_EQ(FPGA_INVALID_PARAM,res);
 }
 
 /**
@@ -1061,12 +1061,12 @@ TEST_P(events_mock_p, invalid_uafu_event_request_01){
 TEST_P(events_mock_p, invalid_uafu_event_request_02){
   int port_op = FPGA_IRQ_ASSIGN;
   auto res = send_uafu_event_request(handle_dev_,eh_,0,port_op);
-  EXPECT_EQ(FPGA_EXCEPTION,res) << "\t result is " << res;
+  EXPECT_EQ(FPGA_NOT_SUPPORTED,res) << "\t result is " << res;
 
   gEnableIRQ = false;
   system_->register_ioctl_handler(FPGA_PORT_GET_INFO, port_info);
   res = send_uafu_event_request(handle_dev_,eh_,0,port_op);
-  EXPECT_EQ(FPGA_EXCEPTION,res);
+  EXPECT_EQ(FPGA_NOT_SUPPORTED,res);
 
   gEnableIRQ = true;
   system_->register_ioctl_handler(FPGA_PORT_GET_INFO, port_info);
@@ -1135,7 +1135,7 @@ TEST_P(events_mock_p, afu_interrupts_check){
   // interrupt ioctl
   system_->register_ioctl_handler(FPGA_PORT_GET_INFO, dummy_ioctl<-1,EINVAL>);
   res = check_interrupts_supported(handle_accel_,&obj);
-  EXPECT_EQ(FPGA_EXCEPTION,res);
+  EXPECT_EQ(FPGA_INVALID_PARAM,res);
 
   // change sysfspath
   strncpy(t->sysfspath,"null",sizeof(t->sysfspath));

--- a/testing/xfpga/test_umsg_c.cpp
+++ b/testing/xfpga/test_umsg_c.cpp
@@ -427,7 +427,7 @@ TEST_P(umsg_c_mock_p, get_num_umsg_ioctl_err) {
 
   // register an ioctl handler that will return -1 and set errno to EFAULT
   system_->register_ioctl_handler(FPGA_PORT_GET_INFO, dummy_ioctl<-1,EFAULT>);
-  EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaGetNumUmsg(handle_, &num));
+  EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaGetNumUmsg(handle_, &num));
 
   // register an ioctl handler that will return -1 and set errno to ENOTSUP
   system_->register_ioctl_handler(FPGA_PORT_GET_INFO, dummy_ioctl<-1,ENOTSUP>);


### PR DESCRIPTION
add the folloing functions:
* opae_get_fme_info
* opae_get_port_info
* opae_get_port_region_info

Change code that uses the ioctl interface directly to instead use these
functions.

Because these functions call one common ioctl wrapper that returns error
codes according to errno, some tests had to be updated for to expect the
appropriate error codes.