### PR TITLE
tests: fix metadata version in bitstreams

### DIFF
--- a/testing/platform/fpga_hw.cpp
+++ b/testing/platform/fpga_hw.cpp
@@ -81,7 +81,7 @@ const char *skx_mdata =
         }
       ]
      },
-     "platform-name": "MCP"}";
+     "platform-name": "MCP"}"
 )mdata";
 
 const char *rc_mdata =
@@ -100,7 +100,7 @@ const char *rc_mdata =
         }
       ]
      },
-     "platform-name": "PAC"}";
+     "platform-name": "PAC"}"
 )mdata";
 
 static platform_db MOCK_PLATFORMS = {

--- a/testing/platform/fpga_hw.cpp
+++ b/testing/platform/fpga_hw.cpp
@@ -65,7 +65,7 @@ test_device test_device::unknown() {
 
 
 const char *skx_mdata =
-    R"mdata({"version": 640,
+    R"mdata({"version": 1,
    "afu-image":
     {"clock-frequency-high": 312,
      "clock-frequency-low": 156,
@@ -85,7 +85,7 @@ const char *skx_mdata =
 )mdata";
 
 const char *rc_mdata =
-    R"mdata({"version": 112,
+    R"mdata({"version": 1,
    "afu-image":
     {"clock-frequency-high": 312,
      "clock-frequency-low": 156,


### PR DESCRIPTION
We currently use bitstream metadata revision 1.