### PR TITLE
fix static code analysis issues

### DIFF
--- a/libopae/plugins/xfpga/metrics/metrics_utils.c
+++ b/libopae/plugins/xfpga/metrics/metrics_utils.c
@@ -255,7 +255,7 @@ fpga_result enum_thermalmgmt_metrics(fpga_metric_vector *vector,
 	for (i = 0; i < pglob.gl_pathc; i++) {
 
 		if (!pglob.gl_pathv)
-			continue;
+			break;
 
 		char *dir_name = strrchr(pglob.gl_pathv[i], '/');
 
@@ -332,7 +332,7 @@ fpga_result enum_powermgmt_metrics(fpga_metric_vector *vector,
 	for (i = 0; i < pglob.gl_pathc; i++) {
 
 		if (!pglob.gl_pathv)
-			continue;
+			break;
 
 		char *dir_name = strrchr(pglob.gl_pathv[i], '/');
 

--- a/libopae/plugins/xfpga/metrics/metrics_utils.c
+++ b/libopae/plugins/xfpga/metrics/metrics_utils.c
@@ -254,8 +254,10 @@ fpga_result enum_thermalmgmt_metrics(fpga_metric_vector *vector,
 
 	for (i = 0; i < pglob.gl_pathc; i++) {
 
-		if (!pglob.gl_pathv)
+		if (!pglob.gl_pathv) {
+			FPGA_ERR("No matching pattern");
 			break;
+		}
 
 		char *dir_name = strrchr(pglob.gl_pathv[i], '/');
 
@@ -331,8 +333,10 @@ fpga_result enum_powermgmt_metrics(fpga_metric_vector *vector,
 
 	for (i = 0; i < pglob.gl_pathc; i++) {
 
-		if (!pglob.gl_pathv)
+		if (!pglob.gl_pathv) {
+			FPGA_ERR("No matching pattern");
 			break;
+		}
 
 		char *dir_name = strrchr(pglob.gl_pathv[i], '/');
 

--- a/libopae/plugins/xfpga/metrics/metrics_utils.c
+++ b/libopae/plugins/xfpga/metrics/metrics_utils.c
@@ -254,6 +254,9 @@ fpga_result enum_thermalmgmt_metrics(fpga_metric_vector *vector,
 
 	for (i = 0; i < pglob.gl_pathc; i++) {
 
+		if (!pglob.gl_pathv)
+			continue;
+
 		char *dir_name = strrchr(pglob.gl_pathv[i], '/');
 
 		if (!dir_name)
@@ -327,6 +330,9 @@ fpga_result enum_powermgmt_metrics(fpga_metric_vector *vector,
 	}
 
 	for (i = 0; i < pglob.gl_pathc; i++) {
+
+		if (!pglob.gl_pathv)
+			continue;
 
 		char *dir_name = strrchr(pglob.gl_pathv[i], '/');
 

--- a/tools/base/libboard/board_rc/board_rc.c
+++ b/tools/base/libboard/board_rc/board_rc.c
@@ -329,5 +329,9 @@ fpga_result print_board_info(fpga_token token)
 	printf("Last Power down cause:%s\n", pwr_down_cause);
 	printf("Last Reset cause: %s\n", reset_cause);
 
+	res = fpgaDestroyObject(&bmc_object);
+	if (res != FPGA_OK) {
+		OPAE_ERR("Failed to Destroy Object");
+	}
 	return res;
 }

--- a/tools/base/libboard/board_rc/board_rc.c
+++ b/tools/base/libboard/board_rc/board_rc.c
@@ -306,6 +306,10 @@ fpga_result print_board_info(fpga_token token)
 			printf("Last Reset cause: %s\n", "Not Supported");
 			return res;
 		}
+		res = fpgaDestroyObject(&bmc_object);
+		if (res != FPGA_OK) {
+			OPAE_ERR("Failed to Destroy Object");
+		}
 
 	}
 
@@ -329,9 +333,5 @@ fpga_result print_board_info(fpga_token token)
 	printf("Last Power down cause:%s\n", pwr_down_cause);
 	printf("Last Reset cause: %s\n", reset_cause);
 
-	res = fpgaDestroyObject(&bmc_object);
-	if (res != FPGA_OK) {
-		OPAE_ERR("Failed to Destroy Object");
-	}
 	return res;
 }


### PR DESCRIPTION
 - Suspicious dereference of pointer 'pglob.gl_pathv' before NULL check
 - Memory leak. Dynamic memory stored in 'bmc_object'
   allocated through function 'fpgaTokenGetObject'