### PR TITLE
Convert typedef of sysfs_fpga_region into a foreward declaration

### DIFF
--- a/libopae/plugins/xfpga/sysfs_int.h
+++ b/libopae/plugins/xfpga/sysfs_int.h
@@ -44,10 +44,10 @@ extern "C" {
 #endif
 
 
-typedef struct _sysfs_fpga_device sysfs_fpga_device;
+struct _sysfs_fpga_device;
 
 typedef struct _sysfs_fpga_region {
-	sysfs_fpga_device *device;
+	struct _sysfs_fpga_device *device;
 	char sysfs_path[SYSFS_PATH_MAX];
 	char sysfs_name[SYSFS_PATH_MAX];
 	fpga_objtype type;


### PR DESCRIPTION
The use of the struct _sysfs_fpga_device is equivalent to
sysfs_fpga_device for the element 'device' in the the
sysfs_fpga_region structure.

Fixes a compliler error with clang

.../opae-sdk/libopae/plugins/xfpga/sysfs_int.h:70:3: error: redefinition of typedef 'sysfs_fpga_device' is a C11 feature [-Werror,-Wtypedef-redefinition]
} sysfs_fpga_device;
  ^
.../fpga/opae-sdk/libopae/plugins/xfpga/sysfs_int.h:47:35: note: previous definition is here
typedef struct _sysfs_fpga_device sysfs_fpga_device;