### PR TITLE
remove var. name in catch statement 

### DIFF
--- a/tools/extra/fpgadiag/perf_counters.cpp
+++ b/tools/extra/fpgadiag/perf_counters.cpp
@@ -200,7 +200,7 @@ uint64_t fpga_cache_counters::read_counter(fpga_cache_counters::ctr_t c)
         if (counter) {
           return counter->read64();
         }
-    }catch(not_found &err) {
+    }catch(not_found &) {
        return 0;
     }
 
@@ -360,7 +360,7 @@ uint64_t fpga_fabric_counters::read_counter(fpga_fabric_counters::ctr_t c)
         if (counter) {
           return counter->read64();
         }
-    }catch(not_found &err) {
+    }catch(not_found &) {
        return 0;
     }
 


### PR DESCRIPTION
When catching 'not_found', simply return 0.
No need for processing exception variable.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>