### PR TITLE
opae.admin: add pci_driver tool

### DIFF
--- a/python/opae.admin/opae/admin/sysfs.py
+++ b/python/opae.admin/opae/admin/sysfs.py
@@ -29,6 +29,7 @@ import glob
 import os
 import re
 from contextlib import contextmanager
+from pathlib import Path
 from subprocess import CalledProcessError
 from opae.admin.path import sysfs_path
 from opae.admin.utils.process import call_process, DRY_RUN
@@ -269,7 +270,9 @@ class pci_node(sysfs_node):
             This function is recursively called with any children found in
             this node, incrementing the level every recursive call.
         """
-        text = '{}{}\n'.format(' ' * level*4, self)
+        driver = self.find_one('driver')
+        driver_name = Path(driver.sysfs_path).resolve().stem if driver else 'no driver'
+        text = '{}{} ({})\n'.format(' ' * level*4, self, driver_name)
         for n in self.children:
             text += n.tree(level+1)
         return text
@@ -744,3 +747,7 @@ class sysfs_device(sysfs_node):
             return self.node('driver_override')
 
         self.log.warn('driver_override not supported')
+
+
+class pcie_device(sysfs_device):
+    DEVICE_ROOT = 'bus/pci/devices'

--- a/python/opae.admin/opae/admin/tools/pci_device.py
+++ b/python/opae.admin/opae/admin/tools/pci_device.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# Copyright(c) 2020, Intel Corporation
+# Copyright(c) 2021, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:

--- a/python/opae.admin/opae/admin/tools/pci_device.py
+++ b/python/opae.admin/opae/admin/tools/pci_device.py
@@ -1,0 +1,106 @@
+#! /usr/bin/env python
+# Copyright(c) 2020, Intel Corporation
+#
+# Redistribution  and  use  in source  and  binary  forms,  with  or  without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of  source code  must retain the  above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name  of Intel Corporation  nor the names of its contributors
+#   may be used to  endorse or promote  products derived  from this  software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+# IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+# LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+# CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+# SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+# INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+# CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import re
+from argparse import ArgumentParser
+from opae.admin.sysfs import pcie_device, pci_node
+
+
+PCI_ADDRESS_PATTERN = (r'^(?P<pci_address>'
+                       r'(?:(?P<segment>[\da-f]{4}):)?'
+                       r'(?P<bdf>(?P<bus>[\da-f]{2}):'
+                       r'(?P<device>[\da-f]{2})\.(?P<function>[0-7]{1})))$')
+PCI_ADDRESS_RE = re.compile(PCI_ADDRESS_PATTERN, re.IGNORECASE)
+
+
+def pci_address(inp):
+    m = PCI_ADDRESS_RE.match(inp)
+    if not m:
+        raise ValueError('wrong pci address format: {}'.format(inp))
+
+    d = m.groupdict()
+    return '{}:{}'.format(d.get('segment') or '0000', d['bdf'])
+
+
+class pci_op(object):
+    def __init__(self, op):
+        if op not in dir(pci_node):
+            raise KeyError(f'{op} is not a valid operation')
+        self.op = op
+
+    def __call__(self, pci_device, args):
+        if not args.other_endpoints:
+            getattr(pci_device.pci_node, self.op)()
+        else:
+            for p in pci_device.pci_node.root.endpoints:
+                if p.pci_address != args.device:
+                    getattr(p, self.op)()
+
+
+def rescan(pci_device, args):
+    pci_device.pci_node.pci_bus.node('rescan').value = 1
+
+
+def topology(pci_device, args):
+    for line in pci_device.pci_node.root.tree().split('\n'):
+        if pci_device.pci_node.pci_address in line:
+            line = '\033[92m{}\033[00m' .format(line)
+        elif '(pcieport)' not in line:
+            line = '\033[96m{}\033[00m' .format(line)
+        print(line)
+
+
+def main():
+    actions = {'unbind': pci_op('unbind'),
+               'rescan': rescan,
+               'remove': pci_op('remove'),
+               'topology': topology}
+
+    parser = ArgumentParser()
+    parser.add_argument('device', type=pci_address,
+                        help=('pcie address of device '
+                              '([segment:]bus:device.function)'))
+    parser.add_argument('action', choices=sorted(actions.keys()),
+                        help='action to perform on device')
+    parser.add_argument('-E', '--other-endpoints', action='store_true',
+                        default=False,
+                        help='perform action on peer pcie devices')
+    args = parser.parse_args()
+
+    pci_devices = pcie_device.enum([{'pci_node.pci_address': args.device}])
+    if not pci_devices:
+        raise SystemExit(f'{args.device} not found')
+
+    if len(pci_devices) > 1:
+        raise SystemExit(f'more than one device found for: {args.device}')
+
+    pci_device = pci_devices[0]
+
+    actions[args.action](pci_device, args)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/opae.admin/setup.py
+++ b/python/opae.admin/setup.py
@@ -41,6 +41,7 @@ setup(
             'bitstreaminfo = opae.admin.tools.bitstream_info:main',
             'opaevfio = opae.admin.tools.opaevfio:main',
             'opaeuio = opae.admin.tools.opaeuio:main',
+            'pci_device = opae.admin.tools.pci_device:main',
             'regmap-debugfs = opae.admin.tools.regmap_debugfs:main',
         ]
     },


### PR DESCRIPTION
* Modify pci_node.tree function to add driver name
* Add pci_device.py tool
  This is a helper script to manage pci devices.
  To use this tool, call run:
  ```console
  pci_device <pci address> <action> [--other-endpoints]
  ```

  This initial implementation supports four actions:
  * unbind
    This action will unbind any bound drivers
  * remove
    This action will remove the pci device
  * rescan
    This action will trigger a bus rescan from the root port
  * topology
    This action will print out the pcie tree topology.
    This will print out the line showing the target device (as identified by the first position command line argument) as green
    and other endpoints as cyan.
![image](https://user-images.githubusercontent.com/22808196/103960473-11315a00-5107-11eb-9d65-67c06c0c0cd3.png)


  NOTE: If `--other-endpoints` argument is present, actions like remove or
  unbind will operate on the ohter endpoints in the pcie topology.

