### PR TITLE
testing: add mock_opae class

### DIFF
--- a/testing/mock/mock_opae.h
+++ b/testing/mock/mock_opae.h
@@ -1,0 +1,77 @@
+// Copyright(c) 2017-2019, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+/*
+ * mock_opae.h
+ */
+#pragma once
+
+
+
+#include <opae/fpga.h>
+#include "gtest/gtest.h"
+#include "test_system.h"
+
+namespace opae {
+namespace testing {
+
+template<int _T = 2>
+class mock_opae_p : public ::testing::TestWithParam<std::string> {
+ protected:
+  mock_opae_p(): tokens_{ {} } {}
+
+  virtual void SetUp() override {
+    ASSERT_TRUE(test_platform::exists(GetParam()));
+    platform_ = test_platform::get(GetParam());
+    system_ = test_system::instance();
+    system_->initialize();
+    system_->prepare_syfs(platform_);
+    test_setup();
+  }
+
+  virtual void TearDown() override {
+    for (auto &t : tokens_) {
+      if (t) {
+        EXPECT_EQ(fpgaDestroyToken(&t), FPGA_OK);
+        t = nullptr;
+      }
+    }
+    test_teardown();
+    system_->finalize();
+  }
+
+  virtual void test_setup() {
+  }
+
+  virtual void test_teardown() {
+  }
+
+  std::array<fpga_token, _T> tokens_;
+  test_platform platform_;
+  test_system *system_;
+};
+
+} // end of namespace testing
+} // end of namespace opae

--- a/testing/opae-c/test_buffer_c.cpp
+++ b/testing/opae-c/test_buffer_c.cpp
@@ -42,26 +42,19 @@ extern "C" {
 #include <string>
 #include <vector>
 #include <unistd.h>
-#include "gtest/gtest.h"
-#include "test_system.h"
+#include "mock_opae.h"
 
 using namespace opae::testing;
 
-class buffer_c_p : public ::testing::TestWithParam<std::string> {
+class buffer_c_p : public mock_opae_p<2> {
  protected:
-  buffer_c_p() : tokens_{{nullptr, nullptr}} {}
+  buffer_c_p() {}
 
-  virtual void SetUp() override {
-    ASSERT_TRUE(test_platform::exists(GetParam()));
-    platform_ = test_platform::get(GetParam());
-    system_ = test_system::instance();
-    system_->initialize();
-    system_->prepare_syfs(platform_);
-
+  virtual void test_setup() override {
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
     ASSERT_EQ(fpgaGetProperties(nullptr, &filter_), FPGA_OK);
     ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
-    ASSERT_EQ(fpgaPropertiesSetDeviceID(filter_, 
+    ASSERT_EQ(fpgaPropertiesSetDeviceID(filter_,
               platform_.devices[0].device_id), FPGA_OK);
     num_matches_ = 0;
     ASSERT_EQ(fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
@@ -72,29 +65,19 @@ class buffer_c_p : public ::testing::TestWithParam<std::string> {
     pg_size_ = (size_t) sysconf(_SC_PAGE_SIZE);
   }
 
-  virtual void TearDown() override {
+  virtual void test_teardown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
     if (accel_) {
         EXPECT_EQ(fpgaClose(accel_), FPGA_OK);
         accel_ = nullptr;
     }
-    for (auto &t : tokens_) {
-      if (t) {
-        EXPECT_EQ(fpgaDestroyToken(&t), FPGA_OK);
-        t = nullptr;
-      }
-    }
     fpgaFinalize();
-    system_->finalize();
   }
 
-  std::array<fpga_token, 2> tokens_;
   fpga_properties filter_;
   fpga_handle accel_;
   size_t pg_size_;
-  test_platform platform_;
   uint32_t num_matches_;
-  test_system *system_;
 };
 
 /**


### PR DESCRIPTION
`mock_opae_p` class is a templated class that derives from TestWithParam
and is meant to be a mock class for mock platforms.
The template argument is used to specify how many tokens to use
(if any).

This class implements the SetUp/TearDown that google test uses in the fixture
but also defines test_setup/test_teardown functions that can be overridden by
a sub-class.

This is a first step in refactoring tests to avoid code cloning.