### PR TITLE
tools: fix mmlink build error

### DIFF
--- a/tools/extra/mmlink/remote_dbg/streaming/stream_dbg.h
+++ b/tools/extra/mmlink/remote_dbg/streaming/stream_dbg.h
@@ -31,7 +31,7 @@ class stream_dbg : public remote_dbg
 public:
   stream_dbg(){}
   virtual ~stream_dbg(){}
-  int run(volatile uint64_t *mmio, const char *address, int port);
+  int run(volatile uint64_t *mmio, const char *address, int port) override;
   void terminate() override;
 
 };


### PR DESCRIPTION
error: 'run' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  int run(volatile uint64_t *mmio, const char *address, int port);

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>