### PR TITLE
fix samples and add a note to doxygen of c_type fn

### DIFF
--- a/common/include/opae/cxx/core/shared_buffer.h
+++ b/common/include/opae/cxx/core/shared_buffer.h
@@ -87,6 +87,10 @@ class shared_buffer {
   void release();
 
   /** Retrieve the virtual address of the buffer base.
+   *
+   *  @note assiging this to a variable should be done in limited scopes
+   *  as the variable can outlive the shared_buffer object creating the danger
+   *  of a dangling pointer
    */
   volatile uint8_t *c_type() const { return virt_; }
 

--- a/common/include/opae/cxx/core/shared_buffer.h
+++ b/common/include/opae/cxx/core/shared_buffer.h
@@ -88,9 +88,17 @@ class shared_buffer {
 
   /** Retrieve the virtual address of the buffer base.
    *
-   *  @note assiging this to a variable should be done in limited scopes
-   *  as the variable can outlive the shared_buffer object creating the danger
-   *  of a dangling pointer
+   *  @note Instances of a shared buffer can only be created using either
+   *  'allocate' or 'attach' static factory function. Because these
+   *  functions return a shared pointer (std::shared_ptr) to the instance,
+   *  references to an instance are counted automatically by design of the
+   *  shared_ptr class. Calling 'c_type()' function is provided to get access
+   *  to the raw data but isn't used in tracking its reference count.
+   *  Assigning this to a variable should be done in limited scopes as this
+   *  variable can be defined in an outer scope and may outlive the
+   *  shared_buffer object. Once the reference count in the shared_ptr reaches
+   *  zero, the shared_buffer object will be released and deallocated, turning
+   *  any variables assigned from a call to 'c_type()' into dangling pointers.
    */
   volatile uint8_t *c_type() const { return virt_; }
 

--- a/libopaecxx/samples/hello_fpga-1.cpp
+++ b/libopaecxx/samples/hello_fpga-1.cpp
@@ -108,7 +108,7 @@ int main(__attribute__((unused)) int argc,
   // temporarily "borrow" a raw pointer to the buffer
   // status_ptr can be dangling pointer if dsm is the only reference
   // and it is reset or goes out of scope before status_ptr
-  volatile uint8_t *status_ptr = dsm->c_type() + DSM_STATUS_TEST_COMPLETE;
+  volatile uint8_t* status_ptr = dsm->c_type() + DSM_STATUS_TEST_COMPLETE;
   // start the test
   accel->write_csr32(CSR_CTL, 3);
 

--- a/libopaecxx/samples/hello_fpga-1.cpp
+++ b/libopaecxx/samples/hello_fpga-1.cpp
@@ -64,11 +64,11 @@ int main(__attribute__((unused)) int argc,
   std::cout << "Using OPAE C++ Core library version '" << version::as_string()
             << "' build '" << version::build() << "'\n";
   // look for accelerator with NLB0_AFUID
-  auto filter = properties::get();
+  properties::ptr_t filter = properties::get();
   filter->guid.parse(NLB0_AFUID);
   filter->type = FPGA_ACCELERATOR;
 
-  auto tokens = token::enumerate({filter});
+  std::vector<token::ptr_t> tokens = token::enumerate({filter});
 
   // assert we have found at least one
   if (tokens.size() < 1) {
@@ -78,12 +78,14 @@ int main(__attribute__((unused)) int argc,
   token::ptr_t tok = tokens[0];
 
   // open accelerator and map MMIO
-  auto accel = handle::open(tok, FPGA_OPEN_SHARED);
+  handle::ptr_t accel = handle::open(tok, FPGA_OPEN_SHARED);
 
   // allocate buffers
-  auto dsm = shared_buffer::allocate(accel, LPBK1_DSM_SIZE);
-  auto inp = shared_buffer::allocate(accel, LPBK1_BUFFER_ALLOCATION_SIZE);
-  auto out = shared_buffer::allocate(accel, LPBK1_BUFFER_ALLOCATION_SIZE);
+  shared_buffer::ptr_t dsm = shared_buffer::allocate(accel, LPBK1_DSM_SIZE);
+  shared_buffer::ptr_t inp =
+      shared_buffer::allocate(accel, LPBK1_BUFFER_ALLOCATION_SIZE);
+  shared_buffer::ptr_t out =
+      shared_buffer::allocate(accel, LPBK1_BUFFER_ALLOCATION_SIZE);
 
   std::cout << "Running Test\n";
 
@@ -103,7 +105,10 @@ int main(__attribute__((unused)) int argc,
   accel->write_csr32(CSR_CFG, 0x42000);
 
   // get ptr to device status memory - test complete
-  auto status_ptr = dsm->c_type() + DSM_STATUS_TEST_COMPLETE;
+  // temporarily "borrow" a raw pointer to the buffer
+  // status_ptr can be dangling pointer if dsm is the only reference
+  // and it is reset or goes out of scope before status_ptr
+  volatile uint8_t *status_ptr = dsm->c_type() + DSM_STATUS_TEST_COMPLETE;
   // start the test
   accel->write_csr32(CSR_CTL, 3);
 
@@ -116,8 +121,8 @@ int main(__attribute__((unused)) int argc,
   accel->write_csr32(CSR_CTL, 7);
 
   // check output buffer contents
-  auto mm = std::mismatch(inp->c_type(), inp->c_type() + LPBK1_BUFFER_SIZE,
-                          out->c_type());
+  std::pair<volatile uint8_t*, volatile uint8_t*> mm = std::mismatch(
+      inp->c_type(), inp->c_type() + LPBK1_BUFFER_SIZE, out->c_type());
   if (mm.second < out->c_type() + LPBK1_BUFFER_SIZE) {
     std::cerr << "output does NOT match input at offset: "
               << (mm.second - out->c_type()) << "\n";


### PR DESCRIPTION
Fix the C++ sample for hello_fpga-1.cpp to use explicit types instead of
the `auto` keyword. This is done to make it clearer as to the types of
objects being created.

Add a note in shared_buffer::c_type doxygen markup to warn developers of
the dangers of _stealing_ a raw pointer from the shared_buffer object.