### PR TITLE
ci: add paths to python ci job

### DIFF
--- a/.github/workflows/python-static-analysis.yml
+++ b/.github/workflows/python-static-analysis.yml
@@ -1,6 +1,18 @@
 name: python static analysis
 
-on: push
+on:
+  push:
+    paths:
+      - 'python/**'
+      - 'tools/extra/fpgabist/**'
+      - 'tools/extra/packager/*.py'
+      - 'tools/extra/packager/metadata/**'
+      - 'tools/extra/packager/test/*.py'
+      - 'tools/extra/pac_hssi_config/*.py'
+      - 'tools/extra/fpgadiag/**'
+      - 'tools/utilities/**'
+      - 'platforms/scripts/platmgr/**'
+      - '.github/workflows/python-static-analysis.yml'
 
 jobs:
   analyze:


### PR DESCRIPTION
Adding path to the 'on' field will make it so this workflow is triggered
only when changed files are in the list of paths specified.