### PR TITLE
Work around a glitch in the ASE DDR model

### DIFF
--- a/libopae/plugins/ase/rtl/device_models/dcp_emif_model_basic/emif_ddr4.v
+++ b/libopae/plugins/ase/rtl/device_models/dcp_emif_model_basic/emif_ddr4.v
@@ -122,8 +122,11 @@ typedef struct
 Response read_response_queue_slave[`NUM_SLAVES][$];
 
 // ddr user clock frequency = 266.666.. Mhz
-assign ddr4a_avmm_clk_clk = ddr4a_pll_ref_clk_clock_sink_clk;
-assign ddr4b_avmm_clk_clk = ddr4a_pll_ref_clk_clock_sink_clk;
+// We shift the clock because altera_avalon_mm_slave_bfm shifts
+// its monitor_request() task #1, which leads to glitches in
+// waitrequest and causes random errors in simulation.
+assign #10 ddr4a_avmm_clk_clk = ddr4a_pll_ref_clk_clock_sink_clk;
+assign #10 ddr4b_avmm_clk_clk = ddr4a_pll_ref_clk_clock_sink_clk;
 
 altera_avalon_mm_slave_bfm #(
 	.AV_ADDRESS_W               (DDR_ADDR_WIDTH),


### PR DESCRIPTION
The DDR simulation model's Avalon ready/enable protocol deliberately uses clock offsets, which wreak havoc even in the Qsys-supplied bridges. Adding a small delay to the simulated DDR clock passed to the AFU causes the AFU to sample signals when they are stable.