### PR TITLE
Fix call to hwloc_set_membind_nodeset

### DIFF
--- a/tools/extra/pac/fpgabist/dma_vc/fpga_dma_test.c
+++ b/tools/extra/pac/fpgabist/dma_vc/fpga_dma_test.c
@@ -727,8 +727,9 @@ int main(int argc, char *argv[])
 					| HWLOC_MEMBIND_BYNODESET);
 #else
 			retval = hwloc_set_membind_nodeset(
-				topology, obj2->nodeset, HWLOC_MEMBIND_THREAD,
-				HWLOC_MEMBIND_MIGRATE);
+				topology, obj2->nodeset,
+				HWLOC_MEMBIND_BIND,
+				HWLOC_MEMBIND_THREAD | HWLOC_MEMBIND_MIGRATE);
 #endif
 			ON_ERR_GOTO(retval, out_close,
 				    "hwloc_set_membind");


### PR DESCRIPTION
In hwloc v1.11 the api for hwloc_set_membind_nodeset is

HWLOC_DECLSPEC int hwloc_set_membind_nodeset(hwloc_topology_t topology,
                                             hwloc_const_nodeset_t nodeset,
                                             hwloc_membind_policy_t policy,
                                             int flags);

The third parameter has a type of hwloc_membind_policy_t, however
HWLOC_MEMBIND_THREAD is of type hwloc_membind_flags_t.
This mismatch causes a compile error on the latest gcc

.../opae-sdk/tools/extra/pac/fpgabist/dma_vc/fpga_dma_test.c:730:30: error: implicit conversion from ‘enum <anonymous>’ to ‘hwloc_membind_policy_t’ [-Werror=enum-conversion]
  730 |     topology, obj2->nodeset, HWLOC_MEMBIND_THREAD,
      |                              ^~~~~~~~~~~~~~~~~~~~

Fix by replicating the calling of hwloc_set_membind_nodeset as is done in
fpga_dma_test_utils.cpp