### PR TITLE
dummy_afu: workaround for spdlog compile error

### DIFF
--- a/samples/dummy_afu/CMakeLists.txt
+++ b/samples/dummy_afu/CMakeLists.txt
@@ -65,6 +65,8 @@ opae_add_executable(TARGET dummy_afu
         ${libuuid_LIBRARIES}
     COMPONENT samplebin
 )
+
+target_compile_options(dummy_afu PUBLIC -Wno-unused-result)
 target_include_directories(dummy_afu
     PRIVATE ${spdlog_ROOT}/include
 )

--- a/tests/dummy_afu/CMakeLists.txt
+++ b/tests/dummy_afu/CMakeLists.txt
@@ -34,6 +34,7 @@ opae_test_add_static_lib(TARGET dummy_afu-static
 target_compile_definitions(dummy_afu-static
     PRIVATE main=dummy_afu_main
 )
+target_compile_options(dummy_afu-static PUBLIC -Wno-unused-result)
 
 target_include_directories(dummy_afu-static
     PRIVATE
@@ -50,6 +51,7 @@ opae_test_add(TARGET test_dummy_afu
     TEST_FPGAD
 )
 
+target_compile_options(test_dummy_afu PUBLIC -Wno-unused-result)
 target_include_directories(test_dummy_afu
     PRIVATE
         ${CMAKE_SOURCE_DIR}/external/CLI11/include


### PR DESCRIPTION
A header file in spdlog has an unused result,
add -Wno-unused-result option in dummy_afu.