### PR TITLE
ASE RTL bug fixes

### DIFF
--- a/libopae/plugins/ase/rtl/ase_sim_local_mem.sv
+++ b/libopae/plugins/ase/rtl/ase_sim_local_mem.sv
@@ -80,7 +80,7 @@ module ase_sim_local_mem_avmm
    // emif model
    genvar b;
    generate
-      for (b = 0; b < NUM_BANKS; b = b + 2)
+      for (b = 0; b < NUM_BANKS; b = b + 1)
       begin : b_emul
          // Slightly different clock on each bank
          always #(delay+b) ddr_pll_ref_clk[b] = ~ddr_pll_ref_clk[b];
@@ -92,37 +92,26 @@ module ase_sim_local_mem_avmm
             )
           emif_ddr4
           (
-            .ddr4a_avmm_waitrequest                (emul_waitrequest[b]),
-            .ddr4a_avmm_readdata                   (emul_readdata[b]),
-            .ddr4a_avmm_readdatavalid              (emul_readdatavalid[b]),
-            .ddr4a_avmm_burstcount                 (emul_burstcount[b]),
-            .ddr4a_avmm_writedata                  (emul_writedata[b]),
-            .ddr4a_avmm_address                    (emul_address[b]),
-            .ddr4a_avmm_write                      (emul_write[b]),
-            .ddr4a_avmm_read                       (emul_read[b]),
-            .ddr4a_avmm_byteenable                 (emul_byteenable[b]),
-            .ddr4a_avmm_clk_clk                    (clks[b]),
+            .ddr_avmm_waitrequest                (emul_waitrequest[b]),
+            .ddr_avmm_readdata                   (emul_readdata[b]),
+            .ddr_avmm_readdatavalid              (emul_readdatavalid[b]),
+            .ddr_avmm_burstcount                 (emul_burstcount[b]),
+            .ddr_avmm_writedata                  (emul_writedata[b]),
+            .ddr_avmm_address                    (emul_address[b]),
+            .ddr_avmm_write                      (emul_write[b]),
+            .ddr_avmm_read                       (emul_read[b]),
+            .ddr_avmm_byteenable                 (emul_byteenable[b]),
+            .ddr_avmm_clk_clk                    (clks[b]),
 
-            .ddr4a_global_reset_reset_sink_reset_n (ddr_reset_n),
-            .ddr4a_pll_ref_clk_clock_sink_clk      (ddr_pll_ref_clk[b]),
-
-            .ddr4b_avmm_waitrequest                (emul_waitrequest[b+1]),
-            .ddr4b_avmm_readdata                   (emul_readdata[b+1]),
-            .ddr4b_avmm_readdatavalid              (emul_readdatavalid[b+1]),
-            .ddr4b_avmm_burstcount                 (emul_burstcount[b+1]),
-            .ddr4b_avmm_writedata                  (emul_writedata[b+1]),
-            .ddr4b_avmm_address                    (emul_address[b+1]),
-            .ddr4b_avmm_write                      (emul_write[b+1]),
-            .ddr4b_avmm_read                       (emul_read[b+1]),
-            .ddr4b_avmm_byteenable                 (emul_byteenable[b+1]),
-            .ddr4b_avmm_clk_clk                    (clks[b+1])
+            .ddr_global_reset_reset_sink_reset_n (ddr_reset_n),
+            .ddr_pll_ref_clk_clock_sink_clk      (ddr_pll_ref_clk[b])
          );
       end
    endgenerate
 
    //
    // Add a bridge between the emulator and the DUT in order to eliminate
-   // timing glitches induces by the DDR model. The model's waitrequest isn't
+   // timing glitches induces by the DDR model. Some model signals aren't
    // quite aligned to the clock, leading to random failures in some RTL
    // emulators.
    //

--- a/libopae/plugins/ase/rtl/ase_top.sv
+++ b/libopae/plugins/ase/rtl/ase_top.sv
@@ -170,18 +170,12 @@ module ase_top_generic
    localparam NUM_LOCAL_MEM_BANKS = `AFU_TOP_REQUIRES_LOCAL_MEMORY_AVALON_MM;
  `endif
 
