### PR TITLE
fix python3 parsing error

### DIFF
--- a/python/opae.admin/opae/admin/sysfs.py
+++ b/python/opae.admin/opae/admin/sysfs.py
@@ -156,7 +156,7 @@ class sysfs_node(loggable):
             will result in an IOError being raised.
         """
         try:
-            with self._open('r') as fd:
+            with self._open('rb') as fd:
                 return fd.read().strip()
         except IOError as err:
             self.log.exception('error opening: %s - %s', self.sysfs_path, err)


### PR DESCRIPTION
Not sure if this entirely correct, but the `fpgaotsu` tool is broken for me without:

```
(python) # fpgaotsu /usr/share/opae/a10-gx-pac/fpgaotsu/base/otsu-09C4.json
[2020-06-15 12:09:06,362] [INFO    ] [MainThread] Intel PAC with Intel Arria 10 GX FPGA 0000:01:00.0 is not secure.
Traceback (most recent call last):
  File "/home/ddcc/opae-sdk/build/python/bin/fpgaotsu", line 11, in <module>
    load_entry_point('opae.admin', 'console_scripts', 'fpgaotsu')()
  File "/home/ddcc/opae-sdk/python/opae.admin/opae/admin/tools/fpgaotsu.py", line 631, in main
    if updater.check_requires():
  File "/home/ddcc/opae-sdk/python/opae.admin/opae/admin/tools/fpgaotsu.py", line 298, in check_requires
    version = getattr(self._pac.fme, comp.label)
  File "/home/ddcc/opae-sdk/python/opae.admin/opae/admin/fpga.py", line 252, in bmc_aux_fw_rev
    return struct.unpack_from('<15BL', node.value)[15]
  File "/home/ddcc/opae-sdk/python/opae.admin/opae/admin/sysfs.py", line 160, in value
    return fd.read().strip()
  File "/usr/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 1: invalid start byte
```