### PR TITLE
fpgad-vc: sensor overrides in config

### DIFF
--- a/tools/base/fpgad/fpgad.cfg
+++ b/tools/base/fpgad/fpgad.cfg
@@ -12,7 +12,20 @@
 		},
 		"fpgad-vc": {
 			"configuration": {
-				"cool-down": 30
+				"cool-down": 30,
+				"config-sensors-enabled": false,
+				"sensors": [
+					{
+						"id": 12,
+						"high-fatal": 100.0,
+						"high-warn": 90.0
+					},
+					{
+						"id": 13,
+						"high-fatal": 85.0,
+						"high-warn": 75.0
+					}
+				]
 			},
 			"enabled": true,
 			"plugin": "libfpgad-vc.so",

--- a/tools/base/fpgad/monitored_device.c
+++ b/tools/base/fpgad/monitored_device.c
@@ -216,6 +216,7 @@ STATIC bool mon_consider_device(struct fpgad_config *c, fpga_token token)
 			fpgad_supported_device *loaded_by;
 			fpgad_monitored_device *monitored;
 			fpgad_plugin_configure_t cfg;
+			int res;
 
 			d->flags |= FPGAD_DEV_DETECTED;
 
@@ -278,7 +279,15 @@ STATIC bool mon_consider_device(struct fpgad_config *c, fpga_token token)
 				continue;
 			}
 
-			cfg(monitored, d->config);
+			res = cfg(monitored, d->config);
+			if (res) {
+				LOG("%s for \"%s\" returned %d.\n",
+				    FPGAD_PLUGIN_CONFIGURE,
+				    d->library_path,
+				    res);
+				free(monitored);
+				continue;
+			}
 
 			if (monitored->type == FPGAD_PLUGIN_TYPE_THREAD) {
 


### PR DESCRIPTION
* fpgad-vc: sensor overrides in config

Allow users to override the sensor trip points using the configuration
file settings.

To do so, add..

"config-sensors-enabled": true,
"sensors": [
	{
		"id": 1,
		"high-fatal": 100.0,
		"high-warn": 90.0,
		"low-warn": 10.0,
		"low-fatal": 0.0
	},
	...
]

If config-sensors-enabled is false, then the entire sensors section
is ignored. If id is not a valid sensor id, then the entry has no
effect. Each of high-fatal, high-warn, low-fatal, and low-warn are
optional. If omitted, then the sensor value is not checked for the
corresponding limit.

* Implement cap of user limits by hw when applicable
(cherry picked from commit 2c8c1e87f1257fe65df7bf1084a48921e348c7e5)