### PR TITLE
opae.admin: add dfl enumeration support

### DIFF
--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -206,6 +206,8 @@ class fme(region):
 
     @property
     def spi_bus(self):
+        if os.path.basename(self.sysfs_path).startswith('dfl'):
+            return self.find_one('dfl-fme.*.*/spi*/spi_master/spi*/spi*')
         return self.find_one('spi*/spi_master/spi*/spi*')
 
     @property

--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -372,6 +372,7 @@ class fpga_base(class_node):
     FME_PATTERN = 'intel-fpga-fme.*'
     PORT_PATTERN = 'intel-fpga-port.*'
     PCI_DRIVER = 'intel-fpga-pci'
+    SYSFS_CLASS = 'fpga'
     BOOT_TYPES = ['bmcimg', 'fpga']
     BOOT_PAGES = {
         (0x8086, 0x0b30): {'fpga': {'user': 1,
@@ -521,6 +522,7 @@ class fpga_region(fpga_base):
     FME_PATTERN = 'dfl-fme.*'
     PORT_PATTERN = 'dfl-port.*'
     PCI_DRIVER = 'dfl-pci'
+    SYSFS_CLASS = 'fpga_region'
 
     @classmethod
     def class_filter(cls, node):

--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -33,15 +33,15 @@ import time
 
 from array import array
 from contextlib import contextmanager
-from opae.admin.path import device_path
+from opae.admin.path import device_path, sysfs_path
 from opae.admin.sysfs import class_node, sysfs_node
 from opae.admin.utils.log import loggable
 from opae.admin.utils import max10_or_nios_version
 
 
 class region(sysfs_node):
-    def __init__(self, sysfs_path, pci_node):
-        super(region, self).__init__(sysfs_path)
+    def __init__(self, path, pci_node):
+        super(region, self).__init__(path)
         self._pci_node = pci_node
         self._fd = -1
 
@@ -539,7 +539,7 @@ class fpga(fpga_base):
     @classmethod
     def enum(cls, filt=[]):
         for drv in cls._drivers:
-            drv_path = os.path.join('/sys/bus/pci/drivers', drv.PCI_DRIVER)
+            drv_path = sysfs_path('/sys/bus/pci/drivers', drv.PCI_DRIVER)
             if os.path.exists(drv_path):
                 return drv.enum(filt)
 

--- a/python/opae.admin/opae/admin/sysfs.py
+++ b/python/opae.admin/opae/admin/sysfs.py
@@ -633,6 +633,17 @@ class class_node(sysfs_node):
         return nodes
 
     @classmethod
+    def class_filter(cls, node):
+        """class_filter Run a class specific filter in enum_class.
+
+        Args:
+            node: A sysfs node to consider for filtering.
+        Returns:
+            True if the node should be kept, false otherwise.
+        """
+        return True
+
+    @classmethod
     def enum(cls, filt=[]):
         """enum Discover and return a list of class_node-derived objects given
                 a filter.
@@ -666,7 +677,8 @@ class class_node(sysfs_node):
         log = LOG(cls.__name__)
 
         def func(obj):
-            if hasattr(cls, 'class_filter') and not cls.class_filter(obj):
+            # if this node is not valid, reject it
+            if not cls.class_filter(obj):
                 return False
             for f in filt:
                 for k, v in f.items():

--- a/python/opae.admin/opae/admin/sysfs.py
+++ b/python/opae.admin/opae/admin/sysfs.py
@@ -666,6 +666,8 @@ class class_node(sysfs_node):
         log = LOG(cls.__name__)
 
         def func(obj):
+            if hasattr(cls, 'class_filter') and not cls.class_filter(obj):
+                return False
             for f in filt:
                 for k, v in f.items():
                     cur_obj = obj

--- a/python/opae.admin/opae/admin/sysfs.py
+++ b/python/opae.admin/opae/admin/sysfs.py
@@ -552,6 +552,7 @@ class class_node(sysfs_node):
     """class_node A class_node object represents a sysfs object directly
                   under '/sys/class' directory.
     """
+    SYSFS_CLASS = None
 
     def __init__(self, path):
         """__init__ Initializes a new class_node object found in /sys/class/..

--- a/python/opae.admin/opae/admin/sysfs.py
+++ b/python/opae.admin/opae/admin/sysfs.py
@@ -689,4 +689,4 @@ class class_node(sysfs_node):
                         if attr_value != v:
                             return False
             return True
-        return list(filter(func, cls.enum_class(cls.__name__, cls)))
+        return list(filter(func, cls.enum_class(cls.SYSFS_CLASS, cls)))


### PR DESCRIPTION
* add 'class_filter' processing in generic sysfs.enum method
  * this, if defined in a class, can do some prefiltering when
  enumerating devices
* rename fpga class to fpga_base
* add fpga_region that can enumerate dfl driver resources
  * define a 'class_filter' method that ignores extra fpga_region links
  in sysfs (/sys/class)