### PR TITLE
fix bug in re_match_(device|region)

### DIFF
--- a/libopae/plugins/xfpga/sysfs.c
+++ b/libopae/plugins/xfpga/sysfs.c
@@ -306,7 +306,7 @@ STATIC fpga_result re_match_device(const char *fmt, char *inpstr, char prefix[],
 		FPGA_ERR("Error copying prefix from string: %s", inpstr);
 		goto out_free;
 	}
-	*(prefix + (ptr - end)) = '\0';
+	*(prefix + (end - ptr)) = '\0';
 	ptr = inpstr + matches[RE_DEVICE_GROUP_NUM].rm_so;
 	errno = 0;
 	*num = strtoul(ptr, NULL, 10);
@@ -373,7 +373,7 @@ STATIC fpga_result re_match_region(const char *fmt, char *inpstr, char type[],
 		FPGA_ERR("Error copying type from string: %s", inpstr);
 		goto out_free;
 	}
-	*(type + (ptr - end)) = '\0';
+	*(type + (end - ptr)) = '\0';
 	ptr = inpstr + matches[RE_REGION_GROUP_NUM].rm_so;
 	errno = 0;
 	*num = strtoul(ptr, NULL, 10);


### PR DESCRIPTION
This fixes a bug in re_match_device and re_match_region where it was
using (ptr-end) when calculating at what point in the string to place a
null byte in to terminate the string.

This was resulting in a negative number and the pointer being
dereferenced pointed to somewhere else in the stack of the calling
function thus corrupting it.

The fix is to swap the pointers to correctly calculate the size of the
string (end-ptr).