### PR TITLE
libbitstream: allow fields to be int or double

### DIFF
--- a/libbitstream/bits_utils.c
+++ b/libbitstream/bits_utils.c
@@ -94,11 +94,30 @@ fpga_result opae_bitstream_get_json_int(json_object *parent,
 	}
 
 	if (!json_object_is_type(obj, json_type_int)) {
-		OPAE_ERR("metadata: \"%s\" key not int", name);
 		return FPGA_EXCEPTION;
 	}
 
 	*value = json_object_get_int(obj);
+	return FPGA_OK;
+}
+
+fpga_result opae_bitstream_get_json_double(json_object *parent,
+					   const char *name,
+					   double *value)
+{
+	json_object *obj = NULL;
+
+	if (!json_object_object_get_ex(parent,
+				       name,
+				       &obj)) {
+		return FPGA_EXCEPTION;
+	}
+
+	if (!json_object_is_type(obj, json_type_double)) {
+		return FPGA_EXCEPTION;
+	}
+
+	*value = json_object_get_double(obj);
 	return FPGA_OK;
 }
 

--- a/libbitstream/bits_utils.h
+++ b/libbitstream/bits_utils.h
@@ -28,7 +28,8 @@
  * @file bits_utils.h
  * @brief Utility functions for GBS metadata parsing.
  *
- * These functions extract basic types (strings, integers)
+ * These functions extract basic types (strings,
+ * integers, doubles)
  * from the given JSON object.
  *
  */
