### PR TITLE
CCI-P byte enable error handling.

### DIFF
--- a/libopae/plugins/ase/rtl/ase_pkg.sv
+++ b/libopae/plugins/ase/rtl/ase_pkg.sv
@@ -923,7 +923,7 @@ package ase_pkg;
     * ASE protocol sniff codes
     */
    // parameter SNIFF_CODE_WIDTH = 5;
-   parameter SNIFF_VECTOR_WIDTH = 35;
+   parameter SNIFF_VECTOR_WIDTH = 36;
  // 2**SNIFF_CODE_WIDTH;
 
    // Error code indices
@@ -965,7 +965,8 @@ package ase_pkg;
 		   SNIFF_C1TX_BYTE_EN_NON_WRITE	 = 31,
 		   SNIFF_C1TX_BYTE_EN_MULTI_LINE = 32,
 		   SNIFF_C1TX_BYTE_EN_BAD_RANGE  = 33,
-		   SNIFF_C1TX_BYTE_EN_NOT_IMPL   = 34
+		   SNIFF_C1TX_BYTE_EN_NOT_IMPL   = 34,
+		   SNIFF_C1TX_BYTE_EN_WRONG_MODE = 35
 		   // --------------------------------- //
 		   } sniff_code_t;
 

--- a/libopae/plugins/ase/rtl/ccip_checker.sv
+++ b/libopae/plugins/ase/rtl/ccip_checker.sv
@@ -521,6 +521,14 @@ module ccip_checker
            print_message_and_log(0, log_str);
         end
 
+          // C1Tx - byte range set but request isn't eMOD_BYTE
+          SNIFF_C1TX_BYTE_EN_WRONG_MODE:
+        begin
+           error_code_q[code] = 1'b1;
+           $sformat(log_str, "[%s] C1TxHdr byte range requested on non-eMOD_BYTE request!\n", errcode_str);
+           print_message_and_log(0, log_str);
+        end
+
           // C0TX - 3CL Request check
           SNIFF_C1TX_3CL_REQUEST:
         begin
@@ -1119,6 +1127,15 @@ module ccip_checker
       end
       else
             error_code_q[SNIFF_C1TX_BYTE_EN_NON_WRITE]=1'b0;
+
+      // ----------------------------------------- //
+      // Byte range set on normal write?
+      if ((ccip_tx.c1.hdr.mode == eMOD_CL) && ccip_tx.c1.valid && isCCIPWriteRequest(ccip_tx.c1.hdr) &&
+          ((ccip_tx.c1.hdr.byte_start != 0) || (ccip_tx.c1.hdr.byte_len != 0))) begin
+            decode_error_code(0, SNIFF_C1TX_BYTE_EN_WRONG_MODE);
+      end
+      else
+            error_code_q[SNIFF_C1TX_BYTE_EN_WRONG_MODE]=1'b0;
 
       // ----------------------------------------- //
       // Check various properties of byte ranges

--- a/tools/base/fpgainfo/errors.c
+++ b/tools/base/fpgainfo/errors.c
@@ -107,10 +107,11 @@ static const char *const INJECT_ERROR[INJECT_ERROR_COUNT] = {
 	"Set Catastrophic  error .", "Set Fatal error.",
 	"Ser Non-fatal error ."};
 
-#define PORT_ERROR_COUNT 52
+#define PORT_ERROR_COUNT 60
 static const char *const PORT_ERROR[PORT_ERROR_COUNT] = {
+	// 0
 	"Tx Channel 0 overflow error detected.",
-	"Tx Channel 0 invalid request encodingr error detected.",
+	"Tx Channel 0 invalid request encoding error detected.",
 	"Tx Channel 0 cl_len=3 not supported error detected.",
 	"Tx Channel 0 request with cl_len=2 does NOT have a 2CL aligned address error detected.",
 	"Tx Channel 0 request with cl_len=4 does NOT have a 4CL aligned address error detected.",
@@ -119,6 +120,7 @@ static const char *const PORT_ERROR[PORT_ERROR_COUNT] = {
 	"RSVD.",
 	"RSVD.",
 	"AFU MMIO RD received while PORT is in reset error detected",
+	// 10
 	"AFU MMIO WR received while PORT is in reset error detected",
 	"RSVD.",
 	"RSVD.",
@@ -129,16 +131,18 @@ static const char *const PORT_ERROR[PORT_ERROR_COUNT] = {
 	"Tx Channel 1 cl_len=3 not supported error detected.",
 	"Tx Channel 1 request with cl_len=2 does NOT have a 2CL aligned address error detected",
 	"Tx Channel 1 request with cl_len=4 does NOT have a 4CL aligned address error detected",
+	// 20
 	"Tx Channel 1 insufficient data payload Error detected",
 	"Tx Channel 1 data payload overrun error detected",
 	"Tx Channel 1 incorrect address on subsequent payloads error detected",
 	"Tx Channel 1 Non-zero SOP detected for requests!=WrLine_* error detected",
+	"Tx Channel 1 SOP expected to be 0 for req_type!=WrLine_*",
 	"Tx Channel 1 Illegal VC_SEL. Atomic request is only supported on VL0 error detected",
 	"RSVD.",
 	"RSVD.",
 	"RSVD.",
 	"RSVD.",
-	"RSVD.",
+	// 30
 	"RSVD.",
 	"RSVD.",
 	"MMIO TimedOut error detected",
@@ -149,6 +153,7 @@ static const char *const PORT_ERROR[PORT_ERROR_COUNT] = {
 	"RSVD.",
 	"RSVD.",
 	"RSVD.",
+	// 40
 	"Number of pending requests: counter overflow error detected",
 	"Request with Address violating SMM range error detected",
 	"Request with Address violating second SMM range error detected",
@@ -159,8 +164,18 @@ static const char *const PORT_ERROR[PORT_ERROR_COUNT] = {
 	"Request with Address violating VGA memory range error detected",
 	"Page Fault error detected",
 	"PMR Erro error detected",
-	"AP6 event detected ",
-	"VF FLR detected on port when PORT configured in PF access mode error detected "};
+	// 50
+	"AP6 event detected",
+	"VF FLR detected on port when PORT configured in PF access mode error detected ",
+	"RSVD.",
+	"RSVD.",
+	"RSVD.",
+	"RSVD.",
+	"Tx Channel 1 byte_len cannot be zero",
+	"Tx Channel 1 illegal operation: sum of byte_len and byte_start should be less than or equal to 64",
+	"Tx Channel 1 illegal operation: cl_len cannot be non-zero when mode is eMOD_BYTE",
+	"Tx Channel 1 byte_len and byte_start should be zero when mode is not eMOD_BYTE"
+};
 
 /*
  * errors command configuration, set during parse_args()


### PR DESCRIPTION
- Update fpgainfo with error text for eMOD_BYTE errors.
- Add error case to ASE: eMOD_CL and byte_start or byte_len non-zero. The hardware
  already detects this case.