### PR TITLE
opae.admin: re-inject legacy path to ifpga_sec..

### DIFF
--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -416,7 +416,10 @@ class fpga_base(class_node):
         spi = f.spi_bus
         if spi:
             ifpga_sec = spi.find_one(
-                'd5005bmc-secure.*.auto/ifpga_sec_mgr/ifpga_sec*')
+                'm10bmc-secure.*.auto/ifpga_sec_mgr/ifpga_sec*')
+            if not ifpga_sec:
+                ifpga_sec = spi.find_one(
+                    'd5005bmc-secure.*.auto/ifpga_sec_mgr/ifpga_sec*')
             if not ifpga_sec:
                 ifpga_sec = spi.find_one(
                     'n3000bmc-secure.*.auto/ifpga_sec_mgr/ifpga_sec*')


### PR DESCRIPTION
in order to support the drivers while they are in transition to
the new format.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>