### PR TITLE
fpgad: start of config file support

### DIFF
--- a/testing/fpgad/test_fpgad_c.cpp
+++ b/testing/fpgad/test_fpgad_c.cpp
@@ -30,12 +30,15 @@ extern "C" {
 
 #include "fpgad/command_line.h"
 #include "fpgad/api/logging.h"
+#include "fpgad/monitored_device.h"
 
 extern struct fpgad_config global_config;
 
 void sig_handler(int sig, siginfo_t *info, void *unused);
 
 int fpgad_main(int argc, char *argv[]);
+
+extern fpgad_supported_device default_supported_devices_table[];
 
 }
 
@@ -83,20 +86,16 @@ class fpgad_fpgad_c_p : public ::testing::TestWithParam<std::string> {
     gbs.write((const char *) gbs_hdr.data(), gbs_hdr.size());
     gbs.close();
 
-    memset_s(&config_, sizeof(config_), 0);
-    config_.poll_interval_usec = 100 * 1000;
-    config_.running = true;
-    config_.api_socket = "/tmp/fpga_event_socket";
-
     global_config.poll_interval_usec = 100 * 1000;
     global_config.running = true;
     global_config.api_socket = "/tmp/fpga_event_socket";
+    global_config.supported_devices = default_supported_devices_table;
 
     optind = 0;
   }
 
   virtual void TearDown() override {
-    cmd_destroy(&config_);
+    cmd_destroy(&global_config);
     log_close();
 
     fpgaFinalize();
@@ -109,7 +108,6 @@ class fpgad_fpgad_c_p : public ::testing::TestWithParam<std::string> {
   }
 
   char tmpnull_gbs_[20];
-  struct fpgad_config config_;
   test_platform platform_;
   test_system *system_;
 };

--- a/testing/mock/fpgad_control.h
+++ b/testing/mock/fpgad_control.h
@@ -48,6 +48,8 @@ bool monitor_is_ready(void);
 bool mon_consider_device(struct fpgad_config *c,
                          fpga_token token);
 
