### PR TITLE
opae.admin: add support for dfl bus

### DIFF
--- a/python/opae.admin/opae/admin/dfl.py
+++ b/python/opae.admin/opae/admin/dfl.py
@@ -38,8 +38,3 @@ class dfl(sysfs_device):
     @property
     def feature_id(self):
         return self.node('feature_id').value
-
-    def driver_override(self, driver):
-        if self.have_node('driver_override'):
-            name = driver.name if isinstance(sysfs_driver) else driver
-            self.node('driver_override').value = name

--- a/python/opae.admin/opae/admin/dfl.py
+++ b/python/opae.admin/opae/admin/dfl.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+# Copyright(c) 2020, Intel Corporation
+#
+# Redistribution  and  use  in source  and  binary  forms,  with  or  without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of  source code  must retain the  above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name  of Intel Corporation  nor the names of its contributors
+#   may be used to  endorse or promote  products derived  from this  software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+# IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+# LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+# CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+# SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+# INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+# CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+
+"""
+from opae.admin.sysfs import sysfs_device, sysfs_driver
+
+
+class dfl(sysfs_device):
+    DEVICE_ROOT = 'bus/dfl/devices'
+
+    @property
+    def feature_id(self):
+        return self.node('feature_id').value
+
+    def driver_override(self, driver):
+        if self.have_node('driver_override'):
+            name = driver.name if isinstance(sysfs_driver) else driver
+            self.node('driver_override').value = name

--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -34,7 +34,7 @@ import time
 from array import array
 from contextlib import contextmanager
 from opae.admin.path import device_path, sysfs_path
-from opae.admin.sysfs import class_node, sysfs_node
+from opae.admin.sysfs import sysfs_device, sysfs_node
 from opae.admin.utils.log import loggable
 from opae.admin.utils import max10_or_nios_version
 
@@ -375,11 +375,10 @@ class avmmi_bmc(region):
             raise IOError('bad completion code: 0x{:8x}'.format(ccode))
 
 
-class fpga_base(class_node):
+class fpga_base(sysfs_device):
     FME_PATTERN = 'intel-fpga-fme.*'
     PORT_PATTERN = 'intel-fpga-port.*'
     PCI_DRIVER = 'intel-fpga-pci'
-    SYSFS_CLASS = 'fpga'
     BOOT_TYPES = ['bmcimg', 'retimer']
     BOOT_PAGES = {
         (0x8086, 0x0b30): {'bmcimg': {'user': 0,
@@ -559,10 +558,10 @@ class fpga_region(fpga_base):
     FME_PATTERN = 'dfl-fme.*'
     PORT_PATTERN = 'dfl-port.*'
     PCI_DRIVER = 'dfl-pci'
-    SYSFS_CLASS = 'fpga_region'
+    DEVICE_ROOT = 'class/fpga_region'
 
     @classmethod
-    def class_filter(cls, node):
+    def enum_filter(cls, node):
         if not node.have_node('device'):
             return False
         if 'dfl-fme-region' in os.readlink(node.node('device').sysfs_path):
@@ -572,6 +571,7 @@ class fpga_region(fpga_base):
 
 class fpga(fpga_base):
     _drivers = [fpga_region, fpga_base]
+    DEVICE_ROOT = 'class/fpga'
 
     @classmethod
     def enum(cls, filt=[]):

--- a/python/opae.admin/opae/admin/sysfs.py
+++ b/python/opae.admin/opae/admin/sysfs.py
@@ -739,7 +739,7 @@ class sysfs_device(sysfs_node):
             self.log.debug('no driver bound')
 
     @property
-    def driver_override(self, driver):
+    def driver_override(self):
         if self.have_node('driver_override'):
             return self.node('driver_override')
 

--- a/python/opae.admin/opae/admin/sysfs.py
+++ b/python/opae.admin/opae/admin/sysfs.py
@@ -54,6 +54,10 @@ class sysfs_node(loggable):
         super(sysfs_node, self).__init__()
         self._sysfs_path = sysfs_path(_sysfs_path)
 
+    @property
+    def name(self):
+        return os.path.basename(self.sysfs_path)
+
     def node(self, *nodes):
         """node Gets a new sysfs_node object using the given paths.
 
@@ -560,11 +564,16 @@ class pci_node(sysfs_node):
         return bool(self.sriov_totalvfs)
 
 
-class class_node(sysfs_node):
-    """class_node A class_node object represents a sysfs object directly
-                  under '/sys/class' directory.
+class sysfs_driver(sysfs_node):
+    pass
+
+
+class sysfs_device(sysfs_node):
+    """sysfs_device A sysfs object is a logical device but can usually
+                    be traced back to a pci device.
+                    A sysfs object can be found under /sys/class or /sys/bus.
     """
-    SYSFS_CLASS = None
+    DEVICE_ROOT = None
 
     def __init__(self, path):
         """__init__ Initializes a new class_node object found in /sys/class/..
