### PR TITLE
fix clang issue -argument unused during compilation: '-pie'

### DIFF
--- a/opae-libs/cmake/modules/OPAECompiler.cmake
+++ b/opae-libs/cmake/modules/OPAECompiler.cmake
@@ -118,8 +118,10 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebI
     endif()
 
     # Linker options
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -pie")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
+    if (NOT ${CMAKE_C_COMPILER} MATCHES  "clang")
+         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -pie")
+         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
+    endif()
 endif()
 
 # Check if support for C++ 11/14/0x is available


### PR DESCRIPTION
clang-9: error: argument unused during compilation: '-pie' [-Werror,-Wunused-command-line-argument]
clang-9: error: argument unused during compilation: '-pie' [-Werror,-Wunused-command-line-argument]