### PR TITLE
opae-c: don't apply versions to modules

### DIFF
--- a/libopae/plugins/xfpga/CMakeLists.txt
+++ b/libopae/plugins/xfpga/CMakeLists.txt
@@ -71,7 +71,7 @@ set(SRC
 
 # Define target
 add_library(xfpga MODULE ${SRC})
-#add_dependencies(xfpga copy-common-opae-header-files)
+
 target_link_libraries(xfpga
   m
   safestr
@@ -100,9 +100,6 @@ endif(CMAKE_BUILD_TYPE STREQUAL "Coverage")
 
 # Target properties
 set_property(TARGET xfpga PROPERTY C_STANDARD 99)
-set_target_properties(xfpga PROPERTIES
-  VERSION ${INTEL_FPGA_API_VERSION}
-  SOVERSION ${INTEL_FPGA_API_VER_MAJOR})
 
 # Add coverage flags
 if(CMAKE_BUILD_TYPE STREQUAL "Coverage")

--- a/libopae/plugins/xfpga/metrics/bmc/CMakeLists.txt
+++ b/libopae/plugins/xfpga/metrics/bmc/CMakeLists.txt
@@ -27,7 +27,7 @@
 include_directories(
 	${OPAE_INCLUDE_DIR} )
 
-add_library(bmc SHARED
+add_library(bmc MODULE
 	bmc.c
 	bmcdata.c
 	bmc_ioctl.c
@@ -44,11 +44,6 @@ set_install_rpath(bmc)
 set_property(TARGET staticbmc PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_link_libraries(bmc safestr m rt ${CMAKE_THREAD_LIBS_INIT})
-
-set_target_properties(bmc PROPERTIES
-  VERSION ${INTEL_FPGA_API_VERSION}
-  SOVERSION ${INTEL_FPGA_API_VER_MAJOR})
-
 
 install(TARGETS bmc
     LIBRARY DESTINATION ${OPAE_LIB_INSTALL_DIR}


### PR DESCRIPTION
Attempting to apply VERSION/SOVERSION to module libraries is causing
build errors on distros with newer versions of cmake. This change
removes the code that was doing that, and it changes the library type of
libbmc.so from SHARED to MODULE (it is dynamically loaded).