### PR TITLE
dummy_afu: add explicit reset after run

### DIFF
--- a/samples/dummy_afu/dummy_afu.h
+++ b/samples/dummy_afu/dummy_afu.h
@@ -209,6 +209,7 @@ public:
       logger_->error(ex.what());
       res = exit_codes::exception;
     }
+    handle_->reset();
     auto pass = res == exit_codes::success ? "PASS" : "FAIL";
     logger_->info("Test {}({}): {}", test->name(), count, pass);
     spdlog::drop_all();


### PR DESCRIPTION
After a test (in dummy_afu) runs, call handle_->reset again.