### PR TITLE
mmlink: fix revcheck

### DIFF
--- a/tools/extra/mmlink/main.cpp
+++ b/tools/extra/mmlink/main.cpp
@@ -270,7 +270,7 @@ int run_mmlink(fpga_handle  port_handle,
 	}
 	//printf("STP DFH = 0x%lx\n" ,value);
 
-	value &= 0x1000;
+	value &= 0xF000;
 	value = value >> FPGA_PORT_STP_DFH_REVBIT;
 
 


### PR DESCRIPTION
The revision bits are 12-15. This fixes the masking so that only these
bits are set when masking with (0xF000) before shifting.