### PR TITLE
Fix fpgabist for PAC regressions

### DIFF
--- a/tools/extra/fpgadiag/nlb0.cpp
+++ b/tools/extra/fpgadiag/nlb0.cpp
@@ -360,7 +360,7 @@ bool nlb0::setup()
     // TODO: Infer pclock from the device id
     // For now, get the pclock frequency from status2 register
     // that frequency (MHz) is encoded in bits [47:32]
-    uint64_t s2 = read_csr64(static_cast<uint32_t>(nlb0_csr::status2));
+    uint64_t s2 = accelerator_->read_csr64(static_cast<uint32_t>(nlb0_csr::status2));
     uint32_t freq = (s2 >> 32) & 0xffff;
     if (freq > 0) {
          // frequency_ is in Hz

--- a/tools/extra/pac/fpgabist/bist/bist_dc.c
+++ b/tools/extra/pac/fpgabist/bist/bist_dc.c
@@ -1,6 +1,6 @@
 // Copyright(c) 2017, Intel Corporation
 //
-// Redistribution  and	use  in source	and  binary  forms,  with  or  without
+// Redistribution  and use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
 //
 // * Redistributions of  source code  must retain the  above copyright notice,
@@ -43,20 +43,6 @@ int usleep(unsigned);
 #ifndef MB
 # define MB(x)			     ((x) * 1024 * 1024)
 #endif // MB
-
-#define CACHELINE_ALIGNED_ADDR(p) ((p) >> LOG2_CL)
-
-#define LPBK1_BUFFER_SIZE	     MB(1)
-#define LPBK1_BUFFER_ALLOCATION_SIZE MB(2)
-#define LPBK1_DSM_SIZE		     MB(2)
-#define CSR_SRC_ADDR		     0x0120
-#define CSR_DST_ADDR		     0x0128
-#define CSR_CTL			     0x0138
-#define CSR_CFG			     0x0140
-#define CSR_NUM_LINES		     0x0130
-#define DSM_STATUS_TEST_COMPLETE     0x40
-#define CSR_AFU_DSM_BASEL	     0x0110
-#define CSR_AFU_DSM_BASEH	     0x0114
 
 /**************** BIST #defines ***************/
 #define ENABLE_DDRA_BIST	      0x08000000
@@ -122,14 +108,6 @@ int main(int argc, char *argv[])
 	fpga_guid	   guid;
 	uint32_t	   num_matches;
 
-	volatile uint64_t *dsm_ptr    = NULL;
-	volatile uint64_t *status_ptr = NULL;
-	volatile uint64_t *input_ptr  = NULL;
-	volatile uint64_t *output_ptr = NULL;
-
-	uint64_t	dsm_wsid;
-	uint64_t	input_wsid;
-	uint64_t	output_wsid;
 	fpga_result	res = FPGA_OK;
 
 	int opt;
@@ -179,72 +157,6 @@ int main(int argc, char *argv[])
 	res = fpgaMapMMIO(accelerator_handle, 0, NULL);
 	ON_ERR_GOTO(res, out_close, "mapping MMIO space");
 
-	/* Allocate buffers */
-	res = fpgaPrepareBuffer(accelerator_handle, LPBK1_DSM_SIZE,
-				(void **)&dsm_ptr, &dsm_wsid, 0);
-	ON_ERR_GOTO(res, out_close, "allocating DSM buffer");
-
-	res = fpgaPrepareBuffer(accelerator_handle, LPBK1_BUFFER_ALLOCATION_SIZE,
-			   (void **)&input_ptr, &input_wsid, 0);
-	ON_ERR_GOTO(res, out_free_dsm, "allocating input buffer");
-
-	res = fpgaPrepareBuffer(accelerator_handle, LPBK1_BUFFER_ALLOCATION_SIZE,
-			   (void **)&output_ptr, &output_wsid, 0);
-	ON_ERR_GOTO(res, out_free_input, "allocating output buffer");
-
-	/* Initialize buffers */
-	memset((void *)dsm_ptr,    0,	 LPBK1_DSM_SIZE);
-	memset((void *)input_ptr,  0xAF, LPBK1_BUFFER_SIZE);
-	memset((void *)output_ptr, 0xBE, LPBK1_BUFFER_SIZE);
-
-	cache_line *cl_ptr = (cache_line *)input_ptr;
-	for (uint32_t i = 0; i < LPBK1_BUFFER_SIZE / CL(1); ++i) {
-		cl_ptr[i].uint[15] = i+1; /* set the last uint in every cacheline */
-	}
-
-	/* Reset accelerator */
-	res = fpgaReset(accelerator_handle);
-	ON_ERR_GOTO(res, out_free_output, "resetting accelerator");
-
-	/* Program DMA addresses */
-	uint64_t iova;
-	res = fpgaGetIOAddress(accelerator_handle, dsm_wsid, &iova);
-	ON_ERR_GOTO(res, out_free_output, "getting DSM IOVA");
-
-	res = fpgaWriteMMIO64(accelerator_handle, 0, CSR_AFU_DSM_BASEL, iova);
-	ON_ERR_GOTO(res, out_free_output, "writing CSR_AFU_DSM_BASEL");
-
-	res = fpgaWriteMMIO32(accelerator_handle, 0, CSR_CTL, 0);
-	ON_ERR_GOTO(res, out_free_output, "writing CSR_CFG");
-	res = fpgaWriteMMIO32(accelerator_handle, 0, CSR_CTL, 1);
-	ON_ERR_GOTO(res, out_free_output, "writing CSR_CFG");
-
-	res = fpgaGetIOAddress(accelerator_handle, input_wsid, &iova);
-	ON_ERR_GOTO(res, out_free_output, "getting input IOVA");
-	res = fpgaWriteMMIO64(accelerator_handle, 0, CSR_SRC_ADDR, CACHELINE_ALIGNED_ADDR(iova));
-	ON_ERR_GOTO(res, out_free_output, "writing CSR_SRC_ADDR");
-
-	res = fpgaGetIOAddress(accelerator_handle, output_wsid, &iova);
-	ON_ERR_GOTO(res, out_free_output, "getting output IOVA");
-	res = fpgaWriteMMIO64(accelerator_handle, 0, CSR_DST_ADDR, CACHELINE_ALIGNED_ADDR(iova));
-	ON_ERR_GOTO(res, out_free_output, "writing CSR_DST_ADDR");
-	res = fpgaWriteMMIO32(accelerator_handle, 0, CSR_NUM_LINES, LPBK1_BUFFER_SIZE / CL(1));
-	ON_ERR_GOTO(res, out_free_output, "writing CSR_NUM_LINES");
-	res = fpgaWriteMMIO32(accelerator_handle, 0, CSR_CFG, 0x42000);
-	ON_ERR_GOTO(res, out_free_output, "writing CSR_CFG");
-
-	status_ptr = dsm_ptr + DSM_STATUS_TEST_COMPLETE/8;
-
-	/* Start the test */
-	res = fpgaWriteMMIO32(accelerator_handle, 0, CSR_CTL, 3);
-	ON_ERR_GOTO(res, out_free_output, "writing CSR_CFG");
-
-	/* Wait for test completion */
-	while (0 == ((*status_ptr) & 0x1)) {
-		usleep(100);
-	}
-
-
 /************* Begin BIST *************/
 	/* Perform BIST Check */
 	printf("Running BIST Test\n");
@@ -253,10 +165,10 @@ int main(int argc, char *argv[])
 	unsigned int bist_mask = ENABLE_DDRA_BIST;
 
 	res = fpgaWriteMMIO32(accelerator_handle, 0, DDR_BIST_CTRL_ADDR, bist_mask);
-	ON_ERR_GOTO(res, out_free_output, "write DDR_BIST_CTRL_ADDR");
+	ON_ERR_GOTO(res, out_close, "write DDR_BIST_CTRL_ADDR");
 
 	res = fpgaReadMMIO64(accelerator_handle, 0, DDR_BIST_CTRL_ADDR, &data);
-	ON_ERR_GOTO(res, out_free_output, "write DDR_BIST_CTRL_ADDR");
+	ON_ERR_GOTO(res, out_close, "write DDR_BIST_CTRL_ADDR");
 
 	while ((CHECK_BIT(data, 27) != 0x08000000)) {
 	  printf("Enable Test: reading result #%f: %04lx\n", count, data);
@@ -269,12 +181,12 @@ int main(int argc, char *argv[])
 	printf("BIST is enabled.  Reading status register\n");
 
 	count = 0;
-	ON_ERR_GOTO(res, out_free_output, "writing CSR_BIST");
+	ON_ERR_GOTO(res, out_close, "writing CSR_BIST");
 	while ((CHECK_BIT(data, 9) != 0x200) && (CHECK_BIT(data, 8) != 0x100) && (CHECK_BIT(data, 7) != 0x80) &&
 		(CHECK_BIT(data, 10) != 0x400) && (CHECK_BIT(data, 11) != 0x800) && (CHECK_BIT(data, 12) != 0x1000)) {
 		res = fpgaReadMMIO64(accelerator_handle, 0, DDR_BIST_STATUS_ADDR,
 			&data);
-		ON_ERR_GOTO(res, out_free_output, "Reading DDR_BIST_STATUS");
+		ON_ERR_GOTO(res, out_close, "Reading DDR_BIST_STATUS");
 		if (count >= MAX_COUNT) {
 			fprintf(stderr, "DDR Bank A BIST Timed Out.\n");
 			break;
@@ -296,11 +208,11 @@ int main(int argc, char *argv[])
 	bist_mask = ENABLE_DDRB_BIST;
 	count = 0;
 	res = fpgaWriteMMIO32(accelerator_handle, 0, DDR_BIST_CTRL_ADDR, bist_mask);
-	ON_ERR_GOTO(res, out_free_output, "writing CSR_BIST");
+	ON_ERR_GOTO(res, out_close, "writing CSR_BIST");
 	while ((CHECK_BIT(data, 10) != 0x400) && (CHECK_BIT(data, 11) != 0x800) && (CHECK_BIT(data, 12) != 0x1000)) {
 		res = fpgaReadMMIO64(accelerator_handle, 0, DDR_BIST_STATUS_ADDR,
 			&data);
-		ON_ERR_GOTO(res, out_free_output, "Reading DDR_BIST_STATUS_ADDR");
+		ON_ERR_GOTO(res, out_close, "Reading DDR_BIST_STATUS_ADDR");
 		if (count >= MAX_COUNT) {
 			fprintf(stderr, "DDR Bank B BIST Timed Out.\n");
 			break;
@@ -324,11 +236,11 @@ int main(int argc, char *argv[])
        	bist_mask = ENABLE_DDRC_BIST;
 	count = 0;
 	res = fpgaWriteMMIO32(accelerator_handle, 0, DDR_BIST_CTRL_ADDR, bist_mask);
-	ON_ERR_GOTO(res, out_free_output, "writing CSR_BIST");
+	ON_ERR_GOTO(res, out_close, "writing CSR_BIST");
 	while ((CHECK_BIT(data, 13) != 0x2000) && (CHECK_BIT(data, 15) != 0x8000) && (CHECK_BIT(data, 14) != 0x4000)) {
 		res = fpgaReadMMIO64(accelerator_handle, 0, DDR_BIST_STATUS_ADDR,
 			&data);
-		ON_ERR_GOTO(res, out_free_output, "Reading DDR_BIST_STATUS_ADDR");
+		ON_ERR_GOTO(res, out_close, "Reading DDR_BIST_STATUS_ADDR");
 		if (count >= MAX_COUNT) {
 			fprintf(stderr, "DDR Bank C BIST Timed Out.\n");
 			break;
@@ -352,11 +264,11 @@ int main(int argc, char *argv[])
        	bist_mask = ENABLE_DDRD_BIST;
 	count = 0;
 	res = fpgaWriteMMIO32(accelerator_handle, 0, DDR_BIST_CTRL_ADDR, bist_mask);
-	ON_ERR_GOTO(res, out_free_output, "writing CSR_BIST");
+	ON_ERR_GOTO(res, out_close, "writing CSR_BIST");
 	while ((CHECK_BIT(data, 16) != 0x10000) && (CHECK_BIT(data, 17) != 0x20000) && (CHECK_BIT(data, 18) != 0x40000)) {
 		res = fpgaReadMMIO64(accelerator_handle, 0, DDR_BIST_STATUS_ADDR,
 			&data);
-		ON_ERR_GOTO(res, out_free_output, "Reading DDR_BIST_STATUS_ADDR");
+		ON_ERR_GOTO(res, out_close, "Reading DDR_BIST_STATUS_ADDR");
 		if (count >= MAX_COUNT) {
 			fprintf(stderr, "DDR Bank D BIST Timed Out.\n");
 			break;
@@ -377,37 +289,7 @@ int main(int argc, char *argv[])
 
 /**************** End BIST *****************/
 
-
-	/* Stop the device */
-	res = fpgaWriteMMIO32(accelerator_handle, 0, CSR_CTL, 7);
-	ON_ERR_GOTO(res, out_free_output, "writing CSR_CFG");
-
-	/* Check output buffer contents */
-	for (uint32_t i = 0; i < LPBK1_BUFFER_SIZE; i++) {
-		if (((uint8_t *)output_ptr)[i] != ((uint8_t *)input_ptr)[i]) {
-			fprintf(stderr, "Output does NOT match input "
-				"at offset %i!\n", i);
-			break;
-		}
-	}
-
 	printf("Done Running Test\n");
-
-	/* Release buffers */
-out_free_output:
-	res = fpgaReleaseBuffer(accelerator_handle, output_wsid);
-	ON_ERR_GOTO(res, out_free_input, "releasing output buffer");
-out_free_input:
-	res = fpgaReleaseBuffer(accelerator_handle, input_wsid);
-	ON_ERR_GOTO(res, out_free_dsm, "releasing input buffer");
-out_free_dsm:
-	res = fpgaReleaseBuffer(accelerator_handle, dsm_wsid);
-	ON_ERR_GOTO(res, out_unmap, "releasing DSM buffer");
-
-	/* Unmap MMIO space */
-out_unmap:
-	res = fpgaUnmapMMIO(accelerator_handle, 0);
-	ON_ERR_GOTO(res, out_close, "unmapping MMIO space");
 
 	/* Release accelerator */
 out_close:

--- a/tools/extra/pac/fpgabist/bist_app.py
+++ b/tools/extra/pac/fpgabist/bist_app.py
@@ -38,9 +38,9 @@ class BistMode(bc.BistMode):
     def __init__(self):
         self.executables = {'bist_app': ''}
 
-    def run(self, gbs_path, bus_num):
+    def run(self, gbs_path, bdf):
         if gbs_path:
-            bc.load_gbs(gbs_path, bus_num)
+            bc.load_gbs(gbs_path, bdf)
         for func, param in self.executables.items():
             print "Running {} test...\n".format(func)
             cmd = "{} {}".format(func, param)

--- a/tools/extra/pac/fpgabist/bist_app.py
+++ b/tools/extra/pac/fpgabist/bist_app.py
@@ -41,6 +41,7 @@ class BistMode(bc.BistMode):
     def run(self, gbs_path, bdf):
         if gbs_path:
             bc.load_gbs(gbs_path, bdf)
+        ret = 0
         for func, param in self.executables.items():
             print "Running {} test...\n".format(func)
             cmd = "{} {}".format(func, param)
@@ -49,4 +50,6 @@ class BistMode(bc.BistMode):
             except subprocess.CalledProcessError as e:
                 print "Failed Test: {}".format(func)
                 print e
+                ret += 1
         print "Finished Executing BIST application\n"
+        return ret

--- a/tools/extra/pac/fpgabist/bist_common.py
+++ b/tools/extra/pac/fpgabist/bist_common.py
@@ -62,9 +62,9 @@ def get_afu_id(gbs_path="", bdf=None):
         accel_data = json_data["afu-image"]["accelerator-clusters"]
         uuid = accel_data[0]["accelerator-type-uuid"].encode("ascii")
         return uuid.lower().replace("-", "")
-    else:
-        pattern = '{:x}:{:x}.{:x}'.format(bdf['bus'], bdf['device'],
-                                          bdf['function'])
+    elif bdf:
+        pattern = '{:02x}:{:02x}.{:x}'.format(bdf['bus'], bdf['device'],
+                                              bdf['function'])
         fpgas = glob.glob('/sys/class/fpga/*')
         for fpga in fpgas:
             slink = os.path.basename(os.readlink(os.path.join(fpga, "device")))
@@ -131,7 +131,7 @@ def load_gbs(gbs_file, bdf):
            hex(bdf['device']), '-F', hex(bdf['function']),
            '-v', gbs_file]
     try:
-        subprocess.check_call(cmd, shell=True)
+        subprocess.check_call(cmd)
     except subprocess.CalledProcessError as e:
         print "Failed to load gbs file: {}".format(gbs_file)
         print "Please try a different gbs"

--- a/tools/extra/pac/fpgabist/bist_def.py
+++ b/tools/extra/pac/fpgabist/bist_def.py
@@ -41,6 +41,7 @@ class DefaultMode(bc.BistMode):
     def run(self, gbs_path, bdf):
         if gbs_path:
             bc.load_gbs(gbs_path, bdf)
+        ret = 0
         for func, param in self.executables.items():
             print "Running Built-in Self test...\n"
             cmd = [func, '-B', hex(bdf['bus']),

--- a/tools/extra/pac/fpgabist/bist_def.py
+++ b/tools/extra/pac/fpgabist/bist_def.py
@@ -38,15 +38,17 @@ class DefaultMode(bc.BistMode):
     def __init__(self):
         self.executables = {'bist': ''}
 
-    def run(self, gbs_path, bus_num):
+    def run(self, gbs_path, bdf):
         if gbs_path:
-            bc.load_gbs(gbs_path, bus_num)
-        ret = 0
+            bc.load_gbs(gbs_path, bdf)
         for func, param in self.executables.items():
             print "Running Built-in Self test...\n"
-            cmd = "{} {}".format(func, param)
+            cmd = [func, '-B', hex(bdf['bus']),
+                   '-D', hex(bdf['device']),
+                   '-F', hex(bdf['function'])]
+            cmd.extend(param.split())
             try:
-                subprocess.check_call(cmd, shell=True)
+                subprocess.check_call(cmd)
             except subprocess.CalledProcessError as e:
                 print "Failed Test: {}".format(func)
                 print e

--- a/tools/extra/pac/fpgabist/bist_dma.py
+++ b/tools/extra/pac/fpgabist/bist_dma.py
@@ -73,9 +73,8 @@ class DmaMode(bc.BistMode):
                     print "Running {} test on {}...\n".format(func, name)
                     ret += self.run_cmd(cmd)
             else:
-                cmd = [func, '-B', hex(bdf['bus']),
-                       '-D', hex(bdf['device']),
-                       '-F', hex(bdf['function'])]
+                print "Running {} test...\n".format(func)
+                cmd = [func, '-B', hex(bdf['bus'])]
                 cmd.extend(param.split())
                 try:
                     subprocess.check_call(cmd)

--- a/tools/extra/pac/fpgabist/bist_dma.py
+++ b/tools/extra/pac/fpgabist/bist_dma.py
@@ -55,9 +55,9 @@ class DmaMode(bc.BistMode):
             ret = 1
         return ret
 
-    def run(self, gbs_path, bus_num, bd_id=0, guid=''):
+    def run(self, gbs_path, bdf, bd_id=0, guid=''):
         if gbs_path:
-            bc.load_gbs(gbs_path, bus_num)
+            bc.load_gbs(gbs_path, bdf)
         ret = 0
         for func, param in self.executables.items():
             if bd_id in dma_list:
@@ -65,16 +65,24 @@ class DmaMode(bc.BistMode):
                     name, size = c
                     if self.dev_id != int(param, 16):
                         continue
-                    cmd = "{} {} -B 0x{} -D {} -S {}".format(func, param,
-                                                             bus_num, i, size)
+                    cmd = "{} {} -B {} -D {} -S {}".format(func, param,
+                                                           hex(bdf['bus']),
+                                                           i, size)
                     if guid:
                         cmd += ' -G {}'.format(guid)
                     print "Running {} test on {}...\n".format(func, name)
                     ret += self.run_cmd(cmd)
             else:
-                print "Running {} test...\n".format(func)
-                cmd = "{} {} {}".format(func, param, bus_num)
-                ret += self.run_cmd(cmd)
+                cmd = [func, '-B', hex(bdf['bus']),
+                       '-D', hex(bdf['device']),
+                       '-F', hex(bdf['function'])]
+                cmd.extend(param.split())
+                try:
+                    subprocess.check_call(cmd)
+                except subprocess.CalledProcessError as e:
+                    print "Failed Test: {}".format(func)
+                    print e
+                    ret += 1
 
         print "Finished Executing DMA Tests\n"
         return ret

--- a/tools/extra/pac/fpgabist/bist_nlb0.py
+++ b/tools/extra/pac/fpgabist/bist_nlb0.py
@@ -34,7 +34,7 @@ afu_clk_freqs = {bc.VCP_ID: 200000000}
 
 
 class Nlb0Mode(bc.BistMode):
-    name = "nlb"
+    name = "nlb_0"
 
     def __init__(self):
         channel = [('vh0', 'vh0'), ('vh1', 'vh1'),
@@ -45,13 +45,16 @@ class Nlb0Mode(bc.BistMode):
         self.executables = {'-'.join(ch): params.format(rvc=ch[0], wvc=ch[1])
                             for ch in channel}
 
-    def run(self, path, bus_num, bd_id=0, guid=''):
+    def run(self, path, bdf, bd_id=0, guid=''):
         tp = self.executables.items()
         tp.sort()
         ret = 0
         for test, param in tp:
             print "Running fpgadiag lpbk1 {} test...".format(test)
-            cmd = "fpgadiag -B 0x{} {}".format(bus_num, param)
+            cmd = "fpgadiag -B {} -D {} -F {} {}".format(hex(bdf['bus']),
+                                                         hex(bdf['device']),
+                                                         hex(bdf['function']),
+                                                         param)
             if guid:
                 cmd += ' -G {}'.format(guid)
             if bd_id != 0:

--- a/tools/extra/pac/fpgabist/bist_nlb3.py
+++ b/tools/extra/pac/fpgabist/bist_nlb3.py
@@ -45,6 +45,7 @@ class Nlb3Mode(bc.BistMode):
     def run(self, gbs_path, bdf):
         if gbs_path:
             bc.load_gbs(gbs_path, bdf)
+        ret = 0
         for test, param in self.executables.items():
             print "Running fpgadiag {} test...\n".format(test)
             cmd = ['fpgadiag', '-B', hex(bdf['bus']),
@@ -52,7 +53,7 @@ class Nlb3Mode(bc.BistMode):
                    '-F', hex(bdf['function'])]
             cmd.extend(param.split())
             try:
-                subprocess.check_call(cmd, shell=True)
+                subprocess.check_call(cmd)
             except subprocess.CalledProcessError as e:
                 print "Failed Test: {}".format(test)
                 print e

--- a/tools/extra/pac/fpgabist/bist_nlb3.py
+++ b/tools/extra/pac/fpgabist/bist_nlb3.py
@@ -42,13 +42,15 @@ class Nlb3Mode(bc.BistMode):
                   '--cont')
         self.executables = {mode: params.format(mode) for mode in modes}
 
-    def run(self, gbs_path, bus_num):
+    def run(self, gbs_path, bdf):
         if gbs_path:
-            bc.load_gbs(gbs_path, bus_num)
-        ret = 0
+            bc.load_gbs(gbs_path, bdf)
         for test, param in self.executables.items():
             print "Running fpgadiag {} test...\n".format(test)
-            cmd = "fpgadiag -B 0x{} {}".format(bus_num, param)
+            cmd = ['fpgadiag', '-B', hex(bdf['bus']),
+                   '-D', hex(bdf['device']),
+                   '-F', hex(bdf['function'])]
+            cmd.extend(param.split())
             try:
                 subprocess.check_call(cmd, shell=True)
             except subprocess.CalledProcessError as e:

--- a/tools/extra/pac/fpgabist/dma/fpga_dma_test.c
+++ b/tools/extra/pac/fpgabist/dma/fpga_dma_test.c
@@ -464,9 +464,9 @@ out_destroy_tok:
    res = fpgaDestroyToken(&afc_token);
    ON_ERR_GOTO(res, out, "fpgaDestroyToken");
 
-out_exit:
-   return 1;
-
 out:
    return 0;
+
+out_exit:
+   return 1;
 }

--- a/tools/extra/pac/fpgabist/fpgabist
+++ b/tools/extra/pac/fpgabist/fpgabist
@@ -91,7 +91,11 @@ def main(args):
     ret = 0
     bist_common.dev_id = dev_id
     for feature in (FEATURES + PRIVATE_FEATURES.get(dev_id, [])):
-        cmd = "fpgainfo {} -B {}".format(feature, hex(bdf['bus']))
+        cmd = ['fpgainfo']
+        cmd.extend(feature)
+        cmd.extend(['-B', hex(bdf['bus']),
+                    '-D', hex(bdf['device']),
+                    '-F', hex(bdf['function'])])
         ret += subprocess.call(cmd, shell=True)
         print("\n")
 
@@ -110,7 +114,7 @@ def main(args):
             afu_ids.update({bist_common.get_afu_id(path): path})
         if not gbs_paths:
             # Get the afu ID of the afu in the slot (defaut persona)
-            afu_ids.update({bist_common.get_afu_id(): ""})
+            afu_ids.update({bist_common.get_afu_id(bdf=bdf): ""})
 
         for afu_id in afu_ids.keys():
             if afu_id == bist_def.DefaultMode().afu_id.replace("-", ""):
@@ -124,7 +128,7 @@ def main(args):
             else:
                 sys.exit("Unknown AFU for available ID {}\n".format(afu_id))
             print "Running mode: {}".format(mode.name)
-            ret += mode.run(afu_ids.get(afu_id), hex(bdf['bus'])[2:])
+            ret += mode.run(afu_ids.get(afu_id), bdf)
 
     print "\nBuilt-in Self-Test Completed.\n"
     sys.exit(ret)

--- a/tools/extra/pac/fpgabist/fpgabist
+++ b/tools/extra/pac/fpgabist/fpgabist
@@ -43,7 +43,7 @@ PRIVATE_FEATURES = {bist_common.VCP_ID: ['phy', 'mac']}
 
 
 def get_afu_id(bus):
-    cmd = 'fpgainfo port -B 0x{}'.format(bus)
+    cmd = 'fpgainfo port -B {}'.format(hex(bus))
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
     output, _ = p.communicate()
     m = re.search('Accelerator Id\\s+:\\s(\\S+)', output)
@@ -51,22 +51,34 @@ def get_afu_id(bus):
     return afu_id
 
 
+def print_cards(bdf):
+    sys.stderr.write("\nAvailable cards:\n")
+    for fpga in sorted(bdf):
+        m = "bus {0}, device {1}, function {2}, device id {3}".format(
+            hex(fpga['bus']), hex(fpga['device']), hex(fpga['function']),
+            hex(fpga['device_id']))
+        sys.stderr.write('  ' + m + '\n')
+
+
 def main(args):
-    bdf = bist_common.get_all_fpga_bdfs(args)
+    all_bdfs = bist_common.get_all_fpga_bdfs(args)
+    if not all_bdfs:
+        sys.exit("No FPGA devices found")
+
+    # Filter the list based on command line arguments
+    bdf = bist_common.get_bdf_from_args(all_bdfs, args)
+    if len(bdf) > 1:
+        sys.stderr.write("Multiple cards found. "
+                         "Specify a bus, device or function.\n")
+        print_cards(bdf)
+        sys.exit(1)
+
     if not bdf:
-        if vars(args)['device_id'] == '09c4':
-            sys.exit("Please use '-i' option to specify FPGA device ID "
-                     "other than 09c4")
-        else:
-            sys.exit("No FPGA devices of device ID {} found"
-                     .format(vars(args)['device_id']))
-    elif len(bdf) > 1 and not any([args.bus, args.device, args.function]):
-        sys.exit("Multiple cards found. Specify a bus, device or function")
-    elif any([vars(args)['bus'], vars(args)['device'],
-              vars(args)['function']]):
-        bdf = bist_common.get_bdf_from_args(args)
-        if len(bdf) > 1 or not bdf:
-            sys.exit("Could not find specified FPGA, please try again")
+        sys.stderr.write("Could not find specified FPGA.\n")
+        print_cards(all_bdfs)
+        sys.exit(1)
+
+    # Down to a single device...
     bdf = bdf[0]
     start = "==========================================================\n\n" \
             "Beginning FPGA Built-In Self-Test\n\n"\
@@ -74,12 +86,12 @@ def main(args):
     print start
 
     # Display data from FPGA info
-    dev_id = int(vars(args)['device_id'], 16)
+    dev_id = bdf['device_id']
     afu_id = get_afu_id(bdf['bus'])
     ret = 0
     bist_common.dev_id = dev_id
     for feature in (FEATURES + PRIVATE_FEATURES.get(dev_id, [])):
-        cmd = "fpgainfo {} -B 0x{}".format(feature, bdf['bus'])
+        cmd = "fpgainfo {} -B {}".format(feature, hex(bdf['bus']))
         ret += subprocess.call(cmd, shell=True)
         print("\n")
 
@@ -89,7 +101,8 @@ def main(args):
             mode = getattr(sys.modules.get(module),
                            '{}Mode'.format(name.capitalize()))()
             print "Running mode: {}".format(mode.name)
-            ret += mode.run(None, bdf['bus'], bist_common.VCP_ID, afu_id)
+            ret += mode.run(None, hex(bdf['bus'])[2:],
+                            bist_common.VCP_ID, afu_id)
     else:
         gbs_paths = args.gbs_paths
         afu_ids = {}
@@ -111,7 +124,7 @@ def main(args):
             else:
                 sys.exit("Unknown AFU for available ID {}\n".format(afu_id))
             print "Running mode: {}".format(mode.name)
-            ret += mode.run(afu_ids.get(afu_id), bdf['bus'])
+            ret += mode.run(afu_ids.get(afu_id), hex(bdf['bus'])[2:])
 
     print "\nBuilt-in Self-Test Completed.\n"
     sys.exit(ret)
@@ -120,6 +133,6 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     bist_common.global_arguments(parser)
-    args = parser.parse_args()
+    args = bist_common.parse_args(parser)
     bist_common.check_required_cmds()
     main(args)

--- a/tools/extra/pac/fpgabist/fpgabist
+++ b/tools/extra/pac/fpgabist/fpgabist
@@ -91,11 +91,9 @@ def main(args):
     ret = 0
     bist_common.dev_id = dev_id
     for feature in (FEATURES + PRIVATE_FEATURES.get(dev_id, [])):
-        cmd = ['fpgainfo']
-        cmd.extend(feature)
-        cmd.extend(['-B', hex(bdf['bus']),
-                    '-D', hex(bdf['device']),
-                    '-F', hex(bdf['function'])])
+        cmd = "fpgainfo {} -B {} -D {} -F {}".format(feature, hex(bdf['bus']),
+                                                     hex(bdf['device']),
+                                                     hex(bdf['function']))
         ret += subprocess.call(cmd, shell=True)
         print("\n")
 


### PR DESCRIPTION
The Vista Creek (VC) merge left fpgabist broken when used with Darby Creek
regressions. The new VC bist code hard-wired the device ID of Rush Creek and
promoted device ID handling so that it had to match the board, even when a
full BDF was supplied.

The changes here:

- Demote --device-id so it is just one of the components in the search for a board.
  The default value is None. The new algorithm looks for all available FPGAs on the
  host and then filters them using the supplied BDF and device ID. The test can run
  as long as the filter matches a single FPGA.

- Cherry pick a few changes from the DC branch.

- Repair the non-trivial merge of the DC and the VC changes.

- Fix nlb0 clock frequency discovery. It was reporting in correct performance.
