### PR TITLE
opae-c: add plugin cfg parsing

### DIFF
--- a/libopae/pluginmgr.c
+++ b/libopae/pluginmgr.c
@@ -265,7 +265,7 @@ STATIC int process_plugin(const char *name, json_object *j_config)
 	JSON_GET(j_config, "configuration", &j_plugin_cfg);
 	JSON_GET(j_config, "enabled", &j_enabled);
 	if (json_object_get_string_len(j_plugin) > PLUGIN_NAME_MAX) {
-		OPAE_ERR("module name too long");
+		OPAE_ERR("plugin name too long");
 		return 1;
 	}
 
@@ -293,8 +293,8 @@ STATIC int process_plugin(const char *name, json_object *j_config)
 		goto out_err;
 	}
 
-	if (strcpy_s(cfg->module, PLUGIN_NAME_MAX, json_object_get_string(j_plugin))) {
-		OPAE_ERR("error copying module name");
+	if (strcpy_s(cfg->plugin, PLUGIN_NAME_MAX, json_object_get_string(j_plugin))) {
+		OPAE_ERR("error copying plugin name");
 		goto out_err;
 	}
 
@@ -309,6 +309,8 @@ out_err:
 	cfg->cfg_size = 0;
 	return 1;
 }
+
+
 
 STATIC int process_cfg_buffer(const char *buffer, const char *filename)
 {
@@ -550,7 +552,7 @@ STATIC int opae_plugin_mgr_load_cfg_plugin(int i)
 	opae_api_adapter_table *adapter = NULL;
 
 	if (cfg->enabled && cfg->cfg && cfg->cfg_size) {
-		adapter = opae_plugin_mgr_alloc_adapter(cfg->module);
+		adapter = opae_plugin_mgr_alloc_adapter(cfg->plugin);
 		if (!adapter) {
 			OPAE_ERR("malloc failed");
 			return 1;

--- a/libopae/pluginmgr.c
+++ b/libopae/pluginmgr.c
@@ -294,7 +294,7 @@ STATIC int process_plugin(const char *name, json_object *j_config)
 	}
 
 	if (strcpy_s(cfg->plugin, PLUGIN_NAME_MAX, json_object_get_string(j_plugin))) {
-		OPAE_ERR("error copying plugin name");
+		OPAE_ERR("error copying plugin file name");
 		goto out_err;
 	}
 

--- a/libopae/pluginmgr.c
+++ b/libopae/pluginmgr.c
@@ -96,7 +96,8 @@ const plugin_cfg *opae_plugin_mgr_get(int i)
 	return plugin_count ? &plugin_list[i] : NULL;
 }
 
-STATIC const char *find_cfg() {
+STATIC const char *find_cfg()
+{
 	int i = 0;
 	struct stat st;
 
@@ -568,7 +569,7 @@ STATIC int opae_plugin_mgr_load_cfg_plugin(int i)
 	return 0;
 }
 
-STATIC int opae_plugin_mgr_load_cfg_plugins()
+STATIC int opae_plugin_mgr_load_cfg_plugins(void)
 {
 	int i = 0;
 	for ( ; i < plugin_count; ++i) {

--- a/libopae/pluginmgr.c
+++ b/libopae/pluginmgr.c
@@ -32,12 +32,14 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <dlfcn.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <dirent.h>
 #include <linux/limits.h>
 #define __USE_GNU
 #include <pthread.h>
 
+#include <json-c/json.h>
 #include "safe_string/safe_string.h"
 
 #include "pluginmgr.h"
@@ -70,6 +72,41 @@ static int initialized;
 STATIC opae_api_adapter_table *adapter_list = (void *)0;
 static pthread_mutex_t adapter_list_lock =
 	PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+
+
+#define MAX_PLUGINS PLUGIN_SUPPORTED_DEVICES_MAX
+static plugin_cfg plugin_list[MAX_PLUGINS];
+static int plugin_count;
+
+#define CFG_PATHS 4
+static const char *_opae_cfg_files[CFG_PATHS] = {
+	"/etc/opae.cfg",
+	"~/.config/opae/config",
+	"~/.local/opae/config",
+	"~/.local/opae.cfg"
+};
+
+int opae_plugin_mgr_plugin_count(void)
+{
+	return plugin_count;
+}
+
+const plugin_cfg *opae_plugin_mgr_get(int i)
+{
+	return plugin_count ? &plugin_list[i] : NULL;
+}
+
+STATIC const char *find_cfg() {
+	int i = 0;
+	struct stat st;
+
+	for (; i < CFG_PATHS; ++i) {
+		if (stat(_opae_cfg_files[i], &st)) {
+			return _opae_cfg_files[i];
+		}
+	}
+	return NULL;
+}
 
 STATIC opae_api_adapter_table *opae_plugin_mgr_alloc_adapter(const char *lib_path)
 {
@@ -133,6 +170,18 @@ STATIC int opae_plugin_mgr_configure_plugin(opae_api_adapter_table *adapter,
 	return cfg(adapter, config);
 }
 
+STATIC void opae_plugin_mgr_reset_cfg(void)
+{
+	int i = 0;
+	for ( ; i < plugin_count; ++i) {
+		if (plugin_list[i].cfg) {
+			free(plugin_list[i].cfg);
+			plugin_list[i].cfg = NULL;
+		}
+	}
+	plugin_count = 0;
+}
+
 STATIC int opae_plugin_mgr_initialize_all(void)
 {
 	int res;
@@ -190,15 +239,166 @@ int opae_plugin_mgr_finalize_all(void)
 	}
 
 	initialized = 0;
-
+	opae_plugin_mgr_reset_cfg();
 	opae_mutex_unlock(res, &adapter_list_lock);
 
 	return errors;
 }
 
-STATIC int opae_plugin_mgr_parse_config(/* json_object *jobj */)
-{
+#define JSON_GET(_jobj, _key, _jvar)                                           \
+	do {                                                                   \
+		if (!json_object_object_get_ex(_jobj, _key, _jvar)) {          \
+			OPAE_ERR("Error getting object: %s", _key);            \
+			return 1;                                              \
+		}                                                              \
+	} while (0)
 
+#define MAX_PLUGIN_CFG_SIZE 1024
+STATIC int process_plugin(const char *name, json_object *j_config)
+{
+	plugin_cfg *cfg = &plugin_list[plugin_count];
+	const char *stringified = NULL;
+	json_object *j_module = NULL;
+	json_object *j_plugin_cfg = NULL;
+	json_object *j_enabled = NULL;
+	JSON_GET(j_config, "module", &j_module);
+	JSON_GET(j_config, "configuration", &j_plugin_cfg);
+	JSON_GET(j_config, "enabled", &j_enabled);
+	if (json_object_get_string_len(j_module) > PLUGIN_NAME_MAX) {
+		OPAE_ERR("module name too long");
+		return 1;
+	}
+
+	stringified = json_object_to_json_string_ext(j_plugin_cfg, JSON_C_TO_STRING_PLAIN);
+	if (!stringified) {
+		OPAE_ERR("error getting plugin configuration");
+		return 1;
+	}
+
+	cfg->cfg_size = strlen(stringified);
+	cfg->cfg = malloc(cfg->cfg_size);
+	if (!cfg->cfg) {
+		OPAE_ERR("error allocating memory for plugin configuration");
+		cfg->cfg_size = 0;
+		return 1;
+	}
+
+	if (strncpy_s(cfg->cfg, MAX_PLUGIN_CFG_SIZE, stringified, cfg->cfg_size)) {
+		OPAE_ERR("error copying plugin configuration");
+		goto out_err;
+	}
+
+	if (strcpy_s(cfg->name, PLUGIN_NAME_MAX, name)) {
+		OPAE_ERR("error copying plugin name");
+		goto out_err;
+	}
+
+	if (strcpy_s(cfg->module, PLUGIN_NAME_MAX, json_object_get_string(j_module))) {
+		OPAE_ERR("error copying module name");
+		goto out_err;
+	}
+
+	cfg->enabled = json_object_get_boolean(j_enabled);
+	plugin_count++;
+	return 0;
+out_err:
+	if (cfg->cfg) {
+		free(cfg->cfg);
+		cfg->cfg = NULL;
+	}
+	cfg->cfg_size = 0;
+	return 1;
+}
+
+STATIC int process_cfg_buffer(const char *buffer, const char *filename)
+{
+	int num_plugins = 0;
+	int num_errors = 0;
+	int i = 0;
+	int res = 1;
+	json_object *root = NULL;
+	json_object *j_plugins = NULL;
+	json_object *j_configs = NULL;
+	json_object *j_plugin = NULL;
+	json_object *j_config = NULL;
+	const char *plugin_name = NULL;
+	enum json_tokener_error j_err = json_tokener_success;
+
+	root = json_tokener_parse_verbose(buffer, &j_err);
+	if (!root) {
+		OPAE_ERR("Error parsing config file: '%s' - %s", filename,
+			 json_tokener_error_desc(j_err));
+		goto out_free;
+	}
+
+	if (!json_object_object_get_ex(root, "plugins", &j_plugins)) {
+		OPAE_ERR("Error parsing config file: '%s' - missing 'plugins'", filename);
+		goto out_free;
+	}
+	if (!json_object_object_get_ex(root, "configurations", &j_configs)) {
+		OPAE_ERR("Error parsing config file: '%s' - missing 'configs'", filename);
+		goto out_free;
+	}
+
+	if (!json_object_is_type(j_plugins, json_type_array)) {
+		OPAE_ERR("'plugins' JSON object not array type");
+		goto out_free;
+	}
+
+	num_plugins = json_object_array_length(j_plugins);
+	num_errors = 0;
+	for (i = 0; i < num_plugins; ++i) {
+		j_plugin = json_object_array_get_idx(j_plugins, i);
+		plugin_name = json_object_get_string(j_plugin);
+
+		if (json_object_object_get_ex(j_configs, plugin_name, &j_config)) {
+			num_errors += process_plugin(plugin_name, j_config);
+		} else {
+			OPAE_ERR("Could not find plugin configuration for '%s'", plugin_name);
+			num_errors += 1;
+		}
+	}
+	res = num_errors;
+
+
+out_free:
+	json_object_put(root);
+	return res;
+
+}
+
+#define MAX_CFG_SIZE 4096
+STATIC int opae_plugin_mgr_parse_config(const char *filename)
+{
+	char buffer[MAX_CFG_SIZE] = { 0 };
+	char *ptr = &buffer[0];
+	size_t bytes_read = 0, total_read = 0;
+	FILE *fp = fopen(filename, "r");
+	if (!fp) {
+		OPAE_ERR("Error opening config file: %s", filename);
+		return 1;
+	}
+
+	while ((bytes_read = fread(ptr + total_read, 1, 1, fp))
+	       && total_read < MAX_CFG_SIZE) {
+		total_read += bytes_read;
+	}
+
+	if (ferror(fp)) {
+		OPAE_ERR("Error reading config file: %s - %s", filename, strerror(errno));
+		goto out_err;
+	}
+	if (!feof(fp)) {
+		OPAE_ERR("Unknown error reading config file: %s", filename);
+		goto out_err;
+	}
+	fclose(fp);
+	fp = NULL;
+
+	return process_cfg_buffer(buffer, filename);
+out_err:
+	fclose(fp);
+	fp = NULL;
 	return 1;
 }
 
@@ -336,6 +536,47 @@ out_close:
 	return errors;
 }
 
+STATIC int opae_plugin_mgr_load_cfg_plugin(int i)
+{
+	int res = 0;
+	plugin_cfg *cfg = &plugin_list[i];
+	opae_api_adapter_table *adapter = NULL;
+
+	if (cfg->enabled && cfg->cfg && cfg->cfg_size) {
+		adapter = opae_plugin_mgr_alloc_adapter(cfg->module);
+		if (!adapter) {
+			OPAE_ERR("malloc failed");
+			return 1;
+		}
+		res = opae_plugin_mgr_configure_plugin(adapter, cfg->cfg);
+		if (res) {
+			opae_plugin_mgr_free_adapter(adapter);
+			OPAE_ERR("failed to configure plugin \"%s\"",
+				 cfg->name);
+			return 1;
+		}
+
+		res = opae_plugin_mgr_register_adapter(adapter);
+		if (res) {
+			opae_plugin_mgr_free_adapter(adapter);
+			OPAE_ERR("Failed to register \"%s\"", cfg->name);
+			return 1;
+		}
+
+	}
+
+	return 0;
+}
+
+STATIC int opae_plugin_mgr_load_cfg_plugins()
+{
+	int i = 0;
+	for ( ; i < plugin_count; ++i) {
+		opae_plugin_mgr_load_cfg_plugin(i);
+	}
+	return 0;
+}
+
 int opae_plugin_mgr_initialize(const char *cfg_file)
 {
 	int i;
@@ -344,10 +585,14 @@ int opae_plugin_mgr_initialize(const char *cfg_file)
 	int errors = 0;
 	int platforms_detected = 0;
 	opae_api_adapter_table *adapter;
+	plugin_count = 0;
 
 	// TODO: parse config file
-	UNUSED_PARAM(cfg_file);
-	opae_plugin_mgr_parse_config();
+	if (!cfg_file) {
+		cfg_file = find_cfg();
+	}
+
+	opae_plugin_mgr_parse_config(cfg_file);
 
 	opae_mutex_lock(res, &adapter_list_lock);
 
@@ -424,6 +669,7 @@ int opae_plugin_mgr_initialize(const char *cfg_file)
 	}
 
 	// TODO: load non-native plugins described in config file.
+	opae_plugin_mgr_load_cfg_plugins();
 
 	// Call each plugin's initialization routine.
 	errors += opae_plugin_mgr_initialize_all();

--- a/libopae/pluginmgr.c
+++ b/libopae/pluginmgr.c
@@ -373,7 +373,14 @@ STATIC int opae_plugin_mgr_parse_config(const char *filename)
 	char buffer[MAX_CFG_SIZE] = { 0 };
 	char *ptr = &buffer[0];
 	size_t bytes_read = 0, total_read = 0;
-	FILE *fp = fopen(filename, "r");
+	FILE *fp = NULL;
+	if (filename) {
+		fp = fopen(filename, "r");
+	} else {
+		OPAE_MSG("config file is NULL");
+		return 1;
+	}
+
 	if (!fp) {
 		OPAE_ERR("Error opening config file: %s", filename);
 		return 1;

--- a/libopae/pluginmgr.h
+++ b/libopae/pluginmgr.h
@@ -45,7 +45,7 @@ int opae_plugin_mgr_for_each_adapter(
 #define PLUGIN_NAME_MAX 64
 typedef struct _plugin_cfg {
 	char name[PLUGIN_NAME_MAX];
-	char module[PLUGIN_NAME_MAX];
+	char plugin[PLUGIN_NAME_MAX];
 	bool enabled;
 	char *cfg;
 	size_t cfg_size;

--- a/libopae/pluginmgr.h
+++ b/libopae/pluginmgr.h
@@ -41,4 +41,17 @@ int opae_plugin_mgr_finalize_all(void);
 int opae_plugin_mgr_for_each_adapter(
 	int (*callback)(const opae_api_adapter_table *, void *), void *context);
 
+#define PLUGIN_SUPPORTED_DEVICES_MAX 256
+#define PLUGIN_NAME_MAX 64
+typedef struct _plugin_cfg {
+	char name[PLUGIN_NAME_MAX];
+	char module[PLUGIN_NAME_MAX];
+	bool enabled;
+	char *cfg;
+	size_t cfg_size;
+	uint32_t supported_devices[PLUGIN_SUPPORTED_DEVICES_MAX];
+} plugin_cfg;
+int opae_plugin_mgr_plugin_count(void);
+const plugin_cfg *opae_plugin_mgr_get(int i);
+
 #endif /* __OPAE_PLUGINMGR_H__ */

--- a/testing/opae-c/test_pluginmgr_c.cpp
+++ b/testing/opae-c/test_pluginmgr_c.cpp
@@ -240,7 +240,7 @@ const char *plugin_cfg_1 = R"plug(
                 "key1b": "hello"
             },
             "enabled": true,
-            "module": "libplugin1.so"
+            "plugin": "libplugin1.so"
         },
         "plugin2": {
             "configuration": {
@@ -248,7 +248,7 @@ const char *plugin_cfg_1 = R"plug(
                 "key1b": "goodbye"
             },
             "enabled": false,
-            "module": "libplugin2.so"
+            "plugin": "libplugin2.so"
         }
     },
     "plugins": [
@@ -268,7 +268,7 @@ const char *plugin_cfg_2 = R"plug(
                 "key1b": "hello"
             },
             "enabled": true,
-            "module": "libplugin1.so"
+            "plugin": "libplugin1.so"
         }
         "plugin2": {
             "configuration": {
@@ -276,7 +276,7 @@ const char *plugin_cfg_2 = R"plug(
                 "key1b": "goodbye"
             },
             "enabled": false,
-            "module": "libplugin2.so"
+            "plugin": "libplugin2.so"
         }
     },
     "plugins": [
@@ -296,7 +296,7 @@ const char *plugin_cfg_3 = R"plug(
                 "key1b": "hello"
             },
             "enable": true,
-            "module": "libplugin1.so"
+            "plugin": "libplugin1.so"
         },
         "plugin2": {
             "configuration": {
@@ -304,7 +304,7 @@ const char *plugin_cfg_3 = R"plug(
                 "key1b": "goodbye"
             },
             "enabled": false,
-            "module": "libplugin2.so"
+            "plugin": "libplugin2.so"
         }
     },
     "plugins": [
@@ -324,7 +324,7 @@ const char *plugin_cfg_4 = R"plug(
                 "key1b": "hello"
             },
             "enabled": true,
