### PR TITLE
Fix "partially relocatable" warnings on rpm package generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 option(HASH_ARCHIVES "Add git commit hash to archive names" OFF)
 mark_as_advanced(HASH_ARCHIVES)
-
+set(CPACK_RPM_RELOCATION_PATHS "/etc")
 set(CPACK_PACKAGE_NAME ${CMAKE_PROJECT_NAME})
 SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Open Programmable Acceleration Engine")
 SET(CPACK_PACKAGE_VENDOR "Intel Corporation")

--- a/opae.spec.in
+++ b/opae.spec.in
@@ -48,6 +48,8 @@ This package contains OPAE base tools binaries
 Summary:    OPAE extra tools binaries
 Group:      tools-extra
 Requires:   opae-libs , opae-devel
+Prefix:     @CPACK_RPM_RELOCATION_PATHS@
+
 
 %description tools-extra
 This package contains OPAE extra tools binaries
@@ -145,9 +147,9 @@ ldconfig
 @CMAKE_INSTALL_PREFIX@/bin/fpgaport
 @CMAKE_INSTALL_PREFIX@/bin/fpgametrics
 @CMAKE_INSTALL_PREFIX@/bin/fpgad
-/etc/opae/fpgad.cfg
-/etc/sysconfig/fpgad.conf
-/etc/systemd/system/fpgad.service
+@CPACK_RPM_RELOCATION_PATHS@/opae/fpgad.cfg
+@CPACK_RPM_RELOCATION_PATHS@/sysconfig/fpgad.conf
+@CPACK_RPM_RELOCATION_PATHS@/systemd/system/fpgad.service
 @CMAKE_INSTALL_PREFIX@/@OPAE_LIB_INSTALL_DIR@/libfpgad-api.so*
 @CMAKE_INSTALL_PREFIX@/@OPAE_LIB_INSTALL_DIR@/libfpgad-xfpga.so*
 @CMAKE_INSTALL_PREFIX@/@OPAE_LIB_INSTALL_DIR@/libfpgad-vc.so*


### PR DESCRIPTION
CMake CPack is complaining about the package being partially relocatable while building RPMs because some of the files for fpgad are not being installed on the “Prefix” for the packages (CMAKE_INSTALL_PREFIX). Hence the package is partially relocatable which means that if a user tried to install the package using "--prefix <dir>" to a different location, they are going to get errors since these 3 files cannot be installed in any other location apart from /etc. This usually is not the standard way of installing files since it obstructs some of the functionality that RPM offers. That being said, we really do need to install these files in /opt for fpgad to function properly. So the solution is to set CPACK_RPM_RELOCATION_PATHS to /etc and add that as a prefix for the opae-tools package. 