### PR TITLE
Resolved xfpga event tests

### DIFF
--- a/testing/xfpga/test_events_c.cpp
+++ b/testing/xfpga/test_events_c.cpp
@@ -308,6 +308,7 @@ class events_p : public ::testing::TestWithParam<std::string> {
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_dev_, FPGA_DEVICE), FPGA_OK);
     ASSERT_EQ(xfpga_fpgaEnumerate(&filter_dev_, 1, tokens_dev_.data(), tokens_dev_.size(),
                             &num_matches_), FPGA_OK);
+    ASSERT_GT(num_matches_, 0);
 
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_accel_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetDeviceID(filter_accel_, 
@@ -315,7 +316,7 @@ class events_p : public ::testing::TestWithParam<std::string> {
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_accel_, FPGA_ACCELERATOR), FPGA_OK);
     ASSERT_EQ(xfpga_fpgaEnumerate(&filter_accel_, 1, tokens_accel_.data(),
                             tokens_accel_.size(), &num_matches_), FPGA_OK);
-
+    ASSERT_GT(num_matches_, 0);
     ASSERT_EQ(xfpga_fpgaOpen(tokens_dev_[0], &handle_dev_, 0), FPGA_OK);
     ASSERT_EQ(xfpga_fpgaOpen(tokens_accel_[0], &handle_accel_, 0), FPGA_OK);
 
@@ -354,8 +355,15 @@ class events_p : public ::testing::TestWithParam<std::string> {
     EXPECT_EQ(fpgaDestroyProperties(&filter_dev_), FPGA_OK);
     EXPECT_EQ(fpgaDestroyProperties(&filter_accel_), FPGA_OK);
 
-    if (handle_dev_) { EXPECT_EQ(xfpga_fpgaClose(handle_dev_), FPGA_OK); handle_dev_ = nullptr;}
-    if (handle_accel_) { EXPECT_EQ(xfpga_fpgaClose(handle_accel_), FPGA_OK); handle_accel_ = nullptr;}
+    if (handle_dev_) { 
+        EXPECT_EQ(xfpga_fpgaClose(handle_dev_), FPGA_OK); 
+        handle_dev_ = nullptr;
+    }
+
+    if (handle_accel_) { 
+        EXPECT_EQ(xfpga_fpgaClose(handle_accel_), FPGA_OK); 
+        handle_accel_ = nullptr;
+    }
  
     for (auto &t : tokens_dev_) {
       if (t) {
@@ -762,7 +770,7 @@ TEST_P(events_dcp_p, invalid_fme_event_request){
 }
 
 INSTANTIATE_TEST_CASE_P(events, events_dcp_p,
-                        ::testing::ValuesIn(test_platform::platforms({"dcp-rc" })));
+                        ::testing::ValuesIn(test_platform::hw_platforms({"dcp-rc" })));
 
 
 class events_mcp_p : public events_p {};

--- a/testing/xfpga/test_events_c.cpp
+++ b/testing/xfpga/test_events_c.cpp
@@ -846,7 +846,7 @@ TEST_P(events_mock_p, valid_fme_event_request){
 
   gEnableIRQ = true;
   system_->register_ioctl_handler(FPGA_FME_GET_INFO, fme_info);
-  auto res = send_fme_event_request(handle_accel_,eh_,fme_op);
+  auto res = send_fme_event_request(handle_dev_,eh_,fme_op);
   EXPECT_EQ(FPGA_OK,res);
 }
 


### PR DESCRIPTION
Follow up PR #1086.

Separated send_fme_event_request and send_port_event_request tests to mcp and dcp platforms only. It will return FPGA_NOT_SUPPORTED for all mcp platforms. FPGA_OK is returned for dcp on hw only. (FPGA_NOT_SUPPORTED is returned for mock. Maybe this should be a FIX_ME?)