### PR TITLE
hssi: increase the mbox timeout to 1 second..

### DIFF
--- a/samples/hssi/hssi.cpp
+++ b/samples/hssi/hssi.cpp
@@ -44,8 +44,14 @@ void sig_handler(int signum)
 
 int main(int argc, char *argv[])
 {
+  int res = 1;
   signal(SIGINT, sig_handler);
   app.register_command<hssi_10g_cmd>();
   app.register_command<hssi_100g_cmd>();
-  return app.main(argc, argv);
+  try {
+    res = app.main(argc, argv);
+  } catch (std::runtime_error &e) {
+    std::cerr << e.what() << std::endl;
+  }
+  return res;
 }

--- a/samples/hssi/hssi_afu.h
+++ b/samples/hssi/hssi_afu.h
@@ -99,7 +99,7 @@ public:
     uint64_t val;
     struct timespec ts;
     uint64_t ticks;
-    const uint64_t max_ticks = 1000ULL;
+    const uint64_t max_ticks = 10000ULL;
 
     val = (((uint64_t)data) << WRITE_DATA_SHIFT);
     *((volatile uint64_t *)(mmio_base + TRAFFIC_CTRL_DATA)) = val;
@@ -117,8 +117,11 @@ public:
             break;
         if (nanosleep(&ts, NULL) != -1 &&
             ticks != NO_TIMEOUT) {
-            if (!ticks)
-                throw std::runtime_error("mbox_write timed out [a]");
+            if (!ticks) {
+                const char *msg = "mbox_write timed out [a]";
+                std::cerr << msg << std::endl;
+                throw std::runtime_error(msg);
+            }
             --ticks;
         }
     } while (!(val & ACK_TRANS));
@@ -132,8 +135,11 @@ public:
             break;
         if (nanosleep(&ts, NULL) != -1 &&
             ticks != NO_TIMEOUT) {
-            if (!ticks)
-                throw std::runtime_error("mbox_write timed out [b]");
+            if (!ticks) {
+                const char *msg = "mbox_write timed out [b]";
+                std::cerr << msg << std::endl;
+                throw std::runtime_error(msg);
+            }
             --ticks;
         }
     } while (val & ACK_TRANS); 
@@ -147,7 +153,7 @@ public:
     uint64_t val;
     struct timespec ts;
     uint64_t ticks;
-    const uint64_t max_ticks = 1000ULL;
+    const uint64_t max_ticks = 10000ULL;
 
     val = (((uint64_t)offset) << AFU_CMD_SHIFT) | READ_CMD;
     *((volatile uint64_t *)(mmio_base + TRAFFIC_CTRL_CMD)) = val;
@@ -162,8 +168,11 @@ public:
             break;
         if (nanosleep(&ts, NULL) != -1 &&
             ticks != NO_TIMEOUT) {
-            if (!ticks)
-                throw std::runtime_error("mbox_read timed out [a]");
+            if (!ticks) {
+                const char *msg = "mbox_read timed out [a]";
+                std::cerr << msg << std::endl;
+                throw std::runtime_error(msg);
+            }
             --ticks;
         }
     } while (!(val & ACK_TRANS));
@@ -180,8 +189,11 @@ public:
             break;
         if (nanosleep(&ts, NULL) != -1 &&
             ticks != NO_TIMEOUT) {
-            if (!ticks)
-                throw std::runtime_error("mbox_read timed out [b]");
+            if (!ticks) {
+                const char *msg = "mbox_read timed out [b]";
+                std::cerr << msg << std::endl;
+                throw std::runtime_error(msg);
+            }
             --ticks;
         }
     } while (val & ACK_TRANS);


### PR DESCRIPTION
and add printouts for mbox exceptions before throwing them.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>