### PR TITLE
add 'type' function to get object type

### DIFF
--- a/common/include/opae/cxx/core/sysobject.h
+++ b/common/include/opae/cxx/core/sysobject.h
@@ -176,6 +176,10 @@ class sysobject {
   std::vector<uint8_t> bytes(uint32_t offset, uint32_t size,
                              int flags = 0) const;
 
+  /** Get the object type (attribute or container)
+   */
+  enum fpga_sysobject_type type() const;
+
   /** Retrieve the underlying fpga_object primitive.
    */
   fpga_object c_type() const { return sysobject_; }

--- a/libopaecxx/src/sysobject.cpp
+++ b/libopaecxx/src/sysobject.cpp
@@ -49,6 +49,12 @@ uint32_t sysobject::size() const {
   return size;
 }
 
+enum fpga_sysobject_type sysobject::type() const {
+  enum fpga_sysobject_type _type;
+  ASSERT_FPGA_OK(fpgaObjectGetType(sysobject_, &_type));
+  return _type;
+}
+
 sysobject::ptr_t sysobject::get(token::ptr_t tok, const std::string &path,
                                 int flags) {
   fpga_object sysobj;

--- a/pyopae/pysysobject.cpp
+++ b/pyopae/pysysobject.cpp
@@ -134,9 +134,16 @@ std::string sysobject_bytes(sysobject::ptr_t obj) {
   return std::string(bytes.begin(), bytes.end());
 }
 
-uint8_t sysobject_getitem(sysobject::ptr_t obj, uint32_t offset) {
-  auto bytes = obj->bytes(offset, 1, FPGA_OBJECT_SYNC);
-  return bytes[0];
+py::object sysobject_getitem(sysobject::ptr_t obj, uint32_t offset) {
+  switch(obj->type()) {
+    case FPGA_OBJECT_ATTRIBUTE:
+      return py::cast(obj->bytes(offset, 1, FPGA_OBJECT_SYNC)[0]);
+      break;
+    case FPGA_OBJECT_CONTAINER:
+      return py::cast(obj->get(offset));
+      break;
+  }
+  return py::object();
 }
 
 std::string sysobject_getslice(sysobject::ptr_t obj, py::slice slice) {

--- a/pyopae/pysysobject.h
+++ b/pyopae/pysysobject.h
@@ -57,7 +57,7 @@ opae::fpga::types::sysobject::ptr_t sysobject_find_sysobject(
     opae::fpga::types::sysobject::ptr_t tok, const std::string &name,
     int flags = 0);
 std::string sysobject_bytes(opae::fpga::types::sysobject::ptr_t obj);
-uint8_t sysobject_getitem(opae::fpga::types::sysobject::ptr_t obj,
+pybind11::object sysobject_getitem(opae::fpga::types::sysobject::ptr_t obj,
                           uint32_t offset);
 std::string sysobject_getslice(opae::fpga::types::sysobject::ptr_t obj,
                                     pybind11::slice slice);


### PR DESCRIPTION
Add sysobject::type function that retrieves the object type enum.
Use this in the Python binding for __getitem__ to allow getting an
indexed item from a container or from an attribute.