### PR TITLE
xfpga: use modbmc for metrics API

### DIFF
--- a/libopae/plugins/xfpga/metrics/bmc/CMakeLists.txt
+++ b/libopae/plugins/xfpga/metrics/bmc/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2018, Intel Corporation
+## Copyright(c) 2018-2019, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -25,26 +25,40 @@
 ## POSSIBILITY OF SUCH DAMAGE.
 
 include_directories(
-	${OPAE_INCLUDE_DIR} )
+    ${OPAE_INCLUDE_DIR})
 
-add_library(bmc MODULE
-	bmc.c
-	bmcdata.c
-	bmc_ioctl.c
-	bmcinfo.c)
+set(SRC
+    bmc.c
+    bmcdata.c
+    bmc_ioctl.c
+    bmcinfo.c)
 
-add_library(staticbmc STATIC
-	bmc.c
-	bmcdata.c
-	bmc_ioctl.c
-	bmcinfo.c)
+add_library(bmc SHARED ${SRC})
 
 set_install_rpath(bmc)
 
+target_link_libraries(bmc
+    safestr
+    m
+    rt
+    ${CMAKE_THREAD_LIBS_INIT})
+
+add_library(staticbmc STATIC ${SRC})
+
 set_property(TARGET staticbmc PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-target_link_libraries(bmc safestr m rt ${CMAKE_THREAD_LIBS_INIT})
+add_library(modbmc MODULE ${SRC})
+
+target_link_libraries(modbmc
+    safestr
+    m
+    rt
+    ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS bmc
+    LIBRARY DESTINATION ${OPAE_LIB_INSTALL_DIR}
+    COMPONENT opaetoolslibs)
+
+install(TARGETS modbmc
     LIBRARY DESTINATION ${OPAE_LIB_INSTALL_DIR}
     COMPONENT opaetoolslibs)

--- a/libopae/plugins/xfpga/metrics/metrics_int.h
+++ b/libopae/plugins/xfpga/metrics/metrics_int.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2019, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -54,7 +54,7 @@
 #define TEMP                                "Centigrade"
 
 
-#define BMC_LIB                              "libbmc.so"
+#define BMC_LIB                             "libmodbmc.so"
 
 // AFU DFH Struct
 struct DFH {

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -27,7 +27,7 @@ mkdir -p coverage_files
 rm -rf coverage_files/*
 
 echo "Making tests"
-make -j4 test_unit xfpga bmc fpgad-xfpga
+make -j4 test_unit xfpga modbmc fpgad-xfpga
 
 lcov --directory . --zerocounters
 lcov -c -i -d . -o coverage.base

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -102,16 +102,6 @@ add_library(bmc-static STATIC
     ${OPAE_SDK_SOURCE}/libopae/plugins/xfpga/metrics/bmc/bmcdata.c
     ${OPAE_SDK_SOURCE}/libopae/plugins/xfpga/metrics/bmc/bmcinfo.c
     )
-    
-
-add_library(libbmc  SHARED
-    ${OPAE_SDK_SOURCE}/libopae/plugins/xfpga/metrics/bmc/bmc.c
-    ${OPAE_SDK_SOURCE}/libopae/plugins/xfpga/metrics/bmc/bmc_ioctl.c
-    ${OPAE_SDK_SOURCE}/libopae/plugins/xfpga/metrics/bmc/bmcdata.c
-    ${OPAE_SDK_SOURCE}/libopae/plugins/xfpga/metrics/bmc/bmcinfo.c
-    )
-    
-
   
 add_library(fpgad-static
     ${OPAE_SDK_SOURCE}/tools/base/fpgad/command_line.c
@@ -570,7 +560,7 @@ target_link_libraries(test_xfpga_events_c
     safestr
     fpgad-static
     fpgad-api-static
-    libbmc
+    bmc
     ${libjson-c_LIBRARIES})
 
 add_unit_test(test_xfpga_metrics_vector_c xfpga-static
@@ -592,8 +582,10 @@ add_unit_test(test_xfpga_metrics_c xfpga-static
 add_unit_test(test_xfpga_bmc_c xfpga-static
     xfpga/test_bmc_c.cpp
 )
-target_link_libraries(test_xfpga_bmc_c bmc-static  safestr
-        ${libjson-c_LIBRARIES})
+target_link_libraries(test_xfpga_bmc_c
+    safestr
+    bmc-static
+    ${libjson-c_LIBRARIES})
 
 ############################################################################
 # fpgad tests ##############################################################

--- a/testing/xfpga/test_metrics_utils_c.cpp
+++ b/testing/xfpga/test_metrics_utils_c.cpp
@@ -706,7 +706,7 @@ TEST_P(metrics_utils_dcp_c_p, test_metric_utils_12) {
   struct _fpga_handle *_handle = (struct _fpga_handle *)handle_;
   fpga_metric_vector vector;
 
-  _handle->bmc_handle = dlopen("libbmc.so", RTLD_LAZY | RTLD_LOCAL);
+  _handle->bmc_handle = dlopen("libmodbmc.so", RTLD_LAZY | RTLD_LOCAL);
 
   if (!_handle->bmc_handle) {
     OPAE_ERR("--------------------------failed to load ");
@@ -723,7 +723,7 @@ TEST_P(metrics_utils_dcp_c_p, test_metric_utils_12) {
 TEST_P(metrics_utils_dcp_c_p, test_metric_utils_13) {
   struct _fpga_handle *_handle = (struct _fpga_handle *)handle_;
 
-  _handle->bmc_handle = dlopen("liblibbmc.so", RTLD_LAZY | RTLD_LOCAL);
+  _handle->bmc_handle = dlopen("libmodbmc.so", RTLD_LAZY | RTLD_LOCAL);
 
   if (!_handle->bmc_handle) {
     OPAE_ERR("--------------------------failed to load ");
@@ -735,7 +735,7 @@ TEST_P(metrics_utils_dcp_c_p, test_metric_utils_13) {
 TEST_P(metrics_utils_dcp_c_p, test_metric_utils_14) {
   struct _fpga_handle *_handle = (struct _fpga_handle *)handle_;
 
-  _handle->bmc_handle = dlopen("liblibbmc.so", RTLD_LAZY | RTLD_LOCAL);
+  _handle->bmc_handle = dlopen("libmodbmc.so", RTLD_LAZY | RTLD_LOCAL);
 
   if (!_handle->bmc_handle) {
     OPAE_ERR("--------------------------failed to load ");


### PR DESCRIPTION
Build libmodbmc.so as a shared module library for use with xfpga's
metrics API, because the API wants to dlopen the library. Leave
libbmc.so as a shared library object for use with pacd.