### PR TITLE
improve finding the fpga

### DIFF
--- a/tools/extra/fpgabist/dma_N3000/fpga_dma_test.c
+++ b/tools/extra/fpgabist/dma_N3000/fpga_dma_test.c
@@ -625,7 +625,7 @@ int main(int argc, char *argv[])
 	fpga_token afc_token;
 	fpga_handle afc_h;
 	fpga_guid guid;
-	uint32_t num_matches = 1;
+	uint32_t num_matches = 0;
 	volatile uint64_t *mmio_ptr = NULL;
 	uint64_t *dma_buf_ptr = NULL;
 	uint32_t use_ase;
@@ -659,7 +659,7 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	res = find_fpga(guid, &afc_token, &num_matches);
+	find_fpga(guid, &afc_token, &num_matches);
 	if (num_matches == 0) {
 		fprintf(stderr, "No suitable slots found.\n");
 		return 1;


### PR DESCRIPTION
clang static analysis reports

fpga_dma_test.c:662:2: warning: Value stored to 'res'
  is never read
        res = find_fpga(guid, &afc_token, &num_matches);
        ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Because num_matches is initialized to 1, when find_fpga
fails and does not set num_matches, the initial value
will be incorrect.  This will lead to other errors.

Intialize num_matches to 0 and depend on the side
effect of setting num_matches > 0 to indicate success.

Signed-off-by: Tom Rix <trix@redhat.com>