### PR TITLE
Change libsafestr to a shared library

### DIFF
--- a/opae-libs/safe_string/CMakeLists.txt
+++ b/opae-libs/safe_string/CMakeLists.txt
@@ -102,8 +102,10 @@ set(SRC
   wmemset_s.c
 )
 
-opae_add_static_library(TARGET safestr
-    SOURCE ${SRC}
+opae_add_shared_library(TARGET safestr
+  SOURCE ${SRC}
+  VERSION ${OPAE_VERSION}
+  SOVERSION ${OPAE_VERSION_MAJOR}
     COMPONENT safestrlib
 )
 


### PR DESCRIPTION
In general it is better to have shared libraries over static
unless there is a specific need for a static library.

Signed-off-by: Tom Rix <trix@redhat.com>