### PR TITLE
opae-c: add dummy plugin and basic test

### DIFF
--- a/libopae/opae_int.h
+++ b/libopae/opae_int.h
@@ -62,7 +62,7 @@
 #define ASSERT_NOT_NULL(__arg) ASSERT_NOT_NULL_MSG(__arg, #__arg " is NULL")
 
 #define ASSERT_NOT_NULL_RESULT(__arg, __result)                                \
-	ASSERT_NOT_NULL_MSG_RESULT(__arg, #__arg "is NULL", __result)
+	ASSERT_NOT_NULL_MSG_RESULT(__arg, #__arg " is NULL", __result)
 
 #define ASSERT_RESULT(__result)                                                \
 	do {                                                                   \

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -7,11 +7,11 @@ function finish() {
 	find testing -iname "*.gcda" -exec chmod 664 '{}' \;
 	find testing -iname "*.gcno" -exec chmod 664 '{}' \;
 
-	lcov --directory testing --capture --output-file coverage.info
+	lcov --directory testing --capture --output-file coverage.info 2> /dev/null
 
 	lcov -a coverage.base -a coverage.info --output-file coverage.total
 	lcov --remove coverage.total '/usr/**' 'tests/**' '*/**/CMakeFiles*' '/usr/*' 'safe_string/**' 'pybind11/*' 'testing/**' --output-file coverage.info.cleaned
-	genhtml --function-coverage -o coverage_report coverage.info.cleaned
+	genhtml --function-coverage -o coverage_report coverage.info.cleaned 2> /dev/null
 
 }
 trap "finish" EXIT
@@ -30,7 +30,7 @@ echo "Making tests"
 make -j4 test_unit bmc xfpga
 
 lcov --directory . --zerocounters
-lcov -c -i -d . -o coverage.base
+lcov -c -i -d . -o coverage.base 2> /dev/null
 
 LD_LIBRARY_PATH=${PWD}/lib \
 CTEST_OUTPUT_ON_FAILURE=1 \

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -352,9 +352,11 @@ add_unit_test(test_opae_init_c opae-c-static
 add_unit_test(test_opae_pluginmgr_c opae-c-static
     opae-c/test_pluginmgr_c.cpp
 )
-
 set_tests_properties(test_opae_pluginmgr_c
     PROPERTIES ENVIRONMENT "LD_LIBRARY_PATH=${LIBRARY_OUTPUT_PATH}")
+add_library(dummy_plugin MODULE opae-c/dummy_plugin.c)
+target_link_libraries(dummy_plugin ${libjson-c_LIBRARIES})
+add_dependencies(test_opae_pluginmgr_c dummy_plugin)
 
 ############################################################################
 # cxx core tests ###########################################################
@@ -638,8 +640,6 @@ add_custom_command(TARGET test_unit
     ${CMAKE_BINARY_DIR}
     )
 
-add_library(dummy_plugin MODULE opae-c/dummy_plugin.c)
-target_link_libraries(dummy_plugin ${libjson-c_LIBRARIES})
 ############################################################################
 # pyopae tests #############################################################
 ############################################################################

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -635,7 +635,8 @@ add_custom_command(TARGET test_unit
     ${CMAKE_BINARY_DIR}
     )
 
-
+add_library(dummy_plugin MODULE opae-c/dummy_plugin.c)
+target_link_libraries(dummy_plugin ${libjson-c_LIBRARIES})
 ############################################################################
 # pyopae tests #############################################################
 ############################################################################

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -353,6 +353,9 @@ add_unit_test(test_opae_pluginmgr_c opae-c-static
     opae-c/test_pluginmgr_c.cpp
 )
 
+set_tests_properties(test_opae_pluginmgr_c
+    PROPERTIES ENVIRONMENT "LD_LIBRARY_PATH=${LIBRARY_OUTPUT_PATH}")
+
 ############################################################################
 # cxx core tests ###########################################################
 ############################################################################

--- a/testing/opae-c/dummy_plugin.c
+++ b/testing/opae-c/dummy_plugin.c
@@ -76,10 +76,19 @@ fpga_result DUMMY_HIDDEN dummy_plugin_fpgaEnumerate(const fpga_properties *filte
 
 	for ( ; i < min; ++i) {
 		dummy_token *t = (dummy_token*)malloc(sizeof(dummy_token));
+		if (!t) {
+			goto err_enum;
+		}
 		t->number = i;
 		tokens[i] = t;
 	}
 	return FPGA_OK;
+err_enum:
+	while (--i) {
+		free(tokens[i]);
+	}
+	free(tokens[0]);
+	return FPGA_NO_MEMORY;
 }
 
 fpga_result DUMMY_HIDDEN dummy_plugin_fpgaDestroyToken(fpga_token *t)
@@ -98,7 +107,7 @@ fpga_result DUMMY_HIDDEN dummy_plugin_fpgaOpen(fpga_token t, fpga_handle *h, int
 	//printf("dummy/fpgaOpen %d %d\n", dh->number, flags);
 	dh->number = dt->number*flags*2;
 	dh->token = dt;
-	h = (fpga_handle)dh;
+	*h = (fpga_handle)dh;
 	return FPGA_OK;
 }
 

--- a/testing/opae-c/dummy_plugin.c
+++ b/testing/opae-c/dummy_plugin.c
@@ -1,0 +1,203 @@
+// Copyright(c) 2018-2019, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include <stdio.h>
+#include <json-c/json.h>
+#include "adapter.h"
+#include "opae_int.h"
+
+#define DUMMY_HIDDEN __attribute__((visibility("hidden")))
+
+static uint32_t _fake_tokens;
+
+int DUMMY_HIDDEN dummy_plugin_initialize(void)
+{
+	return 0;
+}
+
+int DUMMY_HIDDEN dummy_plugin_finalize(void)
+{
+	return 0;
+}
+
+bool DUMMY_HIDDEN dummy_plugin_supports_device(const char *device_type)
+{
+	UNUSED_PARAM(device_type);
+	return true;
+}
+
+bool DUMMY_HIDDEN dummy_plugin_supports_host(const char *hostname)
+{
+	UNUSED_PARAM(hostname);
+	return true;
+}
+
+typedef struct _dummy_token {
+	int number;
+} dummy_token;
+
+typedef struct _dummy_handle {
+	int number;
+	dummy_token *token;
+} dummy_handle;
+
+#define MIN(x,y) (x < y) ? x : y
+fpga_result DUMMY_HIDDEN dummy_plugin_fpgaEnumerate(const fpga_properties *filters,
+						    uint32_t num_filters, fpga_token *tokens,
+						    uint32_t max_tokens, uint32_t *num_matches)
+{
+	uint32_t i = 0;
+	uint32_t min = MIN(_fake_tokens, max_tokens);
+	UNUSED_PARAM(filters);
+	UNUSED_PARAM(num_filters);
+	*num_matches = _fake_tokens;
+
+	for ( ; i < min; ++i) {
+		dummy_token *t = (dummy_token*)malloc(sizeof(dummy_token));
+		t->number = i;
+		tokens[i] = t;
+	}
+	return FPGA_OK;
+}
+
+fpga_result DUMMY_HIDDEN dummy_plugin_fpgaDestroyToken(fpga_token *t)
+{
+	dummy_token *dt = (dummy_token *)*t;
+	free(dt);
+	*t = NULL;
+	return FPGA_OK;
+}
+
+fpga_result DUMMY_HIDDEN dummy_plugin_fpgaOpen(fpga_token t, fpga_handle *h, int flags)
+{
+	UNUSED_PARAM(h);
+	dummy_token *dt = (dummy_token*)t;
+	dummy_handle *dh = (dummy_handle*)malloc(sizeof(dummy_handle));
+	//printf("dummy/fpgaOpen %d %d\n", dh->number, flags);
+	dh->number = dt->number*flags*2;
+	dh->token = dt;
+	h = (fpga_handle)dh;
+	return FPGA_OK;
+}
+
+fpga_result DUMMY_HIDDEN dummy_plugin_fpgaClose(fpga_handle h)
+{
+	dummy_handle *dh = (dummy_handle *)h;
+	//printf("dummy/fpgaClose %d\n", dh->number);
+	free(dh);
+	return FPGA_OK;
+}
+
+#define DUMMY_JSON_GET(_jobj, _key, _jval)                      \
+  do {                                                          \
+    if (!json_object_object_get_ex(_jobj, _key, _jval)) {       \
+      fprintf(stderr, "error getting value for key: %s", _key); \
+      return 1;                                                 \
+    }                                                           \
+  } while (0)
+int __attribute__((visibility("default"))) opae_plugin_configure(opae_api_adapter_table *adapter,
+				       const char *jsonConfig)
+{
+	json_object *root = NULL;
+	json_object *j_hello = NULL;
+	json_object *j_plugin = NULL;
+	json_object *j_fake_tokens = NULL;
+	enum json_tokener_error j_err = json_tokener_success;
+	//printf("%s\n", jsonConfig);
+	root = json_tokener_parse_verbose(jsonConfig, &j_err);
+	if (j_err != json_tokener_success) {
+		fprintf(stderr, "error parsing plugin config: %s\n",
+				json_tokener_error_desc(j_err));
+		return 1;
+	}
+	DUMMY_JSON_GET(root, "key1", &j_hello);
+	DUMMY_JSON_GET(root, "key2", &j_plugin);
+	DUMMY_JSON_GET(root, "fake_tokens", &j_fake_tokens);
+        printf("%s %s!\n", json_object_get_string(j_hello),
+               json_object_get_string(j_plugin));
+	_fake_tokens = json_object_get_int(j_fake_tokens);
+
+        adapter->initialize = dummy_plugin_initialize;
+	adapter->finalize = NULL;
+	adapter->supports_device = dummy_plugin_supports_device;
+	adapter->supports_host = NULL;
+	adapter->fpgaEnumerate = dummy_plugin_fpgaEnumerate;
+	adapter->fpgaDestroyToken = dummy_plugin_fpgaDestroyToken;
+	adapter->fpgaOpen = dummy_plugin_fpgaOpen;
+	adapter->fpgaClose = dummy_plugin_fpgaClose;
+
+	adapter->fpgaReset = NULL;
+	adapter->fpgaGetPropertiesFromHandle = NULL;
+	adapter->fpgaGetProperties = NULL;
+	adapter->fpgaUpdateProperties = NULL;
+	adapter->fpgaWriteMMIO64 = NULL;
+	adapter->fpgaReadMMIO64 = NULL;
+	adapter->fpgaWriteMMIO32 = NULL;
+	adapter->fpgaReadMMIO32 = NULL;
+	adapter->fpgaMapMMIO = NULL;
+	adapter->fpgaUnmapMMIO = NULL;
+	adapter->fpgaCloneToken = NULL;
+	adapter->fpgaGetNumUmsg = NULL;
+	adapter->fpgaSetUmsgAttributes = NULL;
+	adapter->fpgaTriggerUmsg = NULL;
+	adapter->fpgaGetUmsgPtr = NULL;
+	adapter->fpgaPrepareBuffer = NULL;
+	adapter->fpgaReleaseBuffer = NULL;
+	adapter->fpgaGetIOAddress = NULL;
+	/*
+	**	adapter->fpgaGetOPAECVersion = NULL;
+	**	adapter->fpgaGetOPAECVersionString = NULL;
+	*adapter->fpgaGetOPAECBuildString = NULL;
+	*/
+	adapter->fpgaReadError = NULL;
+	adapter->fpgaClearError = NULL;
+	adapter->fpgaClearAllErrors = NULL;
+	adapter->fpgaGetErrorInfo = NULL;
+	adapter->fpgaCreateEventHandle = NULL;
+	adapter->fpgaDestroyEventHandle = NULL;
+	adapter->fpgaGetOSObjectFromEventHandle = NULL;
+	adapter->fpgaRegisterEvent = NULL;
+	adapter->fpgaUnregisterEvent = NULL;
+	adapter->fpgaAssignPortToInterface = NULL;
+	adapter->fpgaAssignToInterface = NULL;
+	adapter->fpgaReleaseFromInterface = NULL;
+	adapter->fpgaReconfigureSlot = NULL;
+	adapter->fpgaTokenGetObject = NULL;
+	adapter->fpgaHandleGetObject = NULL;
+	adapter->fpgaObjectGetObject = NULL;
+	adapter->fpgaDestroyObject = NULL;
+	adapter->fpgaObjectRead = NULL;
+	adapter->fpgaObjectRead64 = NULL;
+	adapter->fpgaObjectGetSize = NULL;
+	adapter->fpgaObjectWrite64 = NULL;
+	adapter->fpgaSetUserClock = NULL;
+	adapter->fpgaGetUserClock = NULL;
+	adapter->fpgaGetNumMetrics = NULL;
+	adapter->fpgaGetMetricsInfo = NULL;
+	adapter->fpgaGetMetricsByIndex = NULL;
+	adapter->fpgaGetMetricsByName = NULL;
+
+	return 0;
+}


### PR DESCRIPTION
This dummy plugin makes use of the configuration string by parsing it
and then using the values. The first two values are used to print out to
stdout which the tests verifies. The third value is the number of dummy
tokens to create which is then used for the rest of the test for
enumerating and opening/closing tokens.

This also fixes the ASSERT_NOT_NULL_MSG_RESULT macro to include a space
before "is NULL" in the mssage.