### PR TITLE
dma.h - remove HW related entries from fpga_dma_properties

### DIFF
--- a/common/include/opae/dma.h
+++ b/common/include/opae/dma.h
@@ -52,12 +52,7 @@ extern "C" {
  * Output of fpgaDMAPropertiesGet.
  */
 typedef struct {
-	uint64_t max_channel_num; /**< Max number of channels that the DMA engine supports */
-	uint64_t max_ring_size;   /**< Max number of buffers that the DMA can hold */
-	uint64_t max_buffer_size; /**< Max size of one buffer */
-	uint64_t addr_alignment_for_dma;    /**< Address alignment requirement for DMA */
-	uint64_t minimum_xfer_size_for_dma; /**< DMA tranfer size should be multiples of this size */
-	uint64_t capabilities_mask;         /**< Bit mask of fpga_dma_transfer_type */
+	uint64_t channel_num; /**< Number of channels that the DMA engine supports */
 	fpga_guid tx_endp_guid[FPGA_DMA_MAX_CLIENT_NUM]; /**< A table of guid of the connected IP to a Tx channels */
 	fpga_guid rx_endp_guid[FPGA_DMA_MAX_CLIENT_NUM]; /**< A table of guid of the connected IP to a Rx channels */
 	uint32_t tx_client_num; /**< Number of tx clients that the DMA is connected to */

--- a/common/include/opae/types_enum.h
+++ b/common/include/opae/types_enum.h
@@ -196,13 +196,13 @@ typedef enum { FPGA_DMA_FEATURE = 2 } fpga_feature_type;
 typedef enum {
 	HOST_MM_TO_FPGA_ST = (1u << 0), /**< streaming, host to AFU */
 	FPGA_ST_TO_HOST_MM = (1u << 1), /**< streaming, AFU to host */
-	FPGA_MM_TO_FPGA_ST =
-		(1u << 2), /**< streaming, FPGA local mem to AFU   */
-	FPGA_ST_TO_FPGA_MM =
-		(1u << 3),	   /**< streaming, AFU to FPGA local mem   */
-	//HOST_TO_FPGA_MM = (1u << 4), /**< Memory mapped FPGA interface       */
-	//FPGA_TO_HOST_MM = (1u << 5), /**< Memory mapped FPGA interface       */
-	//FPGA_TO_FPGA_MM = (1u << 6), /**< Memory mapped FPGA interface       */
+	PEER_MM_to_FPGA_ST = (1u << 2), /**< streaming, PCIe peer device to AFU */
+	FPGA_ST_TO_PEER_MM = (1u << 3), /**< streaming, AFU to PCIe peer device */
+	FPGA_MM_TO_FPGA_ST = (1u << 4), /**< streaming, FPGA local mem to AFU */
+	FPGA_ST_TO_FPGA_MM = (1u << 5),	/**< streaming, AFU to FPGA local mem */
+	//HOST_TO_FPGA_MM = (1u << 6), /**< Memory mapped FPGA interface       */
+	//FPGA_TO_HOST_MM = (1u << 7), /**< Memory mapped FPGA interface       */
+	//FPGA_TO_FPGA_MM = (1u << 8), /**< Memory mapped FPGA interface       */
 	//FPGA_MAX_TRANSFER_TYPE = FPGA_TO_FPGA_MM,
 } fpga_dma_transfer_type;
 


### PR DESCRIPTION
Removing fields from fpga dma properties structure that are HW related and user does not care about