### PR TITLE
Add support for Qsys blocks that generate VHDL.

### DIFF
--- a/ase/Makefile
+++ b/ase/Makefile
@@ -517,8 +517,18 @@ ifdef DUT_VLOG_SRC_LIST
 	cd $(WORK) ; vlog $(MENT_VLOG_OPT) $(ASE_PLATFORM_INC) -F $(DUT_VLOG_SRC_LIST) -l vlog-afu.log
 endif
 
+$(WORK):
+	mkdir -p $(WORK)
+	@# Link to HEX memory images generated and required by Qsys
+	@if [ -f qsys_hex_sim_files.list ]; then \
+	  for h in `cat qsys_hex_sim_files.list`; do \
+	    echo Linking to $${h} ; \
+	    ln -s ../$${h} work ; \
+	  done ; \
+	fi
+
 ## VCS base Quartus Verilog libraries
-$(WORK)/synopsys_sim_quartus_verilog.setup:
+$(WORK)/synopsys_sim_quartus_verilog.setup: $(WORK)
 	mkdir -p $(WORK)/verilog_libs
 ifeq ($(GLS_SIM), 1)
 	@# Generate the Quartus family-dependent simulation library list
@@ -531,7 +541,7 @@ else
 endif
 
 ## Questasim base Quartus Verilog libraries
-$(WORK)/quartus_msim_verilog_libs:
+$(WORK)/quartus_msim_verilog_libs: $(WORK)
 	mkdir -p $(WORK)/verilog_libs
 ifeq ($(GLS_SIM), 1)
 	@# Generate the Quartus family-dependent simulation library list

--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -479,7 +479,7 @@ def config_qsys_sources(filelist, vlog_srcs, vhdl_srcs):
             open(qsys_sim_files['hex'], "w") as f_hex:
         for d in ip_dirs_copy:
             for dir, subdirs, files in os.walk(d):
-                for fn in files:
+                for fn in sorted(files, key=sort_key_qsys_files):
                     if ((os.path.basename(dir) == 'synth') and
                             (fn.endswith('.v') or fn.endswith('.sv') or
                              fn.endswith('.vhd') or fn.endswith('.hex'))):
@@ -507,6 +507,26 @@ def config_qsys_sources(filelist, vlog_srcs, vhdl_srcs):
             del qsys_sim_files[t]
 
     return qsys_sim_files
+
+
+#
+# Sort qsys generated files since the order they are passed to the
+# simulator may matter. In synth mode, qsys-generate doesn't emit
+# any configuration files that define compilation order, so we are
+# forced to use a heuristic.
+#
+def sort_key_qsys_files(fn):
+    # Sort by prepending an ordering token
+    root, ext = os.path.splitext(fn)
+    if (root.endswith('package') or root.endswith('pkg')):
+        return '0' + fn
+    if (root.endswith('library') or root.endswith('lib')):
+        return '1' + fn
+    if (root.endswith('functions')):
+        return '2' + fn
+    if (root.endswith('components')):
+        return '3' + fn
+    return '4' + fn
 
 
 #

--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -475,8 +475,8 @@ def config_qsys_sources(filelist, vlog_srcs, vhdl_srcs):
                       'hex': 'qsys_hex_sim_files.list'}
     found_qsys_file = {'vlog': False, 'vhdl': False, 'hex': False}
     with open(qsys_sim_files['vlog'], "w") as f_vlog, \
-        open(qsys_sim_files['vhdl'], "w") as f_vhdl, \
-        open(qsys_sim_files['hex'], "w") as f_hex:
+            open(qsys_sim_files['vhdl'], "w") as f_vhdl, \
+            open(qsys_sim_files['hex'], "w") as f_hex:
         for d in ip_dirs_copy:
             for dir, subdirs, files in os.walk(d):
                 for fn in files:

--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -500,9 +500,10 @@ def config_qsys_sources(filelist, vlog_srcs, vhdl_srcs):
                                 f_vlog.write(full_path + "\n")
                                 found_qsys_file['vlog'] = True
 
-    # Drop the file list for Verilog/VHDL when no files are found
+    # Drop any file lists that are empty
     for t, v in found_qsys_file.items():
         if not v:
+            os.remove(qsys_sim_files[t])
             del qsys_sim_files[t]
 
     return qsys_sim_files

--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -470,13 +470,13 @@ def config_qsys_sources(filelist, vlog_srcs, vhdl_srcs):
         sim_files_found.add(os.path.basename(s))
 
     # Find all generated Verilog/SystemVerilog/VHDL sources
-    qsys_sim_files = { 'vlog': 'qsys_vlog_sim_files.list',
-                       'vhdl': 'qsys_vhdl_sim_files.list',
-                       'hex': 'qsys_hex_sim_files.list' }
-    found_qsys_file = { 'vlog': False, 'vhdl': False, 'hex': False }
+    qsys_sim_files = {'vlog': 'qsys_vlog_sim_files.list',
+                      'vhdl': 'qsys_vhdl_sim_files.list',
+                      'hex': 'qsys_hex_sim_files.list'}
+    found_qsys_file = {'vlog': False, 'vhdl': False, 'hex': False}
     with open(qsys_sim_files['vlog'], "w") as f_vlog, \
-         open(qsys_sim_files['vhdl'], "w") as f_vhdl, \
-         open(qsys_sim_files['hex'], "w") as f_hex:
+        open(qsys_sim_files['vhdl'], "w") as f_vhdl, \
+        open(qsys_sim_files['hex'], "w") as f_hex:
         for d in ip_dirs_copy:
             for dir, subdirs, files in os.walk(d):
                 for fn in files:


### PR DESCRIPTION
- Detect generated VHDL files and add them to the simulation.
- Detect HEX memory images and put them in the proper location.