### PR TITLE
opae-c: extend sysobject API, allow container

### DIFF
--- a/common/include/opae/sysobject.h
+++ b/common/include/opae/sysobject.h
@@ -41,8 +41,8 @@ extern "C" {
 
 /**
  * @brief Create an `fpga_object` data structures. An `fpga_object`
- * is a handle to an FPGA resource which can be an attribute or register or
- * driver attribute. This object is read-only.
+ * is a handle to an FPGA resource which can be an attribute, register or
+ * a container. This object is read-only.
  *
  * @param[in] token Token identifying a resource (accelerator or device)
  * @param[in] name A key identifying an object belonging to a resource.
@@ -68,8 +68,8 @@ fpga_result fpgaTokenGetObject(fpga_token token, const char *name,
 
 /**
  * @brief Create an `fpga_object` data structure from a handle.
- * An `fpga_object` is a handle to an FPGA resource which can be an attribute
- * or register.  This object has read/write access..
+ * An `fpga_object` is a handle to an FPGA resource which can be an attribute,
+ * register, or container.  This object has read/write access..
  *
  * @param[in] handle Handle identifying a resource (accelerator or device)
  * @param[in] name A key identifying an object belonging to a resource.
@@ -95,7 +95,7 @@ fpga_result fpgaHandleGetObject(fpga_handle handle, const char *name,
 
 /**
  * @brief Create an `fpga_object` data structure from a parent object.  An
- * `fpga_object` is a handle to an FPGA resource which can be an attribute or,
+ * `fpga_object` is a handle to an FPGA resource which can be an attribute,
  * register, or container.  If the parent object was created with a handle,
  * then the new object will inherit the handle allowing it to have read-write
  * access to the object data.
@@ -126,9 +126,9 @@ fpga_result fpgaObjectGetObject(fpga_object parent, const char *name,
 /**
  * @brief Create an `fpga_object` data structure from a parent object using a
  * given index.  An `fpga_object` is a handle to an FPGA resource which can be
- * an attribute or, register, or container.  If the parent object was created
- * with a handle, then the new object will inherit the handle allowing it to
- * have read-write access to the object data.
+ * an attribute, register, or container.  If the parent object was created with
+ * a handle, then the new object will inherit the handle allowing it to have
+ * read-write access to the object data.
  *
  * @param[in] parent A parent container 'fpga_object'
  * @param[in] idx A positive index less than the size reported by the parent.

--- a/common/include/opae/sysobject.h
+++ b/common/include/opae/sysobject.h
@@ -94,11 +94,11 @@ fpga_result fpgaHandleGetObject(fpga_handle handle, const char *name,
 				fpga_object *object, int flags);
 
 /**
- * @brief Create an `fpga_object` data structure from a parent object.
- * An `fpga_object` is a handle to an FPGA resource which can be an attribute
- * or a register. If the parent object was created with a handle, then the new
- * object will inherit the handle allowing it to have read-write access to the
- * object data.
+ * @brief Create an `fpga_object` data structure from a parent object.  An
+ * `fpga_object` is a handle to an FPGA resource which can be an attribute or,
+ * register, or container.  If the parent object was created with a handle,
+ * then the new object will inherit the handle allowing it to have read-write
+ * access to the object data.
  *
  * @param[in] parent A parent container `fpga_object`.
  * @param[in] name A key identifying a sub-object of the parent container.
@@ -122,6 +122,38 @@ fpga_result fpgaHandleGetObject(fpga_handle handle, const char *name,
  */
 fpga_result fpgaObjectGetObject(fpga_object parent, const char *name,
 				fpga_object *object, int flags);
+
+/**
+ * @brief Create an `fpga_object` data structure from a parent object using a
+ * given index.  An `fpga_object` is a handle to an FPGA resource which can be
+ * an attribute or, register, or container.  If the parent object was created
+ * with a handle, then the new object will inherit the handle allowing it to
+ * have read-write access to the object data.
+ *
+ * @param[in] parent A parent container 'fpga_object'
+ * @param[in] idx A positive index less than the size reported by the parent.
+ * @param[out] object Pointer to memory to store the object in.
+ *
+ * @return FPGA_OK on success. FPGA_INVALID_PARAM if any of the supplied
+ * parameters is invalid - this includes a parent object that is not a
+ * container object. FPGA_NOT_FOUND if an object cannot be found with the given
+ * key. FPGA_NOT_SUPPORTED if this function is not supported by the current
+ * implementation of this API.
+ */
+fpga_result fpgaObjectGetObjectAt(fpga_object parent, size_t idx,
+				  fpga_object *object);
+/**
+ * @brief Get the sysobject type (container or attribute)
+ *
+ * @param[in] obj An fpga_object instance
+ * @param[out] type The type of object (FPGA_OBJECT_CONTAINER or
+ * FPGA_OBJECT_ATTRIBUTE)
+ *
+ * @return FPGA_OK on success, FPGA_INVALID_PARAM if any of the supplied
+ * parameters are null or invalid
+ */
+fpga_result fpgaObjectGetType(fpga_object obj, enum fpga_sysobject_type *type);
+
 /**
  * @brief Free memory used for the fpga_object data structure
  *

--- a/common/include/opae/types_enum.h
+++ b/common/include/opae/types_enum.h
@@ -159,9 +159,9 @@ enum fpga_sysobject_flags {
 
 enum fpga_sysobject_type {
 	FPGA_OBJECT_CONTAINER =
-		(1u << 0), /** represents a group of objects */
+		(1u << 0), /**< Represents a group of objects */
 	FPGA_OBJECT_ATTRIBUTE =
-		(1u << 1) /** an object with an attribute value that can be
+		(1u << 1) /**< An object with an attribute value that can be
 			       read/written */
 };
 

