### PR TITLE
opae-libs: use CMake PYTHON_EXECUTABLE in packager

### DIFF
--- a/opae-libs/cmake/modules/OPAEPackaging.cmake
+++ b/opae-libs/cmake/modules/OPAEPackaging.cmake
@@ -168,7 +168,7 @@ macro(CREATE_PYTHON_EXE EXE_NAME MAIN_MODULE)
         "f.close()\n")
 
     # Run Python to generate the zipped file
-    execute_process(COMMAND python3 "${BUILD_DIR_MAIN}/do_zip.py"
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} "${BUILD_DIR_MAIN}/do_zip.py"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 endmacro(CREATE_PYTHON_EXE)


### PR DESCRIPTION
Branch/PR pulls in commit https://github.com/OPAE/opae-libs/commit/fca219520bbe7041acd44e6eebcbf7d9c476694c into `opae-sdk` `master` via `subtree`.