### PR TITLE
libbitstream: metadata version 640 defaults to 1

### DIFF
--- a/libbitstream/bitstream.c
+++ b/libbitstream/bitstream.c
@@ -172,6 +172,11 @@ STATIC void *opae_bitstream_parse_metadata(const char *metadata,
 
 	switch (*version) {
 
+	// Some invalid GBS's around the BBS 6.4.0 era
+	// incorrectly set the metadata version to 640.
+	// Allow 640 to serve as an alias for 1.
+	case 640:
+		*version = 1;
 	case 1:
 		parsed = opae_bitstream_parse_metadata_v1(root,
 							  pr_interface_id);


### PR DESCRIPTION
Some errant GBS's around BBS 6.4.0 timeframe were created with bitstream
metadata version set to 640. Allow 640 to serve as an alias for version
1 to enable these bitstreams.