### PR TITLE
Fix a race in ASE.

### DIFF
--- a/libopae/plugins/ase/sw/ase_host_memory.c
+++ b/libopae/plugins/ase/sw/ase_host_memory.c
@@ -78,13 +78,14 @@ int ase_host_memory_pin(void *va, uint64_t *iova, uint64_t length)
 		return -1;
 
 	int status = ase_pt_pin_page((uint64_t)va, iova, pt_level);
-	if (status == 0) {
-		note_pinned_page((uint64_t)va, *iova, length);
-	}
 
 	if (pthread_mutex_unlock(&ase_pt_lock)) {
 		ASE_ERR("pthread_mutex_lock could not unlock !\n");
 		status = -1;
+	}
+
+	if (status == 0) {
+		note_pinned_page((uint64_t)va, *iova, length);
 	}
 
 	return status;

--- a/libopae/plugins/ase/sw/mqueue_ops.c
+++ b/libopae/plugins/ase/sw/mqueue_ops.c
@@ -311,8 +311,8 @@ void mqueue_send(int mq, const char *str, int size)
 	ret_tx = write(mq, (void *) str, size);
 
 	if ((ret_tx == 0) || (ret_tx != size)) {
-#ifdef ASE_DEBUG
 		perror("write");
+#ifdef ASE_DEBUG
 		ASE_DBG("write() returned wrong data size.");
 #endif
 	}


### PR DESCRIPTION
Shared buffer allocation and address translation share a lock. Buffer
allocation held the lock too long, making a deadlock possible if the
pipe between the two processes is full.