### PR TITLE
Retry socket select operation if it fails with EINTR

### DIFF
--- a/ase/sw/protocol_backend.c
+++ b/ase/sw/protocol_backend.c
@@ -705,7 +705,7 @@ static void *start_socket_srv(void *args)
 
 	do {
 		FD_SET(sock_fd, &readfds);
-		res = select(sock_fd+1, &readfds, NULL, NULL, &tv);
+		res = TEMP_FAILURE_RETRY(select(sock_fd+1, &readfds, NULL, NULL, &tv));
 		if (res < 0) {
 			ASE_ERR("SIM-C : select error=%s\n", strerror(errno));
 			err_cnt++;


### PR DESCRIPTION
Sometimes the select is interrupted and thus returns EINTR. According to the reference the operation can be retried.

This fixed crashed in the ASE simulation where sockets where the event socket was not working.

I wonder if the use of the gnu macro is ok, or if the same behavior should be included in the opae source. What is the coding style guide for this? 

reference:
https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html