### PR TITLE
tools: fix ras tools clang issues

### DIFF
--- a/tools/extra/ras/main.c
+++ b/tools/extra/ras/main.c
@@ -1024,7 +1024,7 @@ out:
 	result = fpgaDestroyObject(&error_object);
 	if (result != FPGA_OK) {
 		OPAE_ERR("Failed to Destroy Object");
-		resval = resval;
+		resval = result;
 	}
 
 	printf("----------- FME ERROR  END-------- \n \n");


### PR DESCRIPTION
opae-sdk/tools/extra/ras/main.c:1027:10: error: explicitly assigning value of variable
 of type 'fpga_result' to itself [-Werror,-Wself-assign]
                resval = resval;