### PR TITLE
xfpga: add functions for umsg ioctl operations

### DIFF
--- a/libopae/plugins/xfpga/opae_ioctl.c
+++ b/libopae/plugins/xfpga/opae_ioctl.c
@@ -49,6 +49,9 @@ fpga_result opae_ioctl(int fd, int request, ...)
 		case EINVAL:
 			res = FPGA_INVALID_PARAM;
 			break;
+		case ENOTSUP:
+			res = FPGA_NOT_SUPPORTED;
+			break;
 		default:
 			// other errors could be
 			// EBADF - fd is bad file descriptor
@@ -142,4 +145,37 @@ int opae_port_unmap(int fd, uint64_t io_addr)
 
 	/* Dispatch ioctl command */
 	return opae_ioctl(fd, FPGA_PORT_DMA_UNMAP, &dma_unmap);
+}
+
+int opae_port_umsg_cfg(int fd, uint32_t flags, uint32_t hint_bitmap)
+{
+	if (flags) {
+		OPAE_MSG("flags currently not supported in FPGA_PORT_UMSG_SET_MODE");
+	}
+
+	struct fpga_port_umsg_cfg umsg_cfg = {.argsz = sizeof(umsg_cfg),
+					      .flags = 0,
+					      .hint_bitmap = hint_bitmap};
+	return opae_ioctl(fd, FPGA_PORT_UMSG_SET_MODE, &umsg_cfg);
+}
+
+int opae_port_umsg_set_base_addr(int fd, uint32_t flags, uint64_t io_addr)
+{
+	if (flags) {
+		OPAE_MSG("flags currently not supported in FPGA_PORT_UMSG_SET_BASE_ADDR");
+	}
+
+	struct fpga_port_umsg_base_addr baseaddr = {
+		.argsz = sizeof(baseaddr), .flags = 0, .iova = io_addr};
+	return opae_ioctl(fd, FPGA_PORT_UMSG_SET_BASE_ADDR, &baseaddr);
+}
+
+int opae_port_umsg_enable(int fd)
+{
+	return opae_ioctl(fd, FPGA_PORT_UMSG_ENABLE, NULL);
+}
+
+int opae_port_umsg_disable(int fd)
+{
+	return opae_ioctl(fd, FPGA_PORT_UMSG_DISABLE, NULL);
 }

--- a/libopae/plugins/xfpga/opae_ioctl.h
+++ b/libopae/plugins/xfpga/opae_ioctl.h
@@ -58,5 +58,10 @@ int opae_get_port_region_info(int fd, uint32_t index, opae_port_region_info *inf
 int opae_port_map(int fd, void *addr, uint64_t len, uint64_t *io_addr);
 int opae_port_unmap(int fd, uint64_t io_addr);
 
+int opae_port_umsg_cfg(int fd, uint32_t flags, uint32_t hint_bitmap);
+int opae_port_umsg_set_base_addr(int fd, uint32_t flags, uint64_t io_addr);
+int opae_port_umsg_enable(int fd);
+int opae_port_umsg_disable(int fd);
+
 
 #endif /* !OPAE_IOCTL_H */

--- a/libopae/plugins/xfpga/umsg.c
+++ b/libopae/plugins/xfpga/umsg.c
@@ -169,7 +169,7 @@ xfpga_fpgaGetUmsgPtr(fpga_handle handle, uint64_t **umsg_ptr)
 	}
 
 	*umsg_ptr = (uint64_t *) umsg_virt;
-	_handle->umsg_iova = (uint64_t*)io_addr;
+	_handle->umsg_iova = (uint64_t *)io_addr;
 	_handle->umsg_virt = umsg_virt;
 	_handle->umsg_size = umsg_size;
 

--- a/libopae/plugins/xfpga/umsg.c
+++ b/libopae/plugins/xfpga/umsg.c
@@ -143,7 +143,7 @@ xfpga_fpgaGetUmsgPtr(fpga_handle handle, uint64_t **umsg_ptr)
 	umsg_size = (uint64_t)umsg_count  * pagesize;
 	umsg_virt = alloc_buffer(umsg_size);
 	if (umsg_virt == NULL) {
-		OPAE_MSG("Failed to allocate memory");
+		OPAE_ERR("Failed to allocate memory");
 		result = FPGA_NO_MEMORY;
 		goto out_unlock;
 	}
@@ -151,20 +151,20 @@ xfpga_fpgaGetUmsgPtr(fpga_handle handle, uint64_t **umsg_ptr)
 	// Map Umsg Buffer
 	result = opae_port_map(_handle->fddev, umsg_virt, umsg_size, &io_addr);
 	if (result != 0) {
-		OPAE_MSG("Failed to map UMSG buffer");
+		OPAE_ERR("Failed to map UMSG buffer");
 		goto umsg_exit;
 	}
 
 	// Set Umsg Address
 	result = opae_port_umsg_set_base_addr(_handle->fddev, 0, io_addr);
 	if (result != 0) {
-		OPAE_MSG("Failed to set UMSG base address");
+		OPAE_ERR("Failed to set UMSG base address");
 		goto umsg_map_exit;
 	}
 
 	result = opae_port_umsg_enable(_handle->fddev);
 	if (result != 0) {
-		OPAE_MSG("Failed to enable UMSG");
+		OPAE_ERR("Failed to enable UMSG");
 		goto umsg_map_exit;
 	}
 

