### PR TITLE
mmlink: address el7 compile issues

### DIFF
--- a/tools/extra/mmlink/remote_dbg/streaming/CMakeLists.txt
+++ b/tools/extra/mmlink/remote_dbg/streaming/CMakeLists.txt
@@ -39,6 +39,7 @@ opae_add_shared_library(TARGET mml-stream
     COMPONENT toolmmlink
 )
 
+target_compile_options(mml-stream PUBLIC -Wno-strict-aliasing)
 target_include_directories(mml-stream
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..
 )

--- a/tools/extra/mmlink/remote_dbg/streaming/common.c
+++ b/tools/extra/mmlink/remote_dbg/streaming/common.c
@@ -48,18 +48,19 @@ void zero_mem(void *a, size_t length) {
     typedef size_t big_type;
     size_t big_size = sizeof(big_type);
     size_t leftover_offset = 0;
+    size_t i;
 
     if (length > big_size) {
         size_t fast_transfers = length / big_size;
         leftover_offset = fast_transfers * big_size;
         big_type *big_a = (big_type *)a;
-        for (size_t i = 0; i < fast_transfers; ++i) {
+        for (i = 0; i < fast_transfers; ++i) {
             big_a[i] = 0;
         }
 
     }
     size_t leftover = length % big_size;
-    for (size_t i = 0; i < leftover; ++i) {
+    for (i = 0; i < leftover; ++i) {
         ((char *)a)[i + leftover_offset] = 0;
     }
 }
@@ -69,8 +70,10 @@ void fill_mem(void *a, char c, size_t length) {
     size_t big_size = sizeof(big_type);
     size_t leftover_offset = 0;
     char stamp[32];
-    for (unsigned char i = 0; i < big_size; ++i) {
-        stamp[i] = c;
+    size_t i;
+    unsigned char j;
+    for (j = 0; j < big_size; ++j) {
+        stamp[j] = c;
     }
     big_type big_stamp = *((big_type *)stamp);
 
@@ -78,13 +81,13 @@ void fill_mem(void *a, char c, size_t length) {
         size_t fast_transfers = length / big_size;
         leftover_offset = fast_transfers * big_size;
         big_type *big_a = (big_type *)a;
-        for (size_t i = 0; i < fast_transfers; ++i) {
+        for (i = 0; i < fast_transfers; ++i) {
             big_a[i] = big_stamp;
         }
 
     }
     size_t leftover = length % big_size;
-    for (size_t i = 0; i < leftover; ++i) {
+    for (i = 0; i < leftover; ++i) {
         ((char *)a)[i + leftover_offset] = c;
     }
 }

--- a/tools/extra/mmlink/remote_dbg/streaming/packet.c
+++ b/tools/extra/mmlink/remote_dbg/streaming/packet.c
@@ -31,7 +31,8 @@ static unsigned char guardband_private[SIZEOF_PACKET_GUARDBAND] = { 0xDE, 0xAD, 
 const unsigned char *const PACKET_GUARDBAND = guardband_private;
 
 void populate_guardband(unsigned char *bytes) {
-    for (int i = 0; i < SIZEOF_PACKET_GUARDBAND; ++i) {
+    int i;
+    for (i = 0; i < SIZEOF_PACKET_GUARDBAND; ++i) {
         bytes[i] = PACKET_GUARDBAND[i];
     }
 }
@@ -141,7 +142,8 @@ void dump_h2t_packet_header(H2T_PACKET_HEADER *packet) {
 
 void dump_bytes(char *bytes, size_t len) {
     const int COL_WIDTH = 16;
-    for (size_t i = 0; i < len; ++i) {
+    size_t i;
+    for (i = 0; i < len; ++i) {
         if ((i % COL_WIDTH == 0) && (i > 0)) {
             printf("\n");
         }

--- a/tools/extra/mmlink/remote_dbg/streaming/server.c
+++ b/tools/extra/mmlink/remote_dbg/streaming/server.c
@@ -422,7 +422,8 @@ const char *set_driver_parameter(char *cmd, SERVER_CONN *server_conn) {
         const char *param_name = strstr(cmd, SET_DRIVER_PARAM_CMD) + SET_DRIVER_PARAM_CMD_LEN;
         const char *param_value = strstr(param_name, " ") + 1;
         size_t param_name_len = (size_t)(param_value - param_name) - 1;
-        for (size_t i = 0; i < MIN_MACRO(param_name_len, MAX_DRIVER_PARAM_NAME_LEN); ++i) {
+        size_t i;
+        for (i = 0; i < MIN_MACRO(param_name_len, MAX_DRIVER_PARAM_NAME_LEN); ++i) {
             param_name_buff[i] = param_name[i];
         }
         if (server_conn->hw_callbacks.set_param(param_name_buff, param_value) >= 0) {
@@ -769,7 +770,8 @@ void handle_client(SERVER_CONN *server_conn, CLIENT_CONN *client_conn) {
         
         // First handle exceptional conditions
         char disconnect_client = 0;
-        for (int i = 0; i < NUM_FDS; ++i) {
+        int i;
+        for (i = 0; i < NUM_FDS; ++i) {
             if (FD_ISSET(all_fds[i], &except_fds)) {
                 server_conn->hw_callbacks.server_printf("Exception found on socket: %s\n", all_fd_names[i]);
                 disconnect_client = 1;

--- a/tools/extra/mmlink/remote_dbg/streaming/sockets.c
+++ b/tools/extra/mmlink/remote_dbg/streaming/sockets.c
@@ -41,7 +41,8 @@ static char g_socket_send_buff[SW_SOCKET_BUFF_SZ+64];
 
 SOCKET max_of(SOCKET *array, int size) {
     SOCKET result = 0;
-    for (int i = 0; i < size; ++i) {
+    int i;
+    for (i = 0; i < size; ++i) {
         result = MAX_MACRO(array[i], result);
     }
     return result;
@@ -141,7 +142,8 @@ RETURN_CODE socket_send_all_t2h_data(SOCKET fd, const char *buff, const size_t l
     volatile uint64_t *mmio_ptr = (uint64_t *)buff;
     uint64_t *buff64 = (uint64_t *)g_socket_send_buff;
     size_t transfers = (len + 7) / 8;
-    for (size_t i = 0; i < transfers; ++i) {
+    size_t i;
+    for (i = 0; i < transfers; ++i) {
         *buff64++ = *mmio_ptr++;      
     }
     
@@ -211,7 +213,8 @@ RETURN_CODE socket_recv_accumulate_h2t_data(SOCKET sock_fd, char *buff, const si
         volatile uint64_t *mmio_ptr = (uint64_t *)buff;
         uint64_t *buff64 = (uint64_t *)g_socket_recv_buff;
         size_t transfers = (len +7) / 8;
-        for (size_t i = 0; i < transfers; ++i) {
+        size_t i;
+        for (i = 0; i < transfers; ++i) {
             *mmio_ptr++ = *buff64++;
         }
     }

--- a/tools/extra/mmlink/remote_dbg/streaming/st_dbg_ip_driver.c
+++ b/tools/extra/mmlink/remote_dbg/streaming/st_dbg_ip_driver.c
@@ -110,7 +110,8 @@ char *get_h2t_buffer(size_t sz) {
     if (freed_descriptor_slots > 0) {
         g_h2t_descriptor_slots_available += freed_descriptor_slots;
         size_t bytes_freed = 0;
-        for (char i = 0; i < freed_descriptor_slots; ++i) {
+        char i;
+        for (i = 0; i < freed_descriptor_slots; ++i) {
             bytes_freed += g_h2t_descriptor_chain[(g_h2t_descriptor_read_idx + i) % MAX_H2T_DESCRIPTOR_DEPTH];
         }
         g_h2t_descriptor_read_idx = (g_h2t_descriptor_read_idx + freed_descriptor_slots) % MAX_H2T_DESCRIPTOR_DEPTH;
@@ -155,7 +156,8 @@ char *get_mgmt_buffer(size_t sz) {
     if (freed_descriptor_slots > 0) {
         g_mgmt_descriptor_slots_available += freed_descriptor_slots;
         size_t bytes_freed = 0;
-        for (char i = 0; i < freed_descriptor_slots; ++i) {
+        char i;
+        for (i = 0; i < freed_descriptor_slots; ++i) {
             bytes_freed += g_mgmt_descriptor_chain[(g_mgmt_descriptor_read_idx + i) % MAX_MGMT_DESCRIPTOR_DEPTH];
         }
         g_mgmt_descriptor_read_idx = (g_mgmt_descriptor_read_idx + freed_descriptor_slots) % MAX_MGMT_DESCRIPTOR_DEPTH;


### PR DESCRIPTION
In order to build on el7 (which have older cmake/gcc versions), this commit adds
the following changes:

- Adds Wno-strict-aliasing C exception flag for mmlink streaming.
- Separates declaration and definition of `for`-loop counter variables in mmlink streaming
  related functions.

Signed-off-by: Marroquin, Asgard <asgard.marroquin@intel.com>