### PR TITLE
Cherry-pick: Add fpgaflash to deb tools-extra package (#697)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,8 @@ set(CPACK_COMPONENTS_ALL
 	toolfpgametrics
 	toolfpgadiag 
 	toolfpga_dma_test 
-	toolfpgabist 
+	toolfpgabist
+	toolfpgaflash
 	toolfpgadiagapps 
 	toolpackager 
 	jsonschema 


### PR DESCRIPTION
Cherry pick for a deb package fix from the internal vc branch.