### PR TITLE
fpgasupdate: fixes for Partial Reconfiguration

### DIFF
--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -198,6 +198,9 @@ class fme(region):
 
     @property
     def pr_interface_id(self):
+        if os.path.basename(self.sysfs_path).startswith('dfl'):
+            glob_pat = 'dfl-fme-region.*/fpga_region/region*/compat_id'
+            return self.find_one(glob_pat).value
         return self.node('pr/interface_id').value
 
     @property

--- a/python/opae.admin/opae/admin/tools/fpgasupdate.py
+++ b/python/opae.admin/opae/admin/tools/fpgasupdate.py
@@ -62,7 +62,7 @@ else:
 
 DEFAULT_BDF = 'ssss:bb:dd.f'
 
-VALID_GBS_GUID = uuid.UUID('31303076-5342-47b7-4147-50466e6f6558')
+VALID_GBS_GUID = uuid.UUID('58656f6e-4650-4741-b747-425376303031')
 
 BLOCK0_TYPE_STATIC_REGION = 0
 BLOCK0_TYPE_BMC = 1
@@ -176,7 +176,7 @@ def decode_gbs_header(infile):
         infile.seek(orig_pos, os.SEEK_SET)
         return None
 
-    metadata = infile.read(metadata_length)
+    metadata = infile.read(metadata_length).decode()
     LOG.debug('metadata: %s', metadata)
 
     try:


### PR DESCRIPTION
Reverse VALID_GBS_GUID, because the portion of the script which
performs the comparison relies on it being in that order.
The DFL driver moves pr/interface_id to compat_id at a deeper
nesting in the sysfs tree.