### PR TITLE
 Update ModelSim ASE configuration to track unpacked arrays

### DIFF
--- a/libopae/plugins/ase/scripts/generate_ase_environment.py
+++ b/libopae/plugins/ase/scripts/generate_ase_environment.py
@@ -880,7 +880,7 @@ open("vcs_run.tcl", "w").write('dump -depth 0 \ndump -aggregates -add /'
 with open("vsim_run.tcl", "w") as fd:
     fd.write("# Remove \"Memory\" from WildcardFilter so that unpacked\n")
     fd.write("# arrays will be included in the collected data.\n")
-    fd.write("set WildcardFilter [lsearch -not -all -inline " +
+    fd.write("quietly set WildcardFilter [lsearch -not -all -inline " +
              "$WildcardFilter Memory]\n\n")
     fd.write("add wave -r /* \n")
     fd.write("run -all\n")

--- a/libopae/plugins/ase/scripts/generate_ase_environment.py
+++ b/libopae/plugins/ase/scripts/generate_ase_environment.py
@@ -877,4 +877,10 @@ open("vcs_run.tcl", "w").write('dump -depth 0 \ndump -aggregates -add /'
                                '\nrun \nquit\n')
 
 # Generate .DO file
-open("vsim_run.tcl", "w").write("add wave -r /* \nrun -all\n")
+with open("vsim_run.tcl", "w") as fd:
+    fd.write("# Remove \"Memory\" from WildcardFilter so that unpacked\n")
+    fd.write("# arrays will be included in the collected data.\n")
+    fd.write("set WildcardFilter [lsearch -not -all -inline " +
+             "$WildcardFilter Memory]\n\n")
+    fd.write("add wave -r /* \n")
+    fd.write("run -all\n")


### PR DESCRIPTION
ModelSim, by default, does not include "Memory" when matching signals by
wildcard. Even simple unpacked arrays are considered memory. The change
here, suggested by Francis O'Brien, causes ModelSim to include unpacked
arrays in data recorded during simulation. The impact on simulation speed
is minimal. As Francis noted, very large arrays are still not included
due to other filters.