--- a/common/include/opae/types_enum.h
+++ b/common/include/opae/types_enum.h
@@ -145,13 +145,25 @@ enum fpga_reconf_flags {
 };
 
 enum fpga_sysobject_flags {
-  FPGA_OBJECT_SYNC = (1u << 0), /**< Synchronize data from driver */
-  FPGA_OBJECT_GLOB = (1u << 1), /**< Treat names as glob expressions */
-  FPGA_OBJECT_RAW  = (1u << 2), /**< Read or write object data as raw bytes */
-  FPGA_OBJECT_RECURSE_ONE = (1u << 3), /**< Create subobjects one level down from containers */
-  FPGA_OBJECT_RECURSE_ALL = (1u << 4) /**< Create subobjects all levels from from containers */
+	FPGA_OBJECT_SYNC = (1u << 0), /**< Synchronize data from driver */
+	FPGA_OBJECT_GLOB = (1u << 1), /**< Treat names as glob expressions */
+	FPGA_OBJECT_RAW =
+		(1u << 2), /**< Read or write object data as raw bytes */
+	FPGA_OBJECT_RECURSE_ONE =
+		(1u
+		 << 3), /**< Create subobjects one level down from containers */
+	FPGA_OBJECT_RECURSE_ALL =
+		(1u
+		 << 4) /**< Create subobjects all levels from from containers */
 };
 