--- a/testing/xfpga/test_umsg_c.cpp
+++ b/testing/xfpga/test_umsg_c.cpp
@@ -431,7 +431,7 @@ TEST_P(umsg_c_mock_p, get_num_umsg_ioctl_err) {
 
   // register an ioctl handler that will return -1 and set errno to ENOTSUP
   system_->register_ioctl_handler(FPGA_PORT_GET_INFO, dummy_ioctl<-1,ENOTSUP>);
-  EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaGetNumUmsg(handle_, &num));
+  EXPECT_EQ(FPGA_NOT_SUPPORTED, xfpga_fpgaGetNumUmsg(handle_, &num));
 }
 
 /**
@@ -450,12 +450,12 @@ TEST_P(umsg_c_mock_p, set_umsg_attr_ioctl_err) {
 
   // register an ioctl handler that will return -1 and set errno to EFAULT
   system_->register_ioctl_handler(FPGA_PORT_UMSG_SET_MODE, dummy_ioctl<-1,EFAULT>);
-  EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaSetUmsgAttributes(handle_, value));
+  EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaSetUmsgAttributes(handle_, value));
 
 
   // register an ioctl handler that will return -1 and set errno to ENOTSUP
   system_->register_ioctl_handler(FPGA_PORT_UMSG_SET_MODE, dummy_ioctl<-1,ENOTSUP>);
-  EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaSetUmsgAttributes(handle_, value));
+  EXPECT_EQ(FPGA_NOT_SUPPORTED, xfpga_fpgaSetUmsgAttributes(handle_, value));
 }
 
 /**
@@ -477,12 +477,12 @@ TEST_P(umsg_c_mock_p, get_umsg_ptr_ioctl_err) {
   // register an ioctl handler that will return -1 and set errno to EFAULT
   system_->register_ioctl_handler(FPGA_PORT_UMSG_ENABLE, dummy_ioctl<-1,EFAULT>);
   system_->register_ioctl_handler(FPGA_PORT_DMA_UNMAP, dummy_ioctl<-1,EFAULT>);
-  EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaGetUmsgPtr(handle_, &value));
+  EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaGetUmsgPtr(handle_, &value));
 
   // register an ioctl handler that will return -1 and set errno to ENOTSUP
   system_->register_ioctl_handler(FPGA_PORT_UMSG_ENABLE, dummy_ioctl<-1,ENOTSUP>);
   system_->register_ioctl_handler(FPGA_PORT_DMA_UNMAP, dummy_ioctl<-1,ENOTSUP>);
-  EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaGetUmsgPtr(handle_, &value));
+  EXPECT_EQ(FPGA_NOT_SUPPORTED, xfpga_fpgaGetUmsgPtr(handle_, &value));
 }
 
 /**
@@ -500,12 +500,12 @@ TEST_P(umsg_c_mock_p, get_umsg_ptr_ioctl_err_02) {
   // register an ioctl handler that will return -1 and set errno to ENOTSUP
   system_->register_ioctl_handler(FPGA_PORT_UMSG_SET_BASE_ADDR, dummy_ioctl<-1,ENOTSUP>);
   system_->register_ioctl_handler(FPGA_PORT_DMA_UNMAP, dummy_ioctl<-1,ENOTSUP>);
-  EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaGetUmsgPtr(handle_, &value));
+  EXPECT_EQ(FPGA_NOT_SUPPORTED, xfpga_fpgaGetUmsgPtr(handle_, &value));
 
   // register an ioctl handler that will return -1 and set errno to EFAULT
   system_->register_ioctl_handler(FPGA_PORT_UMSG_SET_BASE_ADDR, dummy_ioctl<-1,EFAULT>);
   system_->register_ioctl_handler(FPGA_PORT_DMA_UNMAP, dummy_ioctl<-1,EFAULT>);
-  EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaGetUmsgPtr(handle_, &value));
+  EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaGetUmsgPtr(handle_, &value));
 }
 
 /**
@@ -525,7 +525,7 @@ TEST_P(umsg_c_mock_p, get_umsg_ptr_ioctl_err_03) {
 
   // register an ioctl handler that will return -1 and set errno to EFAULT
   system_->register_ioctl_handler(FPGA_PORT_DMA_MAP, dummy_ioctl<-1,EFAULT>);
-  EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaGetUmsgPtr(handle_, &value));
+  EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaGetUmsgPtr(handle_, &value));
 }
 
 /**
@@ -607,7 +607,7 @@ TEST_P(umsg_c_mock_p, test_umsg_drv_06) {
 TEST_P(umsg_c_mock_p, test_umsg_09) {
   // register an ioctl handler that will return -1 and set errno to EINVAL
   system_->register_ioctl_handler(FPGA_PORT_GET_INFO, dummy_ioctl<-1,EINVAL>);
-  EXPECT_EQ(FPGA_EXCEPTION, xfpga_fpgaTriggerUmsg(handle_, 0));
+  EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaTriggerUmsg(handle_, 0));
 }
 
 INSTANTIATE_TEST_CASE_P(umsg_c, umsg_c_mock_p,


### PR DESCRIPTION
* Also, add code in opae_ioctl to interpret ENOTSUP as FPGA_NOT_SUPPORTED

* Wrapping ioctl calls now standardizes fpga_result codes determined from errno on failed ioctl calls.
Because of this, some tests have to be updated to expect the correct fpga_result code.