### PR TITLE
tools: fix clang static code analysis issues

### DIFF
--- a/tools/extra/integrated/hssi/e10.cpp
+++ b/tools/extra/integrated/hssi/e10.cpp
@@ -41,7 +41,6 @@ namespace hssi
 
 e10::e10()
 : loopback()
-, interactive_(false)
 , config_("e10.json")
 , afu_id_("05189fe4-0676-dd24-b74f-291af34e1783")
 , gen_ctrl_(0)
@@ -51,7 +50,6 @@ e10::e10()
 
 e10::e10(const std::string & name)
 : loopback(name)
-, interactive_(false)
 , config_("e10.json")
 , afu_id_("05189FE4-0676-DD24-B74F-291AF34E1783")
 , gen_ctrl_(0)

--- a/tools/extra/integrated/hssi/e10.h
+++ b/tools/extra/integrated/hssi/e10.h
@@ -110,23 +110,22 @@ public:
     e10(const std::string & name);
     ~e10();
 
-    virtual void assign(opae::fpga::types::handle::ptr_t accelerator_ptr);
+    virtual void assign(opae::fpga::types::handle::ptr_t accelerator_ptr) override;
 
-    virtual const std::string & afu_id()
+    virtual const std::string & afu_id()  override
     {
         return afu_id_;
     }
 
     virtual uint32_t num_ports()  override { return 4; };
-    virtual void clear_status();
-    virtual void internal_loopback(uint32_t port);
-    virtual void external_loopback(uint32_t source_port, uint32_t destination_port);
-    virtual void stop(uint32_t instance, loopback::packet_flow flow);
-    virtual mac_report gen_report(uint32_t instance);
-    virtual std::vector<mac_address_t> get_mac_addresses();
+    virtual void clear_status() override;
+    virtual void internal_loopback(uint32_t port) override;
+    virtual void external_loopback(uint32_t source_port, uint32_t destination_port) override;
+    virtual void stop(uint32_t instance, loopback::packet_flow flow) override;
+    virtual mac_report gen_report(uint32_t instance) override;
+    virtual std::vector<mac_address_t> get_mac_addresses() override;
 private:
     eth_ctrl::ptr_t eth_;
-    bool interactive_;
     std::string config_;
     std::string afu_id_;
     uint32_t gen_ctrl_;

--- a/tools/extra/integrated/hssi/e100.cpp
+++ b/tools/extra/integrated/hssi/e100.cpp
@@ -40,7 +40,6 @@ namespace hssi
 
 e100::e100()
 : loopback("e100")
-, interactive_(false)
 , config_("e100.json")
 , afu_id_("4AFC1716-3224-4753-9BD0-3D5B1F229370")
 , gen_ctrl_(0)
@@ -50,7 +49,6 @@ e100::e100()
 
 e100::e100(const std::string & name)
 : loopback(name)
-, interactive_(false)
 , config_("e100.json")
 , afu_id_("4AFC1716-3224-4753-9BD0-3D5B1F229370")
 , gen_ctrl_(0)

--- a/tools/extra/integrated/hssi/e100.h
+++ b/tools/extra/integrated/hssi/e100.h
@@ -195,23 +195,22 @@ public:
     e100(const std::string & name);
     ~e100();
 
-      virtual void assign(opae::fpga::types::handle::ptr_t accelerator_ptr);
+      virtual void assign(opae::fpga::types::handle::ptr_t accelerator_ptr) override;
 
-    virtual const std::string & afu_id()
+    virtual const std::string & afu_id() override
     {
         return afu_id_;
     }
 
     virtual uint32_t num_ports()  override { return 1; }
-    virtual void clear_status();
-    virtual void internal_loopback(uint32_t port);
-    virtual void external_loopback(uint32_t source_port, uint32_t destination_port);
-    virtual void stop(uint32_t instance, loopback::packet_flow flow);
-    virtual mac_report gen_report(uint32_t instance);
-    virtual std::vector<mac_address_t> get_mac_addresses();
+    virtual void clear_status() override;
+    virtual void internal_loopback(uint32_t port) override;
+    virtual void external_loopback(uint32_t source_port, uint32_t destination_port) override;
+    virtual void stop(uint32_t instance, loopback::packet_flow flow) override;
+    virtual mac_report gen_report(uint32_t instance) override;
+    virtual std::vector<mac_address_t> get_mac_addresses() override;
 private:
     eth_ctrl::ptr_t eth_;
-    bool interactive_;
     std::string config_;
     std::string afu_id_;
     uint32_t gen_ctrl_;

--- a/tools/extra/integrated/hssi/e40.cpp
+++ b/tools/extra/integrated/hssi/e40.cpp
@@ -41,7 +41,6 @@ namespace hssi
 
 e40::e40()
 : loopback()