-   // The ddr4 array size must be an even number, whether or not NUM_LOCAL_MEM_BANKS
-   // is even.  This is due to the way the emulator is structured in emif_ddr4
-   // below.  When NUM_LOCAL_MEM_BANKS is odd an extra slot will be instantiated
-   // but not passed to the AFU.
-   localparam NUM_ALLOC_MEM_BANKS = (((NUM_LOCAL_MEM_BANKS + 1) >> 1) << 1);
-
    // DDR clock will come from the memory emulator
-   logic ddr4_avmm_clk[NUM_ALLOC_MEM_BANKS];
+   logic ddr4_avmm_clk[NUM_LOCAL_MEM_BANKS];
 
    // Interfaces for all DDR memory banks
    avalon_mem_if#(.ENABLE_LOG(1), .NUM_BANKS(NUM_LOCAL_MEM_BANKS))
-      ddr4[NUM_ALLOC_MEM_BANKS](ddr4_avmm_clk, pck_cp2af_softReset);
+      ddr4[NUM_LOCAL_MEM_BANKS](ddr4_avmm_clk, pck_cp2af_softReset);
 `else
    localparam NUM_LOCAL_MEM_BANKS = 0;
 `endif

--- a/libopae/plugins/ase/rtl/ccip_emulator.sv
+++ b/libopae/plugins/ase/rtl/ccip_emulator.sv
@@ -2201,8 +2201,8 @@ module ccip_emulator
             C0RxMmioRdValid <= 0;
             C0RxRdValid     <= 0;
             C0RxUMsgValid   <= 0;
