### PR TITLE
Improve ASE simulation of fpgaPrepareBuffer() failures.

### DIFF
--- a/ase/api/src/buffer.c
+++ b/ase/api/src/buffer.c
@@ -200,7 +200,7 @@ static fpga_result buffer_release(void *addr, uint64_t len)
  * Confirm that a page is mapped at vaddr and that it is at least
  * req_page_bytes.
  */
-static fpga_result check_mapped_page(void* vaddr, size_t req_page_bytes)
+static fpga_result check_mapped_page(void *vaddr, size_t req_page_bytes)
 {
 	char line[MAPS_BUF_SZ];
 	uint64_t addr = (uint64_t)vaddr;
@@ -216,8 +216,8 @@ static fpga_result check_mapped_page(void* vaddr, size_t req_page_bytes)
 
 	while (fgets(line, MAPS_BUF_SZ, f)) {
 		unsigned long long start, end;
-		char* tmp0;
-		char* tmp1;
+		char *tmp0;
+		char *tmp1;
 
 		// Range entries begin with <start addr>-<end addr>
 		start = strtoll(line, &tmp0, 16);
@@ -233,8 +233,7 @@ static fpga_result check_mapped_page(void* vaddr, size_t req_page_bytes)
 			continue;
 		}
 
-		while (fgets(line, MAPS_BUF_SZ, f))
-		{
+		while (fgets(line, MAPS_BUF_SZ, f)) {
 			// Look for KernelPageSize
 			unsigned page_kb;
 			int ret = sscanf_s_u(line, "KernelPageSize: %d kB", &page_kb);
@@ -321,7 +320,7 @@ fpga_result __FPGA_API__ fpgaPrepareBuffer(fpga_handle handle, uint64_t len,
 			result = FPGA_INVALID_PARAM;
 			goto out_unlock;
 		}
-        /* Does the page exist? */
+		/* Does the page exist? */
 		if (FPGA_OK != check_mapped_page(*buf_addr, len)) {
 			FPGA_MSG("Preallocated buffer does not exist or the page is too small");
 			result = FPGA_INVALID_PARAM;

--- a/ase/sw/ase_common.h
+++ b/ase/sw/ase_common.h
@@ -537,6 +537,7 @@ extern "C" {
 	void remove_spaces(char *);
 	void remove_tabs(char *);
 	void remove_newline(char *);
+	int sscanf_s_u(const char *, const char *, unsigned *);
 	int sscanf_s_ii(const char *, const char *, int *, int *);
 	int fscanf_s_i(FILE *, const char *, int *);
 	unsigned int parse_format(const char *format, char pformatList[], unsigned int maxFormats);

--- a/ase/sw/ase_strings.c
+++ b/ase/sw/ase_strings.c
@@ -337,6 +337,27 @@ check_integer_format(const char format)
 }
 
 
+int sscanf_s_u(const char *src, const char *format, unsigned *a)
+{
+	char pformatList[MAX_FORMAT_ELEMENTS];
+	unsigned int index = 0;
+
+	// Determine the number of format options in the format string
+	unsigned int  nfo = parse_format(format, &pformatList[0], MAX_FORMAT_ELEMENTS);
+
+	// Check that there are not too many format options
+	if (nfo != 1) {
+		return ESBADFMT;
+	}
+	// Check that the format is for an integer type
+	if (check_integer_format(pformatList[index]) == 0) {
+		return ESFMTTYP;
+	}
+
+	return sscanf(src, format, a);
+}
+
+
 int sscanf_s_ii(const char *src, const char *format, int *a, int *b)
 {
 	char pformatList[MAX_FORMAT_ELEMENTS];


### PR DESCRIPTION
- When fpgaPrepareBuffer() is called in preallocated mode it should
  fail when there is no page mapped at the buffer address.
- MPF's new VTP speculative mode depends on this behavior.