### PR TITLE
rpm: fix build eth_tools setup.py

### DIFF
--- a/opae.spec.in
+++ b/opae.spec.in
@@ -106,6 +106,7 @@ popd
 
 pushd @CMAKE_SOURCE_DIR@/tools/extra/fpgadiag/
 
+%{__python3} setup.py build_ext --include-dirs=@pybind11_ROOT@
 %{__python3} setup.py build
 popd
 

--- a/opae.spec.in
+++ b/opae.spec.in
@@ -106,7 +106,7 @@ popd
 
 pushd @CMAKE_SOURCE_DIR@/tools/extra/fpgadiag/
 
-%{__python3} setup.py build_ext --include-dirs=@pybind11_ROOT@
+%{__python3} setup.py build_ext --include-dirs=@pybind11_ROOT@/include
 %{__python3} setup.py build
 popd
 


### PR DESCRIPTION
add pybind11_ROOT to include path for calling setup.py