### PR TITLE
Disable building of dma_N3000 if not TBB_FOUND

### DIFF
--- a/tools/extra/fpgabist/CMakeLists.txt
+++ b/tools/extra/fpgabist/CMakeLists.txt
@@ -40,11 +40,11 @@ set(PYTHON_SRC
 
 if(TBB_FOUND)
   add_subdirectory(dma)
+  add_subdirectory(dma_N3000)
 else(TBB_FOUND)
   message(WARNING "Thread Building Blocks not found: not building fpgabist/dma.")
 endif(TBB_FOUND)
 
-add_subdirectory(dma_N3000)
 add_subdirectory(bist)
 
 install(PROGRAMS ${PYTHON_SRC}


### PR DESCRIPTION
dma_N3000/ is similar to dma/ it depends on TBB
So similarly, disable when TBB is not found.

Signed-off-by: Tom Rix <trix@redhat.com>