### PR TITLE
samples: fix static code scanner issues

### DIFF
--- a/samples/object_api.c
+++ b/samples/object_api.c
@@ -326,12 +326,15 @@ out_free:
 		}
 	}
 
-	for (i = 0; i < num_matches; ++i) {
-		if (metrics[i].groups)
-			free(metrics[i].groups);
-	}
-	if (metrics)
+
+	if (metrics) {
+
+		for (i = 0; i < num_matches; ++i) {
+			if (metrics[i].groups)
+				free(metrics[i].groups);
+		}
 		free(metrics);
+	}
 out:
 	return exit_code;
 }


### PR DESCRIPTION
- Pointer may be dereferenced after it was positively checked for NULL
- Result of function that can return NULL may be dereferenced
- Null pointer may be dereferenced