### PR TITLE
libbitstream: enable fallthrough switch case

### DIFF
--- a/cmake/modules/compiler_config.cmake
+++ b/cmake/modules/compiler_config.cmake
@@ -50,6 +50,7 @@ endfunction(SET_CACHED_VARIABLE)
 # Default flags to compiler when build user-space programs.
 # Should come before enabling language.
 
+CHECK_C_COMPILER_FLAG(-Werror=implicit-fallthrough=3 COMPILER_SUPPORTS_IMPLICIT_FALLTHROUGH3)
 
 set(CMAKE_C_FLAGS_DEBUG            "-g -O0 -Wall -Wextra -Werror")
 set(CMAKE_CXX_FLAGS_DEBUG          "-g -O0 -Wall -Wextra -Werror")
@@ -62,6 +63,13 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O2 -Wall -Wextra -Werror")
 
 set(CMAKE_C_FLAGS_MINSIZEREL       "-Os -Wall -Wextra -Werror")
 set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -Wall -Wextra -Werror")
+
+if(COMPILER_SUPPORTS_IMPLICIT_FALLTHROUGH3)
+  set(CMAKE_C_FLAGS_DEBUG          "${CMAKE_C_FLAGS_DEBUG} -Werror=implicit-fallthrough=3")
+  set(CMAKE_C_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE} -Werror=implicit-fallthrough=3")
+  set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -Werror=implicit-fallthrough=3")
+  set(CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_MINSIZEREL} -Werror=implicit-fallthrough=3")
+endif()
 
 # Check if support for C++ 11 is available
 check_cxx_compiler_flag("-std=c++14" COMPILER_SUPPORTS_CXX14)

--- a/cmake/modules/compiler_config.cmake
+++ b/cmake/modules/compiler_config.cmake
@@ -50,7 +50,6 @@ endfunction(SET_CACHED_VARIABLE)
 # Default flags to compiler when build user-space programs.
 # Should come before enabling language.
 
-CHECK_C_COMPILER_FLAG(-Werror=implicit-fallthrough=3 COMPILER_SUPPORTS_IMPLICIT_FALLTHROUGH3)
 
 set(CMAKE_C_FLAGS_DEBUG            "-g -O0 -Wall -Wextra -Werror")
 set(CMAKE_CXX_FLAGS_DEBUG          "-g -O0 -Wall -Wextra -Werror")
@@ -63,13 +62,6 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O2 -Wall -Wextra -Werror")
 
 set(CMAKE_C_FLAGS_MINSIZEREL       "-Os -Wall -Wextra -Werror")
 set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -Wall -Wextra -Werror")
-
-if(COMPILER_SUPPORTS_IMPLICIT_FALLTHROUGH3)
-  set(CMAKE_C_FLAGS_DEBUG          "${CMAKE_C_FLAGS_DEBUG} -Werror=implicit-fallthrough=3")
-  set(CMAKE_C_FLAGS_RELEASE        "${CMAKE_C_FLAGS_RELEASE} -Werror=implicit-fallthrough=3")
-  set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -Werror=implicit-fallthrough=3")
-  set(CMAKE_C_FLAGS_MINSIZEREL     "${CMAKE_C_FLAGS_MINSIZEREL} -Werror=implicit-fallthrough=3")
-endif()
 
 # Check if support for C++ 11 is available
 check_cxx_compiler_flag("-std=c++14" COMPILER_SUPPORTS_CXX14)

--- a/libbitstream/bitstream.c
+++ b/libbitstream/bitstream.c
@@ -177,17 +177,8 @@ STATIC void *opae_bitstream_parse_metadata(const char *metadata,
 	// version to 640/650 respectively.
 	// Allow 640/650 to serve as an alias for 1.
 	case 650:
-		*version = 1;
-		parsed = opae_bitstream_parse_metadata_v1(root,
-							  pr_interface_id);
-	break;
-
 	case 640:
-		*version = 1;
-		parsed = opae_bitstream_parse_metadata_v1(root,
-							  pr_interface_id);
-	break;
-
+		*version = 1; /* FALLTHROUGH */
 	case 1:
 		parsed = opae_bitstream_parse_metadata_v1(root,
 							  pr_interface_id);


### PR DESCRIPTION
Add cmake C compiler check (C++ TBD) for -Werror=implicit-fallthrough=3.
With this option, placing a /* FALLTHROUGH */ comment in the switch
case in question avoids what would otherwise be a warning.