### PR TITLE
hello_fpga: don't use version macros from config.h

### DIFF
--- a/libopae/api-shell.c
+++ b/libopae/api-shell.c
@@ -879,15 +879,18 @@ fpga_result fpgaGetOPAECVersionString(char *version_str, size_t len)
 
 fpga_result fpgaGetOPAECBuildString(char *build_str, size_t len)
 {
-	errno_t err;
+	int err;
 
 	ASSERT_NOT_NULL(build_str);
 
-	err = strncpy_s(build_str, len, INTEL_FPGA_API_HASH,
-			sizeof(INTEL_FPGA_API_HASH));
+	err = snprintf_s_ss(build_str,
+			    len,
+			    "%s%s",
+			    INTEL_FPGA_API_HASH,
+			    INTEL_FPGA_TREE_DIRTY ? "*" : "");
 
-	if (err) {
-		OPAE_ERR("strncpy_s failed with error %d", err);
+	if (err < 0) {
+		OPAE_ERR("snprintf_s_ss failed with error %d", err);
 		return FPGA_EXCEPTION;
 	}
 

--- a/samples/hello_fpga.c
+++ b/samples/hello_fpga.c
@@ -149,6 +149,8 @@ fpga_result parse_args(int argc, char *argv[])
 	int getopt_ret;
 	int option_index;
 	char *endptr = NULL;
+	char version[32];
+	char build[32];
 
 	while (-1 != (getopt_ret = getopt_long(argc, argv, GETOPT_STRING,
 						longopts, &option_index))) {
@@ -175,10 +177,10 @@ fpga_result parse_args(int argc, char *argv[])
 			break;
 
 		case 'v':
-			printf("hello_fpga %s %s%s\n",
-			       INTEL_FPGA_API_VERSION,
-			       INTEL_FPGA_API_HASH,
-			       INTEL_FPGA_TREE_DIRTY ? "*":"");
+			fpgaGetOPAECVersionString(version, sizeof(version));
+			fpgaGetOPAECBuildString(build, sizeof(build));
+			printf("hello_fpga %s %s\n",
+			       version, build);
 			return -1;
 
 		default: /* invalid option */

--- a/testing/opae-c/test_init_c.cpp
+++ b/testing/opae-c/test_init_c.cpp
@@ -302,8 +302,9 @@ class init_ase_cfg_p : public ::testing::TestWithParam<const char*> {
         EXPECT_EQ(ret, 0);
     }
     struct stat st;
-    if (stat(tmpfile_, &st) == 0)
+    if (stat(tmpfile_, &st) == 0) {
       EXPECT_EQ(unlink(tmpfile_), 0);
+    }
   }
 
   char buffer_[PATH_MAX];
@@ -365,8 +366,9 @@ TEST_P(init_ase_cfg_p, find_ase_cfg_2) {
         int ret = rename(inst_cfg_file_.c_str(), OPAE_ASE_CFG_INST_PATH);
         EXPECT_EQ(ret, 0);
     }
-    if (stat(tmpfile2_, &st) == 0)
+    if (stat(tmpfile2_, &st) == 0) {
       EXPECT_EQ(unlink(tmpfile2_), 0);
+    }
 }
 
 /**

--- a/testing/opae-c/test_version_c.cpp
+++ b/testing/opae-c/test_version_c.cpp
@@ -75,17 +75,6 @@ TEST(version, opaec_string) {
 }
 
 /**
- * @test       opaec_string_err
- * @brief      Test: fpgaGetOPAECVersionString
- * @details    When fpgaGetOPAECVersionString is called with invalid params,<br>
- *             then it returns FPGA_EXCEPTION.<br>
- */
-TEST(version, opaec_string_err) {
-  char ver_str[4097];
-  EXPECT_EQ(fpgaGetOPAECVersionString(ver_str, sizeof(ver_str)), FPGA_EXCEPTION);
-}
-
-/**
  * @test       opaec_build_string
  * @brief      Test: fpgaGetOPAECBuildString
  * @details    When fpgaGetOPAECBuildString is called with valid params,<br>
@@ -95,18 +84,11 @@ TEST(version, opaec_string_err) {
 TEST(version, opaec_build_string) {
   char b_str[32];
   EXPECT_EQ(fpgaGetOPAECBuildString(b_str, sizeof(b_str)), FPGA_OK);
-  EXPECT_STREQ(b_str, INTEL_FPGA_API_HASH);
-}
-
-/**
- * @test       opaec_build_string_err
- * @brief      Test: fpgaGetOPAECBuildString
- * @details    When fpgaGetOPAECBuildString is called with invalid params,<br>
- *             then it returns FPGA_EXCEPTION.<br>
- */
-TEST(version, opaec_build_string_err) {
-  char b_str[4097];
-  EXPECT_EQ(fpgaGetOPAECBuildString(b_str, sizeof(b_str)), FPGA_EXCEPTION);
+  if (INTEL_FPGA_TREE_DIRTY) {
+      EXPECT_STREQ(b_str, INTEL_FPGA_API_HASH "*");
+  } else {
+      EXPECT_STREQ(b_str, INTEL_FPGA_API_HASH);
+  }
 }
 
 /**

--- a/testing/xfpga/test_properties_c.cpp
+++ b/testing/xfpga/test_properties_c.cpp
@@ -85,10 +85,10 @@ class properties_c_p : public ::testing::TestWithParam<std::string> {
   virtual void TearDown() override {
     if (prop_) { EXPECT_EQ(fpgaDestroyProperties(&prop_), FPGA_OK); };
 
-    if (filter_accel_) EXPECT_EQ(fpgaDestroyProperties(&filter_accel_), FPGA_OK);
-    if (filter_dev_) EXPECT_EQ(fpgaDestroyProperties(&filter_dev_), FPGA_OK);
-    if (handle_accel_) EXPECT_EQ(xfpga_fpgaClose(handle_accel_), FPGA_OK);
-    if (handle_dev_) EXPECT_EQ(xfpga_fpgaClose(handle_dev_), FPGA_OK);
+    if (filter_accel_) { EXPECT_EQ(fpgaDestroyProperties(&filter_accel_), FPGA_OK); }
+    if (filter_dev_) { EXPECT_EQ(fpgaDestroyProperties(&filter_dev_), FPGA_OK); }
+    if (handle_accel_) { EXPECT_EQ(xfpga_fpgaClose(handle_accel_), FPGA_OK); }
+    if (handle_dev_) { EXPECT_EQ(xfpga_fpgaClose(handle_dev_), FPGA_OK); }
 
     for (auto &t : tokens_accel_) {
       if (t) {


### PR DESCRIPTION
Relying on config.h broke the ASE regression, which peeks inside
the OPAE tree to build hello_fpga. Use the version API's instead
to query the version.