+extern fpgad_supported_device default_supported_devices_table[];
+
 }
 
 namespace opae {
@@ -69,6 +71,7 @@ class fpgad_control {
     fpgad_config_.api_socket = "/tmp/fpga_event_socket";
     strcpy(fpgad_config_.logfile, tmpfpgad_log_);
     strcpy(fpgad_config_.pidfile, tmpfpgad_pid_);
+    fpgad_config_.supported_devices = default_supported_devices_table;
 
     log_open(tmpfpgad_log_);
 

--- a/tools/base/fpgad/command_line.c
+++ b/tools/base/fpgad/command_line.c
@@ -30,6 +30,8 @@
 
 #include <getopt.h>
 #include "command_line.h"
+#include "config_file.h"
+#include "monitored_device.h"
 
 #ifdef LOG
 #undef LOG
@@ -37,7 +39,9 @@
 #define LOG(format, ...) \
 log_printf("args: " format, ##__VA_ARGS__)
 
-#define OPT_STR ":hdl:p:s:n:"
+extern fpgad_supported_device default_supported_devices_table[];
+
+#define OPT_STR ":hdl:p:s:n:c:"
 
 STATIC struct option longopts[] = {
 	{ "help",           no_argument,       NULL, 'h' },
@@ -46,6 +50,7 @@ STATIC struct option longopts[] = {
 	{ "pidfile",        required_argument, NULL, 'p' },
 	{ "socket",         required_argument, NULL, 's' },
 	{ "null-bitstream", required_argument, NULL, 'n' },
+	{ "config",         required_argument, NULL, 'c' },
 
 	{ 0, 0, 0, 0 }
 };
@@ -54,6 +59,7 @@ STATIC struct option longopts[] = {
 #define DEFAULT_DIR_ROOT_SIZE 13
 #define DEFAULT_LOG           "fpgad.log"
 #define DEFAULT_PID           "fpgad.pid"
+#define DEFAULT_CFG           "fpgad.cfg"
 
 void cmd_show_help(FILE *fptr)
 {
@@ -65,6 +71,7 @@ void cmd_show_help(FILE *fptr)
 	fprintf(fptr, "\t-s,--socket <sock>          the unix domain socket [/tmp/fpga_event_socket].\n");
 	fprintf(fptr, "\t-n,--null-bitstream <file>  NULL bitstream (for AP6 handling, may be\n"
 		      "\t                            given multiple times).\n");
+	fprintf(fptr, "\t-c,--config <file>          the configuration file [%s].\n", DEFAULT_CFG);
 }
 
 STATIC bool cmd_register_null_gbs(struct fpgad_config *c, char *null_gbs_path)
@@ -167,6 +174,16 @@ int cmd_parse_args(struct fpgad_config *c, int argc, char *argv[])
 			}
 			break;
 
+		case 'c':
+			if (tmp_optarg) {
+				strncpy_s(c->cfgfile, sizeof(c->cfgfile),
+						tmp_optarg, PATH_MAX);
+			} else {
+				LOG("missing cfgfile parameter.\n");
+				return 1;
+			}
+			break;
+
 		case ':':
 			LOG("Missing option argument.\n");
 			return 1;
@@ -191,6 +208,7 @@ void cmd_canonicalize_paths(struct fpgad_config *c)
 	bool def;
 	mode_t mode;
 	struct stat stat_buf;
+	bool search = true;
 
 	if (!geteuid()) {
 		// If we're being run as root, then use DEFAULT_DIR_ROOT
@@ -294,6 +312,57 @@ void cmd_canonicalize_paths(struct fpgad_config *c)
 				"%s/%s", c->directory, tmp);
 	}
 	LOG("daemon pid file is %s\n", c->pidfile);
+
+	// Verify cfgfile doesn't contain ".."
+	def = false;
+	sub = NULL;
+	strstr_s(c->cfgfile, sizeof(c->cfgfile),
+			"..", 2, &sub);
+	if (sub)
+		def = true;
+
+	if (def || (c->cfgfile[0] == '\0')) {
+		search = true;
+	} else {
+		char *canon_path;
+
+		canon_path = canonicalize_file_name(c->cfgfile);
+		if (canon_path) {
+			if (!stat(canon_path, &stat_buf)) {
+				strncpy_s(c->cfgfile,
+					  sizeof(c->cfgfile),
+					  canon_path,
+					  strnlen_s(canon_path, PATH_MAX));
+
+				if (!cfg_load_config(c)) {
+					LOG("daemon cfg file is %s\n",
+					    c->cfgfile);
+					search = false; // found and loaded it
+				}
+			}
+
+			free(canon_path);
+		}
+	}
+
+	if (search) {
+		c->cfgfile[0] = '\0';
+		if (cfg_find_config_file(c))
+			LOG("failed to find config file.\n");
+		else {
+			if (cfg_load_config(c))
+				LOG("failed to load config file %s\n",
+				    c->cfgfile);
+			else
+				LOG("daemon cfg file is %s\n", c->cfgfile);
+		}
+	}
+
+	if (!c->supported_devices) {
+		LOG("using default configuration.\n");
+		c->cfgfile[0] = '\0';
+		c->supported_devices = default_supported_devices_table;
+	}
 }
 
 void cmd_destroy(struct fpgad_config *c)
@@ -309,4 +378,10 @@ void cmd_destroy(struct fpgad_config *c)
 		opae_unload_bitstream(&c->null_gbs[i]);
 	}
 	c->num_null_gbs = 0;
+
+	if (c->supported_devices &&
+	    (c->supported_devices != default_supported_devices_table)) {
+		free(c->supported_devices);
+	}
+	c->supported_devices = NULL;
 }

