### PR TITLE
OPAE in containers: don't enumerate missing device

### DIFF
--- a/libopae/plugins/xfpga/enum.c
+++ b/libopae/plugins/xfpga/enum.c
@@ -343,6 +343,18 @@ STATIC fpga_result enum_fme(const char *sysfspath, const char *name,
 
 	snprintf_s_s(dpath, sizeof(dpath), FPGA_DEV_PATH "/%s", name);
 
+	// Make device node exists
+	if (stat(dpath, &stats) != 0) {
+		FPGA_MSG("stat failed: %s", strerror(errno));
+		return FPGA_OK;
+	}
+
+	// In ideal case we need to check that device that we open is really an
+	// FPGA device, but that will prevent easy unittesting
+	//
+	// if (!S_ISCHR(stats.st_mode))
+	// 	return FPGA_OK;
+
 	pdev = add_dev(sysfspath, dpath, parent);
 	if (!pdev) {
 		FPGA_MSG("Failed to allocate device");
@@ -420,6 +432,18 @@ STATIC fpga_result enum_afu(const char *sysfspath, const char *name,
 	int res;
 
 	snprintf_s_s(dpath, sizeof(dpath), FPGA_DEV_PATH "/%s", name);
+
+	// Make device node exists
+	if (stat(dpath, &stats) != 0) {
+		FPGA_MSG("stat failed: %s", strerror(errno));
+		return FPGA_OK;
+	}
+
+	// In ideal case we need to check that device that we open is really an
+	// FPGA device, but that will prevent easy unittesting
+	//
+	// if (!S_ISCHR(stats.st_mode))
+	// 	return FPGA_OK;
 
 	pdev = add_dev(sysfspath, dpath, parent);
 	if (!pdev) {

--- a/tools/extra/fpgadiag/diag_utils.cpp
+++ b/tools/extra/fpgadiag/diag_utils.cpp
@@ -68,11 +68,14 @@ properties::ptr_t get_properties(intel::utils::option_map::ptr_t opts, fpga_objt
 token::ptr_t get_parent_token(handle::ptr_t h)
 {
     auto props = properties::get(h);
-
-    auto tokens = token::enumerate({properties::get(props->parent)});
-    if (!tokens.empty())
-    {
-        return tokens[0];
+    try {
+        auto tokens = token::enumerate({properties::get(props->parent)});
+        if (!tokens.empty())
+        {
+            return tokens[0];
+        }
+    }catch(not_found &) {
+        // If process doesn't have access to FME, return empty enumeration result
     }
     return token::ptr_t();
 }

--- a/tools/extra/fpgadiag/perf_counters.cpp
+++ b/tools/extra/fpgadiag/perf_counters.cpp
@@ -48,6 +48,7 @@ fpga_cache_counters::fpga_cache_counters(token::ptr_t fme)
 : fme_(fme)
 , perf_feature_rev_(-1)
 {
+    if (!fme) return;
     auto rev = sysobject::get(fme_, "*perf/revision", FPGA_OBJECT_GLOB);
     if (rev) {
         perf_feature_rev_ = rev->read64();
@@ -218,6 +219,7 @@ fpga_fabric_counters::fpga_fabric_counters(token::ptr_t fme)
 : fme_(fme)
 , perf_feature_rev_(-1)
 {
+   if (!fme) return;
     auto rev = sysobject::get(fme_, "*perf/revision", FPGA_OBJECT_GLOB);
     if (rev) {
         perf_feature_rev_ = rev->read64();


### PR DESCRIPTION
In case of container usages with FPGA, sysfs entries might have
more information than actually available to the container.
Ignore devices during enumeration that don't have valid /dev
nodes.