### PR TITLE
Prevent user from hurting himself

### DIFF
--- a/tools/extra/pac/fpgabist/bist_app.py
+++ b/tools/extra/pac/fpgabist/bist_app.py
@@ -41,9 +41,9 @@ class BistMode(bc.BistMode):
         bc.load_gbs(gbs_path, bus_num)
         for func, param in self.executables.items():
             print "Running {} test...\n".format(func)
-            cmd = "{} {}".format(func, param)
+            cmd = [func, param]
             try:
-                subprocess.check_call(cmd, shell=True)
+                subprocess.check_call(cmd)
             except subprocess.CalledProcessError as e:
                 print "Failed Test: {}".format(func)
                 print e

--- a/tools/extra/pac/fpgabist/bist_common.py
+++ b/tools/extra/pac/fpgabist/bist_common.py
@@ -35,6 +35,7 @@ BIST_MODES = ['bist_afu', 'dma_afu', 'nlb_mode_3']
 REQ_CMDS = ['lspci', 'fpgainfo', 'fpgaconf', 'fpgadiag', 'fpga_dma_test',
             'bist_app']
 
+
 def find_exec(cmd, paths):
     for p in paths:
         f = os.path.join(p, cmd)
@@ -60,7 +61,7 @@ def get_all_fpga_bdfs():
         m = bdf_pattern.match(symlink)
         data = m.groupdict() if m else {}
         if data:
-            bdf_list.append(dict([(k, hex(int(v,16)).lstrip("0x"))
+            bdf_list.append(dict([(k, hex(int(v, 16)).lstrip("0x"))
                             for (k, v) in data.iteritems()]))
     return bdf_list
 

--- a/tools/extra/pac/fpgabist/bist_common.py
+++ b/tools/extra/pac/fpgabist/bist_common.py
@@ -94,9 +94,9 @@ def get_mode_from_path(gbs_path):
 
 def load_gbs(gbs_file, bus_num):
     print "Attempting Partial Reconfiguration:"
-    cmd = "{} -B 0x{} -v {}".format('fpgaconf', bus_num, gbs_file)
+    cmd = ['fpgaconf', '-B', '0x{}'.format(bus_num), '-v', gbs_file]
     try:
-        subprocess.check_call(cmd, shell=True)
+        subprocess.check_call(cmd)
     except subprocess.CalledProcessError as e:
         print "Failed to load gbs file: {}".format(gbs_file)
         print "Please try a different gbs"

--- a/tools/extra/pac/fpgabist/bist_dma.py
+++ b/tools/extra/pac/fpgabist/bist_dma.py
@@ -41,9 +41,9 @@ class DmaMode(bc.BistMode):
         bc.load_gbs(gbs_path, bus_num)
         for func, param in self.executables.items():
             print "Running {} test...\n".format(func)
-            cmd = "{} {} {}".format(func, param, bus_num)
+            cmd = [func, param, bus_num]
             try:
-                subprocess.check_call(cmd, shell=True)
+                subprocess.check_call(cmd)
             except subprocess.CalledProcessError as e:
                 print "Failed Test: {}".format(func)
                 print e

--- a/tools/extra/pac/fpgabist/bist_nlb3.py
+++ b/tools/extra/pac/fpgabist/bist_nlb3.py
@@ -45,9 +45,9 @@ class Nlb3Mode(bc.BistMode):
         bc.load_gbs(gbs_path, bus_num)
         for test, param in self.executables.items():
             print "Running fpgadiag {} test...\n".format(test)
-            cmd = "fpgadiag -B {} {}".format(bus_num, param)
+            cmd = ['fpgadiag', '-B', bus_num, param]
             try:
-                subprocess.check_call(cmd, shell=True)
+                subprocess.check_call(cmd)
             except subprocess.CalledProcessError as e:
                 print "Failed Test: {}".format(test)
                 print e

--- a/tools/extra/pac/fpgabist/fpgabist
+++ b/tools/extra/pac/fpgabist/fpgabist
@@ -61,7 +61,7 @@ def main(args):
 
     # Display data from FPGA info
     for feature in FEATURES:
-        cmd = ['fpainfo', feature, '-B', '0x{}'.format(bdf['bus'])
+        cmd = ['fpainfo', feature, '-B', '0x{}'.format(bdf['bus'])]
         subprocess.call(cmd)
 
     gbs_paths = args.gbs_paths

--- a/tools/extra/pac/fpgabist/fpgabist
+++ b/tools/extra/pac/fpgabist/fpgabist
@@ -61,8 +61,8 @@ def main(args):
 
     # Display data from FPGA info
     for feature in FEATURES:
-        cmd = "fpgainfo {} -B 0x{}".format(feature, bdf['bus'])
-        subprocess.call(cmd, shell=True)
+        cmd = ['fpainfo', feature, '-B', '0x{}'.format(bdf['bus'])
+        subprocess.call(cmd)
 
     gbs_paths = args.gbs_paths
     for path in gbs_paths:


### PR DESCRIPTION
Python has many ways of executing shell commands. By passing 'shell=True'
we've been exposing program for malicious behavior.
To prevent from doing that use built-in solution in Python [1] which helps
with blocking from shell injection.

[1] https://docs.python.org/2/library/subprocess.html#frequently-used-arguments

Signed-off-by: Dariusz Smigiel dariusz.smigiel@intel.com