@@ -586,8 +595,14 @@ class class_node(sysfs_node):
             This class is designed to be inherited from and contains a lot
             of the boiler-plate code that sub-classes get for free.
         """
-        super(class_node, self).__init__(path)
+        super(sysfs_device, self).__init__(path)
         self._pci_node = self._parse_class_path(path)
+
+    @property
+    def driver(self):
+        if self.have_node('driver'):
+            driver_path = os.path.realpath(self.node('driver').sysfs_path)
+            return sysfs_driver(driver_path)
 
     @property
     def pci_node(self):
@@ -617,37 +632,27 @@ class class_node(sysfs_node):
             node = pci_node(match.groupdict(), parent=node)
             path.append(node)
         # the last node is the fpga node
-        LOG('enum_class').debug('found device at %s -tree is\n %s',
-                                node.pci_address,
-                                path[0].tree())
+        LOG('_parse_class_path').debug('found device at %s -tree is\n %s',
+                                       node.pci_address,
+                                       path[0].tree())
         return node
 
     @classmethod
-    def enum_class(cls, sysfs_class_name, sysfs_class=None):
-        """enum_class Discover class_node objects under a given "class".
+    def enum_devices(cls):
+        """enum_devices Discover sysfs devices under a given device root.
 
-        Args:
-            sysfs_class_name: The name of the class under /sys/class to look
-                              at.
-            sysfs_class(class_node): The class_node or deriving class to use
-                                     when creating class_node objects.
 
-        Notes:
-            If 'sysfs_class' is not specified, it will use this class.
-            This is meant so that classes deriving from this can omit this.
         """
-        sysfs_class = sysfs_class or cls
-        log = LOG(cls.__name__)
         nodes = []
-        class_paths = glob.glob(sysfs_path('class', sysfs_class_name, '*'))
-        log.debug('found %s objects: %s', sysfs_class_name, class_paths)
-        for path in class_paths:
-            nodes.append(sysfs_class(path))
+        paths = glob.glob(sysfs_path(cls.DEVICE_ROOT, '*'))
+        # log.debug('found %s objects: %s', sysfs_class_name, class_paths)
+        for path in paths:
+            nodes.append(cls(path))
         return nodes
 
     @classmethod
-    def class_filter(cls, node):
-        """class_filter Run a class specific filter in enum_class.
+    def enum_filter(cls, node):
+        """enum_filter Run a specific filter in enum_devices.
 
         Args:
             node: A sysfs node to consider for filtering.
@@ -691,7 +696,7 @@ class class_node(sysfs_node):
 
         def func(obj):
             # if this node is not valid, reject it
-            if not cls.class_filter(obj):
+            if not cls.enum_filter(obj):
                 return False
             for f in filt:
                 for k, v in f.items():
@@ -713,5 +718,7 @@ class class_node(sysfs_node):
                             v = v.lower()
                         if attr_value != v:
                             return False
+                    else:
+                        return False
             return True
-        return list(filter(func, cls.enum_class(cls.SYSFS_CLASS, cls)))
+        return list(filter(func, cls.enum_devices()))

--- a/python/opae.admin/opae/admin/sysfs.py
+++ b/python/opae.admin/opae/admin/sysfs.py
@@ -565,7 +565,12 @@ class pci_node(sysfs_node):
 
 
 class sysfs_driver(sysfs_node):
-    pass
+    def unbind(self, device):
+        if not self.have_node('unbind'):
+            self.log.warn('unbind not supported')
+            return
+        name = device.name if isinstance(device, sysfs_device) else device
+        self.node('unbind').value = name
 
 
 class sysfs_device(sysfs_node):
@@ -722,3 +727,21 @@ class sysfs_device(sysfs_node):
                         return False
             return True
         return list(filter(func, cls.enum_devices()))
+
+    def unbind(self):
+        driver = self.driver
+        if driver is not None:
+            driver.unbind(self.name)
+        else:
+            self.log.debug('no driver bound')
+
+    def driver_override(self, driver):
+        if not self.have_node('driver_override'):
+            self.log.warn('driver_override not supported')
+            return
+        override = self.node('driver_override')
+        if not driver:
+            override.value = '\n'
+        else:
+            driver_name = driver.name if isinstance(sysfs_driver) else driver
+            override.value = driver_name

--- a/python/opae.admin/opae/admin/sysfs.py
+++ b/python/opae.admin/opae/admin/sysfs.py
@@ -54,6 +54,9 @@ class sysfs_node(loggable):
         super(sysfs_node, self).__init__()
         self._sysfs_path = sysfs_path(_sysfs_path)
 
+    def __str__(self):
+        return self.name
+
     @property
     def name(self):
         return os.path.basename(self.sysfs_path)
@@ -735,13 +738,9 @@ class sysfs_device(sysfs_node):
         else:
             self.log.debug('no driver bound')
 
+    @property
     def driver_override(self, driver):
-        if not self.have_node('driver_override'):
-            self.log.warn('driver_override not supported')
-            return
-        override = self.node('driver_override')
-        if not driver:
-            override.value = '\n'
-        else:
-            driver_name = driver.name if isinstance(sysfs_driver) else driver
-            override.value = driver_name
+        if self.have_node('driver_override'):
+            return self.node('driver_override')
+
+        self.log.warn('driver_override not supported')


### PR DESCRIPTION
* refactor class_node to sysfs_device
  * a sysfs_device object is meant to be something that an be enumerated
    in a bus (physical or logical) or a class.
  * modify fpga Python classes to derive from a sysfs_device
* add 'name' property to sysfs_node
  * name returns the basename (or stem) of the path
* add dfl.py with dfl class
  * dfl class derives from sysfs_device and is meant to look for devices
    in /sys/bus/dfl/devices
  * add 'feature_id' property to dfl class