### PR TITLE
VC: Address fpgad leaks in tests

### DIFF
--- a/testing/fpgad/test_event_dispatcher_thread_c.cpp
+++ b/testing/fpgad/test_event_dispatcher_thread_c.cpp
@@ -156,6 +156,7 @@ TEST_P(fpgad_evt_c_p, normal_dispatch) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
   fpgad_monitored_device d;
+  d.object_id = platform_.devices[0].fme_object_id;
   EXPECT_TRUE(evt_queue_response(stop_running_response,
                                  &d,
                                  NULL));

--- a/tools/base/fpgad/command_line.c
+++ b/tools/base/fpgad/command_line.c
@@ -85,9 +85,13 @@ STATIC bool cmd_register_null_gbs(struct fpgad_config *c, char *null_gbs_path)
 
 		if (canon_path) {
 
+			memset_s(&c->null_gbs[c->num_null_gbs],
+				 sizeof(opae_bitstream_info), 0);
+
 			if (opae_load_bitstream(canon_path,
 						&c->null_gbs[c->num_null_gbs])) {
 				LOG("failed to load NULL GBS \"%s\"\n", canon_path);
+				opae_unload_bitstream(&c->null_gbs[c->num_null_gbs]);
 				free(canon_path);
 				return false;
 			}


### PR DESCRIPTION
* fpgad: fix mem leak for invalid GBS test
* Fixed uninitialized value in fpgad test.