### PR TITLE
Add INTEL_FPGA_API_VERSION version to shared objects.

### DIFF
--- a/libopae/CMakeLists.txt
+++ b/libopae/CMakeLists.txt
@@ -68,6 +68,9 @@ set_property(TARGET opae-c PROPERTY C_STANDARD 99)
 set_target_properties(opae-c PROPERTIES
   VERSION ${INTEL_FPGA_API_VERSION}
   SOVERSION ${INTEL_FPGA_API_VER_MAJOR})
+set_target_properties(opae-c-ase PROPERTIES
+  VERSION ${INTEL_FPGA_API_VERSION}
+  SOVERSION ${INTEL_FPGA_API_VER_MAJOR})
 
 # Add coverage flags
 if(CMAKE_BUILD_TYPE STREQUAL "Coverage")

--- a/libopae/plugins/xfpga/CMakeLists.txt
+++ b/libopae/plugins/xfpga/CMakeLists.txt
@@ -102,6 +102,9 @@ endif(CMAKE_BUILD_TYPE STREQUAL "Coverage")
 
 # Target properties
 set_property(TARGET xfpga PROPERTY C_STANDARD 99)
+set_target_properties(xfpga PROPERTIES
+  VERSION ${INTEL_FPGA_API_VERSION}
+  SOVERSION ${INTEL_FPGA_API_VER_MAJOR})
 
 # Add coverage flags
 if(CMAKE_BUILD_TYPE STREQUAL "Coverage")

--- a/libopae/plugins/xfpga/CMakeLists.txt
+++ b/libopae/plugins/xfpga/CMakeLists.txt
@@ -102,9 +102,6 @@ endif(CMAKE_BUILD_TYPE STREQUAL "Coverage")
 
 # Target properties
 set_property(TARGET xfpga PROPERTY C_STANDARD 99)
-set_target_properties(xfpga PROPERTIES
-  VERSION ${INTEL_FPGA_API_VERSION}
-  SOVERSION ${INTEL_FPGA_API_VER_MAJOR})
 
 # Add coverage flags
 if(CMAKE_BUILD_TYPE STREQUAL "Coverage")

--- a/libopaecxx/CMakeLists.txt
+++ b/libopaecxx/CMakeLists.txt
@@ -64,6 +64,11 @@ add_executable(hello_cxxcore samples/hello_fpga-1.cpp)
 target_link_libraries(hello_cxxcore opae-c ${CMAKE_THREAD_LIBS_INIT} opae-cxx-core )
 
 
+# Target properties
+set_target_properties(opae-cxx-core PROPERTIES
+  VERSION ${INTEL_FPGA_API_VERSION}
+  SOVERSION ${INTEL_FPGA_API_VER_MAJOR})
+
 # Define headers for this library. PUBLIC headers are used for
 # compiling the library, and will be added to consumers' build
 # paths. Keep current directory private.


### PR DESCRIPTION
Most of the shared objects are of the form <name>.so.<INTEL_API_VERSION>
In this case <name>.so.1.4.0 with standard symlinks <name>.so.1 and
<name>.so.  For those that do not, provide the versioning to make them
consistent.