### PR TITLE
release: update opae release branch targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ option(OPAE_BUILD_LEGACY "Enable building of OPAE legacy tools" OFF)
 mark_as_advanced(OPAE_BUILD_LEGACY)
 
 if(OPAE_BUILD_LEGACY)
-    set(OPAE_LEGACY_TAG "master" CACHE STRING "Desired branch for opae-legacy")
+    set(OPAE_LEGACY_TAG "release/2.0.1-1" CACHE STRING "Desired branch for opae-legacy")
     mark_as_advanced(OPAE_LEGACY_TAG)
 endif(OPAE_BUILD_LEGACY)
 

--- a/opae-libs/CMakeLists.txt
+++ b/opae-libs/CMakeLists.txt
@@ -102,12 +102,12 @@ option(OPAE_PRESERVE_REPOS "Disable refresh of external repos" OFF)
 mark_as_advanced(OPAE_PRESERVE_REPOS)
 
 if(OPAE_BUILD_TESTS)
-    set(OPAE_TEST_TAG "master" CACHE STRING "Desired branch for opae-test")
+    set(OPAE_TEST_TAG "release/2.0.1-1" CACHE STRING "Desired branch for opae-test")
     mark_as_advanced(OPAE_TEST_TAG)
 endif(OPAE_BUILD_TESTS)
 
 if(OPAE_BUILD_SIM)
-    set(OPAE_SIM_TAG "master" CACHE STRING "Desired branch for opae-sim")
+    set(OPAE_SIM_TAG "release/2.0.1-1" CACHE STRING "Desired branch for opae-sim")
     mark_as_advanced(OPAE_SIM_TAG)
 endif(OPAE_BUILD_SIM)
 


### PR DESCRIPTION
Update the following opae dependencies for opae-sdk `release/2.0.1-1` so that said dependencies point to a snapshot release branch/tag, and not to continue tracking `master`.
- `opae-libs`
  - Subtree has been updated to handle `opae-test` and `opae-sim`
- `opae-legacy`

This commit should not be pulled back into `master`, as the `master` branch should naturally track the latest HEAD of each opae dependency. Rather, this commit will be the tag target for release `2.0.1-1`.