### PR TITLE
tools: fix DMA tools clang issues

### DIFF
--- a/tools/extra/pac/fpgabist/dma/CMakeLists.txt
+++ b/tools/extra/pac/fpgabist/dma/CMakeLists.txt
@@ -38,6 +38,11 @@ include_directories(${OPAE_INCLUDE_DIR}
 
 file(GLOB CSources *.cpp *.S)
 add_executable(fpga_dma_test ${CSources})
+set(clang_compiler "clang")
+if (${CMAKE_C_COMPILER} MATCHES  "${clang_compiler}")
+    set_source_files_properties(x86-sse2.S  PROPERTIES COMPILE_FLAGS -fno-integrated-as)
+endif() 
+
 set_install_rpath(fpga_dma_test)
 
 target_link_libraries(fpga_dma_test opae-c ${libjson-c_LIBRARIES} uuid rt ${TBB_LIBRARIES} ${HWLOC_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})

--- a/tools/extra/pac/fpgabist/dma/fpga_dma.cpp
+++ b/tools/extra/pac/fpgabist/dma/fpga_dma.cpp
@@ -112,7 +112,11 @@ static void *local_memcpy(void *dst, void *src, size_t n)
 
 	if (n)
 	{
+#if __cplusplus  <= 199711L
 		register unsigned long int dummy;
+#else
+		unsigned long int dummy
+#endif 
 		debug_print("copying 0x%lx bytes with REP MOVSB\n", n);
 		__asm__ __volatile__("rep movsb\n":"=&D"(ldst), "=&S"(lsrc), "=&c"(dummy):"0"(ldst), "1"(lsrc), "2"(n):"memory");
 	}

--- a/tools/extra/pac/fpgabist/dma/fpga_pattern_checker.cpp
+++ b/tools/extra/pac/fpgabist/dma/fpga_pattern_checker.cpp
@@ -30,6 +30,7 @@
  */
 #include "fpga_dma_common.h"
 #include "fpga_pattern_checker.h"
+#include "safe_string/safe_string.h"
 #include <math.h>
 #include <unistd.h>
 /*
@@ -93,8 +94,10 @@ fpga_result checker_copy_to_mmio(fpga_handle fpga_h, uint32_t *checker_ctrl_addr
 // Set the control bits
 fpga_result start_checker(fpga_handle fpga_h, uint64_t transfer_len) {
 	fpga_result res = FPGA_OK;
-	pattern_checker_control_t checker_ctrl = {0,0,0,0,0};
-	pattern_checker_status_t status ={0};
+	pattern_checker_control_t checker_ctrl;
+	pattern_checker_status_t status = { 0 };
+
+	memset_s(&checker_ctrl, sizeof(pattern_checker_control_t), 0);
 
 	checker_ctrl.payload_len = ceil(transfer_len/(double)PATTERN_WIDTH);
 	checker_ctrl.pattern_len = PATTERN_LENGTH;

--- a/tools/extra/pac/fpgabist/dma/fpga_pattern_gen.cpp
+++ b/tools/extra/pac/fpgabist/dma/fpga_pattern_gen.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "fpga_pattern_gen.h"
+#include "safe_string/safe_string.h"
 #include <math.h>
 /*
  * macro for checking return codes
@@ -91,8 +92,10 @@ fpga_result generator_copy_to_mmio(fpga_handle fpga_h, uint32_t *generator_ctrl_
 // Set the control bits
 fpga_result start_generator(fpga_handle fpga_h, uint64_t transfer_len, int pkt_transfer) {
 	fpga_result res = FPGA_OK;
-	pattern_gen_control_t generator_ctrl = {0,0,0,0,0};
+	pattern_gen_control_t generator_ctrl;
 	pattern_gen_status_t status ={0};
+
+	memset_s(&generator_ctrl, sizeof(pattern_gen_control_t), 0);
 
 	generator_ctrl.payload_len = ceil(transfer_len/(double)PATTERN_WIDTH);
 	generator_ctrl.pattern_len = PATTERN_LENGTH;

--- a/tools/extra/pac/fpgabist/dma_vc/CMakeLists.txt
+++ b/tools/extra/pac/fpgabist/dma_vc/CMakeLists.txt
@@ -36,6 +36,10 @@ include_directories(${OPAE_INCLUDE_DIR}
 
 file(GLOB CSources *.c *.S)
 add_executable(fpga_dma_vc_test ${CSources})
+set(clang_compiler "clang")
+if (${CMAKE_C_COMPILER} MATCHES  "${clang_compiler}")
+    set_source_files_properties(x86-sse2.S  PROPERTIES COMPILE_FLAGS -fno-integrated-as)
+endif()    
 set_install_rpath(fpga_dma_vc_test)
 
 target_link_libraries(fpga_dma_vc_test opae-c ${libjson-c_LIBRARIES} uuid rt ${HWLOC_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})

--- a/tools/extra/pac/fpgabist/dma_vc/fpga_dma_test.c
+++ b/tools/extra/pac/fpgabist/dma_vc/fpga_dma_test.c
@@ -703,8 +703,13 @@ int main(int argc, char *argv[])
 		// Find the device from the topology
 		hwloc_topology_t topology;
 		hwloc_topology_init(&topology);
+#if HWLOC_API_VERSION >= 0x00020000
 		hwloc_topology_set_flags(topology,
-					 HWLOC_TOPOLOGY_FLAG_IO_DEVICES);
+			HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM);
+#else
+		hwloc_topology_set_flags(topology,
+			HWLOC_TOPOLOGY_FLAG_IO_DEVICES);
+#endif
 		hwloc_topology_load(topology);
 		hwloc_obj_t obj = hwloc_get_pcidev_by_busid(topology, dom, bus,
 							    dev, func);
@@ -720,11 +725,11 @@ int main(int argc, char *argv[])
 		printf("NODESET is %s\n", str);
 #endif
 		if (memory_affinity) {
-#if HWLOC_API_VERSION > 0x00020000
+#if HWLOC_API_VERSION >= 0x00020000
 			retval = hwloc_set_membind(
-				topology, obj2->nodeset, HWLOC_MEMBIND_THREAD,
-				HWLOC_MEMBIND_MIGRATE
-					| HWLOC_MEMBIND_BYNODESET);
+				topology, obj2->nodeset,
+				HWLOC_MEMBIND_BIND,
+				HWLOC_MEMBIND_THREAD | HWLOC_MEMBIND_MIGRATE);
 #else
 			retval = hwloc_set_membind_nodeset(
 				topology, obj2->nodeset,


### PR DESCRIPTION
1)  error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]

opae-sdk/tools/extra/pac/fpgabist/dma/fpga_dma.cpp:115:3: error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]
                register unsigned long int dummy;
               ^~~~~~~~~

2) Deprecated Functions & Enum in latest HWLOC-DEVL 2.04 version

use of undeclared identifier 'HWLOC_TOPOLOGY_FLAG_IO_DEVICES'
                                        HWLOC_TOPOLOGY_FLAG_IO_DEVICES);

opae-sdk/tools/extra/pac/fpgabist/dma/fpga_dma_test_utils.cpp:654:5: error: 'hwloc_set_membind_nodeset' is deprecated [-Werror,-Wdeprecated-declarations]
                                hwloc_set_membind_nodeset(topology, obj2->nodeset,

3) LLVM's integrated assembler fix / Disable integrated assembler
<instantiation>:2:1: error: unknown directive
.func aligned_block_copy_movsb
^
<instantiation>:4:5: note: while in macro instantiation
    asm_function_helper aligned_block_copy_movsb
    ^
/home/lab/workspace/ananda/clang_dma_fix/opae-sdk/tools/extra/pac/fpgabist/dma/x86-sse2.S:69:1: note: while in macro instantiation
asm_function aligned_block_copy_movsb
^
/tmp/x86-sse2-28619b.s:64:1: error: unknown directive

4) Deprecated Functions & Enum in latest HWLOC-DEVL 2.04 version
use of undeclared identifier 'HWLOC_TOPOLOGY_FLAG_IO_DEVICES'
                                        HWLOC_TOPOLOGY_FLAG_IO_DEVICES);

opae-sdk/tools/extra/pac/fpgabist/dma_vc/fpga_dma_test_utils.cpp:654:5: error: 'hwloc_s