### PR TITLE
Fix exec stack in fpga_dma_vc_test

### DIFF
--- a/tools/extra/pac/fpgabist/dma_vc/x86-sse2.S
+++ b/tools/extra/pac/fpgabist/dma_vc/x86-sse2.S
@@ -263,6 +263,10 @@ asm_function aligned_block_fill_nt_sse2
     ret
 .endfunc
 
+/* No exec stack */	
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif
 /*****************************************************************************/
 
 #endif


### PR DESCRIPTION
Found with rpmlint of the tools-extra package
Reproduced standalone with

readelf -lW .../bin/fpga_dma_vc_test | grep STACK
  GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RWE 0x10

The 'E' in RWE is executable

Fix with method described
https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart

Now result is
readelf -lW .../bin/fpga_dma_vc_test | grep STACK
  GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RW  0x10