### PR TITLE
Set the source0 value in the opae.spec to the upstream source.

### DIFF
--- a/opae.spec
+++ b/opae.spec
@@ -7,7 +7,7 @@ Group:          Development/Libraries
 Vendor:         Intel Corporation
 Requires:       uuid, json-c, python
 URL:            https://github.com/OPAE/%{name}-sdk
-Source0:        https://github.com/OPAE/%{name}/%{name}.tar.gz
+Source0:        https://github.com/OPAE/opae-sdk/releases/download/%{version}-%{release}/%{name}-%{version}-%{release}.tar.gz
 
 BuildRequires:  gcc, gcc-c++
 BuildRequires:  cmake

--- a/scripts/create-rpms.sh
+++ b/scripts/create-rpms.sh
@@ -17,6 +17,11 @@ fi
 rm -rf ~/rpmbuild
 rpmdev-setuptree
 
+#query spec for version details
+version=`grep 'Version:' ../opae.spec | awk '{ print $2 }'`
+release=`grep 'Release:' ../opae.spec | awk '{ print $2 }'`
+full_version=${version}-${release}
+
 #create source tarball
 rm -rf ../build
 mkdir ../build
@@ -55,9 +60,9 @@ tar --transform='s/opae-sdk/opae/' \
   --exclude=testing/.clang-format \
   --exclude=testing/xfpga/.clang-format \
   --exclude=tools/base/argsfilter/.clang-format \
-  -z -c -f opae.tar.gz opae-sdk
+  -z -c -f opae-${full_version}.tar.gz opae-sdk
 
-mv opae.tar.gz ~/rpmbuild/SOURCES/
+mv opae-${full_version}.tar.gz ~/rpmbuild/SOURCES/
 cp "${BUILD_DIR}/../opae.spec" ~/rpmbuild/SPECS/
 
 cd ~/rpmbuild/SPECS/


### PR DESCRIPTION
rpmbuild will fetch the source tarball from its upstream location
if it is not found locally.  So improve the Source0 value to point
to that location.  Change the create-rpm script to use the new
tarball name.

Fixes the error with fedora-review

WARNING: Cannot download url: https://github.com/OPAE/opae/opae.tar.gz
INFO: No upstream for (Source0): opae.tar.gz