### PR TITLE
Fix cmake warnings when finding uuid and json-c include paths

### DIFF
--- a/opae-libs/cmake/modules/FindUUID.cmake
+++ b/opae-libs/cmake/modules/FindUUID.cmake
@@ -38,7 +38,8 @@ pkg_check_modules(PC_UUID QUIET uuid)
 # Use pkg-config to get hints about paths
 execute_process(COMMAND pkg-config --cflags uuid --silence-errors
   COMMAND cut -d I -f 2
-  OUTPUT_VARIABLE UUID_PKG_CONFIG_INCLUDE_DIRS)
+  OUTPUT_VARIABLE UUID_PKG_CONFIG_INCLUDE_DIRS
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
 set(UUID_PKG_CONFIG_INCLUDE_DIRS "${UUID_PKG_CONFIG_INCLUDE_DIRS}" CACHE STRING "Compiler flags for UUID library")
 
 # Include dir

--- a/opae-libs/cmake/modules/Findjson-c.cmake
+++ b/opae-libs/cmake/modules/Findjson-c.cmake
@@ -38,7 +38,8 @@ pkg_check_modules(PC_JSON_C QUIET json-c)
 # Use pkg-config to get hints about paths
 execute_process(COMMAND pkg-config --cflags json-c --silence-errors
   COMMAND cut -d I -f 2
-  OUTPUT_VARIABLE JSON-C_PKG_CONFIG_INCLUDE_DIRS)
+  OUTPUT_VARIABLE JSON-C_PKG_CONFIG_INCLUDE_DIRS
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
 set(JSON-C_PKG_CONFIG_INCLUDE_DIRS "${JSON-C_PKG_CONFIG_INCLUDE_DIRS}" CACHE STRING "Compiler flags for JSON-C library")
 
 # Include dir


### PR DESCRIPTION
The warning are
CMake Warning:
  Value of JSON-C_PKG_CONFIG_INCLUDE_DIRS contained a newline; truncating
CMake Warning:
  Value of UUID_PKG_CONFIG_INCLUDE_DIRS contained a newline; truncating

This happens because using pkg-config has a newline in its output.
To remove the newline, use the OUTPUT_STRIP_TRAILING_WHITESPACE option of
execute_process.

Signed-off-by: Tom Rix <trix@redhat.com>