### PR TITLE
libbitstream: remove fall-through switch case

### DIFF
--- a/libbitstream/bitstream.c
+++ b/libbitstream/bitstream.c
@@ -177,8 +177,17 @@ STATIC void *opae_bitstream_parse_metadata(const char *metadata,
 	// version to 640/650 respectively.
 	// Allow 640/650 to serve as an alias for 1.
 	case 650:
+		*version = 1;
+		parsed = opae_bitstream_parse_metadata_v1(root,
+							  pr_interface_id);
+	break;
+
 	case 640:
 		*version = 1;
+		parsed = opae_bitstream_parse_metadata_v1(root,
+							  pr_interface_id);
+	break;
+
 	case 1:
 		parsed = opae_bitstream_parse_metadata_v1(root,
 							  pr_interface_id);


### PR DESCRIPTION
Newer versions of gcc flag fall-through switch cases as warnings,
which become build errors, because we're using -Werror.