### PR TITLE
Add a default FPGA family to the base discrete_pcie3 PIM family.

### DIFF
--- a/platforms/platform_db/discrete_pcie3.json
+++ b/platforms/platform_db/discrete_pcie3.json
@@ -9,6 +9,18 @@
          "using either the preferred avalon_mm_if SystemVerilog interface object",
          "or with the legacy two-bank collection of Avalon wires."
       ],
+
+   "comment":
+      [
+         "These will be defined as Verilog preprocessor macros and may be",
+         "tested in RTL after platform_if.vh is loaded. Pick a default",
+         "family here because some tools require one."
+      ],
+   "define":
+      [
+         "PLATFORM_FPGA_FAMILY_A10"
+      ],
+
    "module-ports-offered" :
       [
          {


### PR DESCRIPTION
This affects ASE simulation only in the rare case, which we documented, that users
specify a generic discrete_pcie3 platform. ASE's Makefile was changed to pass the
FPGA family to Quartus and winds up passing "UNKNOWN" when no family is defined.
Quartus doesn't appreciate that, and blows up.