### PR TITLE
hssi: add pause after loopback enable

### DIFF
--- a/samples/hssi/hssi_cmd.h
+++ b/samples/hssi/hssi_cmd.h
@@ -81,6 +81,7 @@ public:
     else
       cmd += std::string(" loopback off");
     run_process(cmd);
+    usleep(1000);
   }
 
   template <typename X>


### PR DESCRIPTION
Empirical evidence suggests that a brief pause is necessary after
$ ethtool --features <ifc> loopback on

Without the pause, it was observed that the number of rx packets
(serial test) can be 0 when num_packets (100) was expected.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>