-, interactive_(false)
 , config_("e40.json")
 , afu_id_("26b40788-034b-4389-b3c1-51a1b62ed6c2")
 , gen_ctrl_(0)
@@ -51,7 +50,6 @@ e40::e40()
 
 e40::e40(const std::string & name)
 : loopback(name)
-, interactive_(false)
 , config_("e40.json")
 , afu_id_("26B40788-034B-4389-B3C1-51A1B62ED6C2")
 , gen_ctrl_(0)

--- a/tools/extra/integrated/hssi/e40.h
+++ b/tools/extra/integrated/hssi/e40.h
@@ -137,23 +137,22 @@ public:
 
     ~e40();
 
-    virtual void assign(opae::fpga::types::handle::ptr_t accelerator_ptr);
+    virtual void assign(opae::fpga::types::handle::ptr_t accelerator_ptr) override;
 
-    virtual const std::string & afu_id()
+    virtual const std::string & afu_id() override
     {
         return afu_id_;
     }
 
     virtual uint32_t num_ports()  override { return 2; }
-    virtual void clear_status();
-    virtual void internal_loopback(uint32_t port);
-    virtual void external_loopback(uint32_t source_port, uint32_t destination_port);
-    virtual void stop(uint32_t instance, loopback::packet_flow flow);
-    virtual mac_report gen_report(uint32_t instance);
-    virtual std::vector<mac_address_t> get_mac_addresses();
+    virtual void clear_status() override;
+    virtual void internal_loopback(uint32_t port) override;
+    virtual void external_loopback(uint32_t source_port, uint32_t destination_port) override;
+    virtual void stop(uint32_t instance, loopback::packet_flow flow) override;
+    virtual mac_report gen_report(uint32_t instance) override;
+    virtual std::vector<mac_address_t> get_mac_addresses() override;
 private:
     eth_ctrl::ptr_t eth_;
-    bool interactive_;
     std::string config_;
     std::string afu_id_;
     uint32_t gen_ctrl_;

--- a/tools/extra/integrated/hssi/eth_ctrl.cpp
+++ b/tools/extra/integrated/hssi/eth_ctrl.cpp
@@ -46,8 +46,6 @@ namespace hssi
 
 eth_ctrl::eth_ctrl(przone_interface::ptr_t przone, gbs_version version)
 : przone_(przone)
-, scratch_      (prtable[static_cast<uint8_t>(version)][0])
-, eth_arst_     (prtable[static_cast<uint8_t>(version)][1])
 , eth_ctrl_addr_(prtable[static_cast<uint8_t>(version)][2])
 , eth_wr_data_  (prtable[static_cast<uint8_t>(version)][3])
 , eth_rd_data_  (prtable[static_cast<uint8_t>(version)][4])

--- a/tools/extra/integrated/hssi/eth_ctrl.h
+++ b/tools/extra/integrated/hssi/eth_ctrl.h
@@ -76,8 +76,6 @@ public:
 
 private:
     przone_interface::ptr_t przone_;
-    uint32_t scratch_;
-    uint32_t eth_arst_;
     uint32_t eth_ctrl_addr_;
     uint32_t eth_wr_data_;
     uint32_t eth_rd_data_;

--- a/tools/extra/integrated/hssi/loopback.h
+++ b/tools/extra/integrated/hssi/loopback.h
@@ -105,16 +105,16 @@ public:
 
     virtual ~loopback();
 
-    virtual intel::utils::option_map & get_options()
+    virtual intel::utils::option_map & get_options() override
     {
         return options_;
     }
     virtual void assign(opae::fpga::types::handle::ptr_t accelerator) override;
-    virtual const std::string & afu_id() = 0;
+    virtual const std::string & afu_id() override = 0 ;
 
-    virtual bool setup();
+    virtual bool setup() override;
 
-    virtual bool run();
+    virtual bool run() override;
 
     virtual opae::fpga::types::shared_buffer::ptr_t dsm() const override
     { return opae::fpga::types::shared_buffer::allocate(accelerator_, loopback::dsm_size_); }

--- a/tools/extra/ras/main.c
+++ b/tools/extra/ras/main.c
@@ -1024,7 +1024,7 @@ out:
 	result = fpgaDestroyObject(&error_object);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Destroy Object");
-		resval = resval;
+		resval = result;
 	}
 
 	printf("----------- FME ERROR  END-------- \n \n");


### PR DESCRIPTION

1) function but is not marked 'override' [-Werror,-Winconsistent-missing-override]

2) 'fpga_result' to itself [-Werror,-Wself-assign]