### PR TITLE
Update platform RTL Quartus IP from 18.1.

### DIFF
--- a/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/gen_platform_ip.sh
+++ b/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/gen_platform_ip.sh
@@ -27,11 +27,25 @@ src_files="\
 
 for s in $src_files; do
     src="${QUARTUS_REL}/${s}"
+    if [ ! -f "${src}" ]; then
+        if [ -f "${src}.terp" ]; then
+            # Templated file
+            src="${src}.terp"
+        else
+            echo "File not found: ${src}"
+            continue
+        fi
+    fi
+
     dst=`basename "${s}" | sed -e 's/^altera/platform_utils/'`
     echo "$dst"
 
+    # Drop the suffix
+    dst_module="${dst%.*}"
+
     # The final replacement enables synchronous reset by default
-    sed -e 's/ altera_std/ platform_utils_std/g' \
+    sed -e "s/\$substitute_entity_name/${dst_module}/g" \
+        -e 's/ altera_std/ platform_utils_std/g' \
         -e 's/ altera_avalon/ platform_utils_avalon/g' \
         -e 's/ altera_dcfifo/ platform_utils_dcfifo/g' \
         -e 's/parameter SYNC_RESET \([ ]*\)= 0/parameter SYNC_RESET \1= 1/' \

--- a/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_dc_fifo.sdc
+++ b/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_dc_fifo.sdc
@@ -1,7 +1,7 @@
-# $File: //acds/rel/18.0/ip/sopc/components/altera_avalon_dc_fifo/altera_avalon_dc_fifo.sdc $
-# $Revision: #1 $
-# $Date: 2018/02/08 $
-# $Author: psgswbuild $
+# $File: //acds/rel/18.1/ip/sopc/components/altera_avalon_dc_fifo/altera_avalon_dc_fifo.sdc $
+# $Revision: #2 $
+# $Date: 2018/08/03 $
+# $Author: kknagar $
 
 #-------------------------------------------------------------------------------
 # TimeQuest constraints to constrain the timing across asynchronous clock domain crossings.
@@ -15,7 +15,7 @@
 # Do not declare the FIFO clocks as asynchronous at the top level, or false path these crossings,
 # because that will override these constraints.
 #-------------------------------------------------------------------------------
-
+set all_dc_fifo [get_entity_instances platform_utils_avalon_dc_fifo]
 
 set_max_delay -from [get_registers {*|in_wr_ptr_gray[*]}] -to [get_registers {*|platform_utils_dcfifo_synchronizer_bundle:write_crosser|platform_utils_std_synchronizer_nocut:sync[*].u|din_s1}] 200
 set_min_delay -from [get_registers {*|in_wr_ptr_gray[*]}] -to [get_registers {*|platform_utils_dcfifo_synchronizer_bundle:write_crosser|platform_utils_std_synchronizer_nocut:sync[*].u|din_s1}] -200
@@ -25,6 +25,18 @@ set_min_delay -from [get_registers {*|out_rd_ptr_gray[*]}] -to [get_registers {*
 
 set_net_delay -max -get_value_from_clock_period dst_clock_period -value_multiplier 0.8 -from [get_pins -compatibility_mode {*|in_wr_ptr_gray[*]*}] -to [get_registers {*|platform_utils_dcfifo_synchronizer_bundle:write_crosser|platform_utils_std_synchronizer_nocut:sync[*].u|din_s1}] 
 set_net_delay -max -get_value_from_clock_period dst_clock_period -value_multiplier 0.8 -from [get_pins -compatibility_mode {*|out_rd_ptr_gray[*]*}] -to [get_registers {*|platform_utils_dcfifo_synchronizer_bundle:read_crosser|platform_utils_std_synchronizer_nocut:sync[*].u|din_s1}]
+
+
+foreach dc_fifo_inst $all_dc_fifo {
+   if { [ llength [query_collection -report -all [get_registers $dc_fifo_inst|in_wr_ptr_gray[*]]]] > 0  } {
+      set_max_skew -get_skew_value_from_clock_period src_clock_period -skew_value_multiplier 0.8  -from [get_registers $dc_fifo_inst|in_wr_ptr_gray[*]] -to [get_registers $dc_fifo_inst|write_crosser|sync[*].u|din_s1] 
+   }
+
+   if { [ llength [query_collection -report -all [get_registers $dc_fifo_inst|out_rd_ptr_gray[*]]]] > 0 } {
+      set_max_skew -get_skew_value_from_clock_period src_clock_period -skew_value_multiplier 0.8  -from [get_registers $dc_fifo_inst|out_rd_ptr_gray[*]] -to [get_registers $dc_fifo_inst|read_crosser|sync[*].u|din_s1] 
+   }
+}
+
 
 # add in timing constraints across asynchronous clock domain crossings for simple dual clock memory inference
 

--- a/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_dc_fifo.v
+++ b/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_dc_fifo.v
@@ -1,6 +1,6 @@
-// $File: //acds/rel/18.0/ip/sopc/components/altera_avalon_dc_fifo/altera_avalon_dc_fifo.v $
+// $File: //acds/rel/18.1/ip/sopc/components/altera_avalon_dc_fifo/altera_avalon_dc_fifo.v $
 // $Revision: #1 $
-// $Date: 2018/02/08 $
+// $Date: 2018/07/29 $
 // $Author: psgswbuild $
 //-------------------------------------------------------------------------------
 // Description: Dual clocked single channel FIFO with fill levels and status

--- a/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_mm_bridge.v
+++ b/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_avalon_mm_bridge.v
@@ -28,11 +28,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
-// $Id: //acds/rel/18.0/ip/merlin/altera_avalon_mm_bridge/altera_avalon_mm_bridge.v#1 $
-// $Revision: #1 $
-// $Date: 2018/02/08 $
-// $Author: psgswbuild $
 // --------------------------------------
 // Avalon-MM pipeline bridge
 //
@@ -40,7 +35,7 @@
 // --------------------------------------
 
 `timescale 1 ns / 1 ns
-module platform_utils_avalon_mm_bridge
+module platform_utils_avalon_mm_bridge 
 #(
     parameter DATA_WIDTH           = 32,
     parameter SYMBOL_WIDTH         = 8,

--- a/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_dcfifo_synchronizer_bundle.v
+++ b/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_dcfifo_synchronizer_bundle.v
@@ -1,6 +1,6 @@
-// $File: //acds/rel/18.0/ip/sopc/components/altera_avalon_dc_fifo/altera_dcfifo_synchronizer_bundle.v $
+// $File: //acds/rel/18.1/ip/sopc/components/altera_avalon_dc_fifo/altera_dcfifo_synchronizer_bundle.v $
 // $Revision: #1 $
-// $Date: 2018/02/08 $
+// $Date: 2018/07/29 $
 // $Author: psgswbuild $
 //-------------------------------------------------------------------------------
 

--- a/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_std_synchronizer_nocut.v
+++ b/platforms/platform_if/rtl/platform_shims/utils/quartus_ip/platform_utils_std_synchronizer_nocut.v
@@ -28,7 +28,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 // $Id: //acds/main/ip/sopc/components/primitives/altera_std_synchronizer/altera_std_synchronizer.v#8 $
 // $Revision: #8 $
 // $Date: 2009/02/18 $


### PR DESCRIPTION
- The only synthesis-visible change is a new timing constraint on Avalon DC FIFO.
- Update the script the pulls sources from a Quartus release due to file name changes.