### PR TITLE
rename sysfs internal structures

### DIFF
--- a/libopae/plugins/xfpga/enum.c
+++ b/libopae/plugins/xfpga/enum.c
@@ -499,43 +499,43 @@ STATIC fpga_result enum_fpga_region_resources(struct dev_list *list,
 	fpga_result result                 = FPGA_NOT_FOUND;
 	struct dev_list *pdev              = NULL;
 	int i                              = 0;
-	int region_count                   = 0 ;
-	const sysfs_fpga_region *region    = NULL;
+	int device_count                   = 0 ;
+	const sysfs_fpga_device *device    = NULL;
 
-	region_count = sysfs_region_count();
+	device_count = sysfs_device_count();
 
-	if (region_count <= 0) {
+	if (device_count <= 0) {
 		FPGA_MSG("Not found fpga region's");
 		return FPGA_NO_DRIVER;
 	}
 
-	for (i = 0; i < region_count; i++) {
+	for (i = 0; i < device_count; i++) {
 
-		region  = sysfs_get_region(i);
+		device  = sysfs_get_device(i);
 
-		if (!region) {
+		if (!device) {
 			FPGA_MSG("failed to enum region");
 			return FPGA_NO_DRIVER;
 		}
 
-		pdev = add_dev(region->region_path, "", list);
+		pdev = add_dev(device->sysfs_path, "", list);
 		if (!pdev) {
 			FPGA_MSG("Failed to allocate device");
 			return FPGA_NO_MEMORY;
 		}
 		// Assign bus, function, device
 		// segment,device_id ,vendor_id
-		pdev->function       = region->function;
-		pdev->segment        = region->segment;
-		pdev->bus            = region->bus;
-		pdev->device         = region->device;
-		pdev->device_id      = region->device_id;
-		pdev->vendor_id      = region->vendor_id;
+		pdev->function       = device->function;
+		pdev->segment        = device->segment;
+		pdev->bus            = device->bus;
+		pdev->device         = device->device;
+		pdev->device_id      = device->device_id;
+		pdev->vendor_id      = device->vendor_id;
 
 		// Enum fme
-		if (region->fme) {
-			result = enum_fme(region->fme->res_path,
-							region->fme->res_name, pdev);
+		if (device->fme) {
+			result = enum_fme(device->fme->sysfs_path,
+							device->fme->sysfs_name, pdev);
 			if (result != FPGA_OK) {
 				FPGA_ERR("Failed to enum FME");
 				break;
@@ -543,16 +543,16 @@ STATIC fpga_result enum_fpga_region_resources(struct dev_list *list,
 		}
 
 		// Enum port
-		if (region->port && include_port) {
-			result = enum_afu(region->port->res_path,
-				region->port->res_name, pdev);
+		if (device->port && include_port) {
+			result = enum_afu(device->port->sysfs_path,
+				device->port->sysfs_name, pdev);
 			if (result != FPGA_OK) {
 				FPGA_ERR("Failed to enum PORT");
 				break;
 			}
 		}
 
-	} // end of region loop
+	} // end of device loop
 
 	return result;
 }

--- a/libopae/plugins/xfpga/sysfs.c
+++ b/libopae/plugins/xfpga/sysfs.c
@@ -62,8 +62,8 @@
 
 typedef struct _sysfs_formats {
 	const char *sysfs_class_path;
+	const char *sysfs_device_fmt;
 	const char *sysfs_region_fmt;
-	const char *sysfs_resource_fmt;
 	const char *sysfs_compat_id;
 } sysfs_formats;
 
@@ -76,15 +76,15 @@ static sysfs_formats sysfs_path_table[OPAE_KERNEL_DRIVERS] = {
 	 "intel-fpga-(fme|port)\\.([0-9]+)", "pr/interface_id"} };
 
 static sysfs_formats *_sysfs_format_ptr;
-static uint32_t _sysfs_region_count;
-/* mutex to protect sysfs region data structures */
-pthread_mutex_t _sysfs_region_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+static uint32_t _sysfs_device_count;
+/* mutex to protect sysfs device data structures */
+pthread_mutex_t _sysfs_device_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
 #define SYSFS_FORMAT(s) (_sysfs_format_ptr ? _sysfs_format_ptr->s : NULL)
 
 
-#define SYSFS_MAX_REGIONS 128
-static sysfs_fpga_region _regions[SYSFS_MAX_REGIONS];
+#define SYSFS_MAX_DEVICES 128
+static sysfs_fpga_device _devices[SYSFS_MAX_DEVICES];
 
 #define PCIE_PATH_PATTERN "([0-9a-fA-F]{4}):([0-9a-fA-F]{2}):([0-9]{2})\\.([0-9])/fpga"
 #define PCIE_PATH_PATTERN_GROUPS 5
@@ -99,7 +99,7 @@ static sysfs_fpga_region _regions[SYSFS_MAX_REGIONS];
 		}                                                              \
 	} while (0);
 
-STATIC int parse_pcie_info(sysfs_fpga_region *region, char *buffer)
+STATIC int parse_pcie_info(sysfs_fpga_device *device, char *buffer)
 {
 	char err[128] = {0};
 	regex_t re;
@@ -118,10 +118,10 @@ STATIC int parse_pcie_info(sysfs_fpga_region *region, char *buffer)
 		res = FPGA_EXCEPTION;
 		goto out;
 	} else {
-		PARSE_MATCH_INT(buffer, matches[1], region->segment, 16, out);
-		PARSE_MATCH_INT(buffer, matches[2], region->bus, 16, out);
-		PARSE_MATCH_INT(buffer, matches[3], region->device, 16, out);
-		PARSE_MATCH_INT(buffer, matches[4], region->function, 10, out);
+		PARSE_MATCH_INT(buffer, matches[1], device->segment, 16, out);
+		PARSE_MATCH_INT(buffer, matches[2], device->bus, 16, out);
+		PARSE_MATCH_INT(buffer, matches[3], device->device, 16, out);
+		PARSE_MATCH_INT(buffer, matches[4], device->function, 10, out);
 	}
 	res = FPGA_OK;
 
@@ -163,65 +163,59 @@ int sysfs_parse_attribute64(const char *root, const char *attr_path, uint64_t *v
 	return FPGA_OK;
 }
 
-STATIC int parse_device_vendor_id(sysfs_fpga_region *region)
+STATIC int parse_device_vendor_id(sysfs_fpga_device *device)
 {
 	uint64_t value = 0;
-	int res = sysfs_parse_attribute64(region->region_path, "device/device", &value);
+	int res = sysfs_parse_attribute64(device->sysfs_path, "device/device", &value);
 	if (res) {
-		FPGA_MSG("Error parsing device_id for region: %s",
-			 region->region_path);
+		FPGA_MSG("Error parsing device_id for device: %s",
+			 device->sysfs_path);
 		return res;
 	}
-	region->device_id = value;
+	device->device_id = value;
 
-	res = sysfs_parse_attribute64(region->region_path, "device/vendor", &value);
+	res = sysfs_parse_attribute64(device->sysfs_path, "device/vendor", &value);
 
 	if (res) {
-		FPGA_ERR("Error parsing vendor_id for region: %s",
-			 region->region_path);
+		FPGA_ERR("Error parsing vendor_id for device: %s",
+			 device->sysfs_path);
 		return res;
 	}
-	region->vendor_id = value;
+	device->vendor_id = value;
 
 	return FPGA_OK;
 }
 
-STATIC sysfs_fpga_resource *make_resource(sysfs_fpga_region *region, char *name,
-					  int num, fpga_objtype type)
+STATIC sysfs_fpga_region *make_region(sysfs_fpga_device *device, char *name,
+				      int num, fpga_objtype type)
 {
-	sysfs_fpga_resource *resource = malloc(sizeof(sysfs_fpga_resource));
-	if (resource == NULL) {
-		FPGA_ERR("error creating resource");
+	sysfs_fpga_region *region = malloc(sizeof(sysfs_fpga_region));
+	if (region == NULL) {
+		FPGA_ERR("error creating region");
 		return NULL;
 	}
-	resource->region = region;
-	resource->type = type;
-	resource->num = num;
-	// copy the full path to the parent region object
-	strcpy_s(resource->res_path, SYSFS_PATH_MAX, region->region_path);
-	// add a trailing path seperator '/'
-	int len = strlen(resource->res_path);
-	char *ptr = resource->res_path + len;
-	*ptr = '/';
-	ptr++;
-	*ptr = '\0';
-	// append the name to get the full path to the resource
-	if (cat_sysfs_path(resource->res_path, name)) {
-		FPGA_ERR("error concatenating path");
-		free(resource);
+	region->device = device;
+	region->type = type;
+	region->number = num;
+	// sysfs path of region is sysfs path of device + / + name
+	if (snprintf_s_ss(region->sysfs_path, sizeof(region->sysfs_path),
+			  "%s/%s", device->sysfs_path, name)
+	    < 0) {
+		FPGA_ERR("error formatting path");
+		free(region);
 		return NULL;
 	}
 
-	if (snprintf_s_s(resource->res_name, SYSFS_PATH_MAX, "%s", name) < 0) {
-		FPGA_ERR("Error formatting sysfs name");
-		free(resource);
+	if (strcpy_s(region->sysfs_name, sizeof(region->sysfs_name),  name)) {
+		FPGA_ERR("Error copying sysfs name");
+		free(region);
 		return NULL;
 	}
 
-	return resource;
+	return region;
 }
 
-STATIC int find_resources(sysfs_fpga_region *region)
+STATIC int find_regions(sysfs_fpga_device *device)
 {
 	DIR *dir = NULL;
 	struct dirent *dirent = NULL;
@@ -231,9 +225,9 @@ STATIC int find_resources(sysfs_fpga_region *region)
 	char err[128] = {0};
 	regmatch_t matches[SYSFS_MAX_RESOURCES];
 
-	if (SYSFS_FORMAT(sysfs_resource_fmt)) {
+	if (SYSFS_FORMAT(sysfs_region_fmt)) {
 
-		reg_res = regcomp(&re, SYSFS_FORMAT(sysfs_resource_fmt), REG_EXTENDED);
+		reg_res = regcomp(&re, SYSFS_FORMAT(sysfs_region_fmt), REG_EXTENDED);
 		if (reg_res) {
 			regerror(reg_res, &re, err, 128);
 			FPGA_MSG("Error compiling regex: %s", err);
@@ -241,9 +235,9 @@ STATIC int find_resources(sysfs_fpga_region *region)
 		}
 	}
 
-	dir = opendir(region->region_path);
+	dir = opendir(device->sysfs_path);
 	if (!dir) {
-		FPGA_MSG("failed to open region path: %s", region->region_path);
+		FPGA_MSG("failed to open device path: %s", device->sysfs_path);
 		regfree(&re);
 		return FPGA_EXCEPTION;
 	}
@@ -267,14 +261,15 @@ STATIC int find_resources(sysfs_fpga_region *region)
 			num = strtoul(dirent->d_name + num_beg, NULL, 10);
 			if (!strncmp(FPGA_SYSFS_FME, dirent->d_name + type_beg,
 				     FPGA_SYSFS_FME_LEN)) {
-				region->fme = make_resource(
-					region, dirent->d_name, num, FPGA_DEVICE);
+				device->fme =
+					make_region(device, dirent->d_name, num,
+						    FPGA_DEVICE);
 			} else if (!strncmp(FPGA_SYSFS_PORT,
 					    dirent->d_name + type_beg,
 					    FPGA_SYSFS_PORT_LEN)) {
-				region->port =
-					make_resource(region, dirent->d_name,
-						      num, FPGA_ACCELERATOR);
+				device->port =
+					make_region(device, dirent->d_name, num,
+						    FPGA_ACCELERATOR);
 			}
 		}
 	}
@@ -282,8 +277,8 @@ STATIC int find_resources(sysfs_fpga_region *region)
 	regfree(&re);
 	if (dir)
 		closedir(dir);
-	if (!region->fme && !region->port) {
-		FPGA_MSG("did not find fme/port in region: %s", region->region_path);
+	if (!device->fme && !device->port) {
+		FPGA_MSG("did not find fme/port in device: %s", device->sysfs_path);
 		return FPGA_NOT_FOUND;
 	}
 
@@ -291,104 +286,104 @@ STATIC int find_resources(sysfs_fpga_region *region)
 }
 
 
-STATIC int make_region(sysfs_fpga_region *region, const char *sysfs_class_fpga,
+STATIC int make_device(sysfs_fpga_device *device, const char *sysfs_class_fpga,
 		       char *dir_name, int num)
 {
 	int res = FPGA_OK;
 	char buffer[SYSFS_PATH_MAX] = {0};
 	ssize_t sym_link_len = 0;
-	if (snprintf_s_ss(region->region_path, SYSFS_PATH_MAX, "%s/%s",
+	if (snprintf_s_ss(device->sysfs_path, SYSFS_PATH_MAX, "%s/%s",
 			  sysfs_class_fpga, dir_name)
 	    < 0) {
 		FPGA_ERR("Error formatting sysfs paths");
 		return FPGA_EXCEPTION;
 	}
 
-	if (snprintf_s_s(region->region_name, SYSFS_PATH_MAX, "%s", dir_name) < 0) {
+	if (snprintf_s_s(device->sysfs_name, SYSFS_PATH_MAX, "%s", dir_name) < 0) {
 		FPGA_ERR("Error formatting sysfs name");
 		return FPGA_EXCEPTION;
 	}
 
-	sym_link_len = readlink(region->region_path, buffer, SYSFS_PATH_MAX);
+	sym_link_len = readlink(device->sysfs_path, buffer, SYSFS_PATH_MAX);
 	if (sym_link_len < 0) {
-		FPGA_ERR("Error reading sysfs link: %s", region->region_path);
+		FPGA_ERR("Error reading sysfs link: %s", device->sysfs_path);
 		return FPGA_EXCEPTION;
 	}
 
-	region->number = num;
-	res = parse_pcie_info(region, buffer);
+	device->number = num;
+	res = parse_pcie_info(device, buffer);
 
 	if (res) {
 		FPGA_ERR("Could not parse symlink");
 		return res;
 	}
 
-	res = parse_device_vendor_id(region);
+	res = parse_device_vendor_id(device);
 	if (res) {
 		FPGA_MSG("Could not parse vendor/device id");
 		return res;
 	}
 
-	res = sysfs_parse_attribute64(region->region_path,
+	res = sysfs_parse_attribute64(device->sysfs_path,
 				      "device/sriov_totalvfs",
-				      &region->sriov_totalvfs);
+				      &device->sriov_totalvfs);
 	if (res) {
 		FPGA_MSG("Could not parse sriov_totalvfs");
 		return res;
 	}
 
-	res = sysfs_parse_attribute64(region->region_path,
+	res = sysfs_parse_attribute64(device->sysfs_path,
 				      "device/sriov_numvfs",
-				      &region->sriov_numvfs);
+				      &device->sriov_numvfs);
 	if (res) {
 		FPGA_MSG("Could not parse sriov_numvfs");
 		return res;
 	}
 
 
-	return find_resources(region);
+	return find_regions(device);
 }
 
 
 
-STATIC int sysfs_region_destroy(sysfs_fpga_region *region)
+STATIC int sysfs_device_destroy(sysfs_fpga_device *device)
 {
-	ASSERT_NOT_NULL(region);
-	if (region->fme) {
-		free(region->fme);
-		region->fme = NULL;
+	ASSERT_NOT_NULL(device);
+	if (device->fme) {
+		free(device->fme);
+		device->fme = NULL;
 	}
-	if (region->port) {
-		free(region->port);
-		region->port = NULL;
+	if (device->port) {
+		free(device->port);
+		device->port = NULL;
 	}
 	return FPGA_OK;
 }
 
-int sysfs_region_count(void)
+int sysfs_device_count(void)
 {
 	int res = 0, count = 0;
-	if (!opae_mutex_lock(res, &_sysfs_region_lock)) {
-		count = _sysfs_region_count;
+	if (!opae_mutex_lock(res, &_sysfs_device_lock)) {
+		count = _sysfs_device_count;
 	}
 
-	if (opae_mutex_unlock(res, &_sysfs_region_lock)) {
+	if (opae_mutex_unlock(res, &_sysfs_device_lock)) {
 		count = 0;
 	}
 
 	return count;
 }
 
-void sysfs_foreach_region(region_cb cb, void *context)
+void sysfs_foreach_device(device_cb cb, void *context)
 {
 	uint32_t i = 0;
 	int res = 0;
-	if (!opae_mutex_lock(res, &_sysfs_region_lock)) {
-		for ( ; i < _sysfs_region_count; ++i) {
-			cb(&_regions[i], context);
+	if (!opae_mutex_lock(res, &_sysfs_device_lock)) {
+		for ( ; i < _sysfs_device_count; ++i) {
+			cb(&_devices[i], context);
 		}
 
-		opae_mutex_unlock(res, &_sysfs_region_lock);
+		opae_mutex_unlock(res, &_sysfs_device_lock);
 	}
 }
 
@@ -402,8 +397,8 @@ int sysfs_initialize(void)
 	DIR *dir = NULL;
 	char err[128] = {0};
 	struct dirent *dirent = NULL;
-	regex_t region_re;
-	regmatch_t matches[SYSFS_MAX_REGIONS];
+	regex_t device_re;
+	regmatch_t matches[SYSFS_MAX_DEVICES];
 
 	for (i = 0; i < OPAE_KERNEL_DRIVERS; ++i) {
 		errno = 0;
@@ -424,14 +419,14 @@ int sysfs_initialize(void)
 		return FPGA_NO_DRIVER;
 	}
 
-	_sysfs_region_count = 0;
+	_sysfs_device_count = 0;
 
-	if (SYSFS_FORMAT(sysfs_region_fmt)) {
+	if (SYSFS_FORMAT(sysfs_device_fmt)) {
 
-		reg_res = regcomp(&region_re, SYSFS_FORMAT(sysfs_region_fmt),
+		reg_res = regcomp(&device_re, SYSFS_FORMAT(sysfs_device_fmt),
 			REG_EXTENDED);
 		if (reg_res) {
-			regerror(reg_res, &region_re, err, 128);
+			regerror(reg_res, &device_re, err, 128);
 			FPGA_ERR("Error compling regex: %s", err);
 			return FPGA_EXCEPTION;
 		}
@@ -445,10 +440,10 @@ int sysfs_initialize(void)
 	}
 
 	// open the root sysfs class directory
-	// look in the directory and get region (device) objects
+	// look in the directory and get device objects
 	dir = opendir(sysfs_class_fpga);
 	if (!dir) {
-		FPGA_MSG("failed to open region path: %s", sysfs_class_fpga);
+		FPGA_MSG("failed to open device path: %s", sysfs_class_fpga);
 		res = FPGA_EXCEPTION;
 		goto out_free;
 	}
@@ -458,8 +453,8 @@ int sysfs_initialize(void)
 			continue;
 		if (!strcmp(dirent->d_name, ".."))
 			continue;
-		// if the current directory matches the region (device) regex
-		reg_res = regexec(&region_re, dirent->d_name, SYSFS_MAX_REGIONS,
+		// if the current directory matches the device regex
+		reg_res = regexec(&device_re, dirent->d_name, SYSFS_MAX_DEVICES,
 				  matches, 0);
 		if (!reg_res) {
 			int num_begin = matches[1].rm_so;
@@ -468,30 +463,30 @@ int sysfs_initialize(void)
 				continue;
 			}
 			int num = strtoul(dirent->d_name + num_begin, NULL, 10);
-			// increment our region count after filling out details
-			// of the discovered region in our _regions array
-			if (opae_mutex_lock(res, &_sysfs_region_lock)) {
+			// increment our device count after filling out details
+			// of the discovered device in our _devices array
+			if (opae_mutex_lock(res, &_sysfs_device_lock)) {
 				goto out_free;
 			}
-			if (make_region(&_regions[_sysfs_region_count++],
+			if (make_device(&_devices[_sysfs_device_count++],
 					sysfs_class_fpga, dirent->d_name,
 					num)) {
-				FPGA_MSG("Error processing region: %s",
+				FPGA_MSG("Error processing device: %s",
 					 dirent->d_name);
-				_sysfs_region_count--;
+				_sysfs_device_count--;
 			}
-			if (opae_mutex_unlock(res, &_sysfs_region_lock)) {
+			if (opae_mutex_unlock(res, &_sysfs_device_lock)) {
 				goto out_free;
 			}
 		}
 	}
 
-	if (!_sysfs_region_count) {
-		FPGA_ERR("Error discovering fpga regions");
+	if (!_sysfs_device_count) {
+		FPGA_ERR("Error discovering fpga devices");
 		res = FPGA_NO_DRIVER;
 	}
 out_free:
-	regfree(&region_re);
+	regfree(&device_re);
 	if (dir)
 		closedir(dir);
 	return res;
@@ -501,33 +496,33 @@ int sysfs_finalize(void)
 {
 	uint32_t i = 0;
 	int res = 0;
-	if (opae_mutex_lock(res, &_sysfs_region_lock)) {
+	if (opae_mutex_lock(res, &_sysfs_device_lock)) {
 		FPGA_ERR("Error locking mutex");
 		return FPGA_EXCEPTION;
 	}
-	for (; i < _sysfs_region_count; ++i) {
-		sysfs_region_destroy(&_regions[i]);
+	for (; i < _sysfs_device_count; ++i) {
+		sysfs_device_destroy(&_devices[i]);
 	}
-	_sysfs_region_count = 0;
+	_sysfs_device_count = 0;
 	_sysfs_format_ptr = NULL;
-	if (opae_mutex_unlock(res, &_sysfs_region_lock)) {
+	if (opae_mutex_unlock(res, &_sysfs_device_lock)) {
 		FPGA_ERR("Error unlocking mutex");
 		return FPGA_EXCEPTION;
 	}
 	return FPGA_OK;
 }
 
-const sysfs_fpga_region *sysfs_get_region(size_t num)
+const sysfs_fpga_device *sysfs_get_device(size_t num)
 {
-	const sysfs_fpga_region *ptr = NULL;
+	const sysfs_fpga_device *ptr = NULL;
 	int res = 0;
-	if (!opae_mutex_lock(res, &_sysfs_region_lock)) {
-		if (num >= _sysfs_region_count) {
-			FPGA_ERR("No such region with index: %d", num);
+	if (!opae_mutex_lock(res, &_sysfs_device_lock)) {
+		if (num >= _sysfs_device_count) {
+			FPGA_ERR("No such device with index: %d", num);
 		} else {
-			ptr = &_regions[num];
+			ptr = &_devices[num];
 		}
-		if (opae_mutex_unlock(res, &_sysfs_region_lock)) {
+		if (opae_mutex_unlock(res, &_sysfs_device_lock)) {
 			ptr = NULL;
 		}
 	}
@@ -553,16 +548,16 @@ fpga_result sysfs_get_interface_id(fpga_token token, fpga_guid guid)
 }
 
 
-fpga_result sysfs_get_fme_pr_interface_id(const char *sysfs_res_path, fpga_guid guid)
+fpga_result sysfs_get_fme_pr_interface_id(const char *sysfs_sysfs_path, fpga_guid guid)
 {
 	fpga_result res = FPGA_OK;
 	char sysfs_path[SYSFS_PATH_MAX];
 
 	int len = snprintf_s_ss(sysfs_path, SYSFS_PATH_MAX, "%s/%s",
-		sysfs_res_path, SYSFS_FORMAT(sysfs_compat_id));
+		sysfs_sysfs_path, SYSFS_FORMAT(sysfs_compat_id));
 	if (len < 0) {
 		FPGA_ERR("error concatenating strings (%s, %s)",
-			sysfs_res_path, sysfs_path);
+			sysfs_sysfs_path, sysfs_path);
 		return FPGA_EXCEPTION;
 	}
 

--- a/libopae/plugins/xfpga/sysfs_int.h
+++ b/libopae/plugins/xfpga/sysfs_int.h
@@ -41,23 +41,23 @@ extern "C" {
 #endif
 
 
-typedef struct _sysfs_fpga_region sysfs_fpga_region;
+typedef struct _sysfs_fpga_device sysfs_fpga_device;
 
-typedef struct _sysfs_fpga_resource {
-	sysfs_fpga_region *region;
-	char res_path[SYSFS_PATH_MAX];
-	char res_name[SYSFS_PATH_MAX];
+typedef struct _sysfs_fpga_region {
+	sysfs_fpga_device *device;
+	char sysfs_path[SYSFS_PATH_MAX];
+	char sysfs_name[SYSFS_PATH_MAX];
 	fpga_objtype type;
-	int num;
-} sysfs_fpga_resource;
+	int number;
+} sysfs_fpga_region;
 
 #define SYSFS_MAX_RESOURCES 4
-typedef struct _sysfs_fpga_region {
-	char region_path[SYSFS_PATH_MAX];
-	char region_name[SYSFS_PATH_MAX];
+typedef struct _sysfs_fpga_device {
+	char sysfs_path[SYSFS_PATH_MAX];
+	char sysfs_name[SYSFS_PATH_MAX];
 	int number;
-	sysfs_fpga_resource *fme;
-	sysfs_fpga_resource *port;
+	sysfs_fpga_region *fme;
+	sysfs_fpga_region *port;
   uint32_t segment;
   uint8_t bus;
   uint8_t device;
@@ -66,16 +66,16 @@ typedef struct _sysfs_fpga_region {
   uint32_t vendor_id;
   uint64_t sriov_totalvfs;
   uint64_t sriov_numvfs;
-} sysfs_fpga_region;
+} sysfs_fpga_device;
 
 int sysfs_initialize(void);
 int sysfs_finalize(void);
-int sysfs_region_count(void);
+int sysfs_device_count(void);
 
-typedef void (*region_cb)(sysfs_fpga_region *region, void *context);
-void sysfs_foreach_region(region_cb cb, void *context);
+typedef void (*device_cb)(sysfs_fpga_device *device, void *context);
+void sysfs_foreach_device(device_cb cb, void *context);
 
-const sysfs_fpga_region *sysfs_get_region(size_t num);
+const sysfs_fpga_device *sysfs_get_device(size_t num);
 int sysfs_parse_attribute64(const char *root, const char *attr_path, uint64_t *value);
 
 fpga_result sysfs_get_fme_pr_interface_id(const char *sysfs_res_path, fpga_guid guid);

--- a/testing/xfpga/test_error_c.cpp
+++ b/testing/xfpga/test_error_c.cpp
@@ -69,16 +69,16 @@ class error_c_mock_p : public ::testing::TestWithParam<std::string> {
     system_->prepare_syfs(platform_);
     tmpsysfs_ = system_->get_root();
     ASSERT_EQ(FPGA_OK, xfpga_plugin_initialize());
-    if (sysfs_region_count() > 0) {
-      const sysfs_fpga_region *region = sysfs_get_region(0);
-      ASSERT_NE(region, nullptr);
-      if (region->fme) {
-        sysfs_fme = std::string(region->fme->res_path);
-        dev_fme = std::string("/dev/") + std::string(region->fme->res_name);
+    if (sysfs_device_count() > 0) {
+      const sysfs_fpga_device *device = sysfs_get_device(0);
+      ASSERT_NE(device, nullptr);
+      if (device->fme) {
+        sysfs_fme = std::string(device->fme->sysfs_path);
+        dev_fme = std::string("/dev/") + std::string(device->fme->sysfs_name);
       }
-      if (region->port) {
-        sysfs_port = std::string(region->port->res_path);
-        dev_port = std::string("/dev/") + std::string(region->port->res_name);
+      if (device->port) {
+        sysfs_port = std::string(device->port->sysfs_path);
+        dev_port = std::string("/dev/") + std::string(device->port->sysfs_name);
       }
     }
     strncpy_s(fake_port_token_.sysfspath, sizeof(fake_port_token_.sysfspath),

--- a/testing/xfpga/test_token_list_c.cpp
+++ b/testing/xfpga/test_token_list_c.cpp
@@ -55,18 +55,18 @@ class token_list_c_p : public ::testing::TestWithParam<std::string> {
     system_->prepare_syfs(platform_);
     ASSERT_EQ(xfpga_plugin_initialize(), FPGA_OK);
 
-    if (sysfs_region_count() > 0) {
-      const sysfs_fpga_region* region = sysfs_get_region(0);
-      ASSERT_NE(region, nullptr);
-      if (region->fme) {
-        sysfs_fme = std::string(region->fme->res_path);
+    if (sysfs_device_count() > 0) {
+      const sysfs_fpga_device* device = sysfs_get_device(0);
+      ASSERT_NE(device, nullptr);
+      if (device->fme) {
+        sysfs_fme = std::string(device->fme->sysfs_path);
 
-        dev_fme = std::string("/dev/") + std::string(region->fme->res_name);
+        dev_fme = std::string("/dev/") + std::string(device->fme->sysfs_name);
       }
-      if (region->port) {
-        sysfs_port = std::string(region->port->res_path);
+      if (device->port) {
+        sysfs_port = std::string(device->port->sysfs_path);
 
-        dev_port = std::string("/dev/") + std::string(region->port->res_name);
+        dev_port = std::string("/dev/") + std::string(device->port->sysfs_name);
       }
     }
   }


### PR DESCRIPTION
* rename sysfs_fpga_region to sysfs_fpga_device
  A device represents a pci device discovered at:
  /sys/fpga/<device_pattern>
* rename sysfs_fpga_resource to sysfs_fpga_region
  A region is a platform device (under the pci device) found at:
  /sys/fpga/<device_pattern>/<region_pattern>

The reason for doing this is to make it easier to trace back to pci
devices vs platform devices. This will also make it easier when
refactoring syfs discover routine to allow for re-scanning devices
within the lifetime of an application and discovering added/removed
devices.