### PR TITLE
Use POSIX-friendly commands in the ASE Makefile

### DIFF
--- a/libopae/plugins/ase/Makefile
+++ b/libopae/plugins/ase/Makefile
@@ -537,7 +537,7 @@ ifeq ($(GLS_SIM), 1)
 	cd $(WORK); quartus_sh --simlib_comp -family $(FPGA_FAMILY) -tool vcsmx -language verilog -gen_only -cmd_file quartus_vcs_verilog.sh; chmod a+x quartus_vcs_verilog.sh
 	@# Compile the libraries
 	cd $(WORK); ./quartus_vcs_verilog.sh
-	ls -1d $(WORK)/verilog_libs/* | awk -F / '{print $$NF ": " $$0}' > $@
+	find $(WORK)/verilog_libs -mindepth 1 -maxdepth 1 -type d -printf '%f: %p\n' > $@
 else
 	@echo > $@
 endif
@@ -551,7 +551,7 @@ ifeq ($(GLS_SIM), 1)
 	@# Compile the libraries
 	cd $(WORK); vsim -c -do quartus_msim_verilog.do
 	@# Generate an -L command to load these libraries in vsim
-	cd $(WORK)/verilog_libs; libs=`echo *_ver`; echo -L $${libs// / -L } > ../quartus_msim_verilog_libs
+	cd $(WORK)/verilog_libs; find . -mindepth 1 -maxdepth 1 -type d -printf '-L %f ' > ../quartus_msim_verilog_libs
 else
 	@echo > $@
 endif
@@ -565,7 +565,7 @@ ifdef DUT_VHD_SRC_LIST
 	cd $(WORK); quartus_sh --simlib_comp -family $(FPGA_FAMILY) -tool vcsmx -language vhdl -gen_only -cmd_file quartus_vcs_vhdl.sh; chmod a+x quartus_vcs_vhdl.sh
 	@# Compile the libraries
 	cd $(WORK); ./quartus_vcs_vhdl.sh
-	ls -1d $(WORK)/vhdl_libs/* | awk -F / '{print $$NF ": " $$0}' > $@
+	find $(WORK)/vhdl_libs -mindepth 1 -maxdepth 1 -type d -printf '%f: %p\n' > $@
   else
 	@echo > $@
   endif


### PR DESCRIPTION
ASE failed to build on Ubuntu, where dash is the default shell. Replace non-POSIX
bash string substitution with variations of the "find" command.
