### PR TITLE
libopaevfio: manage IOVA space with allocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2017-2020, Intel Corporation
+## Copyright(c) 2017-2021, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -162,6 +162,8 @@ set(CPACK_COMPONENTS_ALL
 	vfiotest
 	uiolib
 	uiotest
+	memlib
+	memtest
 	opaecxxutils
 	opaecxxlib
 	opaecxxnlb
@@ -182,6 +184,8 @@ define_pkg(tools
   vfiotest
   uiolib
   uiotest
+  memlib
+  memtest
   toolargsfilter
   toolfpgainfo
   toolfpgametrics

--- a/opae.spec.in
+++ b/opae.spec.in
@@ -196,12 +196,14 @@ ldconfig
 @CMAKE_INSTALL_PREFIX@/bin/fpgad
 @CMAKE_INSTALL_PREFIX@/bin/opaevfiotest
 @CMAKE_INSTALL_PREFIX@/bin/opaeuiotest
+@CMAKE_INSTALL_PREFIX@/bin/opaememtest
 @CPACK_RPM_RELOCATION_PATHS@/opae/fpgad.cfg
 @CPACK_RPM_RELOCATION_PATHS@/sysconfig/fpgad.conf
 @CPACK_RPM_RELOCATION_PATHS@/systemd/system/fpgad.service
 @CMAKE_INSTALL_PREFIX@/@OPAE_LIB_INSTALL_DIR@/libfpgad-api.so*
 @CMAKE_INSTALL_PREFIX@/@OPAE_LIB_INSTALL_DIR@/libopaevfio.so*
 @CMAKE_INSTALL_PREFIX@/@OPAE_LIB_INSTALL_DIR@/libopaeuio.so*
+@CMAKE_INSTALL_PREFIX@/@OPAE_LIB_INSTALL_DIR@/libopaemem.so*
 @CMAKE_INSTALL_PREFIX@/@OPAE_LIB_INSTALL_DIR@/opae/libfpgad-xfpga.so*
 @CMAKE_INSTALL_PREFIX@/@OPAE_LIB_INSTALL_DIR@/opae/libfpgad-vc.so*
 @CMAKE_INSTALL_PREFIX@/@OPAE_LIB_INSTALL_DIR@/opae/libboard_n3000.so*

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2017-2020, Intel Corporation
+## Copyright(c) 2017-2021, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -34,6 +34,7 @@ opae_add_subdirectory(fpgainfo)
 opae_add_subdirectory(fpgametrics)
 opae_add_subdirectory(libopaevfio)
 opae_add_subdirectory(libopaeuio)
+opae_add_subdirectory(memalloc)
 
 # extra
 # Top level OPAE_BUILD_EXTRA_TOOLS controls building all the extra tools

--- a/tools/memalloc/CMakeLists.txt
+++ b/tools/memalloc/CMakeLists.txt
@@ -24,31 +24,15 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-try_compile(PLATFORM_SUPPORTS_VFIO
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/vfiocheck.c
-    OUTPUT_VARIABLE TRY_COMPILE_OUTPUT
+opae_add_shared_library(TARGET opaemem
+    SOURCE mem_alloc.c
+    VERSION ${OPAE_VERSION}
+    SOVERSION ${OPAE_VERSION_MAJOR}
+    COMPONENT memlib
 )
-
-if (PLATFORM_SUPPORTS_VFIO)
-    set(PLATFORM_SUPPORTS_VFIO TRUE CACHE BOOL "Platform supports vfio driver")
-    opae_add_shared_library(TARGET opaevfio
-        SOURCE opaevfio.c
-        LIBS
-            ${CMAKE_THREAD_LIBS_INIT}
-            opaemem
-        VERSION ${OPAE_VERSION}
-        SOVERSION ${OPAE_VERSION_MAJOR}
-        COMPONENT vfiolib
-    )
-
-    opae_add_executable(TARGET opaevfiotest
-        SOURCE opaevfiotest.c
-        LIBS opaevfio
-        COMPONENT vfiotest
-    )
-else(PLATFORM_SUPPORTS_VFIO)
-    message(WARNING
-        "Could not compile VFIO. See errors in platform_vfio_errors.txt")
-    file(WRITE ${CMAKE_BINARY_DIR}/platform_vfio_errors.txt ${TRY_COMPILE_OUTPUT})
-endif(PLATFORM_SUPPORTS_VFIO)
+    
+opae_add_executable(TARGET opaememtest
+    SOURCE memtest.c
+    LIBS opaemem
+    COMPONENT memtest
+)

--- a/tools/memalloc/mem_alloc.c
+++ b/tools/memalloc/mem_alloc.c
@@ -1,0 +1,253 @@
+// Copyright(c) 2020-2021, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include <opae/mem_alloc.h>
+
+#define __SHORT_FILE__                                    \
+({                                                        \
+	const char *file = __FILE__;                      \
+	const char *p = file;                             \
+	while (*p)                                        \
+		++p;                                      \
+	while ((p > file) && ('/' != *p) && ('\\' != *p)) \
+		--p;                                      \
+	if (p > file)                                     \
+		++p;                                      \
+	p;                                                \
+})
+
+#define ERR(format, ...)                                \
+fprintf(stderr, "%s:%u:%s() **ERROR** [%s] : " format , \
+	__SHORT_FILE__, __LINE__, __func__, strerror(errno), ##__VA_ARGS__)
+
+void mem_alloc_init(struct mem_alloc *m)
+{
+	m->free.address = 0;
+	m->free.size = 0;
+	m->free.prev = &m->free;
+	m->free.next = &m->free;
+	m->allocated.address = 0;
+	m->allocated.size = 0;
+	m->allocated.prev = &m->allocated;
+	m->allocated.next = &m->allocated;
+}
+
+void mem_alloc_destroy(struct mem_alloc *m)
+{
+	struct mem_link *p;
+	struct mem_link *trash;
+
+	for (p = m->free.next ; p != &m->free ; ) {
+		trash = p;
+		p = p->next;
+		free(trash);
+	}
+
+	for (p = m->allocated.next ; p != &m->allocated ; ) {
+		trash = p;
+		p = p->next;
+		free(trash);
+	}
+
+	mem_alloc_init(m);
+}
+
+STATIC struct mem_link * mem_link_alloc(uint64_t address, uint64_t size)
+{
+	struct mem_link *m;
+	m = malloc(sizeof(struct mem_link));
+	if (m) {
+		m->address = address;
+		m->size = size;
+		m->prev = m;
+		m->next = m;
+	}
+	return m;
+}
+
+static inline void link_before(struct mem_link *a, struct mem_link *b)
+{
+	a->prev = b->prev;
+	a->next = b;
+	b->prev = a;
+	a->prev->next = a;
+}
+
+static inline void link_unlink(struct mem_link *x)
+{
+	x->next->prev = x->prev;
+	x->prev->next = x->next;
+}
+
+STATIC void mem_alloc_coalesce(struct mem_link *head,
+			       struct mem_link *l)
+{
+	struct mem_link *prev = l->prev;
+	struct mem_link *next = l->next;
+
+	if (prev == head && next == head)
+		return;
+
+	if (prev != head) {
+		if (prev->address + prev->size == l->address) {
+			l->address = prev->address;
+			l->size += prev->size;
+			link_unlink(prev);
+			free(prev);
+		}
+	}
+
+	next = l->next;
+	if (next != head) {
+		if (l->address + l->size == next->address) {
+			next->address = l->address;
+			next->size += l->size;
+			link_unlink(l);
+			free(l);
+		}
+	}
+}
+
+int mem_alloc_add_free(struct mem_alloc *m, uint64_t address, uint64_t size)
+{
+	struct mem_link *node;
+	struct mem_link *p;
+
+	node = mem_link_alloc(address, size);
+	if (!node) {
+		ERR("malloc() failed\n");
+		return 1;
+	}
+
+	for (p = m->free.next ; p != &m->free ; p = p->next) {
+		if (address < p->address) {
+			link_before(node, p);
+			mem_alloc_coalesce(&m->free, node);
+			return 0;
+		} else if (address == p->address) {
+			// double free
+			ERR("double free detected 0x%lx\n", address);
+			return 2;
+		} else {
+			// address > p->address
+			break;
+		}
+
+	}
+
+	while ((address > p->address) && (p != &m->free)) {
+		p = p->next;
+	}
+
+	link_before(node, p);
+	mem_alloc_coalesce(&m->free, node);
+
+	return 0;
+}
+
+STATIC int mem_alloc_allocate_node(struct mem_alloc *m,
+				   struct mem_link *node,
+				   uint64_t *address,
+				   uint64_t size)
+{
+	struct mem_link *p;
+
+	if (node->size == size) {
+		// If we have an exact fit, recycle the node struct.
+		link_unlink(node);
+		link_before(node, &m->allocated);
+		*address = node->address;
+		return 0;
+	}
+
+	// node->size > size
+
+	p = mem_link_alloc(node->address, size);
+	if (!p) {
+		ERR("malloc() failed\n");
+		return 1;
+	}
+
+	node->address += size;
+	node->size -= size;
+
+	link_before(p, &m->allocated);
+	*address = p->address;
+
+	return 0;
+}
+
+int mem_alloc_get(struct mem_alloc *m, uint64_t *address, uint64_t size)
+{
+	struct mem_link *p;
+
+	for (p = m->free.next ; p != &m->free ; p = p->next) {
+		if (size <= p->size) { // First fit.
+			return mem_alloc_allocate_node(m, p, address, size);
+		}
+	}
+
+	ERR("no free block of sufficient size found\n");
+	return 1; // Out of memory.
+}
+
+STATIC int mem_alloc_free_node(struct mem_alloc *m,
+			       struct mem_link *node)
+{
+	uint64_t address;
+	uint64_t size;
+
+	address = node->address;
+	size = node->size;
+
+	link_unlink(node);
+	free(node);
+
+	return mem_alloc_add_free(m, address, size);
+}
+
+int mem_alloc_put(struct mem_alloc *m, uint64_t address)
+{
+	struct mem_link *p;
+
+	for (p = m->allocated.next ; p != &m->allocated ; p = p->next) {
+		if (address == p->address) {
+			return mem_alloc_free_node(m, p);
+		}
+	}
+
+	ERR("attempt to free non-allocated 0x%lx\n", address);
+	return 1; // Address not found.
+}

--- a/tools/memalloc/memtest.c
+++ b/tools/memalloc/memtest.c
@@ -1,0 +1,356 @@
+// Copyright(c) 2021, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <assert.h>
+
+#include <opae/mem_alloc.h>
+
+void test_insert_basic(void)
+{
+	struct mem_alloc m;
+	struct mem_link *a;
+	struct mem_link *b;
+
+	mem_alloc_init(&m);
+
+	mem_alloc_add_free(&m, 0x1000, 4096);
+	a = m.free.next;
+	assert(a);
+	assert(a->address == 0x1000);
+	assert(a->size == 4096);
+	assert(a->prev == &m.free);
+	assert(a->next == &m.free);
+	assert(m.free.next == a);
+	assert(m.free.prev == a);
+
+	mem_alloc_add_free(&m, 0x0000, 4096);
+	a = m.free.next;
+	assert(a);
+	assert(a->address == 0x0000);
+	assert(a->size == 2 * 4096);
+	assert(a->prev == &m.free);
+	assert(a->next == &m.free);
+	assert(m.free.next == a);
+	assert(m.free.prev == a);
+
+	mem_alloc_add_free(&m, 0x2000, 4096);
+	a = m.free.next;
+	assert(a);
+	assert(a->address == 0x0000);
+	assert(a->size == 3 * 4096);
+	assert(a->prev == &m.free);
+	assert(a->next == &m.free);
+	assert(m.free.next == a);
+	assert(m.free.prev == a);
+
+	mem_alloc_destroy(&m);
+
+
+	mem_alloc_add_free(&m, 0x0000, 4096);
+	a = m.free.next;
+	assert(a);
+	assert(a->address == 0x0000);
+	assert(a->size == 4096);
+	assert(a->prev == &m.free);
+	assert(a->next == &m.free);
+	assert(m.free.next == a);
+	assert(m.free.prev == a);
+
+	mem_alloc_add_free(&m, 0x2000, 4096);
+	a = m.free.next;
+	b = m.free.prev;
+	assert(a);
+	assert(a->address == 0x0000);
+	assert(a->size == 4096);
+	assert(b->address == 0x2000);
+	assert(b->size == 4096);
+	assert(a->prev == &m.free);
+	assert(a->next == b);
+	assert(b->prev == a);
+	assert(b->next == &m.free);
+	assert(m.free.prev == b);
+	assert(m.free.next == a);
+
+	mem_alloc_add_free(&m, 0x1000, 4096);
+	a = m.free.next;
+	assert(a);
+	assert(a->address == 0x0000);
+	assert(a->size == 3 * 4096);
+	assert(a->prev == &m.free);
+	assert(a->next == &m.free);
+	assert(m.free.next == a);
+	assert(m.free.prev == a);
+
+	mem_alloc_destroy(&m);
+
+
+	mem_alloc_add_free(&m, 0x0000, 4096);
+	a = m.free.next;
+	assert(a);
+	assert(a->address == 0x0000);
+	assert(a->size == 4096);
+	assert(a->prev == &m.free);
+	assert(a->next == &m.free);
+	assert(m.free.next == a);
+	assert(m.free.prev == a);
+
+	mem_alloc_add_free(&m, 0x1000, 4096);
+	a = m.free.next;
+	assert(a);
+	assert(a->address == 0x0000);
+	assert(a->size == 2 * 4096);
+	assert(a->prev == &m.free);
+	assert(a->next == &m.free);
+	assert(m.free.next == a);
+	assert(m.free.prev == a);
+
+	mem_alloc_add_free(&m, 0x2000, 4096);
+	a = m.free.next;
+	assert(a);
+	assert(a->address == 0x0000);
+	assert(a->size == 3 * 4096);
+	assert(a->prev == &m.free);
+	assert(a->next == &m.free);
+	assert(m.free.next == a);
+	assert(m.free.prev == a);
+
+	mem_alloc_destroy(&m);
+}
+
+void test_insert_stress(int iters)
+{
+	struct {
+		uint64_t address;
+		uint64_t size;
+	} addresses[] = {
+		{ 0x0000, 4096 },
+		{ 0x1000, 4096 },
+		{ 0x2000, 4096 },
+		{ 0x3000, 4096 },
+		{ 0x4000, 4096 },
+		{ 0x5000, 4096 },
+		{ 0x6000, 4096 },
+		{ 0x7000, 4096 },
+		{ 0x8000, 4096 },
+		{ 0x9000, 4096 }
+	};
+	int addrs = sizeof(addresses) / sizeof(addresses[0]);
+
+	int i;
+	int j;
+	int r;
+	uint64_t temp;
+
+	struct mem_alloc m;
+	struct mem_link *a;
+
+	mem_alloc_init(&m);
+
+	for (i = 0 ; i < iters ; ++i) {
+
+		for (j = addrs - 1 ; j > 0 ; --j) {
+			r = rand() % j;
+			temp = addresses[r].address;
+			addresses[r].address = addresses[j].address;
+			addresses[j].address = temp;
+		}
+
+		/*
+		printf("----\n");
+		for (j = 0 ; j < addrs ; ++j) {
+			printf("0x%lx\n", addresses[j].address);
+		}
+		*/
+
+		for (j = 0 ; j < addrs ; ++j) {
+			//printf("addr: 0x%lx\n", addresses[j].address);
+			assert(0 == mem_alloc_add_free(&m, addresses[j].address, addresses[j].size));
+		}
+
+		a = m.free.next;
+		assert(a);
+		assert(a->address == 0x0000);
+		assert(a->size == 10 * 4096);
+		assert(a->prev == &m.free);
+		assert(a->next == &m.free);
+		assert(m.free.next == a);
+		assert(m.free.prev == a);
+
+		mem_alloc_destroy(&m);
+	}
+
+}
+
+void test_alloc_free_stress(int iters)
+{
+	struct {
+		uint64_t address;
+		uint64_t size;
+	} addresses[] = {
+		{ 0x0000, 4096 },
+		{ 0x2000, 4096 },
+		{ 0x4000, 4096 },
+		{ 0x6000, 4096 },
+		{ 0x8000, 4096 }
+	};
+	int addrs = sizeof(addresses) / sizeof(addresses[0]);
+
+	int i;
+	int j;
+	int k;
+	int r;
+
+	struct mem_alloc m;
+	struct mem_link *a;
+	struct mem_link *b;
+
+	uint64_t size = 1024;
+	uint64_t allocated[addrs * 4];
+	uint64_t temp;
+
+	for (i = 0 ; i < iters ; ++i) {
+		mem_alloc_init(&m);
+
+		for (j = 0 ; j < addrs ; ++j) {
+			assert(0 == mem_alloc_add_free(&m, addresses[j].address, addresses[j].size));
+		}
+
+		a = m.free.next;
+		assert(a);
+		assert(a->address == 0x0000);
+		assert(a->size == 4096);
+		assert(a->prev == &m.free);
+
+		b = a->next;
+		assert(b);
+		assert(b->address == 0x2000);
+		assert(b->size == 4096);
+		assert(b->prev == a);
+
+		a = b;
+		b = b->next;
+		assert(b);
+		assert(b->address == 0x4000);
+		assert(b->size == 4096);
+		assert(b->prev == a);
+
+		a = b;
+		b = b->next;
+		assert(b);
+		assert(b->address == 0x6000);
+		assert(b->size == 4096);
+		assert(b->prev == a);
+
+		a = b;
+		b = b->next;
+		assert(b);
+		assert(b->address == 0x8000);
+		assert(b->size == 4096);
+		assert(b->prev == a);
+
+		assert(b->next == &m.free);
+		assert(m.free.prev == b);
+
+
+		k = 0;
+		while (0 == mem_alloc_get(&m, &allocated[k], size)) {
+			++k;
+		}
+
+		assert(k == addrs * 4);
+
+		assert(m.free.next == &m.free);
+		assert(m.free.prev == &m.free);
+
+		for (j = k - 1 ; j > 0 ; --j) {
+			r = rand() % j;
+			temp = allocated[r];
+			allocated[r] = allocated[j];
+			allocated[j] = temp;
+
+			assert(0 == mem_alloc_put(&m, allocated[j]));
+		}
+		assert(0 == mem_alloc_put(&m, allocated[0]));
+
+		assert(m.allocated.next == &m.allocated);
+		assert(m.allocated.prev == &m.allocated);
+
+		a = m.free.next;
+		assert(a);
+		assert(a->address == 0x0000);
+		assert(a->size == 4096);
+		assert(a->prev == &m.free);
+
+		b = a->next;
+		assert(b);
+		assert(b->address == 0x2000);
+		assert(b->size == 4096);
+		assert(b->prev == a);
+
+		a = b;
+		b = b->next;
+		assert(b);
+		assert(b->address == 0x4000);
+		assert(b->size == 4096);
+		assert(b->prev == a);
+
+		a = b;
+		b = b->next;
+		assert(b);
+		assert(b->address == 0x6000);
+		assert(b->size == 4096);
+		assert(b->prev == a);
+
+		a = b;
+		b = b->next;
+		assert(b);
+		assert(b->address == 0x8000);
+		assert(b->size == 4096);
+		assert(b->prev == a);
+
+		assert(b->next == &m.free);
+		assert(m.free.prev == b);
+
+		mem_alloc_destroy(&m);
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	(void) argc;
+	(void) argv;
+
+	srand(time(NULL));
+
+	test_insert_basic();
+	test_insert_stress(10000000);
+	test_alloc_free_stress(10000000);
+
+	return 0;
+}


### PR DESCRIPTION
Add management of the IOVA space for DMA buffers.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>