### PR TITLE
xfpga: revert changes to track sriov attr.

### DIFF
--- a/libopae/plugins/xfpga/sysfs.c
+++ b/libopae/plugins/xfpga/sysfs.c
@@ -324,23 +324,6 @@ STATIC int make_device(sysfs_fpga_device *device, const char *sysfs_class_fpga,
 		return res;
 	}
 
-	res = sysfs_parse_attribute64(device->sysfs_path,
-				      "device/sriov_totalvfs",
-				      &device->sriov_totalvfs);
-	if (res) {
-		FPGA_MSG("Could not parse sriov_totalvfs");
-		return res;
-	}
-
-	res = sysfs_parse_attribute64(device->sysfs_path,
-				      "device/sriov_numvfs",
-				      &device->sriov_numvfs);
-	if (res) {
-		FPGA_MSG("Could not parse sriov_numvfs");
-		return res;
-	}
-
-
 	return find_regions(device);
 }
 

--- a/libopae/plugins/xfpga/sysfs_int.h
+++ b/libopae/plugins/xfpga/sysfs_int.h
@@ -64,8 +64,6 @@ typedef struct _sysfs_fpga_device {
   uint8_t function;
   uint32_t device_id;
   uint32_t vendor_id;
-  uint64_t sriov_totalvfs;
-  uint64_t sriov_numvfs;
 } sysfs_fpga_device;
 
 int sysfs_initialize(void);


### PR DESCRIPTION
Change sysfs discovery to not track sriov attributes because it will
fail when walking a port device on a virtual function.
Will handle sriov differently (in a new pull request)