### PR TITLE
xfpga: allow enum. to account for device removal

### DIFF
--- a/libopae/plugins/xfpga/enum.c
+++ b/libopae/plugins/xfpga/enum.c
@@ -492,7 +492,6 @@ STATIC fpga_result enum_afu(const char *sysfspath, const char *name,
 	return FPGA_OK;
 }
 
-#define MAX_ENUM_ERRORS 16
 typedef struct _enum_region_ctx{
 	struct dev_list *list;
 	bool include_port;

--- a/libopae/plugins/xfpga/enum.c
+++ b/libopae/plugins/xfpga/enum.c
@@ -500,7 +500,7 @@ typedef struct _enum_region_ctx{
 
 STATIC fpga_result enum_regions(const sysfs_fpga_device *device, void *context)
 {
-	enum_region_ctx *ctx = (enum_region_ctx*)context;
+	enum_region_ctx *ctx = (enum_region_ctx *)context;
 	fpga_result result = FPGA_OK;
 	struct dev_list *pdev = add_dev(device->sysfs_path, "", ctx->list);
 	if (!pdev) {

--- a/libopae/plugins/xfpga/enum.c
+++ b/libopae/plugins/xfpga/enum.c
@@ -521,7 +521,7 @@ STATIC fpga_result enum_regions(const sysfs_fpga_device *device, void *context)
 				  device->fme->sysfs_name, pdev);
 		if (result != FPGA_OK) {
 			FPGA_ERR("Failed to enum FME");
-			return FPGA_EXCEPTION;
+			return result;
 		}
 	}
 
@@ -531,7 +531,7 @@ STATIC fpga_result enum_regions(const sysfs_fpga_device *device, void *context)
 				  device->port->sysfs_name, pdev);
 		if (result != FPGA_OK) {
 			FPGA_ERR("Failed to enum PORT");
-			return FPGA_EXCEPTION;
+			return result;
 		}
 	}
 	return FPGA_OK;

--- a/libopae/plugins/xfpga/sysfs.c
+++ b/libopae/plugins/xfpga/sysfs.c
@@ -374,17 +374,34 @@ int sysfs_device_count(void)
 	return count;
 }
 
-void sysfs_foreach_device(device_cb cb, void *context)
+fpga_result sysfs_foreach_device(device_cb cb, void *context)
 {
 	uint32_t i = 0;
 	int res = 0;
+	fpga_result result = FPGA_OK;
 	if (!opae_mutex_lock(res, &_sysfs_device_lock)) {
+		result = sysfs_finalize();
+		if (result) {
+			goto out_unlock;
+		}
+		result = sysfs_initialize();
+		if (result) {
+			goto out_unlock;
+		}
 		for ( ; i < _sysfs_device_count; ++i) {
-			cb(&_devices[i], context);
+			result = cb(&_devices[i], context);
+			if (result) {
+				goto out_unlock;
+			}
 		}
 
+out_unlock:
 		opae_mutex_unlock(res, &_sysfs_device_lock);
+	} else {
+		result = FPGA_EXCEPTION;
 	}
+
+	return result;
 }
 
 int sysfs_initialize(void)

--- a/libopae/plugins/xfpga/sysfs_int.h
+++ b/libopae/plugins/xfpga/sysfs_int.h
@@ -72,8 +72,8 @@ int sysfs_initialize(void);
 int sysfs_finalize(void);
 int sysfs_device_count(void);
 
-typedef void (*device_cb)(sysfs_fpga_device *device, void *context);
-void sysfs_foreach_device(device_cb cb, void *context);
+typedef fpga_result (*device_cb)(const sysfs_fpga_device *device, void *context);
+fpga_result sysfs_foreach_device(device_cb cb, void *context);
 
 const sysfs_fpga_device *sysfs_get_device(size_t num);
 int sysfs_parse_attribute64(const char *root, const char *attr_path, uint64_t *value);

