### PR TITLE
build: consolidate inclusion of externals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ endif()
 ## Sub-projects ############################################################
 ############################################################################
 opae_add_subdirectory(opae-libs)
+opae_add_subdirectory(external)
 opae_add_subdirectory(platforms)
 opae_add_subdirectory(tools)
 opae_add_subdirectory(samples)
@@ -68,8 +69,6 @@ if(OPAE_BUILD_TESTS)
     enable_testing()
     opae_add_subdirectory(tests)
 endif()
-
-opae_add_subdirectory(external)
 
 ############################################################################
 ## Add 'documentation' target ##############################################

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -26,6 +26,20 @@
 
 cmake_minimum_required(VERSION 2.8.12)
 
+opae_external_project_add(PROJECT_NAME CLI11
+                          GIT_URL https://github.com/CLIUtils/CLI11.git
+                          GIT_TAG v1.9.1
+                          PRESERVE_REPOS ${OPAE_PRESERVE_REPOS}
+                          NO_ADD_SUBDIRECTORY
+)
+
+opae_external_project_add(PROJECT_NAME spdlog
+                          GIT_URL https://github.com/gabime/spdlog.git
+                          GIT_TAG v1.7.0
+                          PRESERVE_REPOS ${OPAE_PRESERVE_REPOS}
+                          NO_ADD_SUBDIRECTORY
+)
+
 if(OPAE_BUILD_LEGACY)
     opae_external_project_add(PROJECT_NAME opae-legacy
                               GIT_URL https://github.com/OPAE/opae-legacy.git

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -26,16 +26,30 @@
 
 cmake_minimum_required(VERSION 2.8.12)
 
+set(CLI11_URL
+    https://github.com/CLIUtils/CLI11.git
+    CACHE STRING "URL for CLI11 Project")
+set(CLI11_TAG
+    v1.9.1
+    CACHE STRING "Tag for CLI11")
+
 opae_external_project_add(PROJECT_NAME CLI11
-                          GIT_URL https://github.com/CLIUtils/CLI11.git
-                          GIT_TAG v1.9.1
+                          GIT_URL ${CLI11_URL}
+                          GIT_TAG ${CLI11_TAG}
                           PRESERVE_REPOS ${OPAE_PRESERVE_REPOS}
                           NO_ADD_SUBDIRECTORY
 )
 
+set(SPDLOG_URL
+    https://github.com/gabime/spdlog.git
+    CACHE STRING "URL for spdlog Project")
+set(SPDLOG_TAG
+    v1.7.0
+    CACHE STRING "Tag for spdlog")
+
 opae_external_project_add(PROJECT_NAME spdlog
-                          GIT_URL https://github.com/gabime/spdlog.git
-                          GIT_TAG v1.7.0
+                          GIT_URL ${SPDLOG_URL}
+                          GIT_TAG ${SPDLOG_TAG}
                           PRESERVE_REPOS ${OPAE_PRESERVE_REPOS}
                           NO_ADD_SUBDIRECTORY
 )

--- a/samples/dummy_afu/CMakeLists.txt
+++ b/samples/dummy_afu/CMakeLists.txt
@@ -24,32 +24,6 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-set(CLI11_URL
-    https://github.com/CLIUtils/CLI11.git
-    CACHE STRING "URL for CLI11 Project")
-set(CLI11_TAG
-    v1.9.1
-    CACHE STRING "Tag to checkout for CLI11")
-
-set(SPDLOG_URL
-    https://github.com/gabime/spdlog.git
-    CACHE STRING "URL for SPDLOG Project")
-set(SPDLOG_TAG
-    v1.7.0
-    CACHE STRING "Tag to checkout for SPDLOG")
-
-opae_external_project_add(PROJECT_NAME CLI11
-                          GIT_URL ${CLI11_URL}
-                          GIT_TAG ${CLI11_TAG}
-                          NO_ADD_SUBDIRECTORY
-)
-
-opae_external_project_add(PROJECT_NAME spdlog
-                          GIT_URL ${SPDLOG_URL}
-                          GIT_TAG ${SPDLOG_TAG}
-                          NO_ADD_SUBDIRECTORY
-)
-
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CLI11_ROOT}/include

--- a/samples/hssi/CMakeLists.txt
+++ b/samples/hssi/CMakeLists.txt
@@ -26,12 +26,6 @@
 
 set(CMAKE_CXX_STANDARD 11)
 
-opae_external_project_add(PROJECT_NAME CLI11
-                          GIT_URL https://github.com/CLIUtils/CLI11.git
-                          GIT_TAG v1.9.1
-                          NO_ADD_SUBDIRECTORY
-)
-
 opae_add_executable(TARGET hssi
     SOURCE hssi.cpp
     LIBS
@@ -44,7 +38,7 @@ target_compile_options(hssi PUBLIC -Wno-unused-result)
 
 target_include_directories(hssi
     PRIVATE
-        ${CMAKE_SOURCE_DIR}/external/CLI11/include
-        ${CMAKE_SOURCE_DIR}/external/spdlog/include
+        ${CLI11_ROOT}/include
+        ${spdlog_ROOT}/include
         ${CMAKE_SOURCE_DIR}/samples/dummy_afu
 )


### PR DESCRIPTION
During development, both dummy_afu and hssi were loading CLI11
and spdlog. Move those macro invocations to a single location
(external CMakeLists.txt) and process external/ prior to the
samples so that the variables are available.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>