### PR TITLE
Add byte write data encoding to CCI-P

### DIFF
--- a/platforms/platform_db/platform_defaults/defaults_ccip.json
+++ b/platforms/platform_db/platform_defaults/defaults_ccip.json
@@ -28,6 +28,13 @@
 
    "comment":
       [
+         "Boolean (0/1) indicating whether the platform supports byte-enable",
+         "to update only a portion of a cache line."
+      ],
+   "byte-en-supported": 0,
+
+   "comment":
+      [
          "Minimum number of outstanding lines that must be in flight to",
          "saturate bandwidth on each virtual channel.  (Index of the parameter",
          "is the virtual channel number.)  Maximum bandwidth is typically a",

--- a/platforms/platform_if/rtl/device_cfg/ccip_cfg_pkg.sv
+++ b/platforms/platform_if/rtl/device_cfg/ccip_cfg_pkg.sv
@@ -42,6 +42,11 @@
 // the package long.
 //
 
+// Provide defaults for new parameters
+`ifndef PLATFORM_PARAM_CCI_P_BYTE_EN_SUPPORTED
+  `define PLATFORM_PARAM_CCI_P_BYTE_EN_SUPPORTED 0
+`endif
+
 package ccip_cfg_pkg;
 
     parameter VERSION_NUMBER = 1;
@@ -80,6 +85,9 @@ package ccip_cfg_pkg;
 
     // Is a given request length supported, indexed by t_ccip_clLen?  (0 or 1)
     parameter int CL_LEN_SUPPORTED[4] = `PLATFORM_PARAM_CCI_P_CL_LEN_SUPPORTED;
+
+    // Does the platform honor byte enable to update a sub-region of a line?
+    parameter int BYTE_EN_SUPPORTED = `PLATFORM_PARAM_CCI_P_BYTE_EN_SUPPORTED;
 
     // Recommended number of edge register stages for CCI-P request/response
     // signals.  This is expected to be one on all platforms, reflecting the

--- a/platforms/platform_if/rtl/device_if/ccip_if.vh
+++ b/platforms/platform_if/rtl/device_if/ccip_if.vh
@@ -43,6 +43,13 @@
 // Speculative loads: eREQ_RDLSPEC and the error flag in t_ccip_c0_RspMemHdr
 `define CCIP_RDLSPEC_AVAIL 1
 
+// Byte enable, controlling which bytes in a line are updated.
+// Be careful! This flag only indicates whether the CCI-P data structures
+// can encode byte enable. The flag does not indicate whether the platform
+// actually honors the encoding. For that, AFUs must check the value of
+// ccip_cfg_pkg::BYTE_EN_SUPPORTED.
+`define CCIP_BYTE_EN_AVAIL 1
+
 
 import ccip_if_pkg::*;
 

--- a/platforms/platform_if/rtl/device_if/ccip_if_pkg.sv
+++ b/platforms/platform_if/rtl/device_if/ccip_if_pkg.sv
@@ -38,6 +38,9 @@ parameter CCIP_VERSION_NUMBER    = 12'h080;
 parameter CCIP_CLADDR_WIDTH      = 42;
 parameter CCIP_CLDATA_WIDTH      = 512;
 
+// Number of bytes in a cache line
+parameter CCIP_CLDATA_BYTE_WIDTH = CCIP_CLDATA_WIDTH / 8;
+
 parameter CCIP_MMIOADDR_WIDTH    = 16;
 parameter CCIP_MMIODATA_WIDTH    = 64;
 parameter CCIP_TID_WIDTH         = 9;
@@ -67,6 +70,9 @@ typedef logic [CCIP_MDATA_WIDTH-1:0]    t_ccip_mdata;
 
 typedef logic [1:0]                     t_ccip_clNum;
 typedef logic [2:0]                     t_ccip_qwIdx;
+
+// Index into a cache line when organized as an array of bytes
+typedef logic [$clog2(CCIP_CLDATA_BYTE_WIDTH)-1:0] t_ccip_clByteIdx;
 
 
 // Request Type  Encodings
@@ -127,6 +133,13 @@ typedef enum logic [1:0] {
     eCL_LEN_4 = 2'b11
 } t_ccip_clLen;
 
+// Memory Access Mode Encodings
+//----------------------------------------------------------------------
+typedef enum logic [0:0] {
+    eMOD_CL   = 1'b0,           // Memory full CL access
+    eMOD_BYTE = 1'h1            // Memory byte access
+} t_ccip_mem_access_mode;
+
 //
 // Structures for Request and Response headers
 //----------------------------------------------------------------------
@@ -142,15 +155,15 @@ typedef struct packed {
 parameter CCIP_C0TX_HDR_WIDTH = $bits(t_ccip_c0_ReqMemHdr);
 
 typedef struct packed {
-    logic [5:0]     rsvd2;      // [79:74]  reserved, drive 0
-    t_ccip_vc       vc_sel;     // [73:72]
-    logic           sop;        // [71]
-    logic           rsvd1;      // [70]     reserved, drive 0
-    t_ccip_clLen    cl_len;     // [69:68]
-    t_ccip_c1_req   req_type;   // [67:64]
-    logic [5:0]     rsvd0;      // [63:58]  reserved, drive 0
-    t_ccip_clAddr   address;    // [57:16]
-    t_ccip_mdata    mdata;      // [15:0]
+    t_ccip_clByteIdx       byte_len;    // [79:74]
+    t_ccip_vc              vc_sel;      // [73:72]
+    logic                  sop;         // [71]
+    t_ccip_mem_access_mode mode;        // [70]
+    t_ccip_clLen           cl_len;      // [69:68]
+    t_ccip_c1_req          req_type;    // [67:64]
+    t_ccip_clByteIdx       byte_start;  // [63:58]
+    t_ccip_clAddr          address;     // [57:16]
+    t_ccip_mdata           mdata;       // [15:0]
 } t_ccip_c1_ReqMemHdr;
 parameter CCIP_C1TX_HDR_WIDTH = $bits(t_ccip_c1_ReqMemHdr);
 


### PR DESCRIPTION
Note: this is merely a change in write request encoding. Old platforms ignore the encoding, which uses fields that were previously reserved. Actual support requires an updated platform.