--- a/tools/base/fpgad/command_line.c
+++ b/tools/base/fpgad/command_line.c
@@ -328,17 +328,15 @@ void cmd_canonicalize_paths(struct fpgad_config *c)
 
 		canon_path = canonicalize_file_name(c->cfgfile);
 		if (canon_path) {
-			if (!stat(canon_path, &stat_buf)) {
-				strncpy_s(c->cfgfile,
-					  sizeof(c->cfgfile),
-					  canon_path,
-					  strnlen_s(canon_path, PATH_MAX));
+			strncpy_s(c->cfgfile,
+				  sizeof(c->cfgfile),
+				  canon_path,
+				  strnlen_s(canon_path, PATH_MAX));
 
-				if (!cfg_load_config(c)) {
-					LOG("daemon cfg file is %s\n",
-					    c->cfgfile);
-					search = false; // found and loaded it
-				}
+			if (!cfg_load_config(c)) {
+				LOG("daemon cfg file is %s\n",
+				    c->cfgfile);
+				search = false; // found and loaded it
 			}
 
 			free(canon_path);

--- a/tools/base/fpgad/command_line.h
+++ b/tools/base/fpgad/command_line.h
@@ -30,6 +30,8 @@
 #include "fpgad.h"
 #include "bitstream.h"
 
+typedef struct _fpgad_supported_device fpgad_supported_device;
+
 #define MAX_NULL_GBS 32
 
 struct fpgad_config {
@@ -39,6 +41,7 @@ struct fpgad_config {
 	char directory[PATH_MAX];
 	char logfile[PATH_MAX];
 	char pidfile[PATH_MAX];
+	char cfgfile[PATH_MAX];
 	mode_t filemode;
 
 	bool running;
@@ -52,6 +55,8 @@ struct fpgad_config {
 	pthread_t monitor_thr;
 	pthread_t event_dispatcher_thr;
 	pthread_t events_api_thr;
+
+	fpgad_supported_device *supported_devices;
 };
 
 extern struct fpgad_config global_config;

--- a/tools/base/fpgad/config_file.c
+++ b/tools/base/fpgad/config_file.c
@@ -204,7 +204,7 @@ STATIC cfg_vendor_device_id *alloc_device(uint16_t vendor_id,
 }
 
 STATIC cfg_plugin_configuration *alloc_configuration(bool enabled,
-					 	     char *library,
+						     char *library,
 						     cfg_vendor_device_id *devs)
 {
 	cfg_plugin_configuration *p;

--- a/tools/base/fpgad/config_file.c
+++ b/tools/base/fpgad/config_file.c
@@ -30,7 +30,257 @@
 
 #include "config_file.h"
 
+#include <json-c/json.h>
 
+#ifdef LOG
+#undef LOG
+#endif
+#define LOG(format, ...) \
+log_printf("cfg: " format, ##__VA_ARGS__)
 
+int cfg_find_config_file(struct fpgad_config *c)
+{
+	char path[PATH_MAX];
+	char *e;
+	char *canon = NULL;
+	struct stat stat_buf;
 
+	e = getenv("HOME");
+	if (e) {
+		// try $HOME/.opae/fpgad.cfg
+		snprintf_s_s(path, sizeof(path),
+			     "%s/.opae/fpgad.cfg", e);
 
+		canon = canonicalize_file_name(path);
+		if (canon) {
+			if (!stat(canon, &stat_buf)) {
+				errno_t err;
+				// found it
+				err = strncpy_s(c->cfgfile,
+						sizeof(c->cfgfile),
+						canon,
+						strnlen_s(canon, PATH_MAX));
+				if (err)
+					LOG("strncpy_s failed.\n");
+				else {
+					free(canon);
+					return 0;
+				}
+			}
+
+			free(canon);
+		}
+
+	}
+
+	// try /etc/opae/fpgad.cfg
+	canon = canonicalize_file_name("/etc/opae/fpgad.cfg");
+	if (canon) {
+		if (!stat(canon, &stat_buf)) {
+			errno_t err;
+			// found it
+			err = strncpy_s(c->cfgfile,
+					sizeof(c->cfgfile),
+					canon,
+					strnlen_s(canon, PATH_MAX));
+			if (err)
+				LOG("strncpy_s failed.\n");
+			else {
+				free(canon);
+				return 0;
+			}
+
+		}
+
+		free(canon);
+	}
+
+	// try /var/lib/opae/fpgad.cfg
+	canon = canonicalize_file_name("/var/lib/opae/fpgad.cfg");
+	if (canon) {
+		if (!stat(canon, &stat_buf)) {
+			errno_t err;
+			// found it
+			err = strncpy_s(c->cfgfile,
+					sizeof(c->cfgfile),
+					canon,
+					strnlen_s(canon, PATH_MAX));
+			if (err)
+				LOG("strncpy_s failed.\n");
+			else {
+				free(canon);
+				return 0;
+			}
+
+		}
+
+		free(canon);
+	}
+
+	return 1; // not found
+}
+
+STATIC char *cfg_read_file(const char *file)
+{
+	FILE *fp;
+	size_t len;
+	char *buf;
+
+	fp = fopen(file, "r");
+	if (!fp) {
+		LOG("fopen failed.\n");
+		return NULL;
+	}
+
+	if (fseek(fp, 0, SEEK_END)) {
+		LOG("fseek failed.\n");
+		fclose(fp);
+		return NULL;
+	}
+
+	len = (size_t)ftell(fp);
+	++len; // for \0
+
+	if (len == 1) {
+		LOG("%s is empty.\n", file);
+		fclose(fp);
+		return NULL;
+	}
+
+	if (fseek(fp, 0, SEEK_SET)) {
+		LOG("fseek failed.\n");
+		fclose(fp);
+		return NULL;
+	}
+
+	buf = (char *)malloc(len);
+	if (!buf) {
+		LOG("malloc failed.\n");
+		fclose(fp);
+		return NULL;
+	}
+
+	if ((fread(buf, 1, len - 1, fp) != len - 1) ||
+	    ferror(fp)) {
+		LOG("fread failed.\n");
+		fclose(fp);
+		free(buf);
+		return NULL;
+	}
+
+	fclose(fp);
+	buf[len - 1] = '\0';
+
+	return buf;
+}
+
+typedef struct _cfg_vendor_device_id {
+	uint16_t vendor_id;
+	uint16_t device_id;
+	struct _cfg_vendor_device_id *next;
+} cfg_vendor_device_id;
+
+typedef struct _cfg_plugin_configuration {
+	bool enabled;
+	char *library;
+	cfg_vendor_device_id *devices;
+	struct _cfg_plugin_configuration *next;
+} cfg_plugin_configuration;
+
+#if 0
+STATIC cfg_vendor_device_id *alloc_device(uint16_t vendor_id,
+					  uint16_t device_id)
+{
+	cfg_vendor_device_id *p;
+
+	p = (cfg_vendor_device_id *)malloc(sizeof(cfg_vendor_device_id));
+	if (p) {
+		p->vendor_id = vendor_id;
+		p->device_id = device_id;
+		p->next = NULL;
+	}
+
+	return p;
+}
+
+STATIC cfg_plugin_configuration *alloc_configuration(bool enabled,
+					 	     char *library,
+						     cfg_vendor_device_id *devs)
+{
+	cfg_plugin_configuration *p;
+
+	p = (cfg_plugin_configuration *)
+		malloc(sizeof(cfg_plugin_configuration));
+	if (p) {
+		p->enabled = enabled;
+		p->library = library;
+		p->devices = devs;
+		p->next = NULL;
+	}
+
+	return p;
+}
+#endif
+
+int cfg_load_config(struct fpgad_config *c)
+{
+	char *cfg_buf;
+	json_object *root = NULL;
+	json_object *j_configurations = NULL;
+	json_object *j_plugins = NULL;
+	enum json_tokener_error j_err = json_tokener_success;
+	int res = 1;
+	int num_plugins;
+	int i;
+	cfg_plugin_configuration *configurations = NULL;
+
+	(void)configurations;
+
+	cfg_buf = cfg_read_file(c->cfgfile);
+	if (!cfg_buf)
+		return res;
+
+	root = json_tokener_parse_verbose(cfg_buf, &j_err);
+	if (!root) {
+		LOG("error parsing %s: %s\n",
+		    c->cfgfile,
+		    json_tokener_error_desc(j_err));
+		goto out_free;
+	}
+
+	if (!json_object_object_get_ex(root,
+				       "configurations",
+				       &j_configurations)) {
+		LOG("failed to find configurations section in %s.\n",
+		    c->cfgfile);
+		goto out_put;
+	}
+
+	if (!json_object_object_get_ex(root, "plugins", &j_plugins)) {
+		LOG("failed to find plugins section in %s.\n", c->cfgfile);
+		goto out_put;
+	}
+
+	if (!json_object_is_type(j_plugins, json_type_array)) {
+		LOG("'plugins' JSON object not array.\n");
+		goto out_put;
+	}
+
+	num_plugins = json_object_array_length(j_plugins);
+	for (i = 0 ; i < num_plugins ; ++i) {
+		json_object *j_plugin;
+		const char *plugin_name;
+
+		j_plugin = json_object_array_get_idx(j_plugins, i);
+		plugin_name = json_object_get_string(j_plugin);
+
+		(void)plugin_name;
+
+	}
+
+out_put:
+	json_object_put(root);
+out_free:
+	free(cfg_buf);
+	return res;
+}

--- a/tools/base/fpgad/config_file.h
+++ b/tools/base/fpgad/config_file.h
@@ -29,5 +29,10 @@
 
 #include "fpgad.h"
 
+// 0 on success
+int cfg_find_config_file(struct fpgad_config *c);
+
+// 0 on success
+int cfg_load_config(struct fpgad_config *c);
 
 #endif /* __FPGAD_CONFIG_FILE_H__ */

--- a/tools/base/fpgad/fpgad.c
+++ b/tools/base/fpgad/fpgad.c
@@ -181,7 +181,7 @@ out_stop_event_dispatcher:
 		LOG("failed to join event_dispatcher_thread\n");
 	}
 out_destroy:
-	mon_destroy();
+	mon_destroy(&global_config);
 	cmd_destroy(&global_config);
 	log_close();
 	return res;

--- a/tools/base/fpgad/monitor_thread.c
+++ b/tools/base/fpgad/monitor_thread.c
@@ -164,7 +164,7 @@ void *monitor_thread(void *thread_context)
 		usleep(c->global->poll_interval_usec);
 	}
 
-	mon_destroy();
+	mon_destroy(c->global);
 	mon_is_ready = false;
 
 	LOG("exiting\n");
@@ -196,8 +196,7 @@ out_unlock:
 	fpgad_mutex_unlock(err, &mon_list_lock);
 }
 
-extern fpgad_supported_device supported_devices_table[];
-void mon_destroy(void)
+void mon_destroy(struct fpgad_config *c)
 {
 	unsigned i;
 	errno_t err;
@@ -243,15 +242,19 @@ void mon_destroy(void)
 	}
 	monitored_device_list = NULL;
 
-	for (i = 0 ; supported_devices_table[i].library_path ; ++i) {
-		fpgad_supported_device *d = &supported_devices_table[i];
+	if (c->supported_devices) {
 
-		if (d->flags & FPGAD_DEV_LOADED) {
-			dlclose(d->dl_handle);
+		for (i = 0 ; c->supported_devices[i].library_path ; ++i) {
+			fpgad_supported_device *d = &c->supported_devices[i];
+
+			if (d->flags & FPGAD_DEV_LOADED) {
+				dlclose(d->dl_handle);
+			}
+
+			d->flags = 0;
+			d->dl_handle = NULL;
 		}
 
-		d->flags = 0;
-		d->dl_handle = NULL;
 	}
 
 	fpgad_mutex_unlock(err, &mon_list_lock);

--- a/tools/base/fpgad/monitor_thread.h
+++ b/tools/base/fpgad/monitor_thread.h
@@ -43,7 +43,7 @@ void *monitor_thread(void *);
 // 0 on success
 int mon_enumerate(struct fpgad_config *c);
 
-void mon_destroy(void);
+void mon_destroy(struct fpgad_config *c);
 
 void mon_monitor_device(fpgad_monitored_device *d);
 

--- a/tools/base/fpgad/monitored_device.c
+++ b/tools/base/fpgad/monitored_device.c
@@ -45,7 +45,7 @@
 #define LOG(format, ...) \
 log_printf("monitored_device: " format, ##__VA_ARGS__)
 
-fpgad_supported_device supported_devices_table[] = {
+fpgad_supported_device default_supported_devices_table[] = {
 	{ 0x8086, 0xbcc0, "libfpgad-xfpga.so", 0, NULL },
 	{ 0x8086, 0xbcc1, "libfpgad-xfpga.so", 0, NULL },
 	{ 0x8086, 0x0b30,    "libfpgad-vc.so", 0, NULL },
@@ -53,14 +53,15 @@ fpgad_supported_device supported_devices_table[] = {
 	{      0,      0,                NULL, 0, NULL },
 };
 
-STATIC fpgad_supported_device *mon_is_loaded(const char *library_path)
+STATIC fpgad_supported_device *mon_is_loaded(struct fpgad_config *c,
+					     const char *library_path)
 {
 	errno_t err;
 	unsigned i;
 	int res = 0;
 
-	for (i = 0 ; supported_devices_table[i].library_path ; ++i) {
-		fpgad_supported_device *d = &supported_devices_table[i];
+	for (i = 0 ; c->supported_devices[i].library_path ; ++i) {
+		fpgad_supported_device *d = &c->supported_devices[i];
 
 		err = strcmp_s(library_path, PATH_MAX,
 				d->library_path, &res);
@@ -206,8 +207,8 @@ STATIC bool mon_consider_device(struct fpgad_config *c, fpga_token token)
 
 	fpgaDestroyProperties(&props);
 
-	for (i = 0 ; supported_devices_table[i].library_path ; ++i) {
-		fpgad_supported_device *d = &supported_devices_table[i];
+	for (i = 0 ; c->supported_devices[i].library_path ; ++i) {
+		fpgad_supported_device *d = &c->supported_devices[i];
 
 		// Do we support this device?
 		if (d->vendor_id == vendor_id &&
@@ -219,7 +220,7 @@ STATIC bool mon_consider_device(struct fpgad_config *c, fpga_token token)
 			d->flags |= FPGAD_DEV_DETECTED;
 
 			// Is the fpgad plugin already loaded?
-			loaded_by = mon_is_loaded(d->library_path);
+			loaded_by = mon_is_loaded(c, d->library_path);
 
 			if (loaded_by) {
 				// The two table entries will share the


### PR DESCRIPTION
Add config file search and load support by way of --config,-c.
Coming commits will complete the config file parsing and
utilization of the loaded configuration.