@@ -77,6 +78,20 @@ fpga_result opae_bitstream_get_json_string(json_object *parent,
 fpga_result opae_bitstream_get_json_int(json_object *parent,
 					const char *name,
 					int *value);
+
+/**
+ * Populate double value from JSON object.
+ *
+ * @param[in] parent The JSON object in which to search for `name`.
+ * @param[in] name The search key.
+ * @param[out] value Receives the double value.
+ *
+ * @returns FPGA_OK on success. FPGA_EXCEPTION if `name`
+ * is not found or if `name` is not a key of type double.
+ */ 
+fpga_result opae_bitstream_get_json_double(json_object *parent,
+					   const char *name,
+					   double *value);
 
 #define OPAE_BITSTREAM_PATH_NO_PARENT  0x00000001
 #define OPAE_BITSTREAM_PATH_NO_SYMLINK 0x00000002

--- a/libbitstream/metadatav1.c
+++ b/libbitstream/metadatav1.c
@@ -77,32 +77,59 @@ STATIC fpga_result opae_bitstream_parse_afu_image_v1(json_object *j_afu_image,
 	fpga_result res;
 	json_object *j_accelerator_clusters = NULL;
 	int i = 0;
+	int ival;
 
-	res = opae_bitstream_get_json_int(j_afu_image,
-					  "clock-frequency-high",
-					  &img->clock_frequency_high);
+	res = opae_bitstream_get_json_double(j_afu_image,
+					     "clock-frequency-high",
+					     &img->clock_frequency_high);
 	if (res != FPGA_OK) {
-		// Some errant bitstreams omit the "clock-frequency-high" key.
-		// Allow it to be optional for now.
-		OPAE_MSG("metadata: missing \"clock-frequency-high\" key");
+		ival = 0;
+		res = opae_bitstream_get_json_int(j_afu_image,
+						  "clock-frequency-high",
+						  &ival);
+		img->clock_frequency_high = (double)ival;
+		if (res != FPGA_OK) {
+			// Some errant bitstreams omit
+			// the "clock-frequency-high" key.
+			// Allow it to be optional for now.
+			OPAE_MSG("metadata: missing "
+				 "\"clock-frequency-high\" key");
+		}
 	}
 
-	res = opae_bitstream_get_json_int(j_afu_image,
-					  "clock-frequency-low",
-					  &img->clock_frequency_low);
+	res = opae_bitstream_get_json_double(j_afu_image,
+					     "clock-frequency-low",
+					     &img->clock_frequency_low);
 	if (res != FPGA_OK) {
-		// Some errant bitstreams omit the "clock-frequency-low" key.
-		// Allow it to be optional for now.
-		OPAE_MSG("metadata: missing \"clock-frequency-low\" key");
+		ival = 0;
+		res = opae_bitstream_get_json_int(j_afu_image,
+						  "clock-frequency-low",
+						  &ival);
+		img->clock_frequency_low = (double)ival;
+		if (res != FPGA_OK) {
+			// Some errant bitstreams omit
+			// the "clock-frequency-low" key.
+			// Allow it to be optional for now.
+			OPAE_MSG("metadata: missing "
+				 "\"clock-frequency-low\" key");
+		}
 	}
 
-	res = opae_bitstream_get_json_int(j_afu_image,
-					  "power",
-					  &img->power);
+	res = opae_bitstream_get_json_double(j_afu_image,
+					     "power",
+					     &img->power);
 	if (res != FPGA_OK) {
-		// Some errant bitstreams omit the "power" key.
-		// Allow it to be optional for now.
-		OPAE_MSG("metadata: missing \"power\" key");
+		ival = 0;
+		res = opae_bitstream_get_json_int(j_afu_image,
+						  "power",
+						  &ival);
+		img->power = (double)ival;
+		if (res != FPGA_OK) {
+			// Some errant bitstreams
+			// omit the "power" key.
+			// Allow it to be optional for now.
+			OPAE_MSG("metadata: missing \"power\" key");
+		}
 	}
 
 	res = opae_bitstream_get_json_int(j_afu_image,

--- a/libbitstream/metadatav1.h
+++ b/libbitstream/metadatav1.h
@@ -53,9 +53,9 @@ typedef struct _opae_metadata_accelerator_cluster_v1 {
  * and Partial Reconfiguration interface.
  */
 typedef struct _opae_metadata_afu_image_v1 {
-	int clock_frequency_high;
-	int clock_frequency_low;
-	int power;
+	double clock_frequency_high;
+	double clock_frequency_low;
+	double power;
 	char *interface_uuid;
 	int magic_no;
 	int num_clusters;

--- a/testing/bitstream/test_bits_utils_c.cpp
+++ b/testing/bitstream/test_bits_utils_c.cpp
@@ -230,6 +230,31 @@ TEST_P(bits_utils_c_p, double_err1) {
 }
 
 /**
+ * @test       double_err2
+ * @brief      Test: opae_bitstream_get_json_double
+ * @details    If the given name exists,<br>
+ *             but isn't of type double,<br>
+ *             the fn returns FPGA_EXCEPTION.<br>
+ */
+TEST_P(bits_utils_c_p, double_err2) {
+    const char *mdata =
+    R"mdata({
+"a": 42
+})mdata";
+  json_object *root;
+  double value = 0.0;
+
+  root = parse(mdata);
+  ASSERT_NE(root, nullptr);
+
+  EXPECT_EQ(opae_bitstream_get_json_double(root,
+					   "a",
+					   &value),
+            FPGA_EXCEPTION);
+  EXPECT_EQ(value, 0.0);
+}
+
+/**
  * @test       invalid_chars0
  * @brief      Test: opae_bitstream_path_invalid_chars
  * @details    Given a path that contains non-printable chars,<br>

--- a/testing/bitstream/test_bits_utils_c.cpp
+++ b/testing/bitstream/test_bits_utils_c.cpp
@@ -181,6 +181,55 @@ TEST_P(bits_utils_c_p, int_err1) {
 }
 
 /**
+ * @test       double_err0
+ * @brief      Test: opae_bitstream_get_json_double
+ * @details    If the given name doesn't exist,<br>
+ *             the fn returns FPGA_EXCEPTION.<br>
+ */
+TEST_P(bits_utils_c_p, double_err0) {
+    const char *mdata =
+    R"mdata({
+"a": 3.14
+})mdata";
+  json_object *root;
+  double value = 0.0;
+
+  root = parse(mdata);
+  ASSERT_NE(root, nullptr);
+
+  EXPECT_EQ(opae_bitstream_get_json_double(root,
+					   "b",
+					   &value),
+            FPGA_EXCEPTION);
+  EXPECT_EQ(value, 0.0);
+}
+
+/**
+ * @test       double_err1
+ * @brief      Test: opae_bitstream_get_json_double
+ * @details    If the given name exists,<br>
+ *             but isn't of type double,<br>
+ *             the fn returns FPGA_EXCEPTION.<br>
+ */
+TEST_P(bits_utils_c_p, double_err1) {
+    const char *mdata =
+    R"mdata({
+"a": "str"
+})mdata";
+  json_object *root;
+  double value = 0.0;
+
+  root = parse(mdata);
+  ASSERT_NE(root, nullptr);
+
+  EXPECT_EQ(opae_bitstream_get_json_double(root,
+					   "a",
+					   &value),
+            FPGA_EXCEPTION);
+  EXPECT_EQ(value, 0.0);
+}
+
+/**
  * @test       invalid_chars0
  * @brief      Test: opae_bitstream_path_invalid_chars
  * @details    Given a path that contains non-printable chars,<br>

--- a/testing/bitstream/test_metadatav1_c.cpp
+++ b/testing/bitstream/test_metadatav1_c.cpp
@@ -224,7 +224,7 @@ TEST_P(metadatav1_c_p, image_err0) {
 TEST_P(metadatav1_c_p, image_err1) {
     const char *mdata =
     R"mdata({
-"clock-frequency-high": 312,
+"clock-frequency-high": 31.2,
 "power": 50,
 "interface-uuid": "01234567-89AB-CDEF-0123-456789ABCDEF",
 "magic-no": 488605312,
@@ -252,6 +252,9 @@ TEST_P(metadatav1_c_p, image_err1) {
 					      ifc_id),
             FPGA_OK);
 
+  EXPECT_EQ(img.clock_frequency_high, 31.2);
+  EXPECT_EQ(img.power, 50.0);
+
   free(img.interface_uuid);
   free(img.accelerator_clusters[0].name);
   free(img.accelerator_clusters[0].accelerator_type_uuid);
@@ -268,8 +271,8 @@ TEST_P(metadatav1_c_p, image_err1) {
 TEST_P(metadatav1_c_p, image_err2) {
     const char *mdata =
     R"mdata({
-"clock-frequency-high": 312,
-"clock-frequency-low": 156,
+"clock-frequency-high": 3.12,
+"clock-frequency-low": 1.56,
 "interface-uuid": "01234567-89AB-CDEF-0123-456789ABCDEF",
 "magic-no": 488605312,
 
@@ -295,6 +298,9 @@ TEST_P(metadatav1_c_p, image_err2) {
 					      &img,
 					      ifc_id),
             FPGA_OK);
+
+  EXPECT_EQ(img.clock_frequency_high, 3.12);
+  EXPECT_EQ(img.clock_frequency_low, 1.56);
 
   free(img.interface_uuid);
   free(img.accelerator_clusters[0].name);
@@ -715,9 +721,9 @@ TEST_P(metadatav1_c_p, parse_v1_ok) {
     R"mdata({
   "version": 1,
   "afu-image": {
-    "clock-frequency-high": 312,
+    "clock-frequency-high": 312.0,
     "clock-frequency-low": 156,
-    "power": 50,
+    "power": 50.2,
     "interface-uuid": "01234567-89AB-CDEF-0123-456789ABCDEF",
     "magic-no": 488605312,
 
@@ -768,9 +774,9 @@ TEST_P(metadatav1_c_p, parse_v1_ok) {
   ASSERT_NE(md->platform_name, nullptr);
   EXPECT_STREQ(md->platform_name, "DCP");
 
-  EXPECT_EQ(md->afu_image.clock_frequency_high, 312);
-  EXPECT_EQ(md->afu_image.clock_frequency_low, 156);
-  EXPECT_EQ(md->afu_image.power, 50);
+  EXPECT_EQ(md->afu_image.clock_frequency_high, 312.0);
+  EXPECT_EQ(md->afu_image.clock_frequency_low, 156.0);
+  EXPECT_EQ(md->afu_image.power, 50.2);
 
   ASSERT_NE(md->afu_image.interface_uuid, nullptr);
   EXPECT_STREQ(md->afu_image.interface_uuid, "01234567-89AB-CDEF-0123-456789ABCDEF");


### PR DESCRIPTION
Change the type of the following fields to double and allow them
to appear in the JSON metadata as either int or double:
afu_image.clock_frequency_high
afu_image.clock_frequency_low
afu_image.power