### PR TITLE
afu_test: migrate test_afu to afu_test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ endif()
 ############################################################################
 opae_add_subdirectory(opae-libs)
 opae_add_subdirectory(external)
+opae_add_subdirectory(afu-test)
 opae_add_subdirectory(platforms)
 opae_add_subdirectory(tools)
 opae_add_subdirectory(samples)

--- a/afu-test/CMakeLists.txt
+++ b/afu-test/CMakeLists.txt
@@ -1,0 +1,38 @@
+## Copyright(c) 2017-2020, Intel Corporation
+##
+## Redistribution  and  use  in source  and  binary  forms,  with  or  without
+## modification, are permitted provided that the following conditions are met:
+##
+## * Redistributions of  source code  must retain the  above copyright notice,
+##   this list of conditions and the following disclaimer.
+## * Redistributions in binary form must reproduce the above copyright notice,
+##   this list of conditions and the following disclaimer in the documentation
+##   and/or other materials provided with the distribution.
+## * Neither the name  of Intel Corporation  nor the names of its contributors
+##   may be used to  endorse or promote  products derived  from this  software
+##   without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+## IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+## ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+## LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+## CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+## SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+## INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+## CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+## POSSIBILITY OF SUCH DAMAGE.
+cmake_minimum_required (VERSION 2.8)
+
+project(afu-test)
+add_library(afu-test INTERFACE)
+target_include_directories(afu-test INTERFACE
+    ${OPAE_INCLUDE_PATHS}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CLI11_ROOT}/include
+    ${spdlog_ROOT}/include
+)
+target_link_libraries(afu-test INTERFACE opae-c opae-cxx-core)
+target_compile_options(afu-test INTERFACE -Wno-unused-result)
+

--- a/samples/dummy_afu/CMakeLists.txt
+++ b/samples/dummy_afu/CMakeLists.txt
@@ -24,23 +24,14 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-include_directories(
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CLI11_ROOT}/include
-    ${spdlog_ROOT}/include
-)
-
 opae_add_executable(TARGET dummy_afu
     SOURCE dummy_afu.cpp
     LIBS
         opae-c
         opae-cxx-core
+        afu-test
         ${libjson-c_LIBRARIES}
         ${libuuid_LIBRARIES}
     COMPONENT samplebin
 )
 
-target_compile_options(dummy_afu PUBLIC -Wno-unused-result)
-target_include_directories(dummy_afu
-    PRIVATE ${spdlog_ROOT}/include
-)

--- a/samples/dummy_afu/ddr.h
+++ b/samples/dummy_afu/ddr.h
@@ -26,10 +26,10 @@
 #pragma once
 #include <chrono>
 #include <deque>
-#include "test_afu.h"
+#include "afu_test.h"
 #include "dummy_afu.h"
 
