### PR TITLE
update quick start guide

### DIFF
--- a/doc/src/fpga_api/quick_start/readme.md
+++ b/doc/src/fpga_api/quick_start/readme.md
@@ -38,6 +38,41 @@ The source for the OPAE SDK Linux device drivers is available at the
 [OPAE Linux DFL drivers repository](https://github.com/OPAE/linux-dfl).
 
 ``
+## Build the OPAE Linux device drivers from source ##
+For building the OPAE kernel and kernel driver, the kernel development environment is required. So before you build the kernel, you must install the required packages. Run the following commands:
+
+We using Federa 32 as an example.
+```console
+$ sudo yum install gcc gcc-c++ make kernel-headers kernel-devel elfutils-libelf-devel ncurses-devel openssl-devel bison flex
+```
+
+Download the OPAE upstream kernel tree from github.
+```console
+$ git clone https://github.com/OPAE/linux-dfl.git -b fpga-upstream-dev-5.8.0
+```
+
+Configure the kernel.
+```console
+$ cd linux-dfl
+$ cp /boot/config-`uname -r` .config
+$ cat configs/n3000_d5005_defconfig >> .config 
+$ echo 'CONFIG_LOCALVERSION="-dfl"' >> .config
+$ echo 'CONFIG_LOCALVERSION_AUTO=y' >> .config
+$ make olddefconfig
+```
+
+Compile and install the new kernel.
+```console
+$ make -j
+$ sudo make modules_install
+$ sudo make install
+```
+When installed finished, reboot your system.
+When the system login again, check the kernel version is correctly or not.
+```console
+[figo@localhost linux-dfl]$ uname -a
+Linux localhost.localdomain 5.8.0-rc1-dfl-g73e16386cda0 #6 SMP Wed Aug 19 08:38:32 EDT 2020 x86_64 x86_64 x86_64 GNU/Linux
+```
 
 ## Building and installing the OPAE SDK from source ##
 Download the OPAE SDK source package from the respective [release page on
@@ -66,6 +101,7 @@ by adding `-DCMAKE_INSTALL_PREFIX=<new prefix>` to the `cmake` command above.
 The remainder of this guide assumes you installed into `/usr/local`.
 
 ## Configuring the FPGA (loading an FPGA AFU)##
+
 
 The *fpgaconf* tool exercises the AFU reconfiguration
 functionality. It shows how to read a bitstream from a disk file,
@@ -113,6 +149,11 @@ Usage:
     $ cat /sys/class/fpga_region/region0/dfl-port.0/afu_id
 
     d8424dc4a4a3c413f89e433683f9040b
+```
+```eval_rst
+.. note::
+    The fpgaconf tool is not available for the Intel PAC N3000. The NLB is
+    alrealy include in AFU.
 ```
 
 ## Building a sample application ##
@@ -328,6 +369,13 @@ $ gcc -std=c99 hello_fpga.c -I/usr/local/include -L/usr/local/lib -lopae-c -luui
     Third-party library dependency: The library internally uses
     `libuuid` and `libjson-c`. But they are not distributed as part of the
     library. Make sure you have these libraries properly installed.
+```
+
+```eval_rst
+.. note:
+    The layout of AFU is difference between the N3000 card and Rush Creek/Darby Creek. In N3000 card, the NLB and DMA are contained 
+    in the AFU, so we need to do enumeration again in AFU to discover the NLB. We provide a specify hello_fpga_n3000.c demo code 
+    for N3000 card. You can also find the source for `hello\_fpga` in the `samples` directory of the OPAE SDK repository on github.
 ```
 To run the *hello_fpga* application; just issue:
 

--- a/doc/src/fpga_tools/fecmode/fecmode.md
+++ b/doc/src/fpga_tools/fecmode/fecmode.md
@@ -1,0 +1,62 @@
+# fecmode (N3000 specific tool) #
+
+## SYNOPSIS ##
+```console
+fecmode [<mode>][<args>]
+```
+
+## DESCRIPTION ##
+
+Fecmode changes FEC mode of external ethernet PHY, this tool only support on N3000 Card.
+
+## POSITIONAL ARGUMENTS ##
+`--segment, -S`
+
+ segment number of the PCIe device.
+   
+ `--bus, -B` 
+ 
+ bus number of the PCIe device. 
+   
+ `--device, -D` 
+ 
+device number of the PCIe device.
+
+`--function, -F`
+function number of the PCIe device
+
+`--rsu, -r`
+reboot card only if mode is not configured
+
+`--debug, -d`
+output debug information 
+
+
+
+## FEC Mode ##
+`no`
+no FEC.
+
+`kr`
+BaseR FEC (Fire-Code) correction – 4 orders
+
+`rs`
+Reed-Solomon FEC correction – 7 orders
+
+## EXAMPLE ##
+
+This command change FEC mode to “kr”:
+```console
+# fecmode -B 0x25 kr
+```
+
+This command reboot card (no need to specify bus number if there is only one card):
+```console
+# fecmode -r
+```
+
+This command display the current FEC mode:
+```console
+# fecmode
+```
+

--- a/doc/src/fpga_tools/rsu/rsu.md
+++ b/doc/src/fpga_tools/rsu/rsu.md
@@ -1,0 +1,68 @@
+# rsu #
+
+## SYNOPSIS ##
+```console
+rsu [-h] [-f] [-d] {bmcimg,fpga} [bdf]
+
+```
+
+## DESCRIPTION ##
+
+Perform RSU (remote system update) operation on PAC device
+given its PCIe address.
+An RSU operation sends an instruction to the device to trigger
+a power cycle of the card only. This will force reconfiguration
+from flash for either BMC image (on devices that support it) or the
+FPGA
+
+
+## POSITIONAL ARGUMENTS ##
+`{bmcimg,fpga}`
+
+type of operation
+   
+ `bdf` 
+PCIe address of device to do rsu (e.g. 04:00.0 or 0000:04:00.0) 
+
+##  OPTIONAL ARGUMENTS ##
+`-h, --help`
+show this help message and exit
+
+`-f, --factory`
+reload from factory bank
+
+`-d, --debug`
+log debug statements
+
+## EXAMPLE ##
+
+ This will trigger a boot of the BMC image for a device with a pci address
+ of 25:00.0.
+ NOTE: Both BMC and FPGA images will be reconfigured from user bank.
+```console
+# rsu bmcimg 25:00.0
+```
+
+
+This will trigger a factory boot of the BMC image for a device with a
+ pci address of 25:00.0.
+NOTE: Both BMC image will be reconfigured from factory bank and the
+```console
+# rsu bmcimg 25:00.0 -f
+```
+
+This will trigger a reconfiguration of the FPGA only for a device with a
+pci address of 25:00.0.
+NOTE: The FPGA image will be reconfigured from user bank.
+```console
+# rsu fpga 25:00.0
+```
+
+This will trigger a factory reconfiguration of the FPGA only for a device
+with a pci address of 25:00.0.
+NOTE: The FPGA image will be reconfigured from the factory bank.
+```console
+# rsu fpga 25:00.0 -f
+```
+
+

--- a/doc/src/install_guide/installation_guide.md
+++ b/doc/src/install_guide/installation_guide.md
@@ -11,8 +11,8 @@
 
 The OPAE SDK has been tested on the following configurations.
 
-* Hardware: Intel(R) FPGA Programmable Acceleration Cards: Arria(R) 10 GX, D5005, and N3000.
-* Operating System: Tested on Fedora 31, with Linux kernel 5.7.
+* Hardware: Intel(R) FPGA Programmable Acceleration Cards: Arria(R) 10 GX, N3000.
+* Operating System: Tested on Fedora 32, with Linux kernel 5.8.
 * Arria&reg 10 GX FPGA FIM version: 1.0.3 (1.0 Production)
 
 ## How to download the OPAE SDK ##
@@ -20,193 +20,140 @@ The OPAE SDK has been tested on the following configurations.
 OPAE SDK releases are available on [GitHub](https://github.com/OPAE/opae-sdk/releases).
 Source code for the OPAE DFL device driver for Linux is also available on [GitHub](https://github.com/OPAE/linux-dfl).
 
-## Software requirements ##
+## Install the Fedora 32 ##
+Download the Fedora 32 (x86_64 version) installation file in [fedora](https://getfedora.org/en/workstation/download/), and install the Fedora 32 in yourserver. You can choose Fedora Workstation or Fedora server.
 
-For building the kernel driver, the kernel development environment is required.
+## Build the kernel and DFL drivers ##
 
-For building libopae-c, tools and samples, the following dependences are required:
-
-RHEL/Fedora
-
-* libuuid-devel.x86\_64
-* json-c-devel.x86\_64
-* cmake.x86\_64
-* hwloc-devel.x86\_64
-* tbb-devel.x86\_64
-* python3-devel.x86\_64
-
-Debian/Ubuntu
-
-* uuid-dev
-* libjson-c-dev
-* cmake
-* libhwloc-dev
-* libtbb-dev
-* python3-dev
-
-## OPAE SDK build/installation from OPAE SDK source ##
-Using the following command to untar the source tar ball:
+For building the OPAE kernel and kernel driver, the kernel development environment is required. So before you build the kernel, you must install the required packages. Run the following commands:
 
 ```console
-$ tar zxvf opae-sdk-<release>.tar.gz
+$ sudo yum install gcc gcc-c++ make kernel-headers kernel-devel elfutils-libelf-devel ncurses-devel openssl-devel bison flex
 ```
 
-Following directory shall be created at the working directory where the above command is executed.
+Download the OPAE upstream kernel tree from github.
+```console
+$ git clone https://github.com/OPAE/linux-dfl.git -b fpga-upstream-dev-5.8.0
+```
 
-* `opae-sdk-<release>`
+Configure the kernel.
+```console
+$ cd linux-dfl
+$ cp /boot/config-`uname -r` .config
+$ cat configs/n3000_d5005_defconfig >> .config 
+$ echo 'CONFIG_LOCALVERSION="-dfl"' >> .config
+$ echo 'CONFIG_LOCALVERSION_AUTO=y' >> .config
+$ make olddefconfig
+```
 
-Build the OPAE C library (libopae-c), samples, tools, and the AFU Simulation Environment (ASE)
-library (libopae-c-ase) with the following commands:
+Compile and install the new kernel.
+```console
+$ make -j
+$ sudo make modules_install
+$ sudo make install
+```
+
+When installed finished, reboot your system.
+When the system login again, check the kernel version is correctly or not.
+```console
+[figo@localhost linux-dfl]$ uname -a
+Linux localhost.localdomain 5.8.0-rc1-dfl-g73e16386cda0 #6 SMP Wed Aug 19 08:38:32 EDT 2020 x86_64 x86_64 x86_64 GNU/Linux
+```
+
+And also you can check the OPAE dfl drivers have auto-loaded or not.
+```console
+[figo@localhost linux-dfl]$ lsmod | grep fpga
+ifpga_sec_mgr          20480  1 intel_m10_bmc_secure
+fpga_region            20480  3 dfl_fme_region,dfl_fme,dfl
+fpga_bridge            24576  4 dfl_fme_region,fpga_region,dfl_fme,dfl_fme_br
+fpga_mgr               16384  4 dfl_fme_region,fpga_region,dfl_fme_mgr,dfl_fme
+[figo@localhost linux-dfl]$ lsmod | grep dfl
+dfl_eth_group          36864  0
+dfl_fme_region         20480  0
+dfl_emif               16384  0
+dfl_n3000_nios         20480  0
+dfl_fme_br             16384  0
+dfl_fme_mgr            20480  1
+dfl_fme                49152  0
+dfl_afu                36864  0
+dfl_pci                20480  0
+dfl                    40960  7 dfl_pci,dfl_fme,dfl_fme_br,dfl_eth_group,dfl_n3000_nios,dfl_afu,dfl_emif
+fpga_region            20480  3 dfl_fme_region,dfl_fme,dfl
+fpga_bridge            24576  4 dfl_fme_region,fpga_region,dfl_fme,dfl_fme_br
+fpga_mgr               16384  4 dfl_fme_region,fpga_region,dfl_fme_mgr,dfl_fme
+```
+
+## Build the OPAE-SDK ##
+Before you build the kernel, you must install the required packages. Run the following commands:
 
 ```console
-$ cd opae-sdk-<release>
-$ mkdir mybuild
-$ cd mybuild
-$ cmake .. -DOPAE_BUILD_SIM=ON
-$ make
+$ sudo yum install cmake libuuid libuuid-devel json-c python3-devel python3-libs json-c-devel hwloc-devel uuid python3-pip python3-virtualenv tbb-devel rpm-build
 ```
 
-By default, the OPAE SDK will install into `/usr/local` if you also issue the following:
-
+Download the OPAE-SDK source code from github.
 ```console
-$ make install
+$ git clone https://github.com/OPAE/opae-sdk.git
 ```
 
-You can change this installation prefix from `/usr/local` into something else
-by adding `-DCMAKE_INSTALL_PREFIX=<new prefix>` to the `cmake` command above.
-
-Please see Quick Start Guide on how to run the hello\_fpga sample to verify
-libopae-c and driver are built correctly.
-
-## Building python distributions for tools ##
-
-The tools that can be built with python distutils are:
- - packager
- - fpgaflash
- - fpgadiag
-
+Compile and build the OPAE-SDK.
 ```console
-$ cd opae-sdk-<release>
-$ mkdir mybuild
-$ cd mybuild
-$ cmake .. -DOPAE_BUILD_PYTHON_DIST=ON
-$ make <toolname>-dist
+$ cd opae-sdk
+$ mkdir build
+$ cmake  ..  -DCPACK_GENERATOR=RPM -DOPAE_BUILD_LEGACY=ON
+$ make -j
+$ make -j package_rpm
 ```
-The python distributions will be available in mybuild/<tools-directory>/<toolname>/stage/dist
-
-## Building OPAE SDK rpm and deb packages from the source ##
-In addition to building and installation from the source, users can also
-generate rpm and deb packages for the SDK. The generated packages can then be
-distributed to other users for easy installation. The advantage of this approach
-is that the other users do not need to have the build toolchain on their
-systems to install the OPAE SDK.
-
-* To build rpm packages follow these steps:
-
+After compile successful, there are 8 rpm packages generated.
 ```console
-$ cd opae-sdk-<release>
-$ mkdir mybuild
-$ cd mybuild
-$ cmake .. -DOPAE_BUILD_SIM=ON -DCPACK_GENERATOR=RPM -DCMAKE_INSTALL_PREFIX=<desired install location>
-$ make package_rpm
+opae-2.0.0-1.x86_64.rpm
+opae-devel-2.0.0-1.x86_64.rpm
+opae-libs-2.0.0-1.x86_64.rpm
+opae-opae.admin-2.0.0-1.x86_64.rpm
+opae-PACSign-2.0.0-1.x86_64.rpm
+opae-tests-2.0.0-1.x86_64.rpm
+opae-tools-2.0.0-1.x86_64.rpm
+opae-tools-extra-2.0.0-1.x86_64.rpm
 ```
-.. note::
-```
-Note: Providing CMAKE_INSTALL_PREFIX is optional, by default the install prefix will be /usr.
-```
-This will generate the following rpm packages.
-
-```console
-opae-<release>.x86_64.rpm               (meta package)
-opae-libs-<release>.x86_64.rpm          (libopae-c and samples)
-opae-tools-<release>.x86_64.rpm         (base tools)
-opae-tools-extra-<release>.x86_64.rpm   (extra tools)
-opae-devel-<release>.x86_64.rpm         (headers)
-opae-ase-<release>.x86_64.rpm           (libopae-c-ase)
-```
-
-* To build deb packages follow these steps:
-
- .. note::
-  ```
-  Note: For generating deb packages, cmake version 3.0.0 and above is required.
-  ```
-
-```console
-$ cd opae-sdk-<release>
-$ mkdir mybuild
-$ cd mybuild
-$ cmake .. -DOPAE_BUILD_SIM=ON -DCPACK_GENERATOR=DEB -DCMAKE_INSTALL_PREFIX=<desired install location>
-$ make package_deb
-```
-.. note::
-```
-Note: Providing CMAKE_INSTALL_PREFIX is optional, by default the install prefix will be /usr.
-```
-This will generate the following deb packages.
-
-```console
-opae-libs-<release>.x86_64.deb          (libopae-c and samples)
-opae-tools-<release>.x86_64.deb         (tools)
-opae-tools-extra-<release>.x86_64.deb   (tools)
-opae-devel-<release>.x86_64.deb         (headers)
-opae-ase-<release>.x86_64.deb           (libopae-c-ase)
-```
-
 ## OPAE SDK installation with rpm packages ##
-The rpm packages generated in the previous step can be installed
-using these commands:
+The rpm packages generated in the previous step can be installed using these commands:
 
 ```console
-$ sudo yum install opae-<release>.x86_64.rpm
 $ sudo yum install opae-libs-<release>.x86_64.rpm
 $ sudo yum install opae-tools-<release>.x86_64.rpm
 $ sudo yum install opae-tools-extra-<release>.x86_64.rpm
 $ sudo yum install opae-devel-<release>.x86_64.rpm
-$ sudo yum install opae-ase-<release>.x86_64.rpm
+$ sudo yum install opae-<release>.x86_64.rpm
+$ sudo yum install opae-opae.admin-<release>.x86_64.rpm
+$ sudo yum install opae-PACSign-<release>.x86_64.rpm
+$ sudo yum install opae-tests-<release>.x86_64.rpm
 ```
-
-```eval_rst
-.. note:
-    If you want to install all the packages, you can also do:
-    $ sudo yum install opae-*.rpm
-```
-To uninstall:
-
+When you installed the rpms, you can use fpgainfo command to check the FPGA FME infomation.
 ```console
-$ sudo yum remove opae
+[figo@localhost install_guide]$ fpgainfo fme
+Board Management Controller, MAX10 NIOS FW version: D.2.1.24
+Board Management Controller, MAX10 Build version: D.2.0.7
+//****** FME ******//
+Object Id                        : 0xEF00000
+PCIe s:b:d.f                     : 0000:08:00.0
+Device Id                        : 0x0B30
+Socket Id                        : 0x00
+Ports Num                        : 01
+Bitstream Id                     : 0x2300011001030F
+Bitstream Version                : 0.2.3
+Pr Interface Id                  : f3c99413-5081-4aad-bced-07eb84a6d0bb
+Boot Page                        : user
+```
+
+To uninstall the OPAE rpms, you can use this commands
+```console
 $ sudo yum remove opae-libs
 $ sudo yum remove opae-tools
 $ sudo yum remove opae-tools-extra
 $ sudo yum remove opae-devel
-$ sudo yum remove opae-ase
-```
-
-## OPAE SDK installation with deb packages ##
-The deb packages generated in the previous step can be installed
-using these commands:
-
-```console
-$ sudo dpkg -i opae-libs-<release>.x86_64.deb
-$ sudo dpkg -i opae-tools-<release>.x86_64.deb
-$ sudo dpkg -i opae-tools-extra-<release>.x86_64.deb
-$ sudo dpkg -i opae-devel-<release>.x86_64.deb
-$ sudo dpkg -i opae-ase-<release>.x86_64.deb
-```
-
-```eval_rst
-.. note:
-    If you want to install all the packages, you can also do:
-    $ sudo dpkg -i opae-*.deb
-```
-To uninstall:
-
-```console
-$ sudo dpkg -r opae-libs
-$ sudo dpkg -r opae-tools
-$ sudo dpkg -r opae-tools-extra
-$ sudo dpkg -r opae-devel
-$ sudo dpkg -r opae-ase
+$ sudo yum remove opae
+$ sudo yum remove opae-opae.admin
+$ sudo yum remove opae-PACSign
+$ sudo yum remove opae-tests
 ```
 
 ## FPGA Device Access Permissions ##

--- a/samples/hello_fpga/CMakeLists.txt
+++ b/samples/hello_fpga/CMakeLists.txt
@@ -36,3 +36,16 @@ opae_add_executable(TARGET hello_fpga
 install(FILES hello_fpga.c
   DESTINATION src/opae/samples/hello_fpga
   COMPONENT samplesrc)
+
+opae_add_executable(TARGET hello_fpga_n3000
+    SOURCE hello_fpga_n3000.c
+    LIBS
+        opae-c
+        ${libjson-c_LIBRARIES}
+        ${libuuid_LIBRARIES}
+    COMPONENT samplebin
+)
+
+install(FILES hello_fpga_n3000.c
+  DESTINATION src/opae/samples/hello_fpga_n3000
+  COMPONENT samplesrc)

--- a/samples/hello_fpga/hello_fpga_n3000.c
+++ b/samples/hello_fpga/hello_fpga_n3000.c
@@ -1,0 +1,518 @@
+// Copyright(c) 2017-2020, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file hello_fpga.c
+ * @brief A code sample illustrates the basic usage of the OPAE C API.
+ *
+ * The sample is a host application that demonstrates the basic steps of
+ * interacting with FPGA using the OPAE library. These steps include:
+ *
+ *  - FPGA enumeration
+ *  - Resource acquiring and releasing
+ *  - Managing shared memory buffer
+ *  - MMIO read and write
+ *
+ * The sample also demonstrates OPAE's object model, such as tokens, handles,
+ * and properties.
+ *
+ * The sample requires a native loopback mode (NLB) test image to be loaded on
+ * the FPGA. Refer to
+ * <a href="https://opae.github.io/docs/fpga_api/quick_start/readme.html">Quick
+ * Start Guide</a> for full instructions on building, configuring, and running
+ * this code sample.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <getopt.h>
+#include <unistd.h>
+
+#include <uuid/uuid.h>
+#include <opae/fpga.h>
+
+int usleep(unsigned);
+
+#ifndef TEST_TIMEOUT
+#define TEST_TIMEOUT 30000
+#endif // TEST_TIMEOUT
+
+#ifndef CL
+# define CL(x)                       ((x) * 64)
+#endif // CL
+#ifndef LOG2_CL
+# define LOG2_CL                     6
+#endif // LOG2_CL
+#ifndef MB
+# define MB(x)                       ((x) * 1024 * 1024)
+#endif // MB
+
+#define CACHELINE_ALIGNED_ADDR(p) ((p) >> LOG2_CL)
+
+#define LPBK1_BUFFER_SIZE            MB(1)
+#define LPBK1_BUFFER_ALLOCATION_SIZE MB(2)
+#define LPBK1_DSM_SIZE               MB(2)
+#define CSR_SRC_ADDR                 0x0120
+#define CSR_DST_ADDR                 0x0128
+#define CSR_CTL                      0x0138
+#define CSR_STATUS1                  0x0168
+#define CSR_CFG                      0x0140
+#define CSR_NUM_LINES                0x0130
+#define DSM_STATUS_TEST_COMPLETE     0x40
+#define CSR_AFU_DSM_BASEL            0x0110
+
+/* NLB0 AFU_ID */
+#define VC_AFUID "9AEFFE5F-8457-0612-C000-C9660D824272"
+#define FPGA_NLB0_UUID_H 0xd8424dc4a4a3c413
+#define FPGA_NLB0_UUID_L 0xf89e433683f9040b
+
+
+/*
+ * macro to check return codes, print error message, and goto cleanup label
+ * NOTE: this changes the program flow (uses goto)!
+ */
+#define ON_ERR_GOTO(res, label, desc)              \
+	do {                                       \
+		if ((res) != FPGA_OK) {            \
+			print_err((desc), (res));  \
+			goto label;                \
+		}                                  \
+	} while (0)
+
+/* Type definitions */
+typedef struct {
+	uint32_t uint[16];
+} cache_line;
+
+void print_err(const char *s, fpga_result res)
+{
+	fprintf(stderr, "Error %s: %s\n", s, fpgaErrStr(res));
+}
+
+/*
+ * Global configuration of bus, set during parse_args()
+ * */
+struct config {
+	struct target {
+		int bus;
+	} target;
+	int open_flags;
+}
+
+config = {
+	.target = {
+		.bus = -1,
+	},
+	.open_flags = 0
+};
+
+#define GETOPT_STRING "B:sv"
+fpga_result parse_args(int argc, char *argv[])
+{
+	struct option longopts[] = {
+		{ "bus",     required_argument, NULL, 'B' },
+		{ "shared",  no_argument,       NULL, 's' },
+		{ "version", no_argument,       NULL, 'v' },
+		{ NULL,      0,                 NULL,  0  }
+	};
+
+	int getopt_ret;
+	int option_index;
+	char *endptr = NULL;
+	char version[32];
+	char build[32];
+
+	while (-1 != (getopt_ret = getopt_long(argc, argv, GETOPT_STRING,
+						longopts, &option_index))) {
+		const char *tmp_optarg = optarg;
+		/* Checks to see if optarg is null and if not it goes to value of optarg */
+		if ((optarg) && ('=' == *tmp_optarg)) {
+			++tmp_optarg;
+		}
+
+		switch (getopt_ret) {
+		case 'B': /* bus */
+			if (NULL == tmp_optarg) {
+				return FPGA_EXCEPTION;
+			}
+			endptr = NULL;
+			config.target.bus = (int) strtoul(tmp_optarg, &endptr, 0);
+			if (endptr != tmp_optarg + strnlen(tmp_optarg, 100)) {
+				fprintf(stderr, "invalid bus: %s\n", tmp_optarg);
+				return FPGA_EXCEPTION;
+			}
+			break;
+		case 's':
+			config.open_flags |= FPGA_OPEN_SHARED;
+			break;
+
+		case 'v':
+			fpgaGetOPAECVersionString(version, sizeof(version));
+			fpgaGetOPAECBuildString(build, sizeof(build));
+			printf("hello_fpga %s %s\n",
+			       version, build);
+			return -1;
+
+		default: /* invalid option */
+			fprintf(stderr, "Invalid cmdline option \n");
+			return FPGA_EXCEPTION;
+		}
+	}
+
+	return FPGA_OK;
+}
+
+fpga_result find_fpga(fpga_guid afu_guid,
+		      fpga_token *accelerator_token,
+		      uint32_t *num_matches_accelerators)
+{
+	fpga_properties filter = NULL;
+	fpga_result res1;
+	fpga_result res2 = FPGA_OK;
+
+	res1 = fpgaGetProperties(NULL, &filter);
+	ON_ERR_GOTO(res1, out, "creating properties object");
+
+	res1 = fpgaPropertiesSetObjectType(filter, FPGA_ACCELERATOR);
+	ON_ERR_GOTO(res1, out_destroy, "setting object type");
+
+	res1 = fpgaPropertiesSetGUID(filter, afu_guid);
+	ON_ERR_GOTO(res1, out_destroy, "setting GUID");
+
+	if (-1 != config.target.bus) {
+		res1 = fpgaPropertiesSetBus(filter, config.target.bus);
+		ON_ERR_GOTO(res1, out_destroy, "setting bus");
+	}
+
+	res1 = fpgaEnumerate(&filter, 1, accelerator_token, 1, num_matches_accelerators);
+	ON_ERR_GOTO(res1, out_destroy, "enumerating accelerators");
+
+out_destroy:
+	res2 = fpgaDestroyProperties(&filter);
+	ON_ERR_GOTO(res2, out, "destroying properties object");
+out:
+	return res1 != FPGA_OK ? res1 : res2;
+}
+
+/* function to get the bus number when there are multiple accelerators */
+fpga_result get_bus(fpga_token tok, uint8_t *bus)
+{
+	fpga_result res1;
+	fpga_result res2 = FPGA_OK;
+	fpga_properties props = NULL;
+
+	res1 = fpgaGetProperties(tok, &props);
+	ON_ERR_GOTO(res1, out, "reading properties from Token");
+
+	res1 = fpgaPropertiesGetBus(props, bus);
+	ON_ERR_GOTO(res1, out_destroy, "Reading bus from properties");
+
+out_destroy:
+	res2 = fpgaDestroyProperties(&props);
+	ON_ERR_GOTO(res2, out, "fpgaDestroyProps");
+out:
+	return res1 != FPGA_OK ? res1 : res2;
+}
+
+/* Is the FPGA simulated with ASE? */
+bool probe_for_ase(void)
+{
+	fpga_result r = FPGA_OK;
+	uint16_t device_id = 0;
+	fpga_properties filter = NULL;
+	uint32_t num_matches = 1;
+	fpga_token fme_token;
+
+	/* Connect to the FPGA management engine */
+	fpgaGetProperties(NULL, &filter);
+	fpgaPropertiesSetObjectType(filter, FPGA_DEVICE);
+
+	/* Connecting to one is sufficient to find ASE */
+	fpgaEnumerate(&filter, 1, &fme_token, 1, &num_matches);
+	if (0 != num_matches) {
+		/* Retrieve the device ID of the FME */
+		fpgaDestroyProperties(&filter);
+		fpgaGetProperties(fme_token, &filter);
+		r = fpgaPropertiesGetDeviceID(filter, &device_id);
+		fpgaDestroyToken(&fme_token);
+	}
+	fpgaDestroyProperties(&filter);
+
+	/* ASE's device ID is 0xa5e */
+	return ((FPGA_OK == r) && (0xa5e == device_id));
+}
+
+int main(int argc, char *argv[])
+{
+	fpga_token         accelerator_token;
+	fpga_handle        accelerator_handle;
+	fpga_guid          guid;
+	uint32_t           num_matches_accelerators = 0;
+	uint32_t           use_ase;
+
+	volatile uint64_t *dsm_ptr    = NULL;
+	volatile uint64_t *status_ptr = NULL;
+	volatile uint64_t *input_ptr  = NULL;
+	volatile uint64_t *output_ptr = NULL;
+
+	uint64_t           dsm_wsid;
+	uint64_t           input_wsid;
+	uint64_t           output_wsid;
+	uint8_t            bus = 0xff;
+	uint32_t           i;
+	uint32_t           timeout;
+	fpga_result        res1 = FPGA_OK;
+	fpga_result        res2 = FPGA_OK;
+
+	res1 = parse_args(argc, argv);
+	if ((int)res1 < 0)
+		goto out_exit;
+	ON_ERR_GOTO(res1, out_exit, "parsing arguments");
+
+	if (uuid_parse(VC_AFUID, guid) < 0) {
+		res1 = FPGA_EXCEPTION;
+	}
+	ON_ERR_GOTO(res1, out_exit, "parsing guid");
+
+	use_ase = probe_for_ase();
+	if (use_ase) {
+		printf("Running in ASE mode\n");
+	}
+
+	/* Look for accelerator with NLB0_AFUID */
+	res1 = find_fpga(guid, &accelerator_token, &num_matches_accelerators);
+	ON_ERR_GOTO(res1, out_exit, "finding FPGA accelerator");
+
+	if (num_matches_accelerators <= 0) {
+		res1 = FPGA_NOT_FOUND;
+	}
+	ON_ERR_GOTO(res1, out_exit, "no matching accelerator");
+
+	if (num_matches_accelerators > 1) {
+		printf("Found more than one suitable accelerator. ");
+		res1 = get_bus(accelerator_token, &bus);
+		ON_ERR_GOTO(res1, out_exit, "getting bus num");
+		printf("Running on bus 0x%02x.\n", bus);
+	}
+
+
+	/* Open accelerator and map MMIO */
+	res1 = fpgaOpen(accelerator_token, &accelerator_handle, config.open_flags);
+	ON_ERR_GOTO(res1, out_destroy_tok, "opening accelerator");
+
+	res1 = fpgaMapMMIO(accelerator_handle, 0, NULL);
+	ON_ERR_GOTO(res1, out_close, "mapping MMIO space");
+
+
+	/* Allocate buffers */
+	res1 = fpgaPrepareBuffer(accelerator_handle, LPBK1_DSM_SIZE,
+				(void **)&dsm_ptr, &dsm_wsid, 0);
+	ON_ERR_GOTO(res1, out_close, "allocating DSM buffer");
+
+	res1 = fpgaPrepareBuffer(accelerator_handle, LPBK1_BUFFER_ALLOCATION_SIZE,
+			   (void **)&input_ptr, &input_wsid, 0);
+	ON_ERR_GOTO(res1, out_free_dsm, "allocating input buffer");
+
+	res1 = fpgaPrepareBuffer(accelerator_handle, LPBK1_BUFFER_ALLOCATION_SIZE,
+			   (void **)&output_ptr, &output_wsid, 0);
+	ON_ERR_GOTO(res1, out_free_input, "allocating output buffer");
+
+	printf("Running Test\n");
+
+	bus = 0xff;
+	res1 = get_bus(accelerator_token, &bus);
+	ON_ERR_GOTO(res1, out_free_output, "getting bus num");
+	printf("Running on bus 0x%02x.\n", bus);
+
+
+	/* Initialize buffers */
+	memset((void *)dsm_ptr,    0,    LPBK1_DSM_SIZE);
+	memset((void *)input_ptr,  0xAF, LPBK1_BUFFER_SIZE);
+	memset((void *)output_ptr, 0xBE, LPBK1_BUFFER_SIZE);
+
+	cache_line *cl_ptr = (cache_line *)input_ptr;
+	for (i = 0; i < LPBK1_BUFFER_SIZE / CL(1); ++i) {
+		cl_ptr[i].uint[15] = i+1; /* set the last uint in every cacheline */
+	}
+
+
+	/* Reset accelerator */
+	res1 = fpgaReset(accelerator_handle);
+	ON_ERR_GOTO(res1, out_free_output, "resetting accelerator");
+
+	/* find NLB0 in AFU */
+	int end_of_list = 0;
+	int nlb0_found = 0;
+	uint64_t header = 0;
+	uint64_t uuid_hi = 0;
+	uint64_t uuid_lo = 0;
+	uint64_t next_offset = 0;
+	uint64_t nlb0_offset = 0;
+	do {
+		// Read the next feature header
+		res1 = fpgaReadMMIO64(accelerator_handle, 0, nlb0_offset, &header);
+		ON_ERR_GOTO(res1, out_free_output, "fpgaReadMMIO64");
+		res1 = fpgaReadMMIO64(accelerator_handle, 0, nlb0_offset+8, &uuid_lo);
+		ON_ERR_GOTO(res1, out_free_output, "fpgaReadMMIO64");
+		res1 = fpgaReadMMIO64(accelerator_handle, 0, nlb0_offset+16, &uuid_hi);
+		ON_ERR_GOTO(res1, out_free_output, "fpgaReadMMIO64");
+		// printf("%zx: %zx %zx %zx\n", nlb0_offset, header, uuid_lo, uuid_hi);
+		if ((((header >> 60) & 0xf) == 0x1) &&
+			(uuid_lo == FPGA_NLB0_UUID_L) && (uuid_hi == FPGA_NLB0_UUID_H)) {
+			nlb0_found = 1;
+			break;
+		}
+		// End of the list flag
+		end_of_list = (header >> 40) & 1;
+		// Move to the next feature header
+		next_offset = (header >> 16) & 0xffffff;
+		if ((next_offset == 0xffff) || (next_offset == 0)) {
+			nlb0_found = 0;
+			break;
+		}
+		nlb0_offset = nlb0_offset + next_offset;
+	} while (!end_of_list);
+	if (!nlb0_found) {
+		printf("AFU NLB0 not found\n");
+		goto out_free_output;
+	} else {
+		printf("AFU NLB0 found @ %zx\n", nlb0_offset);
+	}
+
+	/* Program DMA addresses */
+	uint64_t iova = 0;
+	res1 = fpgaGetIOAddress(accelerator_handle, dsm_wsid, &iova);
+	ON_ERR_GOTO(res1, out_free_output, "getting DSM IOVA");
+
+	res1 = fpgaWriteMMIO64(accelerator_handle, 0, nlb0_offset+CSR_AFU_DSM_BASEL, iova);
+	ON_ERR_GOTO(res1, out_free_output, "writing CSR_AFU_DSM_BASEL");
+
+	res1 = fpgaWriteMMIO32(accelerator_handle, 0, nlb0_offset+CSR_CTL, 0);
+	ON_ERR_GOTO(res1, out_free_output, "writing CSR_CFG");
+	res1 = fpgaWriteMMIO32(accelerator_handle, 0, nlb0_offset+CSR_CTL, 1);
+	ON_ERR_GOTO(res1, out_free_output, "writing CSR_CFG");
+
+	res1 = fpgaGetIOAddress(accelerator_handle, input_wsid, &iova);
+	ON_ERR_GOTO(res1, out_free_output, "getting input IOVA");
+	res1 = fpgaWriteMMIO64(accelerator_handle, 0, nlb0_offset+CSR_SRC_ADDR, CACHELINE_ALIGNED_ADDR(iova));
+	ON_ERR_GOTO(res1, out_free_output, "writing CSR_SRC_ADDR");
+
+	res1 = fpgaGetIOAddress(accelerator_handle, output_wsid, &iova);
+	ON_ERR_GOTO(res1, out_free_output, "getting output IOVA");
+	res1 = fpgaWriteMMIO64(accelerator_handle, 0, nlb0_offset+CSR_DST_ADDR, CACHELINE_ALIGNED_ADDR(iova));
+	ON_ERR_GOTO(res1, out_free_output, "writing CSR_DST_ADDR");
+
+	res1 = fpgaWriteMMIO32(accelerator_handle, 0, nlb0_offset+CSR_NUM_LINES, LPBK1_BUFFER_SIZE / CL(1));
+	ON_ERR_GOTO(res1, out_free_output, "writing CSR_NUM_LINES");
+	res1 = fpgaWriteMMIO32(accelerator_handle, 0, nlb0_offset+CSR_CFG, 0x42000);
+	ON_ERR_GOTO(res1, out_free_output, "writing CSR_CFG");
+
+	status_ptr = dsm_ptr + DSM_STATUS_TEST_COMPLETE/sizeof(uint64_t);
+
+
+	/* Start the test */
+	res1 = fpgaWriteMMIO32(accelerator_handle, 0, nlb0_offset+CSR_CTL, 3);
+	ON_ERR_GOTO(res1, out_free_output, "writing CSR_CFG");
+
+	/* Wait for test completion */
+	timeout = TEST_TIMEOUT;
+	while (0 == ((*status_ptr) & 0x1)) {
+		usleep(100);
+		if (!use_ase && (--timeout == 0)) {
+			res1 = FPGA_EXCEPTION;
+			ON_ERR_GOTO(res1, out_free_output, "test timed out");
+		}
+	}
+
+	/* Stop the device */
+	res1 = fpgaWriteMMIO32(accelerator_handle, 0, nlb0_offset+CSR_CTL, 7);
+	ON_ERR_GOTO(res1, out_free_output, "writing CSR_CFG");
+
+	/* Wait for the AFU's read/write traffic to complete */
+	uint32_t afu_traffic_trips = 0;
+	while (afu_traffic_trips < 100) {
+		/*
+		 * CSR_STATUS1 holds two 32 bit values: num pending reads and writes.
+		 * Wait for it to be 0.
+		 */
+		uint64_t s1;
+		res1 = fpgaReadMMIO64(accelerator_handle, 0, nlb0_offset+CSR_STATUS1, &s1);
+		ON_ERR_GOTO(res1, out_free_output, "reading CSR_STATUS1");
+		if (s1 == 0) {
+			break;
+		}
+
+		afu_traffic_trips += 1;
+		usleep(1000);
+	}
+
+	/* Check output buffer contents */
+	for (i = 0; i < LPBK1_BUFFER_SIZE; i++) {
+		if (((uint8_t *)output_ptr)[i] != ((uint8_t *)input_ptr)[i]) {
+			fprintf(stderr, "Output does NOT match input "
+				"at offset %i!\n", i);
+			break;
+		}
+	}
+
+	printf("Done Running Test\n");
+
+
+	/* Release buffers */
+out_free_output:
+	res2 = fpgaReleaseBuffer(accelerator_handle, output_wsid);
+	ON_ERR_GOTO(res2, out_free_input, "releasing output buffer");
+out_free_input:
+	res2 = fpgaReleaseBuffer(accelerator_handle, input_wsid);
+	ON_ERR_GOTO(res2, out_free_dsm, "releasing input buffer");
+out_free_dsm:
+	res2 = fpgaReleaseBuffer(accelerator_handle, dsm_wsid);
+	ON_ERR_GOTO(res2, out_unmap, "releasing DSM buffer");
+
+	/* Unmap MMIO space */
+out_unmap:
+	res2 = fpgaUnmapMMIO(accelerator_handle, 0);
+	ON_ERR_GOTO(res2, out_close, "unmapping MMIO space");
+
+	/* Release accelerator */
+out_close:
+	res2 = fpgaClose(accelerator_handle);
+	ON_ERR_GOTO(res2, out_destroy_tok, "closing accelerator");
+
+	/* Destroy token */
+out_destroy_tok:
+	res2 = fpgaDestroyToken(&accelerator_token);
+	ON_ERR_GOTO(res2, out_exit, "destroying token");
+
+out_exit:
+	return res1 != FPGA_OK ? res1 : res2;
+}


### PR DESCRIPTION
1. add hello_fpga_n3000.c.
The hello_fpga sample code canot work at N3000 card, so we
add N3000 specific hello_fpga sample code, that will convenient
for customers to start-up our OPAE SDK API on N3000.

2. update quick start guide.