### PR TITLE
Reset ASE buffer index counter when client disconnects.

### DIFF
--- a/libopae/plugins/ase/sw/app_backend.c
+++ b/libopae/plugins/ase/sw/app_backend.c
@@ -1431,6 +1431,9 @@ void free_buffers(void)
 
 	ase_host_memory_terminate();
 
+	asebuf_index_count = 0;
+	userbuf_index_count = 0;
+
 	FUNC_CALL_EXIT;
 }
 


### PR DESCRIPTION
When running in server mode, ASE may accept a new connection after the previous
one exits. The buffer index count was not being reset for new connections.
The RTL side depends on buffer index 0 being the MMIO space, so failed to
detect MMIO on all but the first connection.