### PR TITLE
fpgabist: dma: allow configuration without TBB

### DIFF
--- a/cmake/modules/FindTbb.cmake
+++ b/cmake/modules/FindTbb.cmake
@@ -45,5 +45,9 @@ find_path(TBB_INCLUDE_DIRS
           ${PC_TBB_INCLUDE_DIRS}
           ${TBB_INCLUDE_DIRS})
 
+if(TBB_LIBRARIES AND TBB_INCLUDE_DIRS)
+  set(TBB_FOUND true)
+endif(TBB_LIBRARIES AND TBB_INCLUDE_DIRS)
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(TBB REQUIRED_VARS TBB_INCLUDE_DIRS TBB_LIBRARIES)

--- a/cmake/modules/FindTbb.cmake
+++ b/cmake/modules/FindTbb.cmake
@@ -36,14 +36,14 @@ find_library(TBB_LIBRARIES
           ${PC_TBB_LIBRARY_DIRS}
           ${TBB_LIBRARY_DIRS})
 
-if(NOT TBB_INCLUDE_DIRS)
-  set(TBB_INCLUDE_DIRS "")
+if(NOT TBB_INCLUDE)
+  set(TBB_INCLUDE "")
 endif()
 find_path(TBB_INCLUDE_DIRS
     NAMES tbb/tbb.h
     HINTS ${PC_TBB_INCLUDEDIR}
           ${PC_TBB_INCLUDE_DIRS}
-          ${TBB_INCLUDE_DIRS})
+          ${TBB_INCLUDE})
 
 if(TBB_LIBRARIES AND TBB_INCLUDE_DIRS)
   set(TBB_FOUND true)

--- a/cmake/modules/FindTbb.cmake
+++ b/cmake/modules/FindTbb.cmake
@@ -40,7 +40,7 @@ if(NOT TBB_INCLUDE_DIRS)
   set(TBB_INCLUDE_DIRS "")
 endif()
 find_path(TBB_INCLUDE_DIRS
-    NAMES tbb.h
+    NAMES tbb/tbb.h
     HINTS ${PC_TBB_INCLUDEDIR}
           ${PC_TBB_INCLUDE_DIRS}
           ${TBB_INCLUDE_DIRS})

--- a/tools/extra/pac/fpgabist/CMakeLists.txt
+++ b/tools/extra/pac/fpgabist/CMakeLists.txt
@@ -34,9 +34,12 @@ set(PYTHON_SRC
      bist_nlb3.py
      fpgabist)
 
- add_subdirectory(dma)
- add_subdirectory(dma_vc)
- add_subdirectory(bist)
+if(TBB_FOUND)
+  add_subdirectory(dma)
+endif(TBB_FOUND)
+
+add_subdirectory(dma_vc)
+add_subdirectory(bist)
 
 install(PROGRAMS ${PYTHON_SRC}
     DESTINATION bin

--- a/tools/extra/pac/fpgabist/CMakeLists.txt
+++ b/tools/extra/pac/fpgabist/CMakeLists.txt
@@ -34,11 +34,11 @@ set(PYTHON_SRC
      bist_nlb3.py
      fpgabist)
 
-if(TBB_LIBRARIES)
+if(TBB_FOUND)
   add_subdirectory(dma)
-else(TBB_LIBRARIES)
+else(TBB_FOUND)
   message(WARNING "Thread Building Blocks not found: not building fpgabist/dma.")
-endif(TBB_LIBRARIES)
+endif(TBB_FOUND)
 
 add_subdirectory(dma_vc)
 add_subdirectory(bist)

--- a/tools/extra/pac/fpgabist/CMakeLists.txt
+++ b/tools/extra/pac/fpgabist/CMakeLists.txt
@@ -34,9 +34,11 @@ set(PYTHON_SRC
      bist_nlb3.py
      fpgabist)
 
-if(TBB_FOUND)
+if(TBB_LIBRARIES)
   add_subdirectory(dma)
-endif(TBB_FOUND)
+else(TBB_LIBRARIES)
+  message(WARNING "Thread Building Blocks not found: not building fpgabist/dma.")
+endif(TBB_LIBRARIES)
 
 add_subdirectory(dma_vc)
 add_subdirectory(bist)


### PR DESCRIPTION
Allow the cmake and build steps to continue in the case that the TBB
package is not found. When TBB is found, fpgabist/dma is included in
the build.