### PR TITLE
eth_group: add a try_compile to guard eth_group

### DIFF
--- a/tools/extra/fpgadiag/CMakeLists.txt
+++ b/tools/extra/fpgadiag/CMakeLists.txt
@@ -107,7 +107,7 @@ set(fecmodesrc common.py
 
 set(fpgamacsrc common.py
                fpgamac.py)
-               
+
 find_package(PythonLibs)
 include_directories(${PYTHON_INCLUDE_DIRS})
 
@@ -116,7 +116,19 @@ target_include_directories(_opae
     PRIVATE ${PYTHON_INCLUDE_DIRS})
 
 
-pybind11_add_module(eth_group eth_group.cpp)
+try_compile(SUPPORTS_VFIO
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_vfio.c
+    OUTPUT_VARIABLE TRY_COMPILE_OUTPUT
+)
+
+if (SUPPORTS_VFIO)
+    pybind11_add_module(eth_group eth_group.cpp)
+else(SUPPORTS_VFIO)
+    message(WARNING
+        "Could not compile VFIO. See errors in vfio_errors.txt")
+    file(WRITE ${CMAKE_BINARY_DIR}/vfio_errors.txt ${TRY_COMPILE_OUTPUT})
+endif(SUPPORTS_VFIO)
 
 
 CREATE_PYTHON_EXE(fpgalpbk fpgalpbk ${fpgalpbksrc})

--- a/tools/extra/fpgadiag/test_vfio.c
+++ b/tools/extra/fpgadiag/test_vfio.c
@@ -1,0 +1,47 @@
+// Copyright(c) 2020, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <linux/vfio.h>
+
+int main(int argc, char *argv[])
+{
+	struct vfio_group_status group_status;
+	struct vfio_iommu_type1_info iommu_info;
+	struct vfio_iommu_type1_dma_map dma_map;
+
+	struct vfio_iommu_type1_dma_unmap dma_unmap;
+
+	(void) argc;
+	(void) argv;
+
+	(void) group_status;
+	(void) iommu_info;
+	(void) dma_map;
+
+	(void) dma_unmap;
+
+	return 0;
+}


### PR DESCRIPTION
Adds test_vfio.c as a try_compile to guard building eth_group.cpp.
test_vfio.c checks that the minimum structure definitions are found
in linux/vfio.h.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>