### PR TITLE
mmlink: fix mmlink build

### DIFF
--- a/tools/extra/mmlink/remote_dbg/legacy/CMakeLists.txt
+++ b/tools/extra/mmlink/remote_dbg/legacy/CMakeLists.txt
@@ -34,6 +34,8 @@ opae_add_shared_library(TARGET mml-srv
         opae-c
         ${libjson-c_LIBRARIES}
     COMPONENT toolmmlink
+    VERSION ${OPAE_VERSION}
+    SOVERSION ${OPAE_VERSION_MAJOR}
 )
 
 target_include_directories(mml-srv

--- a/tools/extra/mmlink/remote_dbg/streaming/CMakeLists.txt
+++ b/tools/extra/mmlink/remote_dbg/streaming/CMakeLists.txt
@@ -24,6 +24,10 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
+# setting C_STANDARD on cmake 2.8 doesn't work
+# force the flags in this scope
+
+set(CMAKE_C_FLAGS "-std=gnu11 ${CMAKE_C_FLAGS}")
 opae_add_shared_library(TARGET mml-stream
     SOURCE
         common.c
@@ -37,6 +41,8 @@ opae_add_shared_library(TARGET mml-stream
         opae-c
         ${libjson-c_LIBRARIES}
     COMPONENT toolmmlink
+    VERSION ${OPAE_VERSION}
+    SOVERSION ${OPAE_VERSION_MAJOR}
 )
 
 target_include_directories(mml-stream

--- a/tools/extra/mmlink/remote_dbg/streaming/common.c
+++ b/tools/extra/mmlink/remote_dbg/streaming/common.c
@@ -65,7 +65,7 @@ void zero_mem(void *a, size_t length) {
 }
 
 void fill_mem(void *a, char c, size_t length) {
-    typedef size_t big_type;
+    typedef __attribute__((__may_alias__)) size_t big_type;
     size_t big_size = sizeof(big_type);
     size_t leftover_offset = 0;
     char stamp[32];


### PR DESCRIPTION
* set c standard to c99 for mml-stream
* set library versions (VERSION/SOVERSION) for mml-srv and mml-stream
* set compiler attribute for allowing aliasing in streaming/common.c