-using namespace opae::app;
+using test_afu = opae::afu_test::afu;
 namespace dummy_afu {
 
 template<class T>

--- a/samples/dummy_afu/dummy_afu.cpp
+++ b/samples/dummy_afu/dummy_afu.cpp
@@ -33,7 +33,6 @@
 #include "dummy_afu.h"
 
 const char *AFU_ID = "91c2a3a1-4a23-4e21-a7cd-2b36dbf2ed73";
-using namespace opae::app;
 
 int main(int argc, char* argv[])
 {

--- a/samples/dummy_afu/dummy_afu.h
+++ b/samples/dummy_afu/dummy_afu.h
@@ -27,7 +27,7 @@
 #include <opae/cxx/core/events.h>
 #include <opae/cxx/core/shared_buffer.h>
 
-#include "test_afu.h"
+#include "afu_test.h"
 
 namespace dummy_afu {
 using opae::fpga::types::event;
@@ -177,8 +177,8 @@ union ddr_test_bank3_stat  {
   };
 };
 
-using opae::app::test_afu;
-using opae::app::test_command;
+using test_afu = opae::afu_test::afu;
+using test_command = opae::afu_test::command;
 
 class dummy_afu : public test_afu {
 public:

--- a/samples/dummy_afu/lpbk.h
+++ b/samples/dummy_afu/lpbk.h
@@ -24,10 +24,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
-#include "test_afu.h"
+#include "afu_test.h"
 #include "dummy_afu.h"
 
-using namespace opae::app;
+using test_afu = opae::afu_test::afu;
 using opae::fpga::types::shared_buffer;
 
 namespace dummy_afu {

--- a/samples/hssi/CMakeLists.txt
+++ b/samples/hssi/CMakeLists.txt
@@ -29,16 +29,6 @@ set(CMAKE_CXX_STANDARD 11)
 opae_add_executable(TARGET hssi
     SOURCE hssi.cpp
     LIBS
-        opae-c
-        opae-cxx-core
+        afu-test
     COMPONENT sampleshssi
-)
-
-target_compile_options(hssi PUBLIC -Wno-unused-result)
-
-target_include_directories(hssi
-    PRIVATE
-        ${CLI11_ROOT}/include
-        ${spdlog_ROOT}/include
-        ${CMAKE_SOURCE_DIR}/samples/dummy_afu
 )

--- a/samples/hssi/hssi_100g_cmd.h
+++ b/samples/hssi/hssi_100g_cmd.h
@@ -36,8 +36,6 @@
 #define CSR_SRC_ADDR_HI 0x1014
 #define CSR_MLB_RST     0x1016
 
-using namespace opae::app;
-
 class hssi_100g_cmd : public hssi_cmd
 {
 public:

--- a/samples/hssi/hssi_10g_cmd.h
+++ b/samples/hssi/hssi_10g_cmd.h
@@ -50,8 +50,6 @@
 
 #define CSR_MAC_LOOP          0x3e00
 
-using namespace opae::app;
-
 class hssi_10g_cmd : public hssi_cmd
 {
 public:

--- a/samples/hssi/hssi_afu.h
+++ b/samples/hssi/hssi_afu.h
@@ -30,9 +30,9 @@
 #include <exception>
 #include <glob.h>
 #include <time.h>
-#include "test_afu.h"
+#include "afu_test.h"
 
-using namespace opae::app;
+using test_afu =  opae::afu_test::afu;
 using namespace opae::fpga::types;
 
 #define ETH_AFU_DFH           0x0000

--- a/samples/hssi/hssi_cmd.h
+++ b/samples/hssi/hssi_cmd.h
@@ -29,9 +29,9 @@
 #include <cstdio>
 #include <cstring>
 #include <netinet/ether.h>
-#include "test_afu.h"
+#include "afu_test.h"
 
-using namespace opae::app;
+using test_command = opae::afu_test::command;
 
 #define INVALID_MAC 0xffffffffffffffffULL
 

--- a/tests/dummy_afu/CMakeLists.txt
+++ b/tests/dummy_afu/CMakeLists.txt
@@ -27,36 +27,24 @@
 opae_test_add_static_lib(TARGET dummy_afu-static
     SOURCE ${OPAE_SDK_SOURCE}/samples/dummy_afu/dummy_afu.cpp
     LIBS
-        opae-c
-        opae-cxx-core
+        afu-test
 )
 
 target_compile_definitions(dummy_afu-static
     PRIVATE main=dummy_afu_main
 )
-target_compile_options(dummy_afu-static PUBLIC -Wno-unused-result)
-
-target_include_directories(dummy_afu-static
-    PRIVATE
-        ${CMAKE_SOURCE_DIR}/samples/dummy_afu
-        ${CMAKE_SOURCE_DIR}/external/CLI11/include
-        ${CMAKE_SOURCE_DIR}/external/spdlog/include
-)
 
 opae_test_add(TARGET test_dummy_afu
     SOURCE test_dummy_afu.cpp
     LIBS
+        afu-test
         dummy_afu-static
         test-fpgad-static
     TEST_FPGAD
 )
 
-target_compile_options(test_dummy_afu PUBLIC -Wno-unused-result)
 target_include_directories(test_dummy_afu
     PRIVATE
-        ${CMAKE_SOURCE_DIR}/external/CLI11/include
-        ${CMAKE_SOURCE_DIR}/external/spdlog/include
         ${CMAKE_SOURCE_DIR}/samples/dummy_afu
         ${CMAKE_SOURCE_DIR}/external/opae-test/framework/mock/test_fpgad
 )
-

--- a/tests/dummy_afu/test_dummy_afu.cpp
+++ b/tests/dummy_afu/test_dummy_afu.cpp
@@ -44,7 +44,8 @@
 
 const char *AFU_ID = "f7df405c-bd7a-cf72-22f1-44b0b93acd18";
 
-using namespace opae::app;
+using test_command =  opae::afu_test::command;
+using test_afu =  opae::afu_test::afu;
 using namespace opae::testing;
 
 int mmio_ioctl(mock_object * m, int request, va_list argp){
@@ -267,6 +268,7 @@ INSTANTIATE_TEST_CASE_P(dummy_afu, dummy_afu_p,
 
 TEST(dummy_afu, parse_pcie_address)
 {
+  using opae::afu_test::pcie_address;
   auto p = pcie_address::parse("1111:3b:19.4");
   EXPECT_EQ(p.fields.domain, 0x1111);
   EXPECT_EQ(p.fields.bus, 0x3b);


### PR DESCRIPTION
* move test_afu.h from samples/dummy_afu to afu_test
  * make afu_test an interface library in CMakeLists.txt

* rename namespace and classes in afu_test
  * namespace opae::app -> opae::afu_test
  * class test_afu -> afu
  * class test_command -> command
* make necessary changes in dummy_afu and hssi for new afu_test