### PR TITLE
Fixed test platform not removing invalid platforms when running on hw.

### DIFF
--- a/testing/platform/fpga_hw.cpp
+++ b/testing/platform/fpga_hw.cpp
@@ -174,10 +174,11 @@ std::vector<std::string> test_platform::platforms(
   }
   // from the list of platform names requested, remove the ones not found in
   // the platform db
-  std::remove_if(keys.begin(), keys.end(), [](const std::string &n) {
+  keys.erase(
+    std::remove_if(keys.begin(), keys.end(), [](const std::string &n) {
       auto db = fpga_db::instance();
       return !db->exists(n);
-  });
+  }), keys.end());
   return keys;
 }
 


### PR DESCRIPTION
When running on hw, the tests would query if the specified platform was in the database. If not then it should remove it as when running on hw, the only platform in the database should be what is on the system. But the code would fail to remove the platforms that were not applicable. This should fix it.