### PR TITLE
fpgaconf: add option --skip-usrclk

### DIFF
--- a/tests/fpgaconf/test_fpgaconf_c.cpp
+++ b/tests/fpgaconf/test_fpgaconf_c.cpp
@@ -234,7 +234,8 @@ TEST_P(fpgaconf_c_p, parse_args1) {
   char thirteen[20];
   char fourteen[20];
   char fifteen[20];
-  char sixteen[30];
+  char sixteen[20];
+  char seventeen[30];
   strcpy(zero, "fpgaconf");
   strcpy(one, "-V");
   strcpy(two, "-n");
@@ -251,17 +252,19 @@ TEST_P(fpgaconf_c_p, parse_args1) {
   strcpy(thirteen, "2");
   strcpy(fourteen, "-A");
   strcpy(fifteen, "-I");
-  strcpy(sixteen, tmpfilename);
+  strcpy(sixteen, "--skip-usrclk");
+  strcpy(seventeen, tmpfilename);
 
   char *argv[] = { zero, one, two, three, four,
                    five, six, seven, eight, nine,
                    ten, eleven, twelve, thirteen, fourteen,
-                   fifteen, sixteen };
+                   fifteen, sixteen, seventeen };
 
-  EXPECT_EQ(parse_args(17, argv), 0);
+  EXPECT_EQ(parse_args(18, argv), 0);
   EXPECT_EQ(config.verbosity, 1);
   EXPECT_NE(config.dry_run, 0);
   EXPECT_NE(config.flags & FPGA_RECONF_FORCE, 0);
+  EXPECT_NE(config.flags & FPGA_RECONF_SKIP_USRCLK, 0);
   EXPECT_EQ(config.target.segment, 0x1234);
   EXPECT_EQ(config.target.bus, 0x5e);
   EXPECT_EQ(config.target.device, 0xab);
@@ -503,7 +506,7 @@ TEST_P(fpgaconf_c_p, main2) {
 /**
  * @test       main_seg_neg
  * @brief      Test: fpgaconf_main
- * @details    When the command params for sement are invalid,<br>
+ * @details    When the command params for segment are invalid,<br>
  *             fpgaconf_main displays an error and returns non-zero.<br>
  */
 TEST_P(fpgaconf_c_p, main_seg_neg) {

--- a/tools/fpgaconf/fpgaconf.c
+++ b/tools/fpgaconf/fpgaconf.c
@@ -127,12 +127,13 @@ void help(void)
 	       "                -V,--verbose        Increase verbosity\n"
 	       "                -n,--dry-run        Don't actually perform actions\n"
 	       "                --force             Don't try to open accelerator resource\n"
+	       "                --skip-usrclk       Don't program user clocks\n"
 	       "                --segment           Set target segment number\n"
 	       "                -B,--bus            Set target bus number\n"
 	       "                -D,--device         Set target device number\n"
 	       "                -F,--function       Set target function number\n"
 	       "                -S,--socket-id      Set target socket number\n"
-	       "                 -v,--version       Print version info and exit\n"
+	       "                -v,--version        Print version info and exit\n"
 	       /* "                -A,--auto           Automatically choose
 		  target slot if\n" */
 	       /* "                                    multiple valid slots are
@@ -154,16 +155,17 @@ void help(void)
 int parse_args(int argc, char *argv[])
 {
 	struct option longopts[] = {
-		{"help",      no_argument,       NULL, 'h'},
-		{"verbose",   no_argument,       NULL, 'V'},
-		{"dry-run",   no_argument,       NULL, 'n'},
-		{"segment",   required_argument, NULL, 0xe},
-		{"bus",       required_argument, NULL, 'B'},
-		{"device",    required_argument, NULL, 'D'},
-		{"function",  required_argument, NULL, 'F'},
-		{"socket-id", required_argument, NULL, 'S'},
-		{"force",     no_argument,       NULL, 0xf},
-		{"version",   no_argument,       NULL, 'v'},
+		{"help",        no_argument,       NULL, 'h'},
+		{"verbose",     no_argument,       NULL, 'V'},
+		{"dry-run",     no_argument,       NULL, 'n'},
+		{"segment",     required_argument, NULL, 0xe},
+		{"bus",         required_argument, NULL, 'B'},
+		{"device",      required_argument, NULL, 'D'},
+		{"function",    required_argument, NULL, 'F'},
+		{"socket-id",   required_argument, NULL, 'S'},
+		{"force",       no_argument,       NULL, 0xf},
+		{"skip-usrclk", no_argument,       NULL, 0x5},
+		{"version",     no_argument,       NULL, 'v'},
 		/* {"auto",          no_argument,       NULL, 'A'}, */
 		/* {"interactive",   no_argument,       NULL, 'I'}, */
 		/* {"quiet",         no_argument,       NULL, 'Q'}, */
@@ -197,6 +199,10 @@ int parse_args(int argc, char *argv[])
 
 		case 0xf: /* force */
 			config.flags |= FPGA_RECONF_FORCE;
+			break;
+
+		case 0x5: /* skip-usrclk */
+			config.flags |= FPGA_RECONF_SKIP_USRCLK;
 			break;
 
 		case 0xe: /* segment */


### PR DESCRIPTION
Controls setting the new FPGA_RECONF_SKIP_USRCLK flag to
fpgaReconfigureSlot().