### PR TITLE
Generate QSF script paths relative to the current directory.

### DIFF
--- a/platforms/scripts/afu_platform_config
+++ b/platforms/scripts/afu_platform_config
@@ -630,11 +630,12 @@ Platform database directories (OPAE_PLATFORM_DB_PATH):
 
     # Now that arguments are parsed, canonicalize the ofs_plat_if. If it
     # hasn't been changed from the default then make the path relative
-    # to the build directory. The tree will be copied into the AFU's build
+    # to the platform directory. The tree will be copied into the AFU's build
     # tree. Using the local copy makes the AFU build tree easier to package.
     if (args.qsf and args.platform_if and
             (args.platform_if == ofs_plat_if_default)):
-        args.platform_if = 'platform/ofs_plat_if'
+        # The generated script will set THIS_DIR to the script's directory
+        args.platform_if = '${THIS_DIR}/ofs_plat_if'
 
     # Load the platform database
     platform = jsondb(args.platform, platform_db_path, 'platform', args.quiet)

--- a/platforms/scripts/platmgr/emitcfg.py
+++ b/platforms/scripts/platmgr/emitcfg.py
@@ -387,6 +387,9 @@ def emitQsfConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
 
     emitHeader(f, afu_ifc_db, platform_db, comment="##")
 
+    f.write('# Directory of this script for relative paths\n')
+    f.write('set THIS_DIR [file dirname [info script]]\n\n')
+
     f.write('namespace eval platform_cfg {\n')
     f.write("    variable PLATFORM_CLASS_NAME \"" +
             platform_db['platform-name'] + "\"\n")
@@ -417,8 +420,8 @@ def emitQsfConfig(args, afu_ifc_db, platform_db, platform_defaults_db,
 
     if (args.platform_if):
         f.write(
-            "set_global_assignment -name SOURCE_TCL_SCRIPT_FILE " +
-            "{0}/par/platform_if_addenda.qsf\n".format(args.platform_if))
+            'set_global_assignment -name SOURCE_TCL_SCRIPT_FILE "' +
+            '{0}/par/platform_if_addenda.qsf"\n'.format(args.platform_if))
     f.close()
 
 

--- a/platforms/scripts/rtl_src_config
+++ b/platforms/scripts/rtl_src_config
@@ -104,7 +104,13 @@ def emitCfg(opts, cfg):
     # Filtering for specific file types?
     file_type_filter = opts.qsys or opts.ipx or opts.json or opts.tcl
 
+    rel_prefix = ''
     if (not file_type_filter):
+        if (not opts.sim and not opts.abs):
+            # For Quartus, generate a Tcl variable for relative paths
+            print('set THIS_DIR [file dirname [info script]]\n')
+            rel_prefix = '${THIS_DIR}/'
+
         # First emit all preprocessor configuration
         for c in cfg:
             if ("+define+" == c[:8]):
@@ -120,8 +126,8 @@ def emitCfg(opts, cfg):
                 if (opts.sim):
                     print(c)
                 else:
-                    print('set_global_assignment -name SEARCH_PATH "' +
-                          c[8:] + '"')
+                    print('set_global_assignment -name SEARCH_PATH "{0}{1}"'
+                          .format(rel_prefix, c[8:]))
 
     # Emit sources and Quartus/simulator includes
     for c in cfg:
@@ -137,7 +143,7 @@ def emitCfg(opts, cfg):
         elif ("QI:" == c[:3]):
             # Quartus include
             if (not opts.sim and not file_type_filter):
-                print("source " + c[3:])
+                print('source "{0}{1}"'.format(rel_prefix, c[3:]))
         else:
             validateTag(c)
             tag = lookupTag(c, quartus_tag_map)
@@ -162,8 +168,8 @@ def emitCfg(opts, cfg):
                 # and ignore them in Quartus flows. To get a .tcl
                 # file in Quartus, use QI:<path to>.tcl.
                 if (tag is not 'SOURCE_TCL_SCRIPT_FILE'):
-                    print('set_global_assignment -name {0} "{1}"'
-                          .format(tag, c))
+                    print('set_global_assignment -name {0} "{1}{2}"'
+                          .format(tag, rel_prefix, c))
 
 
 #


### PR DESCRIPTION
afu_synth_setup and rtl_src_config were generating paths relative to what
the scripts expected the Quartus working directory to be. Since the working
directory may change, instead generate paths relative to the directories of
the generated QSF scripts.