### PR TITLE
fpgad: tighten the attack surface

### DIFF
--- a/tools/base/fpgad/command_line.h
+++ b/tools/base/fpgad/command_line.h
@@ -71,7 +71,8 @@ int cmd_parse_args(struct fpgad_config *c, int argc, char *argv[]);
 
 void cmd_show_help(FILE *fptr);
 
-void cmd_canonicalize_paths(struct fpgad_config *c);
+// 0 on success
+int cmd_canonicalize_paths(struct fpgad_config *c);
 
 void cmd_destroy(struct fpgad_config *c);
 

--- a/tools/base/fpgad/fpgad.c
+++ b/tools/base/fpgad/fpgad.c
@@ -82,7 +82,10 @@ int main(int argc, char *argv[])
 		goto out_destroy;
 	}
 
-	cmd_canonicalize_paths(&global_config);
+	if (cmd_canonicalize_paths(&global_config)) {
+		LOG("error with paths.\n");
+		goto out_destroy;
+	}
 
 	if (global_config.daemon) {
 		FILE *fp;


### PR DESCRIPTION
Use getpwuid to retrieve the non-root user's home directory.
Check for symlinks in the working directory, log file, and pid file
paths, aborting if they are found.