### PR TITLE
Remove "-v" argument to fpgaconf in fpgabist

### DIFF
--- a/tools/extra/pac/fpgabist/bist_common.py
+++ b/tools/extra/pac/fpgabist/bist_common.py
@@ -130,7 +130,7 @@ def load_gbs(gbs_file, bdf):
     print "Attempting Partial Reconfiguration:"
     cmd = ['fpgaconf', '-B', hex(bdf['bus']), '-D',
            hex(bdf['device']), '-F', hex(bdf['function']),
-           '-v', gbs_file]
+           gbs_file]
     try:
         subprocess.check_call(cmd)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
fpgaconf recently changed it's argument parsing, causing "-v" to print the
version. It fails when specified with other arguments, leading to fpgabist
failures.