### PR TITLE
opae.admin: use default character encoding

### DIFF
--- a/python/opae.admin/opae/admin/tools/bitstream_info.py
+++ b/python/opae.admin/opae/admin/tools/bitstream_info.py
@@ -167,11 +167,12 @@ def main():
             )
 
         LOG.debug("".join("{:02x} ".format(x) for x in json_string.data))
-        LOG.debug(bytearray(json_string.data).decode("utf-8"))
+        LOG.debug(bytearray(json_string.data).decode(sys.getdefaultencoding()))
 
         j_data = None
         if has_json:
-            j_data = json.loads(bytearray(json_string.data).decode("utf-8"))
+            a = bytearray(json_string.data).decode(sys.getdefaultencoding())
+            j_data = json.loads(a)
             LOG.debug(json.dumps(j_data, sort_keys=True, indent=4))
 
         b0 = common_util.BYTE_ARRAY()

--- a/python/opae.admin/opae/admin/tools/fpgasupdate.py
+++ b/python/opae.admin/opae/admin/tools/fpgasupdate.py
@@ -223,10 +223,11 @@ def do_partial_reconf(addr, filename):
     LOG.debug('command: %s', ' '.join(conf_args))
 
     try:
-        output = subprocess.check_output(conf_args).decode('utf-8')
+        output = subprocess.check_output(conf_args)
+        output = output.decode(sys.getdefaultencoding())
     except subprocess.CalledProcessError as exc:
         return (exc.returncode,
-                exc.output.decode('utf-8') +
+                exc.output.decode(sys.getdefaultencoding()) +
                 '\nPartial Reconfiguration failed')
 
     return (0, output + '\nPartial Reconfiguration OK')

--- a/python/opae.admin/opae/admin/utils/process.py
+++ b/python/opae.admin/opae/admin/utils/process.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019, Intel Corporation
+# Copyright(c) 2019-2020, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -25,6 +25,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from __future__ import absolute_import
 import subprocess
+import sys
 from opae.admin.utils.log import LOG
 
 DRY_RUN = False
@@ -43,7 +44,7 @@ def call_process(cmd, no_dry=False):
         LOG('process').debug('process output: %s', err.output)
         raise
     else:
-        return output.decode('UTF-8')
+        return output.decode(sys.getdefaultencoding())
 
 
 def assert_not_running(programs):

--- a/python/opae.admin/opae/admin/utils/progress.py
+++ b/python/opae.admin/opae/admin/utils/progress.py
@@ -1,5 +1,4 @@
-# -*- coding: UTF-8 -*-
-# Copyright(c) 2019, Intel Corporation
+# Copyright(c) 2019-2020, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -43,13 +42,13 @@ else:
     _ftype = file  # noqa pylint: disable=E0602
 
     def wrap_stream(stream):
-        utf_writer = codecs.getwriter('UTF-8')
+        utf_writer = codecs.getwriter(sys.getdefaultencoding())
         return utf_writer(stream)
 
 
 class progress(loggable):
     """progress is a class to show a progress bar on a stream or callback"""
-    BAR = u'\u2588'
+    BAR = u'\u2588' if sys.getdefaultencoding().lower() == 'utf-8' else '#'
 
     def __init__(self, **kwargs):
         """__init__

--- a/python/opae.admin/tests/test_progress.py
+++ b/python/opae.admin/tests/test_progress.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019, Intel Corporation
+# Copyright(c) 2019-2020, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -34,7 +34,7 @@ import re
 from opae.admin.utils.progress import progress
 
 if sys.version_info[0] == 3:
-    temp_cfg = {'encoding': 'utf-8'}
+    temp_cfg = {'encoding': sys.getdefaultencoding()}
 else:
     temp_cfg = {}
 


### PR DESCRIPTION
Change the hard-coded dependency on 'utf-8' to use the value
returned by sys.getdefaultencoding() instead.