-            "module": "libplugin1.so"
+            "plugin": "libplugin1.so"
         },
         "plugin2": {
             "configuration": {
@@ -332,7 +332,7 @@ const char *plugin_cfg_4 = R"plug(
                 "key1b": "goodbye"
             },
             "enabled": false,
-            "module": "libplugin2.so"
+            "plugin": "libplugin2.so"
         }
     },
     "plugins": [
@@ -352,7 +352,7 @@ const char *plugin_cfg_5 = R"plug(
                 "key1b": "hello"
             },
             "enabled": true,
-            "module": "libplugin1.so"
+            "plugin": "libplugin1.so"
         },
         "plugin2": {
             "configuration": {
@@ -360,7 +360,7 @@ const char *plugin_cfg_5 = R"plug(
                 "key1b": "goodbye"
             },
             "enabled": false,
-            "module": "libplugin2.so"
+            "plugin": "libplugin2.so"
         }
     },
     "plugins": 0

--- a/testing/opae-c/test_pluginmgr_c.cpp
+++ b/testing/opae-c/test_pluginmgr_c.cpp
@@ -39,8 +39,9 @@ int opae_plugin_mgr_for_each_adapter
 	(int (*callback)(const opae_api_adapter_table *, void *), void *context);
 int opae_plugin_mgr_configure_plugin(opae_api_adapter_table *adapter,
 				     const char *config);
