### PR TITLE
ci: update python lint jobs

### DIFF
--- a/.github/workflows/python-static-analysis.yml
+++ b/.github/workflows/python-static-analysis.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 bandit
+        python -m pip install pylint flake8 bandit
     - name: Pylint lint
       run: |
         pylint $(find ${{ github.workspace }} -name "*.py") \

--- a/.github/workflows/python-static-analysis.yml
+++ b/.github/workflows/python-static-analysis.yml
@@ -3,16 +3,7 @@ name: python static analysis
 on:
   push:
     paths:
-      - 'python/**'
-      - 'tools/extra/fpgabist/**'
-      - 'tools/extra/packager/*.py'
-      - 'tools/extra/packager/metadata/**'
-      - 'tools/extra/packager/test/*.py'
-      - 'tools/extra/pac_hssi_config/*.py'
-      - 'tools/extra/fpgadiag/**'
-      - 'tools/utilities/**'
-      - 'scripts/*.py'
-      - 'platforms/scripts/platmgr/**'
+      - '**.py'
       - '.github/workflows/python-static-analysis.yml'
 
 jobs:
@@ -34,7 +25,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 bandit
-    - name: Lint
+    - name: Pylint lint
+      run: |
+        pylint $(find ${{ github.workspace }} -name "*.py") \
+          -E -f parseable --disable=E0401 --ignore=__init__.py \
+          --ignore-patterns="test_.*.py" \
+          | tee ${{ github.workspace }}/pylint.log
+    - name: Flake8 lint
       run: |
         flake8 $(find ${{ github.workspace }} -name "*.py") \
           --count --show-source --statistics \
@@ -53,6 +50,7 @@ jobs:
       with:
         name: static-analysis
         path: |
+          ${{ github.workspace }}/pylint.log
           ${{ github.workspace }}/flake8.log
           ${{ github.workspace }}/bandit.log
           ${{ github.workspace }}/bandit.log.csv

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ matrix:
     env:
     - BUILD_JOB=Code Style Check
     install:
-    - pip install --user pylint
-    - pip install --user pycodestyle
-    - pip install --user jsonschema
-    - pip install --user jinja2
+    - python3 -m pip install --user pylint
+    - python3 -m pip install --user pycodestyle
+    - python3 -m pip install --user jsonschema
+    - python3 -m pip install --user jinja2
     addons:
       apt:
         packages:


### PR DESCRIPTION
Travis CI installed linting libraries with default `pip` module, which may be
linking to `python2` on the default Ubuntu 16.04 VM. Install explicitly with
`python3 -m pip`.

Also, add pylint steps in `.github/worksflows/python-static-analysis.yml`, as
well as simply python fileglob detection for the CI push trigger.

Signed-off-by: Marroquin, Asgard <asgard.marroquin@intel.com>
