### PR TITLE
dummy_afu: retain loopback buffers through reset

### DIFF
--- a/samples/dummy_afu/lpbk.h
+++ b/samples/dummy_afu/lpbk.h
@@ -28,6 +28,8 @@
 #include "dummy_afu.h"
 
 using namespace opae::app;
+using opae::fpga::types::shared_buffer;
+
 namespace dummy_afu {
 
 class lpbk_test : public test_command
@@ -50,17 +52,21 @@ public:
     (void)app;
     auto d_afu = dynamic_cast<dummy_afu*>(afu);
     auto done = d_afu->register_interrupt();
-    auto source = d_afu->allocate(64);
-    d_afu->fill(source);
-    auto destination = d_afu->allocate(64);
-    d_afu->write64(MEM_TEST_SRC_ADDR, source->io_address());
-    d_afu->write64(MEM_TEST_DST_ADDR, destination->io_address());
+    source_ = d_afu->allocate(64);
+    d_afu->fill(source_);
+    destination_ = d_afu->allocate(64);
+    d_afu->write64(MEM_TEST_SRC_ADDR, source_->io_address());
+    d_afu->write64(MEM_TEST_DST_ADDR, destination_->io_address());
     d_afu->write64(MEM_TEST_CTRL, 0x0);
     d_afu->write64(MEM_TEST_CTRL, 0b1);
     d_afu->interrupt_wait(done, 1000);
-    d_afu->compare(source, destination);
+    d_afu->compare(source_, destination_);
     return 0;
   }
+
+protected:
+  shared_buffer::ptr_t source_;
+  shared_buffer::ptr_t destination_;
 };
 
 } // end of namespace dummy_afu


### PR DESCRIPTION
Hold a reference to the shared buffer pointers so that they are
not freed before afu reset is asserted.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>