### PR TITLE
Fixed the plugin config read size to account for a null terminator.

### DIFF
--- a/libopae/pluginmgr.c
+++ b/libopae/pluginmgr.c
@@ -323,7 +323,7 @@ STATIC int process_plugin(const char *name, json_object *j_config)
 		return 1;
 	}
 
-	cfg->cfg_size = strlen(stringified);
+	cfg->cfg_size = strlen(stringified) + 1;
 	cfg->cfg = malloc(cfg->cfg_size);
 	if (!cfg->cfg) {
 		OPAE_ERR("error allocating memory for plugin configuration");


### PR DESCRIPTION
strlen() was being used as the size to malloc for the cfg, which would contain the config file string. Except strlen() does not count the null terminator which we are trying to copy to cfg (line 334) which causes an invalid write.