### PR TITLE
fix bugs related to use of `realpath`

### DIFF
--- a/libopae/plugins/xfpga/enum.c
+++ b/libopae/plugins/xfpga/enum.c
@@ -77,7 +77,7 @@ STATIC bool matches_filter(const struct dev_list *attr, const fpga_properties fi
 	struct _fpga_properties *_filter = (struct _fpga_properties *)filter;
 	bool res = true;
 	int err = 0;
-	char buffer[SYSFS_PATH_MAX] = {0};
+	char buffer[PATH_MAX] = {0};
 
 	if (pthread_mutex_lock(&_filter->lock)) {
 		FPGA_MSG("Failed to lock filter mutex");
@@ -87,7 +87,7 @@ STATIC bool matches_filter(const struct dev_list *attr, const fpga_properties fi
 	if (FIELD_VALID(_filter, FPGA_PROPERTY_PARENT)) {
 		struct _fpga_token *_parent_tok =
 			(struct _fpga_token *)_filter->parent;
-		char spath[SYSFS_PATH_MAX] = {0};
+		char spath[PATH_MAX] = {0};
 
 		if (FPGA_ACCELERATOR != attr->objtype) {
 			res = false; // Only accelerator can have a parent
@@ -418,7 +418,7 @@ STATIC fpga_result enum_afu(const char *sysfspath, const char *name,
 	int resval = 0;
 	struct stat stats;
 	struct dev_list *pdev;
-	char spath[SYSFS_PATH_MAX];
+	char spath[PATH_MAX];
 	char dpath[DEV_PATH_MAX];
 	uint64_t value = 0;
 	// Make sure it's a directory.

--- a/libopae/plugins/xfpga/reconf.c
+++ b/libopae/plugins/xfpga/reconf.c
@@ -32,6 +32,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <limits.h>
 #include <sys/types.h>
 
 #include "safe_string/safe_string.h"
@@ -188,8 +189,8 @@ free_props:
 // clears port errors
 STATIC fpga_result clear_port_errors(fpga_handle handle)
 {
-	char sysfs_path[SYSFS_PATH_MAX]    = {0};
-	char sysfs_errpath[SYSFS_PATH_MAX] = {0};
+	char sysfs_path[PATH_MAX]         = {0};
+	char sysfs_errpath[SYSFS_PATH_MAX]= {0};
 	fpga_result result                = FPGA_OK;
 	uint64_t error                    = 0 ;
 
@@ -223,7 +224,7 @@ fpga_result set_afu_userclock(fpga_handle handle,
 				uint64_t usrlclock_high,
 				uint64_t usrlclock_low)
 {
-	char sysfs_path[SYSFS_PATH_MAX]    = {0};
+	char sysfs_path[PATH_MAX]         = {0};
 	fpga_result result                = FPGA_OK;
 	uint64_t userclk_high             = 0;
 	uint64_t userclk_low              = 0;

--- a/libopae/plugins/xfpga/reconf.c
+++ b/libopae/plugins/xfpga/reconf.c
@@ -189,10 +189,10 @@ free_props:
 // clears port errors
 STATIC fpga_result clear_port_errors(fpga_handle handle)
 {
-	char sysfs_path[PATH_MAX]         = {0};
-	char sysfs_errpath[SYSFS_PATH_MAX]= {0};
-	fpga_result result                = FPGA_OK;
-	uint64_t error                    = 0 ;
+	char sysfs_path[PATH_MAX]          = {0};
+	char sysfs_errpath[SYSFS_PATH_MAX] = {0};
+	fpga_result result                 = FPGA_OK;
+	uint64_t error                     = 0 ;
 
 	result = get_port_sysfs(handle, sysfs_path);
 	if (result != FPGA_OK) {

--- a/libopae/plugins/xfpga/token_list.c
+++ b/libopae/plugins/xfpga/token_list.c
@@ -179,7 +179,7 @@ struct _fpga_token *token_get_parent(struct _fpga_token *_t)
 {
 	char *p;
 	char spath[SYSFS_PATH_MAX];
-	char rpath[SYSFS_PATH_MAX];
+	char rpath[PATH_MAX];
 	struct token_map *itr;
 	int err = 0;
 	char *rptr = NULL;


### PR DESCRIPTION
Recent changes use `realpath` to get the realpath (without symlinks) to
sysfs nodes and uses that for comparing/identifying certain kinds of
nodes in the OPAE sysfs tree. According to the man page of [realpath](http://man7.org/linux/man-pages/man3/realpath.3.html),
there are bugs and it states that "it is impossible to determine a
suitable size for the output buffer".

This change assures that the buffers that are ultimately used as the
output variable to the call to realpath are of size PATH_MAX
(4096 as defined limits.h).

It has also been observed that calling realpath with a buffer smaller
than PATH_MAX can overflow the buffer even though the lengths of the
resolved paths are ~128.