### PR TITLE
opae.admin: update spi path for dfl drivers

### DIFF
--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -208,7 +208,7 @@ class fme(region):
     def spi_bus(self):
         if os.path.basename(self.sysfs_path).startswith('dfl'):
             return self.find_one('dfl-fme.*.*/'
-                                 'subdev_spi_altera.*.auto/'
+                                 '*spi*/'
                                  'spi_master/spi*/spi*')
         return self.find_one('spi*/spi_master/spi*/spi*')
 

--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -207,7 +207,9 @@ class fme(region):
     @property
     def spi_bus(self):
         if os.path.basename(self.sysfs_path).startswith('dfl'):
-            return self.find_one('dfl-fme.*.*/subdev_spi_altera.*.auto/spi_master/spi*/spi*')
+            return self.find_one('dfl-fme.*.*/'
+                                 'subdev_spi_altera.*.auto/'
+                                 'spi_master/spi*/spi*')
         return self.find_one('spi*/spi_master/spi*/spi*')
 
     @property

--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -207,7 +207,7 @@ class fme(region):
     @property
     def spi_bus(self):
         if os.path.basename(self.sysfs_path).startswith('dfl'):
-            return self.find_one('dfl-fme.*.*/spi*/spi_master/spi*/spi*')
+            return self.find_one('dfl-fme.*.*/subdev_spi_altera.*.auto/spi_master/spi*/spi*')
         return self.find_one('spi*/spi_master/spi*/spi*')
 
     @property


### PR DESCRIPTION
The glob to find the location of the spi path in sysfs has changed
to dfl-fme.*.*/subdev_spi_altera.*.auto/... Update opae.admin to use
the new glob pattern for dfl drivers.