--- a/testing/mock/test_system.h
+++ b/testing/mock/test_system.h
@@ -122,6 +122,7 @@ class test_system {
   void finalize();
   void prepare_syfs(const test_platform &platform);
   void remove_sysfs();
+  int remove_sysfs_dir(const char *path);
   std::string get_sysfs_claass_path(const std::string &path);
 
   int open(const std::string &path, int flags);

--- a/testing/opae-c/test_enum_c.cpp
+++ b/testing/opae-c/test_enum_c.cpp
@@ -46,22 +46,15 @@ extern "C" {
 #include <memory>
 #include <string>
 #include <vector>
-#include "gtest/gtest.h"
-#include "test_system.h"
+#include "mock_opae.h"
 
 using namespace opae::testing;
 
-class enum_c_p : public ::testing::TestWithParam<std::string> {
+class enum_c_p : public mock_opae_p<2, none_> {
  protected:
-  enum_c_p() : filter_(nullptr), tokens_{{nullptr, nullptr}} {}
+  enum_c_p() {}
 
-  virtual void SetUp() override {
-    ASSERT_TRUE(test_platform::exists(GetParam()));
-    platform_ = test_platform::get(GetParam());
-    system_ = test_system::instance();
-    system_->initialize();
-    system_->prepare_syfs(platform_);
-    invalid_device_ = test_device::unknown();
+  virtual void test_setup() override {
 
     ASSERT_EQ(fpgaInitialize(NULL), FPGA_OK);
     filter_ = nullptr;
@@ -69,29 +62,19 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
     num_matches_ = 0;
   }
 
-  void DestroyTokens() {
-    for (auto &t : tokens_) {
-      if (t) {
-        EXPECT_EQ(fpgaDestroyToken(&t), FPGA_OK);
-        t = nullptr;
-      }
-    }
-    num_matches_ = 0;
-  }
 
-  virtual void TearDown() override {
-    DestroyTokens();
+  virtual void test_teardown() override {
+    num_matches_ = 0;
     if (filter_ != nullptr) {
       EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
     }
     fpgaFinalize();
-    system_->finalize();
   }
 
   // Need a concrete way to determine the number of fpgas on the system
   // without relying on fpgaEnumerate() since that is the function that
   // is under test.
-  int GetNumFpgas() {
+  virtual int GetNumFpgas() {
     if (platform_.mock_sysfs != nullptr) {
       return platform_.devices.size();
     }
@@ -105,11 +88,11 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
     return value;
   }
 
-  int GetNumMatchedFpga () {
+  virtual int GetNumMatchedFpga () {
     if (platform_.mock_sysfs != nullptr) {
       return 1;
     }
-    
+
     int matches = 0;
     int socket_id;
     int i;
@@ -126,7 +109,7 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
     return matches;
   }
 
-  int GetNumDeviceID() {
+  virtual int GetNumDeviceID() {
     if (platform_.mock_sysfs != nullptr) {
       return 1;
     }
@@ -147,7 +130,7 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
     return value;
   }
 
-  void ExecuteCmd(std::string cmd, int &value) {
+  virtual void ExecuteCmd(std::string cmd, int &value) {
     std::string line;
     std::string command = cmd + " > output.txt";
 
@@ -165,11 +148,7 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
   }
 
   fpga_properties filter_;
-  std::array<fpga_token, 2> tokens_;
   uint32_t num_matches_;
-  test_platform platform_;
-  test_device invalid_device_;
-  test_system *system_;
 };
 
 TEST_P(enum_c_p, nullfilter) {

--- a/testing/xfpga/test_enum_c.cpp
+++ b/testing/xfpga/test_enum_c.cpp
@@ -36,10 +36,9 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include "gtest/gtest.h"
-#include "test_system.h"
 #include "types_int.h"
 #include "sysfs_int.h"
+#include "mock_opae.h"
 extern "C" {
 #include "token_list_int.h"
 }
@@ -52,39 +51,22 @@ int xfpga_plugin_finalize(void);
 
 using namespace opae::testing;
 
-class enum_c_p : public ::testing::TestWithParam<std::string> {
+class enum_c_p : public mock_opae_p<2, xfpga_> {
  protected:
-  enum_c_p() : tokens_{{nullptr, nullptr}}, filter_(nullptr) {}
+  enum_c_p() : filter_(nullptr) {}
 
   virtual ~enum_c_p() {}
 
-  virtual void SetUp() override {
-    ASSERT_TRUE(test_platform::exists(GetParam()));
-    platform_ = test_platform::get(GetParam());
-    system_ = test_system::instance();
-    system_->initialize();
-    system_->prepare_syfs(platform_);
+  virtual void test_setup() override {
     ASSERT_EQ(xfpga_plugin_initialize(), FPGA_OK);
     ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
     num_matches_ = 0xc01a;
-    invalid_device_ = test_device::unknown();
   }
 
-  virtual void TearDown() override {
+  virtual void test_teardown() override {
     EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-    DestroyTokens();
     token_cleanup();
     xfpga_plugin_finalize();
-    system_->finalize();
-  }
-
-  void DestroyTokens() {
-    for (auto & t : tokens_) {
-      if (t != nullptr) {
-        EXPECT_EQ(xfpga_fpgaDestroyToken(&t), FPGA_OK);
-        t = nullptr;
-      }
-    }
   }
 
   // Need a concrete way to determine the number of fpgas on the system
@@ -108,7 +90,7 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
     if (platform_.mock_sysfs != nullptr) {
       return 1;
     }
-    
+
     int matches = 0;
     int socket_id;
     int i;
@@ -142,12 +124,8 @@ class enum_c_p : public ::testing::TestWithParam<std::string> {
     value = std::stoi(line);
   }
 
-  std::array<fpga_token, 2> tokens_;
   fpga_properties filter_;
   uint32_t num_matches_;
-  test_platform platform_;
-  test_device invalid_device_;
-  test_system *system_;
 };
 
 /**
@@ -994,6 +972,9 @@ TEST_P(enum_c_p, get_guid) {
   EXPECT_EQ(fpgaDestroyProperties(&prop), FPGA_OK);
 }
 
+
+
+
 INSTANTIATE_TEST_CASE_P(enum_c, enum_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({})));
 
@@ -1058,3 +1039,36 @@ TEST_P(enum_socket_c_p, socket_id) {
 
 INSTANTIATE_TEST_CASE_P(enum_c, enum_socket_c_p,
                           ::testing::ValuesIn(test_platform::platforms({ "skx-p"})));
+
+class enum_mock_only : public enum_c_p {};
+
+/**
+ * @test       remove_port
+ *
+ * @brief      Given I have a system with at least one FPGA And I
+ *             enumerate with a filter of objtype of FPGA_ACCELERATOR
+ *             and I get one token for that accelerator
+ *             When I remove the port device from the system
+ *             And I enumerate again with the same filter
+ *             Then I get zero tokens as the result.
+ *
+ */
+TEST_P(enum_mock_only, remove_port) {
+  fpga_properties filterp = NULL;
+
+  ASSERT_EQ(xfpga_fpgaGetProperties(NULL, &filterp), FPGA_OK);
+  EXPECT_EQ(fpgaPropertiesSetObjectType(filterp, FPGA_ACCELERATOR), FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaEnumerate(&filterp, 1, tokens_.data(), 1, &num_matches_),
+            FPGA_OK);
+  EXPECT_EQ(num_matches_, 1);
+  const char *sysfs_port = "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-port.0";
+
+  ASSERT_EQ(system_->remove_sysfs_dir(sysfs_port), 0)
+      << "error removing intel-fpga-port.0: " << strerror(errno);
+  EXPECT_EQ(xfpga_fpgaEnumerate(&filterp, 1, tokens_.data(), 1, &num_matches_),
+            FPGA_OK);
+  EXPECT_EQ(num_matches_, 0);
+}
+
+INSTANTIATE_TEST_CASE_P(enum_c, enum_mock_only,
+                          ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p"})));

--- a/testing/xfpga/test_enum_c.cpp
+++ b/testing/xfpga/test_enum_c.cpp
@@ -1063,11 +1063,12 @@ TEST_P(enum_mock_only, remove_port) {
   EXPECT_EQ(num_matches_, 1);
   const char *sysfs_port = "/sys/class/fpga/intel-fpga-dev.0/intel-fpga-port.0";
 
-  ASSERT_EQ(system_->remove_sysfs_dir(sysfs_port), 0)
+  EXPECT_EQ(system_->remove_sysfs_dir(sysfs_port), 0)
       << "error removing intel-fpga-port.0: " << strerror(errno);
   EXPECT_EQ(xfpga_fpgaEnumerate(&filterp, 1, tokens_.data(), 1, &num_matches_),
             FPGA_OK);
   EXPECT_EQ(num_matches_, 0);
+  EXPECT_EQ(fpgaDestroyProperties(&filterp), FPGA_OK);
 }
 
 INSTANTIATE_TEST_CASE_P(enum_c, enum_mock_only,

--- a/testing/xfpga/test_sysfs_c.cpp
+++ b/testing/xfpga/test_sysfs_c.cpp
@@ -169,7 +169,7 @@ TEST_P(sysfsinit_c_p, sysfs_initialize) {
   // define a callback to be used with sysfs_foreach_device
   // this callback is given a map of devices using the sbdf as the key
   // (as a 32-bit number);
-  auto cb = [](sysfs_fpga_device *r, void* data) {
+  auto cb = [](const sysfs_fpga_device *r, void* data) -> fpga_result {
     auto& devs = *reinterpret_cast<std::map<uint64_t, test_device>*>(data);
     auto id = to_uint32(r->segment, r->bus, r->device, r->function);
     auto it = devs.find(id);
@@ -179,6 +179,7 @@ TEST_P(sysfsinit_c_p, sysfs_initialize) {
         devs.erase(id);
       }
     }
+    return FPGA_OK;
   };
 
   // build a map of tests devices where the key is the sbdf as a 32-bit number


### PR DESCRIPTION
* Change xfpa_fpgaEnumerate to use sysfs_foreach_device
* Change sysfs_foreach_device to call
  * sysfs_finalize and sysfs_initialize
  * This in essense resets the discovered devices so that when this fn
    is called, it will start from scratch (and not allow for stale
    internal sysf data structures)
  * This is also protected by a mutex so it will be close to a guarantee
    that none of the devices discovered in one call will be stale -
    there's still a small race condition if a device goes away while
    this function is executing.
* Add remove_sysfs_dir to test_system
  * This will recursively remove a directory under the mock sysfs tree
* Add a unit test to verify that subsequent calls for xfpga_fpgaEnumerate
  will reflect devices as represented under /sys/class/fpga(_region)
* Extend mock_opae_p template class to include a prefix template
  argument to specify if certain function it needs should be a plugin or
  an API function. This is needed to call fpgaDestroyToken or
  xfpga_fpgaDestroyToken.