+enum fpga_sysobject_type {
+	FPGA_OBJECT_CONTAINER =
+		(1u << 0), /** represents a group of objects */
+	FPGA_OBJECT_ATTRIBUTE =
+		(1u << 1) /** an object with an attribute value that can be
+			       read/written */
+};
 
 /** fpga metrics types
 * opae defines power,thermal, performance counter

--- a/libopae/plugins/xfpga/sysfs.c
+++ b/libopae/plugins/xfpga/sysfs.c
@@ -1832,7 +1832,7 @@ fpga_result opae_glob_paths(const char *path, size_t found_max, char *found[],
 			if (!found[i]) {
 				// we had an error duplicating the string
 				// undo what we've duplicated so far
-				while(i) {
+				while (i) {
 					free(found[--i]);
 					found[i] = NULL;
 				}

--- a/libopae/plugins/xfpga/sysfs.c
+++ b/libopae/plugins/xfpga/sysfs.c
@@ -1760,7 +1760,7 @@ fpga_result destroy_fpga_object(struct _fpga_object *obj)
 	fpga_result res = FPGA_OK;
 	if (pthread_mutex_destroy(&obj->lock)) {
 		FPGA_ERR("Error destroying mutex");
-		return FPGA_EXCEPTION;
+		res = FPGA_EXCEPTION;
 	}
 	FREE_IF(obj->path);
 	FREE_IF(obj->name);
@@ -1775,7 +1775,7 @@ fpga_result destroy_fpga_object(struct _fpga_object *obj)
 	}
 	FREE_IF(obj->objects);
 	free(obj);
-	return FPGA_OK;
+	return res;
 }
 
 fpga_result opae_glob_path(char *path)

--- a/libopae/plugins/xfpga/sysfs.c
+++ b/libopae/plugins/xfpga/sysfs.c
@@ -1758,10 +1758,6 @@ out_err:
 fpga_result destroy_fpga_object(struct _fpga_object *obj)
 {
 	fpga_result res = FPGA_OK;
-	if (pthread_mutex_destroy(&obj->lock)) {
-		FPGA_ERR("Error destroying mutex");
-		res = FPGA_EXCEPTION;
-	}
 	FREE_IF(obj->path);
 	FREE_IF(obj->name);
 	FREE_IF(obj->buffer);
@@ -1774,6 +1770,15 @@ fpga_result destroy_fpga_object(struct _fpga_object *obj)
 		}
 	}
 	FREE_IF(obj->objects);
+
+	if (pthread_mutex_unlock(&obj->lock)) {
+		FPGA_MSG("pthread_mutex_unlock() failed");
+	}
+
+	if (pthread_mutex_destroy(&obj->lock)) {
+		FPGA_ERR("Error destroying mutex");
+		res = FPGA_EXCEPTION;
+	}
 	free(obj);
 	return res;
 }

--- a/libopae/plugins/xfpga/sysfs_int.h
+++ b/libopae/plugins/xfpga/sysfs_int.h
@@ -128,6 +128,7 @@ fpga_result cat_sysfs_path(char *dest, const char *path);
 fpga_result cat_handle_sysfs_path(char *dest, fpga_handle handle,
 				  const char *path);
 struct _fpga_object *alloc_fpga_object(const char *sysfspath, const char *name);
+fpga_result destroy_fpga_object(struct _fpga_object *obj);
 fpga_result sync_object(fpga_object object);
 fpga_result make_sysfs_group(char *sysfspath, const char *name,
 			     fpga_object *object, int flags, fpga_handle handle);

--- a/libopae/plugins/xfpga/sysobject.c
+++ b/libopae/plugins/xfpga/sysobject.c
@@ -189,6 +189,10 @@ fpga_result __FPGA_API__ xfpga_fpgaDestroyObject(fpga_object *obj)
 		return FPGA_INVALID_PARAM;
 	}
 	struct _fpga_object *_obj = (struct _fpga_object *)*obj;
+	if (pthread_mutex_lock(&_obj->lock)) {
+		FPGA_ERR("pthread_mutex_lock() failed");
+	}
+
 	res = destroy_fpga_object(_obj);
 	*obj = NULL;
 	return res;

--- a/libopae/plugins/xfpga/sysobject.c
+++ b/libopae/plugins/xfpga/sysobject.c
@@ -39,13 +39,6 @@
 #include <opae/sysobject.h>
 #include <opae/log.h>
 
-#define FREE_IF(var)                                                           \
-	do {                                                                   \
-		if (var) {                                                     \
-			free(var);                                             \
-			var = NULL;                                            \
-		}                                                              \
-	} while (false);
 
 #define VALIDATE_NAME(_N)                                                      \
 	do {                                                                   \
@@ -120,6 +113,44 @@ fpga_result __FPGA_API__ xfpga_fpgaObjectGetObject(fpga_object parent, const cha
 	return make_sysfs_object(objpath, name, object, flags, _obj->handle);
 }
 
+fpga_result __FPGA_API__ xfpga_fpgaCloneObject(fpga_object src, fpga_object *dst)
+{
+	size_t i = 0;
+	fpga_result res = FPGA_OK;
+	ASSERT_NOT_NULL(src);
+	ASSERT_NOT_NULL(dst);
+	struct _fpga_object *_src = (struct _fpga_object *)src;
+	struct _fpga_object *_dst = alloc_fpga_object(_src->path, _src->name);
+	if (!_dst) {
+		return FPGA_NO_MEMORY;
+	}
+	_dst->handle = _src->handle;
+	_dst->perm = _src->perm;
+	_dst->size = _src->size;
+	_dst->max_size = _src->max_size;
+	if (_src->type == FPGA_SYSFS_FILE) {
+		memcpy_s(_dst->buffer, _dst->max_size, _src->buffer,
+			 _src->max_size);
+	} else {
+		_dst->buffer = NULL;
+		_dst->objects = calloc(_src->size, sizeof(fpga_object));
+		for (i = 0; i < _src->size; ++i) {
+			res = xfpga_fpgaCloneObject(_src->objects[i],
+						    &_dst->objects[i]);
+			if (res) {
+				_dst->size = i;
+				goto out_err;
+			}
+		}
+	}
+	*dst = _dst;
+	return res;
+out_err:
+	destroy_fpga_object(_dst);
+	*dst = NULL;
+	return res;
+}
+
 fpga_result __FPGA_API__ xfpga_fpgaObjectGetObjectAt(fpga_object parent,
 						     size_t idx,
 						     fpga_object *object)
@@ -133,30 +164,20 @@ fpga_result __FPGA_API__ xfpga_fpgaObjectGetObjectAt(fpga_object parent,
 	if (idx >= _obj->size) {
 		return FPGA_INVALID_PARAM;
 	}
-	*object = _obj->objects[idx];
-	return FPGA_OK;
+	return xfpga_fpgaCloneObject(_obj->objects[idx], object);
 }
 
 fpga_result __FPGA_API__ xfpga_fpgaDestroyObject(fpga_object *obj)
 {
+	fpga_result res = FPGA_OK;
 	if (NULL == obj || NULL == *obj) {
 		FPGA_MSG("Invalid object pointer");
 		return FPGA_INVALID_PARAM;
 	}
 	struct _fpga_object *_obj = (struct _fpga_object *)*obj;
-
-	FREE_IF(_obj->path);
-	FREE_IF(_obj->name);
-	FREE_IF(_obj->buffer);
-	while (_obj->size && _obj->objects) {
-		if (xfpga_fpgaDestroyObject(&_obj->objects[--_obj->size])) {
-			FPGA_ERR("Error freeing subobject");
-		}
-	}
-	FREE_IF(_obj->objects);
-	free(_obj);
+	res = destroy_fpga_object(_obj);
 	*obj = NULL;
-	return FPGA_OK;
+	return res;
 }
 
 fpga_result __FPGA_API__ xfpga_fpgaObjectGetSize(fpga_object obj,

--- a/libopae/plugins/xfpga/sysobject.c
+++ b/libopae/plugins/xfpga/sysobject.c
@@ -179,7 +179,6 @@ fpga_result __FPGA_API__ xfpga_fpgaObjectGetObjectAt(fpga_object parent,
 		FPGA_ERR("pthread_mutex_unlock() failed");
 	}
 	return res;
-
 }
 
 fpga_result __FPGA_API__ xfpga_fpgaDestroyObject(fpga_object *obj)
@@ -328,6 +327,11 @@ fpga_result __FPGA_API__ xfpga_fpgaObjectGetType(fpga_object obj,
 	struct _fpga_object *_obj = (struct _fpga_object *)obj;
 	ASSERT_NOT_NULL(obj);
 	ASSERT_NOT_NULL(type);
+	if (pthread_mutex_lock(&_obj->lock)) {
+		FPGA_ERR("pthread_mutex_lock() failed");
+		return FPGA_EXCEPTION;
+	}
+
 	switch (_obj->type) {
 	case FPGA_SYSFS_DIR:
 	case FPGA_SYSFS_LIST:
@@ -339,6 +343,11 @@ fpga_result __FPGA_API__ xfpga_fpgaObjectGetType(fpga_object obj,
 	default:
 		res = FPGA_INVALID_PARAM;
 	}
+
+	if (pthread_mutex_unlock(&_obj->lock)) {
+		FPGA_ERR("pthread_mutex_unlock() failed");
+	}
+
 	return res;
 }
 
@@ -349,9 +358,19 @@ fpga_result __FPGA_API__ xfpga_fpgaObjectGetName(fpga_object obj, char *name,
 	struct _fpga_object *_obj = (struct _fpga_object *)obj;
 	ASSERT_NOT_NULL(obj);
 	ASSERT_NOT_NULL(name);
+	if (pthread_mutex_lock(&_obj->lock)) {
+		FPGA_ERR("pthread_mutex_lock() failed");
+		return FPGA_EXCEPTION;
+	}
+
 	ASSERT_NOT_NULL(_obj->name);
 	if (strncpy_s(name, max_len, _obj->name, strlen(_obj->name))) {
 		res = FPGA_EXCEPTION;
 	}
+
+	if (pthread_mutex_unlock(&_obj->lock)) {
+		FPGA_ERR("pthread_mutex_unlock() failed");
+	}
+
 	return res;
 }

--- a/libopae/plugins/xfpga/sysobject.c
+++ b/libopae/plugins/xfpga/sysobject.c
@@ -134,6 +134,10 @@ fpga_result __FPGA_API__ xfpga_fpgaCloneObject(fpga_object src, fpga_object *dst
 	} else {
 		_dst->buffer = NULL;
 		_dst->objects = calloc(_src->size, sizeof(fpga_object));
+		if (!_dst->objects) {
+			res = FPGA_NO_MEMORY;
+			goto out_err;
+		}
 		for (i = 0; i < _src->size; ++i) {
 			res = xfpga_fpgaCloneObject(_src->objects[i],
 						    &_dst->objects[i]);

--- a/libopae/plugins/xfpga/types_int.h
+++ b/libopae/plugins/xfpga/types_int.h
@@ -35,6 +35,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <limits.h>
 #include <pthread.h>
 #include <opae/types.h>
 #include <opae/sysobject.h>
@@ -220,7 +221,11 @@ struct token_map {
 	struct token_map *next;
 };
 
-typedef enum { FPGA_SYSFS_DIR = 0, FPGA_SYSFS_FILE } fpga_sysfs_type;
+typedef enum {
+	FPGA_SYSFS_DIR = 0,
+	FPGA_SYSFS_LIST,
+	FPGA_SYSFS_FILE
+} fpga_sysfs_type;
 
 struct _fpga_object {
 	pthread_mutex_t lock;
@@ -235,6 +240,7 @@ struct _fpga_object {
 	fpga_object *objects;
 };
 
+typedef char max_path_t[PATH_MAX];
 
 #ifdef __cplusplus
 }

--- a/libopae/plugins/xfpga/xfpga.h
+++ b/libopae/plugins/xfpga/xfpga.h
@@ -104,7 +104,13 @@ fpga_result xfpga_fpgaHandleGetObject(fpga_token handle, const char *name,
 				      fpga_object *object, int flags);
 fpga_result xfpga_fpgaObjectGetObject(fpga_object parent, const char *name,
 				      fpga_object *object, int flags);
+fpga_result xfpga_fpgaObjectGetObjectAt(fpga_object parent, size_t idx,
+					fpga_object *object);
 fpga_result xfpga_fpgaDestroyObject(fpga_object *obj);
+fpga_result xfpga_fpgaObjectGetType(fpga_object obj,
+				    enum fpga_sysobject_type *type);
+fpga_result xfpga_fpgaObjectGetName(fpga_object obj, char *name,
+				    size_t max_len);
 fpga_result xfpga_fpgaObjectGetSize(fpga_object obj, uint32_t *value,
 				    int flags);
 fpga_result xfpga_fpgaObjectRead(fpga_object obj, uint8_t *buffer,

--- a/platforms/platform_if/rtl/device_cfg/ccip_cfg_pkg.sv
+++ b/platforms/platform_if/rtl/device_cfg/ccip_cfg_pkg.sv
@@ -52,7 +52,9 @@ package ccip_cfg_pkg;
     typedef enum
     {
         C0_REQ_RDLINE_S = 1,
-        C0_REQ_RDLINE_I = 2
+        C0_REQ_RDLINE_I = 2,
+        C0_REQ_RDLSPEC_S = 4,
+        C0_REQ_RDLSPEC_I = 8
     }
     e_c0_req;
 

--- a/testing/xfpga/test_sysfs_c.cpp
+++ b/testing/xfpga/test_sysfs_c.cpp
@@ -702,17 +702,20 @@ TEST_P(sysfs_c_mock_p, glob_bitstream_objs) {
                                      FPGA_OBJECT_GLOB),
             FPGA_OK);
   enum fpga_sysobject_type type;
-  ASSERT_EQ(xfpga_fpgaObjectGetType(container, &type), FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaObjectGetType(container, &type), FPGA_OK);
   EXPECT_EQ(type, FPGA_OBJECT_CONTAINER);
   uint32_t sz = 0;
-  ASSERT_EQ(xfpga_fpgaObjectGetSize(container, &sz, 0), FPGA_OK);
-  ASSERT_EQ(sz, 2);
+  EXPECT_EQ(xfpga_fpgaObjectGetSize(container, &sz, 0), FPGA_OK);
+  EXPECT_EQ(sz, 2);
   EXPECT_EQ(xfpga_fpgaObjectGetObjectAt(container, 0, &bitstream1), FPGA_OK);
   EXPECT_EQ(xfpga_fpgaObjectGetObjectAt(container, 1, &bitstream2), FPGA_OK);
   char name1[64] = {'\0'};
   char name2[64] = {'\0'};
   EXPECT_EQ(xfpga_fpgaObjectGetName(bitstream1, name1, sizeof(name1)), FPGA_OK);
   EXPECT_EQ(xfpga_fpgaObjectGetName(bitstream2, name2, sizeof(name2)), FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&bitstream1), FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&bitstream2), FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaDestroyObject(&container), FPGA_OK);
 }
 
 /**

--- a/testing/xfpga/test_sysfs_c.cpp
+++ b/testing/xfpga/test_sysfs_c.cpp
@@ -38,7 +38,7 @@ fpga_result sysfs_get_bitstream_id(int, int, uint64_t *);
 fpga_result sysfs_sbdf_from_path(const char *, int *, int *, int *, int *);
 fpga_result opae_glob_path(char *);
 fpga_result opae_glob_paths(const char *path, size_t found_max,
-                            max_path_t found[], size_t *num_found);
+                            char *found[], size_t *num_found);
 fpga_result make_sysfs_group(char *, const char *, fpga_object *, int,
                              fpga_handle);
 ssize_t eintr_write(int, void *, size_t);
@@ -432,12 +432,17 @@ TEST_P(sysfs_c_p, glob_tests) {
 }
 
 TEST_P(sysfs_c_p, glob_paths) {
-  max_path_t paths[16];
+  char *paths[16];
   auto bitstream_glob = sysfs_fme + "/bitstream*";
   size_t found = 0;
   ASSERT_EQ(opae_glob_paths(bitstream_glob.c_str(), 16, paths, &found),
             FPGA_OK);
   EXPECT_EQ(found, 2);
+  // opae_glob_paths allocates memory for each path found
+  // let's free it here since we don't need it any longer
+  for (int i = 0; i < found; ++i) {
+    free(paths[i]);
+  }
 }
 
 /**

--- a/testing/xfpga/test_sysfs_c.cpp
+++ b/testing/xfpga/test_sysfs_c.cpp
@@ -37,6 +37,8 @@ fpga_result sysfs_get_slots(int, int, uint32_t *);
 fpga_result sysfs_get_bitstream_id(int, int, uint64_t *);
 fpga_result sysfs_sbdf_from_path(const char *, int *, int *, int *, int *);
 fpga_result opae_glob_path(char *);
+fpga_result opae_glob_paths(const char *path, size_t found_max,
+                            max_path_t found[], size_t *num_found);
 fpga_result make_sysfs_group(char *, const char *, fpga_object *, int,
                              fpga_handle);
 ssize_t eintr_write(int, void *, size_t);
@@ -429,6 +431,15 @@ TEST_P(sysfs_c_p, glob_tests) {
   EXPECT_EQ(FPGA_NOT_FOUND, res);
 }
 
+TEST_P(sysfs_c_p, glob_paths) {
+  max_path_t paths[16];
+  auto bitstream_glob = sysfs_fme + "/bitstream*";
+  size_t found = 0;
+  ASSERT_EQ(opae_glob_paths(bitstream_glob.c_str(), 16, paths, &found),
+            FPGA_OK);
+  EXPECT_EQ(found, 2);
+}
+
 /**
 * @test    cat_sysfs_path_errors
 * @details
@@ -683,6 +694,25 @@ TEST_P(sysfs_c_mock_p, make_object_glob) {
                               FPGA_OBJECT_GLOB, 0),
             FPGA_OK);
   EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
+}
+
+TEST_P(sysfs_c_mock_p, glob_bitstream_objs) {
+  fpga_object container, bitstream1, bitstream2;
+  ASSERT_EQ(xfpga_fpgaTokenGetObject(tokens_[0], "bitstream*", &container,
+                                     FPGA_OBJECT_GLOB),
+            FPGA_OK);
+  enum fpga_sysobject_type type;
+  ASSERT_EQ(xfpga_fpgaObjectGetType(container, &type), FPGA_OK);
+  EXPECT_EQ(type, FPGA_OBJECT_CONTAINER);
+  uint32_t sz = 0;
+  ASSERT_EQ(xfpga_fpgaObjectGetSize(container, &sz, 0), FPGA_OK);
+  ASSERT_EQ(sz, 2);
+  EXPECT_EQ(xfpga_fpgaObjectGetObjectAt(container, 0, &bitstream1), FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaObjectGetObjectAt(container, 1, &bitstream2), FPGA_OK);
+  char name1[64] = {'\0'};
+  char name2[64] = {'\0'};
+  EXPECT_EQ(xfpga_fpgaObjectGetName(bitstream1, name1, sizeof(name1)), FPGA_OK);
+  EXPECT_EQ(xfpga_fpgaObjectGetName(bitstream2, name2, sizeof(name2)), FPGA_OK);
 }
 
 /**


### PR DESCRIPTION
* Add a new API level enumeration, fpga_sysobject_type, to indicate if
an object is a system attribute (one that can be read or written) or a
container (one that contains other objects)
* Add APIs to access the sysobject type and to get a contained object by
index
* Add opae_glob_paths internal function to help glob patterns that
yield multiple results
* Add make_sysfs_array internal function that creates a container object
of objects from a glob pattern that yields multiple results
* Add sysfs unit tests
* TODO: Add opae-c plugin implementation