### PR TITLE
Use `set` for defining legacy branch target 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ option(OPAE_BUILD_LEGACY "Enable building of OPAE legacy tools" OFF)
 mark_as_advanced(OPAE_BUILD_LEGACY)
 
 if(OPAE_BUILD_LEGACY)
-    option(OPAE_LEGACY_TAG "Desired branch for opae-legacy" master)
+    set(OPAE_LEGACY_TAG "release/2.0.0" CACHE STRING "Desired branch for opae-legacy")
     mark_as_advanced(OPAE_LEGACY_TAG)
 endif(OPAE_BUILD_LEGACY)
 

--- a/opae-libs/CMakeLists.txt
+++ b/opae-libs/CMakeLists.txt
@@ -102,12 +102,12 @@ option(OPAE_PRESERVE_REPOS "Disable refresh of external repos" OFF)
 mark_as_advanced(OPAE_PRESERVE_REPOS)
 
 if(OPAE_BUILD_TESTS)
-    option(OPAE_TEST_TAG "Desired branch for opae-test" release/2.0.0)
+    set(OPAE_TEST_TAG "release/2.0.0" CACHE STRING "Desired branch for opae-test")
     mark_as_advanced(OPAE_TEST_TAG)
 endif(OPAE_BUILD_TESTS)
 
 if(OPAE_BUILD_SIM)
-    option(OPAE_SIM_TAG "Desired branch for opae-sim" release/2.0.0)
+    set(OPAE_SIM_TAG "release/2.0.0" CACHE STRING "Desired branch for opae-sim")
     mark_as_advanced(OPAE_SIM_TAG)
 endif(OPAE_BUILD_SIM)
 

--- a/opae-libs/include/opae/cxx/core/pvalue.h
+++ b/opae-libs/include/opae/cxx/core/pvalue.h
@@ -164,7 +164,7 @@ struct pvalue {
   typedef typename std::conditional<std::is_same<T, char *>::value,
                                     typename std::string, T>::type copy_t;
 
-  pvalue() : props_(0), is_set_(false), get_(nullptr), set_(nullptr), copy_() {}
+  pvalue() : props_(0), is_set_(false), get_(nullptr), set_(nullptr) {}
 
   /**
    * @brief pvalue contructor that takes in a reference to fpga_properties
@@ -175,7 +175,7 @@ struct pvalue {
    * @param s The setter function
    */
   pvalue(fpga_properties *p, getter_t g, setter_t s)
-      : props_(p), is_set_(false), get_(g), set_(s), copy_() {}
+      : props_(p), is_set_(false), get_(g), set_(s) {}
 
   /**
    * @brief Overload of `=` operator that calls the wrapped setter


### PR DESCRIPTION
Also pull in `opae-libs` `release/2.0.0` changes to capture new external target changes regarding `opae-sim` and `opae-test`.