### PR TITLE
fpgad: verify plugin paths from config file

### DIFF
--- a/testing/fpgad/test_config_file_c.cpp
+++ b/testing/fpgad/test_config_file_c.cpp
@@ -197,6 +197,104 @@ TEST_P(fpgad_config_file_c_p, load3) {
 }
 
 /**
+ * @test       load4
+ * @brief      Test: cfg_load_config, cfg_verify_supported_devices
+ * @details    If the given file contains valid configuration content,<br>
+ *             but a "plugin" key specifies an absolute path,<br>
+ *             then the fn returns non-zero.<br>
+ */
+TEST_P(fpgad_config_file_c_p, load4) {
+  const char *cfg = R"cfg(
+{
+  "configurations": {
+    "a": {
+      "configuration": {},
+      "enabled": true,
+      "plugin": "/my/absolute/path/liba.so",
+      "devices": [
+        [ "0x8086", "0xbcc0" ]
+      ]
+    }
+  },
+  "plugins": [
+    "a"
+  ]
+}
+)cfg";
+
+  write_cfg(cfg);
+  EXPECT_NE(cfg_load_config(&config_), 0);
+}
+
+/**
+ * @test       load5
+ * @brief      Test: cfg_load_config, cfg_verify_supported_devices
+ * @details    If the given file contains valid configuration content,<br>
+ *             but a "plugin" key specifies a path that contains ..,<br>
+ *             then the fn returns non-zero.<br>
+ */
+TEST_P(fpgad_config_file_c_p, load5) {
+  const char *cfg = R"cfg(
+{
+  "configurations": {
+    "a": {
+      "configuration": {},
+      "enabled": true,
+      "plugin": "../liba.so",
+      "devices": [
+        [ "0x8086", "0xbcc0" ]
+      ]
+    }
+  },
+  "plugins": [
+    "a"
+  ]
+}
+)cfg";
+
+  write_cfg(cfg);
+  EXPECT_NE(cfg_load_config(&config_), 0);
+}
+
+/**
+ * @test       load6
+ * @brief      Test: cfg_load_config, cfg_verify_supported_devices
+ * @details    If the given file contains valid configuration content,<br>
+ *             but a "plugin" key specifies a path that contains a symlink,<br>
+ *             then the fn returns non-zero.<br>
+ */
+TEST_P(fpgad_config_file_c_p, load6) {
+  const char *cfg = R"cfg(
+{
+  "configurations": {
+    "a": {
+      "configuration": {},
+      "enabled": true,
+      "plugin": "bar/liba.so",
+      "devices": [
+        [ "0x8086", "0xbcc0" ]
+      ]
+    }
+  },
+  "plugins": [
+    "a"
+  ]
+}
+)cfg";
+
+  write_cfg(cfg);
+
+  ASSERT_EQ(mkdir("bar", 0755), 0);
+  std::string s = std::string("../") + std::string(cfg_file_);
+  ASSERT_EQ(symlink(s.c_str(), "bar/liba.so"), 0);
+
+  EXPECT_NE(cfg_load_config(&config_), 0);
+
+  ASSERT_EQ(unlink("bar/liba.so"), 0);
+  ASSERT_EQ(rmdir("bar"), 0);
+}
+
+/**
  * @test       process_plugin0
  * @brief      Test: cfg_process_plugin
  * @details    If the given file lacks a plugin configuration,<br>

--- a/tools/base/fpgad/command_line.c
+++ b/tools/base/fpgad/command_line.c
@@ -441,7 +441,6 @@ bool cmd_path_is_symlink(const char *path)
 
 			if (fstatat(AT_FDCWD, component,
 				    &stat_buf, AT_SYMLINK_NOFOLLOW)) {
-				LOG("fstatat failed.\n");
 				return false;
 			}
 
@@ -454,7 +453,6 @@ bool cmd_path_is_symlink(const char *path)
 
 		if (fstatat(AT_FDCWD, component,
 			    &stat_buf, AT_SYMLINK_NOFOLLOW)) {
-			LOG("fstatat failed.\n");
 			return false;
 		}
 

--- a/tools/base/fpgad/config_file.c
+++ b/tools/base/fpgad/config_file.c
@@ -584,14 +584,14 @@ int cfg_load_config(struct fpgad_config *c)
 			fpgad_supported_device *trash = c->supported_devices;
 
 			LOG("invalid configuration file\n");
-		
+
 			while (trash->library_path) {
 				free((void *)trash->library_path);
 				if (trash->config)
 					free((void *)trash->config);
 
 				++trash;
-			}	
+			}
 
 			free(c->supported_devices);
 			c->supported_devices = NULL;

--- a/tools/base/fpgad/config_file.c
+++ b/tools/base/fpgad/config_file.c
@@ -481,6 +481,38 @@ cfg_json_to_supported(cfg_plugin_configuration *configurations)
 	return supported;
 }
 
+STATIC bool cfg_verify_supported_devices(fpgad_supported_device *d)
+{
+	while (d->library_path) {
+		char *sub = NULL;
+		errno_t err;
+
+		if (d->library_path[0] == '/') {
+			LOG("plugin library paths may not "
+			    "be absolute paths: %s\n", d->library_path);
+			return false;
+		}
+
+		if (cmd_path_is_symlink(d->library_path)) {
+			LOG("plugin library paths may not "
+			    "contain links: %s\n", d->library_path);
+			return false;
+		}
+
+		err = strstr_s((char *)d->library_path, PATH_MAX,
+			       "..", 2, &sub);
+		if (EOK == err) {
+			LOG("plugin library paths may not "
+			    "contain .. : %s\n", d->library_path);
+			return false;
+		}
+
+		++d;
+	}
+
+	return true;
+}
+
 int cfg_load_config(struct fpgad_config *c)
 {
 	char *cfg_buf;
@@ -544,8 +576,28 @@ int cfg_load_config(struct fpgad_config *c)
 
 	c->supported_devices = cfg_json_to_supported(configurations);
 
-	if (c->supported_devices)
-		res = 0;
+	if (c->supported_devices) {
+
+		if (cfg_verify_supported_devices(c->supported_devices)) {
+			res = 0;
+		} else {
+			fpgad_supported_device *trash = c->supported_devices;
+
+			LOG("invalid configuration file\n");
+		
+			while (trash->library_path) {
+				free((void *)trash->library_path);
+				if (trash->config)
+					free((void *)trash->config);
+
+				++trash;
+			}	
+
+			free(c->supported_devices);
+			c->supported_devices = NULL;
+		}
+
+	}
 
 out_put:
 	json_object_put(root);


### PR DESCRIPTION
Plugin paths as loaded from the configuration file may not
* be absolute paths
* contain ..
* contain any component that is a symlink