### PR TITLE
ci: fix subtree command to add instead of pull

### DIFF
--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -12,7 +12,7 @@ jobs:
         run: |
           git config user.name "OPAE Bot"
           git config user.email opae_robot@intel.com
-          git subtree pull --prefix opae-libs https://github.com/OPAE/opae-libs.git master --squash
+          git subtree add --prefix opae-libs https://github.com/OPAE/opae-libs.git master --squash
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
pull should be used after the subtree has been added.
Because this is a new clone/checkout of master, doing 'add' should work
just as expected.