-
+int process_cfg_buffer(const char *buffer, const char *filename);
 extern opae_api_adapter_table *adapter_list;
+
 }
 
 #include <config.h>
@@ -228,6 +229,181 @@ TEST_P(pluginmgr_c_p, bad_final_all) {
   EXPECT_NE(0, opae_plugin_mgr_finalize_all());
   EXPECT_EQ(nullptr, adapter_list);
   EXPECT_EQ(2, test_plugin_finalize_called);
+}
+
+const char *plugin_cfg_1 = R"plug(
+{
+    "configurations": {
+        "plugin1": {
+            "configuration": {
+                "key1a": 10,
+                "key1b": "hello"
+            },
+            "enabled": true,
+            "module": "libplugin1.so"
+        },
+        "plugin2": {
+            "configuration": {
+                "key1a": 20,
+                "key1b": "goodbye"
+            },
+            "enabled": false,
+            "module": "libplugin2.so"
+        }
+    },
+    "plugins": [
+        "plugin1",
+        "plugin2"
+    ]
+}
+)plug";
+
+// missing comma (,) on line 272
+const char *plugin_cfg_2 = R"plug(
+{
+    "configurations": {
+        "plugin1": {
+            "configuration": {
+                "key1a": 10,
+                "key1b": "hello"
+            },
+            "enabled": true,
+            "module": "libplugin1.so"
+        }
+        "plugin2": {
+            "configuration": {
+                "key1a": 20,
+                "key1b": "goodbye"
+            },
+            "enabled": false,
+            "module": "libplugin2.so"
+        }
+    },
+    "plugins": [
+        "plugin1",
+        "plugin2"
+    ]
+}
+)plug";
+
+// keyword enabled misspelled on line 298
+const char *plugin_cfg_3 = R"plug(
+{
+    "configurations": {
+        "plugin1": {
+            "configuration": {
+                "key1a": 10,
+                "key1b": "hello"
+            },
+            "enable": true,
+            "module": "libplugin1.so"
+        },
+        "plugin2": {
+            "configuration": {
+                "key1a": 20,
+                "key1b": "goodbye"
+            },
+            "enabled": false,
+            "module": "libplugin2.so"
+        }
+    },
+    "plugins": [
+        "plugin1",
+        "plugin2"
+    ]
+}
+)plug";
+
+// plugin name different on line 321
+const char *plugin_cfg_4 = R"plug(
+{
+    "configurations": {
+        "plugin10": {
+            "configuration": {
+                "key1a": 10,
+                "key1b": "hello"
+            },
+            "enabled": true,
+            "module": "libplugin1.so"
+        },
+        "plugin2": {
+            "configuration": {
+                "key1a": 20,
+                "key1b": "goodbye"
+            },
+            "enabled": false,
+            "module": "libplugin2.so"
+        }
+    },
+    "plugins": [
+        "plugin1",
+        "plugin2"
+    ]
+}
+)plug";
+
+// plugins not array type
+const char *plugin_cfg_5 = R"plug(
+{
+    "configurations": {
+        "plugin1": {
+            "configuration": {
+                "key1a": 10,
+                "key1b": "hello"
+            },
+            "enabled": true,
+            "module": "libplugin1.so"
+        },
+        "plugin2": {
+            "configuration": {
+                "key1a": 20,
+                "key1b": "goodbye"
+            },
+            "enabled": false,
+            "module": "libplugin2.so"
+        }
+    },
+    "plugins": 0
+}
+)plug";
+
+
+extern "C" {
+  void opae_plugin_mgr_reset_cfg(void);
+}
+
+TEST(pluginmgr_c_p, process_cfg_buffer) {
+  opae_plugin_mgr_reset_cfg();
+  EXPECT_EQ(opae_plugin_mgr_plugin_count(), 0);
+  ASSERT_EQ(process_cfg_buffer(plugin_cfg_1, "plugin1.json"), 0);
+  EXPECT_EQ(opae_plugin_mgr_plugin_count(), 2);
+  auto p1 = opae_plugin_mgr_get(0);
+  auto p2 = opae_plugin_mgr_get(1);
+  ASSERT_NE(p1, nullptr);
+  ASSERT_NE(p2, nullptr);
+  EXPECT_TRUE(p1->enabled);
+  EXPECT_FALSE(p2->enabled);
+}
+
+TEST(pluginmgr_c_p, process_cfg_buffer_err) {
+  opae_plugin_mgr_reset_cfg();
+  EXPECT_EQ(opae_plugin_mgr_plugin_count(), 0);
+  ASSERT_NE(process_cfg_buffer(plugin_cfg_2, "plugin2.json"), 0);
+
+  opae_plugin_mgr_reset_cfg();
+  EXPECT_EQ(opae_plugin_mgr_plugin_count(), 0);
+  ASSERT_NE(process_cfg_buffer(plugin_cfg_3, "plugin3.json"), 0);
+  EXPECT_EQ(opae_plugin_mgr_plugin_count(), 1);
+
+  opae_plugin_mgr_reset_cfg();
+  EXPECT_EQ(opae_plugin_mgr_plugin_count(), 0);
+  ASSERT_NE(process_cfg_buffer(plugin_cfg_4, "plugin4.json"), 0);
+  EXPECT_EQ(opae_plugin_mgr_plugin_count(), 1);
+
+  opae_plugin_mgr_reset_cfg();
+  EXPECT_EQ(opae_plugin_mgr_plugin_count(), 0);
+  ASSERT_NE(process_cfg_buffer(plugin_cfg_5, "plugin5.json"), 0);
+  EXPECT_EQ(opae_plugin_mgr_plugin_count(), 0);
 }
 
 INSTANTIATE_TEST_CASE_P(pluginmgr_c, pluginmgr_c_p, ::testing::ValuesIn(test_platform::keys(true)));


### PR DESCRIPTION
Add logic in pluginmgr.c to look for and process plugin configuration
files.

The schema is still WIP.