### PR TITLE
packaging: remove python2 support from packaging

### DIFF
--- a/packaging/opae.admin/deb/control
+++ b/packaging/opae.admin/deb/control
@@ -3,14 +3,7 @@ Maintainer: The OPAE Development Team, <opae@lists.01.org>
 Section: python
 Priority: optional
 Standards-Version: 4.1.4
-Build-Depends: debhelper (>= 11), python-all, python3-all
-
-Package: python-opae.admin
-Architecture: all
-Section: python
-Depends: python, sysvinit-utils, pciutils, ${misc:Depends}, ${python:Depends}
-Description: OPAE Administration
- Provides administration capability for Intel FPGA PAC devices.
+Build-Depends: debhelper (>= 11), python3-all
 
 Package: python3-opae.admin
 Architecture: all

--- a/packaging/opae.admin/deb/rules
+++ b/packaging/opae.admin/deb/rules
@@ -3,7 +3,7 @@
 export PYBUILD_NAME = opae.admin
 
 %:
-	dh $@ --with python2,python3 --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild
 
 clean:
 


### PR DESCRIPTION
The source is no longer compatible with python2. Under Ubuntu 20.04,
the .deb build was failing because python-all was mentioned in control
and --with python2 was mentioned in rules.