### PR TITLE
fpgad-vc: add config file parsing

### DIFF
--- a/tools/base/fpgad/plugins/fpgad-vc/fpgad-vc.c
+++ b/tools/base/fpgad/plugins/fpgad-vc/fpgad-vc.c
@@ -528,7 +528,6 @@ STATIC void *monitor_fme_vc_thread(void *arg)
 	return NULL;
 }
 
-// cool-down
 STATIC int vc_parse_config(const char *cfg)
 {
 	json_object *root;


### PR DESCRIPTION
Add config file parsing to plugin. Currently, one key "cool-down" of
type integer specifies the cool-down duration for sensor trip.