### PR TITLE
libopaecxx must not automatically load libopae-c or ASE breaks.

### DIFF
--- a/libopaecxx/CMakeLists.txt
+++ b/libopaecxx/CMakeLists.txt
@@ -58,7 +58,7 @@ set(OPAECXXCORE_SRC src/properties.cpp
                     src/version.cpp)
 
 add_library(opae-cxx-core SHARED ${OPAECXXCORE_SRC})
-target_link_libraries(opae-cxx-core opae-c uuid)
+target_link_libraries(opae-cxx-core uuid)
 
 add_executable(hello_cxxcore samples/hello_fpga-1.cpp)
 target_link_libraries(hello_cxxcore opae-c ${CMAKE_THREAD_LIBS_INIT} opae-cxx-core )

--- a/tools/extra/integrated/hssi/CMakeLists.txt
+++ b/tools/extra/integrated/hssi/CMakeLists.txt
@@ -50,7 +50,7 @@ set_install_rpath(hssi-io)
 set_target_properties(hssi-io PROPERTIES
   VERSION ${INTEL_FPGA_API_VERSION}
   SOVERSION ${INTEL_FPGA_API_VER_MAJOR})
-target_link_libraries(hssi-io opae-cxx-core opae-c++-utils)
+target_link_libraries(hssi-io opae-cxx-core opae-c++-utils opae-c)
 
 add_executable(hssi_loopback loopback_main.cpp
                              loopback_app.h


### PR DESCRIPTION
ASE depends on dynamically loading libopae-c-ase instead of libopae-c.
The C++ OPAE library was claiming dependence on libopae-c. Drop this
and leave it to the application writer to specify the proper OPAE SDK
library during the final link.