### PR TITLE
fpgainfo: add support for revision 2 of port errors

### DIFF
--- a/docker/centos7.6/Dockerfile
+++ b/docker/centos7.6/Dockerfile
@@ -1,4 +1,7 @@
 FROM centos:7.6.1810
+RUN yum install -y https://www.elrepo.org/elrepo-release-7.0-4.el7.elrepo.noarch.rpm
+RUN rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
+RUN yum --enablerepo=elrepo-kernel install -y kernel-ml-headers
 RUN yum install -y python-devel python3 python3-pip python3-devel python3-pybind11 cmake make libuuid-devel json-c-devel gcc clang gcc-c++ hwloc-devel tbb-devel rpm-build rpmdevtools git
 WORKDIR /root
 COPY docker/buildit.sh /buildit.sh


### PR DESCRIPTION
With Intel OFS, the definition of the port error bits have
changed to reflect the transition from CCI-P to AXI-S TLP.
The fpgainfo command now checks the revision sysfs entry
to use the correct port error bit definitions.

Signed-off-by: Matthew Gerlach <matthew.gerlach@linux.intel.com>