### PR TITLE
mmlink: fix shadowed variable

### DIFF
--- a/tools/extra/mmlink/main.cpp
+++ b/tools/extra/mmlink/main.cpp
@@ -282,7 +282,6 @@ int run_mmlink(fpga_handle  port_handle,
 	value = value >> FPGA_PORT_STP_DFH_REVBIT;
 
 
-  remote_dbg *srv = nullptr;
   switch (value) {
     case MMLINK_LEGACY:
       srv = new legacy_dbg();


### PR DESCRIPTION
remove declaration of remote_dbg *srv variable from run_mmlink function
as it shadows the static variable that is referenced in the signal
handler to shutdown.