### PR TITLE
rsu: add logic to unbind ep drivers

### DIFF
--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -530,6 +530,13 @@ class fpga_base(class_node):
 
         with self.disable_aer(*to_disable):
             self.log.info('[%s] performing RSU operation', self.pci_node)
+
+            self.log.debug('unbinding drivers from other endpoints')
+
+            for node in self.pci_node.root.endpoints:
+                if node.pci_address != self.node.pci_address:
+                    node.unbind()
+
             try:
                 self.rsu_boot(factory, **kwargs)
             except IOError as err:

--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -533,9 +533,9 @@ class fpga_base(class_node):
 
             self.log.debug('unbinding drivers from other endpoints')
 
-            for node in self.pci_node.root.endpoints:
-                if node.pci_address != self.node.pci_address:
-                    node.unbind()
+            for ep in self.pci_node.root.endpoints:
+                if ep.pci_address != self.pci_node.pci_address:
+                    ep.unbind()
 
             try:
                 self.rsu_boot(factory, **kwargs)


### PR DESCRIPTION
Before doing RSU operation, unbind drivers from all endpoints except for
the management endpoint with the RSU interface.