-            C0RxHdr         <= RxHdr_t'({CCIP_RX_HDR_WIDTH{1'b0}});
-            C0RxData        <= {CCIP_DATA_WIDTH{1'b0}};
+            C0RxHdr         <= RxHdr_t'('x);
+            C0RxData        <= {CCIP_DATA_WIDTH{'x}};
         end
         else if (mmioreq_valid) begin
             C0RxMmioWrValid <= mmio_wrvalid;
@@ -2235,8 +2235,8 @@ module ccip_emulator
             C0RxMmioRdValid <= 0;
             C0RxRdValid     <= 0;
             C0RxUMsgValid   <= 0;
-            C0RxHdr         <= RxHdr_t'({CCIP_RX_HDR_WIDTH{1'b0}});
-            C0RxData        <= {CCIP_DATA_WIDTH{1'b0}};
+            C0RxHdr         <= RxHdr_t'('x);
+            C0RxData        <= {CCIP_DATA_WIDTH{'x}};
         end
     end
 

--- a/libopae/plugins/ase/rtl/device_models/dcp_emif_model_basic/emif_ddr4.v
+++ b/libopae/plugins/ase/rtl/device_models/dcp_emif_model_basic/emif_ddr4.v
@@ -29,9 +29,6 @@
 import verbosity_pkg::*;
 import avalon_mm_pkg::*;
 
-// emif_ddr4 implements two banks per instance
-`define NUM_SLAVES 2
-
 //---------------------------------------------------
 // Constants
 //---------------------------------------------------
@@ -49,30 +46,19 @@ module emif_ddr4 #(
 	parameter SYMBOL_WIDTH = 8,
 	parameter NUM_SYMBOLS = (DDR_DATA_WIDTH + SYMBOL_WIDTH - 1) / SYMBOL_WIDTH
 ) (
-	output wire         ddr4a_avmm_waitrequest,
-	output wire [DDR_DATA_WIDTH-1:0] ddr4a_avmm_readdata,
-	output wire         ddr4a_avmm_readdatavalid,
-	input  wire [BURST_W-1:0]   ddr4a_avmm_burstcount,
-	input  wire [DDR_DATA_WIDTH-1:0] ddr4a_avmm_writedata,
-	input  wire [DDR_ADDR_WIDTH-1:0]  ddr4a_avmm_address,
-	input  wire         ddr4a_avmm_write,
-	input  wire         ddr4a_avmm_read,
-	input  wire [NUM_SYMBOLS-1:0]  ddr4a_avmm_byteenable,
-	output wire         ddr4a_avmm_clk_clk,
+	output wire         ddr_avmm_waitrequest,
+	output wire [DDR_DATA_WIDTH-1:0] ddr_avmm_readdata,
+	output wire         ddr_avmm_readdatavalid,
+	input  wire [BURST_W-1:0]   ddr_avmm_burstcount,
+	input  wire [DDR_DATA_WIDTH-1:0] ddr_avmm_writedata,
+	input  wire [DDR_ADDR_WIDTH-1:0]  ddr_avmm_address,
+	input  wire         ddr_avmm_write,
+	input  wire         ddr_avmm_read,
+	input  wire [NUM_SYMBOLS-1:0]  ddr_avmm_byteenable,
+	output wire         ddr_avmm_clk_clk,
 
-	input  wire         ddr4a_global_reset_reset_sink_reset_n,
-	input  wire         ddr4a_pll_ref_clk_clock_sink_clk,
-
-	output wire         ddr4b_avmm_waitrequest,
-	output wire [DDR_DATA_WIDTH-1:0] ddr4b_avmm_readdata,
-	output wire         ddr4b_avmm_readdatavalid,
-	input  wire [BURST_W-1:0]   ddr4b_avmm_burstcount,
-	input  wire [DDR_DATA_WIDTH-1:0] ddr4b_avmm_writedata,
-	input  wire [DDR_ADDR_WIDTH-1:0]  ddr4b_avmm_address,
-	input  wire         ddr4b_avmm_write,
-	input  wire         ddr4b_avmm_read,
-	input  wire [NUM_SYMBOLS-1:0]  ddr4b_avmm_byteenable,
-	output wire         ddr4b_avmm_clk_clk
+	input  wire         ddr_global_reset_reset_sink_reset_n,
+	input  wire         ddr_pll_ref_clk_clock_sink_clk
 );
 
 //---------------------------------------------------
@@ -93,7 +79,7 @@ typedef enum bit
 } Burstmode;
 
 // model memory banks as associative arrays
-logic [DDR_DATA_WIDTH-1:0] memory[`NUM_SLAVES][*];
+logic [DDR_DATA_WIDTH-1:0] memory[*];
 
 typedef struct
 {
@@ -114,14 +100,9 @@ typedef struct
 } Response;
 
 // slave response queue
-Response read_response_queue_slave[`NUM_SLAVES][$];
+Response read_response_queue_slave[$];
 
-// ddr user clock frequency = 266.666.. Mhz
-// We shift the clock because altera_avalon_mm_slave_bfm shifts
-// its monitor_request() task #1, which leads to glitches in
-// waitrequest and causes random errors in simulation.
-assign #10 ddr4a_avmm_clk_clk = ddr4a_pll_ref_clk_clock_sink_clk;
-assign #10 ddr4b_avmm_clk_clk = ddr4a_pll_ref_clk_clock_sink_clk;
+assign ddr_avmm_clk_clk = ddr_pll_ref_clk_clock_sink_clk;
 
 altera_avalon_mm_slave_bfm #(
 	.AV_ADDRESS_W               (DDR_ADDR_WIDTH),
@@ -145,98 +126,47 @@ altera_avalon_mm_slave_bfm #(
 	.AV_WRITE_WAIT_TIME         (0),
 	.REGISTER_WAITREQUEST       (0),
 	.AV_REGISTERINCOMINGSIGNALS (0),
+	.AV_WAITREQUEST_ALLOWANCE   (1),
 	.VHDL_ID                    (0),
 	.PRINT_HELLO                (0)
-)  avs_bfm_inst_ddra (
-	.clk                  	(ddr4a_pll_ref_clk_clock_sink_clk),
-	.reset                	(~ddr4a_global_reset_reset_sink_reset_n),
+)  avs_bfm_inst (
+	.clk                  	(ddr_pll_ref_clk_clock_sink_clk),
+	.reset                	(~ddr_global_reset_reset_sink_reset_n),
 
-	.avs_writedata        	(ddr4a_avmm_writedata),
-	.avs_readdata         	(ddr4a_avmm_readdata),
-	.avs_address          	(ddr4a_avmm_address),
-	.avs_waitrequest      	(ddr4a_avmm_waitrequest),
-	.avs_write            	(ddr4a_avmm_write),
-	.avs_read             	(ddr4a_avmm_read),
-	.avs_byteenable       	(ddr4a_avmm_byteenable),
-	.avs_readdatavalid    	(ddr4a_avmm_readdatavalid),
-	.avs_burstcount       	(ddr4a_avmm_burstcount)
+	.avs_writedata        	(ddr_avmm_writedata),
+	.avs_readdata         	(ddr_avmm_readdata),
+	.avs_address          	(ddr_avmm_address),
+	.avs_waitrequest      	(ddr_avmm_waitrequest),
+	.avs_write            	(ddr_avmm_write && !ddr_avmm_waitrequest),
+	.avs_read             	(ddr_avmm_read && !ddr_avmm_waitrequest),
+	.avs_byteenable       	(ddr_avmm_byteenable),
+	.avs_readdatavalid    	(ddr_avmm_readdatavalid),
+	.avs_burstcount       	(ddr_avmm_burstcount)
 );
 
-altera_avalon_mm_slave_bfm #(
-	.AV_ADDRESS_W               (DDR_ADDR_WIDTH),
-	.AV_NUMSYMBOLS              (NUM_SYMBOLS),
-	.AV_BURSTCOUNT_W            (BURST_W),
-	.AV_READRESPONSE_W          (1),
-	.AV_WRITERESPONSE_W         (1),
-	.USE_BEGIN_TRANSFER         (0),
-	.USE_BEGIN_BURST_TRANSFER   (0),
-	.USE_WAIT_REQUEST           (1),
-	.USE_TRANSACTIONID          (0),
-	.USE_WRITERESPONSE          (1),
-	.USE_READRESPONSE           (1),
-	.USE_CLKEN                  (0),
-	.AV_BURST_LINEWRAP          (0),
-	.AV_BURST_BNDR_ONLY         (0),
-	.AV_MAX_PENDING_READS       (0),
-	.AV_MAX_PENDING_WRITES      (0),
-	.AV_FIX_READ_LATENCY        (0),
-	.AV_READ_WAIT_TIME          (1),
-	.AV_WRITE_WAIT_TIME         (0),
-	.REGISTER_WAITREQUEST       (0),
-	.AV_REGISTERINCOMINGSIGNALS (0),
-	.VHDL_ID                    (0),
-	.PRINT_HELLO                (0)
-)  avs_bfm_inst_ddrb (
-	.clk                  	(ddr4a_pll_ref_clk_clock_sink_clk),
-	.reset                	(~ddr4a_global_reset_reset_sink_reset_n),
 
-	.avs_writedata        	(ddr4b_avmm_writedata),
-	.avs_readdata         	(ddr4b_avmm_readdata),
-	.avs_address          	(ddr4b_avmm_address),
-	.avs_waitrequest      	(ddr4b_avmm_waitrequest),
-	.avs_write            	(ddr4b_avmm_write),
-	.avs_read             	(ddr4b_avmm_read),
-	.avs_byteenable       	(ddr4b_avmm_byteenable),
-	.avs_readdatavalid    	(ddr4b_avmm_readdatavalid),
-	.avs_burstcount       	(ddr4b_avmm_burstcount)
-);
+function automatic Command get_command_from_slave();
+	Command cmd;
 
-// Macros
-`define SLAVE0 avs_bfm_inst_ddra
-`define SLAVE1 avs_bfm_inst_ddrb
+	avs_bfm_inst.pop_command();
+	cmd.burstcount          = avs_bfm_inst.get_command_burst_count();
+	cmd.addr                = avs_bfm_inst.get_command_address();
 
-`define MACRO_PENDING_READ_CYCLES(SLAVE_ID) \
-	int pending_read_cycles_slave_``SLAVE_ID = 0; \
-	always @(posedge `SLAVE``SLAVE_ID.clk) begin \
-		if (pending_read_cycles_slave_``SLAVE_ID > 0) begin \
-			pending_read_cycles_slave_``SLAVE_ID--; \
-		end \
+	if (avs_bfm_inst.get_command_request() == REQ_WRITE) begin
+		cmd.trans = WRITE;
+		for(int i = 0; i < cmd.burstcount; i++) begin
+			cmd.data[i]       =avs_bfm_inst.get_command_data(i);
+			cmd.byteenable[i] =avs_bfm_inst.get_command_byte_enable(i);
+		end
+	end else begin
+		cmd.trans = READ;
+		for(int i = 0; i < cmd.burstcount; i++) begin
+			cmd.byteenable[i] =avs_bfm_inst.get_command_byte_enable(i);
+		end
 	end
 
-`define MACRO_GET_COMMAND_FROM_SLAVE(SLAVE_ID) \
-	function automatic Command get_command_from_slave_``SLAVE_ID (); \
-\
-	Command cmd; \
-\
-	`SLAVE``SLAVE_ID.pop_command(); \
-	cmd.burstcount          = `SLAVE``SLAVE_ID.get_command_burst_count(); \
-	cmd.addr                = `SLAVE``SLAVE_ID.get_command_address(); \
-\
-	if (`SLAVE``SLAVE_ID.get_command_request() == REQ_WRITE) begin \
-		cmd.trans = WRITE; \
-		for(int i = 0; i < cmd.burstcount; i++) begin \
-			cmd.data[i]       =`SLAVE``SLAVE_ID.get_command_data(i); \
-			cmd.byteenable[i] =`SLAVE``SLAVE_ID.get_command_byte_enable(i); \
-		end \
-	end else begin \
-		cmd.trans = READ; \
-		for(int i = 0; i < cmd.burstcount; i++) begin \
-			cmd.byteenable[i] =`SLAVE``SLAVE_ID.get_command_byte_enable(i); \
-		end \
-	end \
-\
-	return cmd; \
-	endfunction
+	return cmd;
+endfunction
 
 // Functions
 function automatic Response create_response (
@@ -263,92 +193,80 @@ function automatic logic [DDR_DATA_WIDTH-1:0] get_mask (logic [NUM_SYMBOLS-1:0] 
 	return mask;
 endfunction
 
-function automatic Response memory_response (Command cmd, int SLAVE_ID);
+function automatic Response memory_response (Command cmd);
 	Response rsp;
 	
 	rsp.burstcount = (cmd.trans == READ) ? cmd.burstcount : 1;
 	for(int idx = 0; idx < cmd.burstcount; idx++) begin
 		if(cmd.trans == READ) begin
-			rsp.data[idx] = memory[SLAVE_ID][cmd.addr+idx] & get_mask(cmd.byteenable[0]);
+			rsp.data[idx] = memory[cmd.addr+idx] & get_mask(cmd.byteenable[0]);
 			rsp.latency[idx] = $urandom_range(0,MAX_LATENCY); // set a random memory response latency
 		end
 	end
 	return rsp;
 endfunction
 
-`define MACRO_SLAVE_THREAD(SLAVE_ID) \
-	always @(`SLAVE``SLAVE_ID.signal_command_received) begin \
-\
-	Command     actual_cmd, exp_cmd; \
-	Response    rsp; \
-	logic [DDR_DATA_WIDTH-1:0] mask; \
-\
-	automatic int backpressure_cycles; \
-\
-	// set random backpressure cycles for next command \
-	for (int i = 0; i < MAX_BURST; i++) begin \
-		backpressure_cycles = $urandom_range(0, MAX_COMMAND_BACKPRESSURE); \
-		`SLAVE``SLAVE_ID.set_interface_wait_time(backpressure_cycles, i); \
-	end \
-\
-	actual_cmd = get_command_from_slave_``SLAVE_ID(); \
-\
-	// set read response \
-	if (actual_cmd.trans == READ) begin \
-		rsp = memory_response(actual_cmd, SLAVE_ID); \
-		configure_and_push_response_to_slave_``SLAVE_ID(rsp); \
-		read_response_queue_slave[``SLAVE_ID].push_back(rsp); \
-	end \
-\
-	if (actual_cmd.trans == WRITE) begin \
-		for(int idx = 0; idx < actual_cmd.burstcount; idx++) begin\
-			if(memory[SLAVE_ID].exists(actual_cmd.addr+idx)) begin\
-				mask = get_mask(actual_cmd.byteenable[idx]); \
-				memory[SLAVE_ID][actual_cmd.addr+idx] = ((memory[SLAVE_ID][actual_cmd.addr+idx] & ~mask) | \
-					                                     (actual_cmd.data[idx] & mask));\
-			end\
-			else begin\
-				memory[SLAVE_ID][actual_cmd.addr+idx] = actual_cmd.data[idx];\
-			end\
-		end \
-	end \
+// Simple waitrequest emulation: assert waitrequest 80% of the time
+always @(posedge avs_bfm_inst.clk) begin
+	avs_bfm_inst.set_waitrequest(($urandom_range(0, 100) > 80));
 end
 
-`define MACRO_CONFIGURE_AND_PUSH_RESPONSE_TO_SLAVE(SLAVE_ID) \
-task automatic configure_and_push_response_to_slave_``SLAVE_ID ( \
-	Response rsp \
-); \
-\
-	int read_response_latency; \
-\
-	`SLAVE``SLAVE_ID.set_response_request(REQ_READ); \
-	`SLAVE``SLAVE_ID.set_response_burst_size(rsp.burstcount); \
-	for (int i = 0; i < rsp.burstcount; i++) begin \
-		`SLAVE``SLAVE_ID.set_response_data(rsp.data[i], i); \
-\
-		if (i == 0) begin \
-			`SLAVE``SLAVE_ID.set_response_latency(rsp.latency[i] + pending_read_cycles_slave_``SLAVE_ID, i); \
-			read_response_latency = rsp.latency[i]; \
-		end else begin \
-			`SLAVE``SLAVE_ID.set_response_latency(rsp.latency[i], i); \
-			read_response_latency = rsp.latency[i] + read_response_latency; \
-		end \
-\
-	end \
-	`SLAVE``SLAVE_ID.push_response(); \
-	pending_read_cycles_slave_``SLAVE_ID = pending_read_cycles_slave_``SLAVE_ID + read_response_latency + rsp.burstcount + 2; \
+always @(avs_bfm_inst.signal_command_received) begin
+	Command     actual_cmd, exp_cmd;
+	Response    rsp;
+	logic [DDR_DATA_WIDTH-1:0] mask;
+
+	actual_cmd = get_command_from_slave();
+
+	// set read response
+	if (actual_cmd.trans == READ) begin
+		rsp = memory_response(actual_cmd);
+		configure_and_push_response_to_slave(rsp);
+		read_response_queue_slave.push_back(rsp);
+	end
+
+	if (actual_cmd.trans == WRITE) begin
+		for(int idx = 0; idx < actual_cmd.burstcount; idx++) begin
+			if(memory.exists(actual_cmd.addr+idx)) begin
+				mask = get_mask(actual_cmd.byteenable[idx]);
+				memory[actual_cmd.addr+idx] = ((memory[actual_cmd.addr+idx] & ~mask) |
+					                       (actual_cmd.data[idx] & mask));
+			end
+			else begin
+				memory[actual_cmd.addr+idx] = actual_cmd.data[idx];
+			end
+		end
+	end
+end
+
+int pending_read_cycles_slave = 0;
+always @(posedge avs_bfm_inst.clk) begin
+	if (pending_read_cycles_slave > 0) begin
+		pending_read_cycles_slave--;
+	end
+end
+
+task automatic configure_and_push_response_to_slave(
+	Response rsp
+);
+	int read_response_latency;
+
+	avs_bfm_inst.set_response_request(REQ_READ);
+	avs_bfm_inst.set_response_burst_size(rsp.burstcount);
+	for (int i = 0; i < rsp.burstcount; i++) begin
+		avs_bfm_inst.set_response_data(rsp.data[i], i);
+
+		if (i == 0) begin
+			avs_bfm_inst.set_response_latency(rsp.latency[i] + pending_read_cycles_slave, i);
+			read_response_latency = rsp.latency[i];
+		end else begin
+			avs_bfm_inst.set_response_latency(rsp.latency[i], i);
+			read_response_latency = rsp.latency[i] + read_response_latency;
+		end
+
+	end
+	avs_bfm_inst.push_response();
+	pending_read_cycles_slave = pending_read_cycles_slave + read_response_latency + rsp.burstcount + 2;
 endtask
-
-// slave 0
-`MACRO_SLAVE_THREAD(0)
-`MACRO_GET_COMMAND_FROM_SLAVE(0)
-`MACRO_PENDING_READ_CYCLES(0)
-`MACRO_CONFIGURE_AND_PUSH_RESPONSE_TO_SLAVE(0)
-
-// slave 1
-`MACRO_SLAVE_THREAD(1)
-`MACRO_GET_COMMAND_FROM_SLAVE(1)
-`MACRO_PENDING_READ_CYCLES(1)
-`MACRO_CONFIGURE_AND_PUSH_RESPONSE_TO_SLAVE(1)
 
 endmodule


### PR DESCRIPTION
- Previous code forced c0Rx header and data to zero when there was no message.
   I've now seen a few broken AFUs that fail on HW but work in simulation because
   of the default zero state.

- Eliminate an internal error in the AVMM response scheduling by managing
  waitrequest in the ASE model driver. The AVMM model was delaying read responses
  when waitrequest was high, which led to the model trying to schedule multiple
  responses in the same cycle.

- Instantiate one AVMM bank in the lowest level module instead of two. Doing two
  at once was needlessly complicated and made it hard to model systems with an odd
  number of banks.