### PR TITLE
Fix test_system::remove_sysfs.* functions

### DIFF
--- a/testing/mock/mock_opae.h
+++ b/testing/mock/mock_opae.h
@@ -72,6 +72,8 @@ class mock_opae_p : public ::testing::TestWithParam<std::string> {
   virtual void TearDown() override {
     DestroyTokens();
     test_teardown();
+    EXPECT_EQ(system_->remove_sysfs(), 0) << "error removing tmpsysfs: "
+                                          << strerror(errno);
     system_->finalize();
   }
 

--- a/testing/mock/test_system.h
+++ b/testing/mock/test_system.h
@@ -121,8 +121,8 @@ class test_system {
   void initialize();
   void finalize();
   void prepare_syfs(const test_platform &platform);
-  void remove_sysfs();
-  int remove_sysfs_dir(const char *path);
+  int remove_sysfs();
+  int remove_sysfs_dir(const char *path = nullptr);
   std::string get_sysfs_claass_path(const std::string &path);
 
   int open(const std::string &path, int flags);


### PR DESCRIPTION
* Fix the callback function for nftw to do better error handling.
* Change the signature of remove_sysfs_dir to default the path to null
  * Only use the path when appending to the tmp sysfs root
* Change remove_sysfs to call remove_sysfs_dir
  * This removes spawning a separate process