### PR TITLE
2.0.1: update opae targets to RC 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ option(OPAE_BUILD_LEGACY "Enable building of OPAE legacy tools" OFF)
 mark_as_advanced(OPAE_BUILD_LEGACY)
 
 if(OPAE_BUILD_LEGACY)
-    set(OPAE_LEGACY_TAG "master" CACHE STRING "Desired branch for opae-legacy")
+    set(OPAE_LEGACY_TAG "release/2.0.1-2" CACHE STRING "Desired branch for opae-legacy")
     mark_as_advanced(OPAE_LEGACY_TAG)
 endif(OPAE_BUILD_LEGACY)
 

--- a/opae-libs/CMakeLists.txt
+++ b/opae-libs/CMakeLists.txt
@@ -102,12 +102,12 @@ option(OPAE_PRESERVE_REPOS "Disable refresh of external repos" OFF)
 mark_as_advanced(OPAE_PRESERVE_REPOS)
 
 if(OPAE_BUILD_TESTS)
-    set(OPAE_TEST_TAG "master" CACHE STRING "Desired branch for opae-test")
+    set(OPAE_TEST_TAG "release/2.0.1-2" CACHE STRING "Desired branch for opae-test")
     mark_as_advanced(OPAE_TEST_TAG)
 endif(OPAE_BUILD_TESTS)
 
 if(OPAE_BUILD_SIM)
-    set(OPAE_SIM_TAG "master" CACHE STRING "Desired branch for opae-sim")
+    set(OPAE_SIM_TAG "release/2.0.1-2" CACHE STRING "Desired branch for opae-sim")
     mark_as_advanced(OPAE_SIM_TAG)
 endif(OPAE_BUILD_SIM)
 


### PR DESCRIPTION
As development actively occurs on the master branch, pull the next RC from the HEAD of master instead of from the "snapshotted" 2.0.1 release branches.

Updates opae-libs via subtree, as well as the top level CMake opae-legacy target, to `2.0.1-2`.

This is change 2 referenced in comments in https://github.com/OPAE/opae-sdk/pull/1755.

~~This change must wait merge until MR bumping RC 1 to 2 to `master` is completed first (see https://github.com/OPAE/opae-sdk/pull/1757)~~ - Done