### PR TITLE
Force 32-bit struct alignment. Fixes compilation with GCC 9

### DIFF
--- a/tools/extra/pac/fpgabist/dma/fpga_pattern_checker.h
+++ b/tools/extra/pac/fpgabist/dma/fpga_pattern_checker.h
@@ -103,7 +103,7 @@ typedef union {
 	} st;
 } pattern_checker_status_t;
 
-typedef struct __attribute__((__packed__)) {
+typedef struct __attribute__((__packed__,__aligned__(32))) {
 	//0x0
 	uint32_t payload_len;
 	//0x4

--- a/tools/extra/pac/fpgabist/dma/fpga_pattern_gen.h
+++ b/tools/extra/pac/fpgabist/dma/fpga_pattern_gen.h
@@ -98,7 +98,7 @@ typedef union {
 	} st;
 } pattern_gen_status_t;
 
-typedef struct __attribute__((__packed__)) {
+typedef struct __attribute__((__packed__,__aligned__(32))) {
 	//0x0
 	uint32_t payload_len;
 	//0x4


### PR DESCRIPTION
Without this patch, I get the following errors:

```
[233/275] Building CXX object tools/extra/pac/fpgabist/dma/CMakeFiles/fpga_dma_test.dir/fpga_pattern_checker.cpp.o
FAILED: tools/extra/pac/fpgabist/dma/CMakeFiles/fpga_dma_test.dir/fpga_pattern_checker.cpp.o
/usr/bin/c++   -I../common/include -I../libopae/src -Iinclude -std=c++14 -Wno-unused-local-typedefs -Wno-sign-compare -DHAVE_CONFIG_H -std=c++11 -DFPGA_DMA_MAX_BLOCKS=256 -DFPGA_DMA_BLOCK_SIZE=64 -g -O2 -Wall -Wextra -Werror   -std=gnu++14 -MD -MT tools/extra/pac/fpgabist/dma/CMakeFiles/fpga_dma_test.dir/fpga_pattern_checker.cpp.o -MF tools/extra/pac/fpgabist/dma/CMakeFiles/fpga_dma_test.dir/fpga_pattern_checker.cpp.o.d -o tools/extra/pac/fpgabist/dma/CMakeFiles/fpga_dma_test.dir/fpga_pattern_checker.cpp.o -c ../tools/extra/pac/fpgabist/dma/fpga_pattern_checker.cpp
../tools/extra/pac/fpgabist/dma/fpga_pattern_checker.cpp: In function ‘fpga_result start_checker(fpga_handle, uint64_t)’:
../tools/extra/pac/fpgabist/dma/fpga_pattern_checker.cpp:113:113: error: converting a packed ‘pattern_checker_control_t’ pointer (alignment 1) to a ‘uint32_t’ {aka ‘unsigned int’} pointer (alignment 4) may result in an unaligned pointer value [-Werror=address-of-packed-member]
  113 |  res = checker_copy_to_mmio(fpga_h, (uint32_t*)&checker_ctrl, (sizeof(checker_ctrl)-sizeof(checker_ctrl.status)));
      |                                                                                                                 ^
In file included from ../tools/extra/pac/fpgabist/dma/fpga_pattern_checker.cpp:32:
../tools/extra/pac/fpgabist/dma/fpga_pattern_checker.h:106:44: note: defined here
  106 | typedef struct __attribute__((__packed__)) {
      |                                            ^
cc1plus: all warnings being treated as errors
[234/275] Building CXX object tools/extra/pac/fpgabist/dma/CMakeFiles/fpga_dma_test.dir/fpga_pattern_gen.cpp.o
FAILED: tools/extra/pac/fpgabist/dma/CMakeFiles/fpga_dma_test.dir/fpga_pattern_gen.cpp.o
/usr/bin/c++   -I../common/include -I../libopae/src -Iinclude -std=c++14 -Wno-unused-local-typedefs -Wno-sign-compare -DHAVE_CONFIG_H -std=c++11 -DFPGA_DMA_MAX_BLOCKS=256 -DFPGA_DMA_BLOCK_SIZE=64 -g -O2 -Wall -Wextra -Werror   -std=gnu++14 -MD -MT tools/extra/pac/fpgabist/dma/CMakeFiles/fpga_dma_test.dir/fpga_pattern_gen.cpp.o -MF tools/extra/pac/fpgabist/dma/CMakeFiles/fpga_dma_test.dir/fpga_pattern_gen.cpp.o.d -o tools/extra/pac/fpgabist/dma/CMakeFiles/fpga_dma_test.dir/fpga_pattern_gen.cpp.o -c ../tools/extra/pac/fpgabist/dma/fpga_pattern_gen.cpp
../tools/extra/pac/fpgabist/dma/fpga_pattern_gen.cpp: In function ‘fpga_result start_generator(fpga_handle, uint64_t, int)’:
../tools/extra/pac/fpgabist/dma/fpga_pattern_gen.cpp:117:121: error: converting a packed ‘pattern_gen_control_t’ pointer (alignment 1) to a ‘uint32_t’ {aka ‘unsigned int’} pointer (alignment 4) may result in an unaligned pointer value [-Werror=address-of-packed-member]
  117 |  res = generator_copy_to_mmio(fpga_h, (uint32_t*)&generator_ctrl, (sizeof(generator_ctrl)-sizeof(generator_ctrl.status)));
      |                                                                                                                         ^
In file included from ../tools/extra/pac/fpgabist/dma/fpga_pattern_gen.cpp:32:
../tools/extra/pac/fpgabist/dma/fpga_pattern_gen.h:101:44: note: defined here
  101 | typedef struct __attribute__((__packed__)) {
      |                                            ^
cc1plus: all warnings being treated as errors
[250/275] Building CXX object pyopae/CMakeFiles/_opae.dir/opae.cpp.o
ninja: build stopped: subcommand failed.
```