### PR TITLE
fpgadiag: handle insufficient privilege gracefully

### DIFF
--- a/tools/extra/fpgadiag/nlb0_main.cpp
+++ b/tools/extra/fpgadiag/nlb0_main.cpp
@@ -98,7 +98,13 @@ int main(int argc, char* argv[])
     if (accelerator_list.size() >= 1)
     {
         token::ptr_t accelerator_tok = accelerator_list[0];
-        auto h = handle::open(accelerator_tok, (shared ? FPGA_OPEN_SHARED: 0));
+        handle::ptr_t h;
+        try {
+            h = handle::open(accelerator_tok, (shared ? FPGA_OPEN_SHARED: 0));
+        } catch (no_access &e) {
+            std::cerr << "Error: insufficient privileges to access device." << std::endl;
+            return 103;
+        }
         nlb.assign(h);
         if (nlb.setup())
         {

--- a/tools/extra/fpgadiag/nlb3_main.cpp
+++ b/tools/extra/fpgadiag/nlb3_main.cpp
@@ -98,7 +98,13 @@ int main(int argc, char* argv[])
     if (accelerator_list.size() >= 1)
     {
         token::ptr_t accelerator_tok = accelerator_list[0];
-        auto h = handle::open(accelerator_tok, (shared ? FPGA_OPEN_SHARED: 0));
+        handle::ptr_t h;
+        try {
+            h = handle::open(accelerator_tok, (shared ? FPGA_OPEN_SHARED: 0));
+        } catch (no_access &e) {
+            std::cerr << "Error: insufficient privileges to access device." << std::endl;
+            return 103;
+        }
         nlb.assign(h);
         if (nlb.setup())
         {

--- a/tools/extra/fpgadiag/nlb7_main.cpp
+++ b/tools/extra/fpgadiag/nlb7_main.cpp
@@ -99,7 +99,13 @@ int main(int argc, char* argv[])
     if (accelerator_list.size() >= 1)
     {
         token::ptr_t accelerator_tok = accelerator_list[0];
-        auto h = handle::open(accelerator_tok, (shared ? FPGA_OPEN_SHARED: 0));
+        handle::ptr_t h;
+        try {
+            h = handle::open(accelerator_tok, (shared ? FPGA_OPEN_SHARED: 0));
+        } catch(no_access &e) {
+            std::cerr << "Error: insufficient privileges to access device." << std::endl;
+            return 103;
+        }
         nlb.assign(h);
         if (nlb.setup())
         {


### PR DESCRIPTION
Add a try/catch for no_access to the handle::open() call, printing
a message and exiting gracefully.