### PR TITLE
libopae: fix error API clear routine

### DIFF
--- a/libopae/plugins/xfpga/error.c
+++ b/libopae/plugins/xfpga/error.c
@@ -40,6 +40,8 @@
 
 #include "error_int.h"
 
+#define INJECT_ERROR "inject_error"
+
 fpga_result __FPGA_API__ xfpga_fpgaReadError(fpga_token token, uint32_t error_num, uint64_t *value)
 {
 	struct _fpga_token *_token = (struct _fpga_token *)token;
@@ -99,7 +101,7 @@ fpga_result __FPGA_API__ xfpga_fpgaClearError(fpga_token token, uint32_t error_n
 				return FPGA_NOT_SUPPORTED;
 			}
 
-			if (strcmp(p->info.name, "inject_error") == 0) {
+			if (strcmp(p->info.name, INJECT_ERROR) == 0) {
 				value = 0;
 			} else {
 				// read current error value

--- a/libopae/plugins/xfpga/error.c
+++ b/libopae/plugins/xfpga/error.c
@@ -98,10 +98,15 @@ fpga_result __FPGA_API__ xfpga_fpgaClearError(fpga_token token, uint32_t error_n
 				FPGA_MSG("can't clear error '%s'", p->info.name);
 				return FPGA_NOT_SUPPORTED;
 			}
-			// read current error value
-			res = xfpga_fpgaReadError(token, error_num, &value);
-			if (res != FPGA_OK)
-				return res;
+
+			if (strcmp(p->info.name, "inject_error") == 0) {
+				value = 0;
+			} else {
+				// read current error value
+				res = xfpga_fpgaReadError(token, error_num, &value);
+				if (res != FPGA_OK)
+					return res;
+			}
 
 			// write to 'clear' file
 			if (stat(p->clear_file, &st) == -1) {


### PR DESCRIPTION
The current method to clear errors reads the value of the error and
writes it back to the clear file. Clearing ras injected errors is
different in that it must be a zero to clear (instead of the current
value). This adds a check for the error name being cleared and uses zero
if it is 'inject_error'.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>