### PR TITLE
vfio-plugin: refactor and fix bugs in enumeration

### DIFF
--- a/plugins/vfio/opae_vfio.c
+++ b/plugins/vfio/opae_vfio.c
@@ -175,7 +175,7 @@ out:
 void free_token_list(vfio_token *tokens)
 {
 	while (tokens) {
-		vfio_token *t = tokens;;
+		vfio_token *t = tokens;
 		tokens = tokens->next;
 		free(t);
 	}

--- a/plugins/vfio/opae_vfio.c
+++ b/plugins/vfio/opae_vfio.c
@@ -86,7 +86,6 @@ typedef struct _vfio_buffer
 
 
 static pci_device_t *_pci_devices;
-static vfio_token *_vfio_tokens;
 static vfio_buffer *_vfio_buffers;
 static pthread_mutex_t _buffers_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
@@ -173,21 +172,22 @@ out:
 	return res;
 }
 
+void free_token_list(vfio_token *tokens)
+{
+	while (tokens) {
+		vfio_token *t = tokens;;
+		tokens = tokens->next;
+		free(t);
+	}
+}
+
 void free_device_list()
 {
 	while (_pci_devices) {
 		pci_device_t *p = _pci_devices;
 		_pci_devices = _pci_devices->next;
+		free_token_list(p->tokens);
 		free(p);
-	}
-}
-
-void free_token_list()
-{
-	while (_vfio_tokens) {
-		vfio_token *t = _vfio_tokens;
-		_vfio_tokens = _vfio_tokens->next;
-		free(t);
 	}
 }
 
@@ -298,6 +298,8 @@ vfio_token *clone_token(vfio_token *src)
 		return NULL;
 	}
 	memcpy(token, src, sizeof(vfio_token));
+	if (src->parent)
+		token->parent = clone_token(src->parent);
 	return token;
 }
 
@@ -468,9 +470,8 @@ close:
 	return res;
 }
 
-int features_discover()
+int features_discover(pci_device_t *p)
 {
-	pci_device_t *p = _pci_devices;
 	while(p) {
 		walk(p);
 		p = p->next;
@@ -836,17 +837,16 @@ void print_dfh(uint32_t offset, dfh *h)
 
 vfio_token *find_token(const pci_device_t *p, uint32_t region)
 {
-	vfio_token *t = _vfio_tokens;
+	vfio_token *t = p->tokens;
 	while (t) {
-		if (t->region == region &&
-		    !strncmp(t->device->addr, p->addr, PCIADDR_MAX))
+		if (t->region == region)
 			return t;
 		t = t->next;
 	}
 	return t;
 }
 
-vfio_token *get_token(const pci_device_t *p, uint32_t region, int type)
+vfio_token *get_token(pci_device_t *p, uint32_t region, int type)
 {
 	vfio_token *t = find_token(p, region);
 	if (t) return t;
@@ -860,11 +860,38 @@ vfio_token *get_token(const pci_device_t *p, uint32_t region, int type)
 	t->device = p;
 	t->region = region;
 	t->type = type;
-	t->next = _vfio_tokens;
-	_vfio_tokens = t;
+	t->next = p->tokens;
+	p->tokens = t;
 	return t;
 }
 
+bool pci_matches_filter(const fpga_properties *filter, pci_device_t *dev)
+{
+	struct _fpga_properties *_prop = (struct _fpga_properties *)filter;
+	if (FIELD_VALID(_prop, FPGA_PROPERTY_SEGMENT))
+		if (_prop->segment != dev->bdf.segment) return false;
+	if (FIELD_VALID(_prop, FPGA_PROPERTY_BUS))
+		if (_prop->bus != dev->bdf.bus) return false;
+	if (FIELD_VALID(_prop, FPGA_PROPERTY_DEVICE))
+		if (_prop->device != dev->bdf.device) return false;
+	if (FIELD_VALID(_prop, FPGA_PROPERTY_FUNCTION))
+		if (_prop->function != dev->bdf.function) return false;
+	if (FIELD_VALID(_prop, FPGA_PROPERTY_SOCKETID))
+		if (_prop->socket_id != dev->numa_node) return false;
+	return true;
+
+}
+
+bool pci_matches_filters(const fpga_properties *filters, uint32_t num_filters,
+		 pci_device_t *dev)
+{
+	if (!filters) return true;
+	for (uint32_t i = 0; i < num_filters; ++i) {
+		if (pci_matches_filter(filters[i], dev))
+			return true;
+	}
+	return false;
+}
 
 bool matches_filter(const fpga_properties *filter, vfio_token *t)
 {
@@ -881,16 +908,6 @@ bool matches_filter(const fpga_properties *filter, vfio_token *t)
 
 	if (FIELD_VALID(_prop, FPGA_PROPERTY_OBJTYPE))
 		if (_prop->objtype != t->type) return false;
-	if (FIELD_VALID(_prop, FPGA_PROPERTY_SEGMENT))
-		if (_prop->segment != t->device->bdf.segment) return false;
-	if (FIELD_VALID(_prop, FPGA_PROPERTY_BUS))
-		if (_prop->bus != t->device->bdf.bus) return false;
-	if (FIELD_VALID(_prop, FPGA_PROPERTY_DEVICE))
-		if (_prop->device != t->device->bdf.device) return false;
-	if (FIELD_VALID(_prop, FPGA_PROPERTY_FUNCTION))
-		if (_prop->function != t->device->bdf.function) return false;
-	if (FIELD_VALID(_prop, FPGA_PROPERTY_SOCKETID))
-		if (_prop->socket_id != t->device->numa_node) return false;
 	if (FIELD_VALID(_prop, FPGA_PROPERTY_GUID)) {
 		if (memcmp(_prop->guid, t->guid, sizeof(fpga_guid))) return false;
 	}
@@ -902,9 +919,9 @@ bool matches_filters(const fpga_properties *filters, uint32_t num_filters,
 {
 	if (!filters) return true;
 	for (uint32_t i = 0; i < num_filters; ++i) {
-		if (!matches_filter(filters[i], t)) return false;
+		if (matches_filter(filters[i], t)) return true;
 	}
-	return true;
+	return false;
 }
 
 void dump_csr(uint8_t *begin, uint8_t *end, uint32_t index)
@@ -944,19 +961,24 @@ fpga_result vfio_fpgaEnumerate(const fpga_properties *filters,
 			       uint32_t num_filters, fpga_token *tokens,
 			       uint32_t max_tokens, uint32_t *num_matches)
 {
-	vfio_token *ptr = _vfio_tokens;
+	pci_device_t *dev = _pci_devices;
 	uint32_t matches = 0;
-	while(ptr) {
-		if (matches_filters(filters, num_filters, ptr)) {
-			if (matches < max_tokens) {
-				vfio_token *tok = clone_token(ptr);
-				if (ptr->parent)
-					tok->parent = clone_token(tok->parent);
-				tokens[matches] = tok;
+	while(dev) {
+		if (pci_matches_filters(filters, num_filters, dev)) {
+			features_discover(dev);
+			vfio_token *ptr = dev->tokens;
+			while(ptr) {
+				if (matches_filters(filters, num_filters, ptr)) {
+					if (matches < max_tokens) {
+						tokens[matches] =
+							clone_token(ptr);
+					}
+					++matches;
+				}
+				ptr = ptr->next;
 			}
-			++matches;
 		}
-		ptr = ptr->next;
+		dev = dev->next;
 	}
 	*num_matches = matches;
 	return FPGA_OK;

--- a/plugins/vfio/opae_vfio.h
+++ b/plugins/vfio/opae_vfio.h
@@ -79,7 +79,7 @@ typedef struct _pci_device
 	uint32_t vendor;
 	uint32_t device;
 	uint32_t numa_node;
-  struct _vfio_token *tokens;
+	struct _vfio_token *tokens;
 	struct _pci_device *next;
 } pci_device_t;
 

--- a/plugins/vfio/opae_vfio.h
+++ b/plugins/vfio/opae_vfio.h
@@ -69,6 +69,7 @@ typedef union _bdf
 	};
 	uint32_t bdf;
 } bdf_t;
+struct _vfio_token;
 
 #define PCIADDR_MAX 16
 typedef struct _pci_device
@@ -78,6 +79,7 @@ typedef struct _pci_device
 	uint32_t vendor;
 	uint32_t device;
 	uint32_t numa_node;
+  struct _vfio_token *tokens;
 	struct _pci_device *next;
 } pci_device_t;
 
@@ -92,7 +94,7 @@ typedef struct _vfio_token
 	uint32_t magic;
 	fpga_guid guid;
 	fpga_guid compat_id;
-	const pci_device_t *device;
+	pci_device_t *device;
 	uint32_t region;
 	uint32_t offset;
 	uint32_t mmio_size;
@@ -133,6 +135,6 @@ pci_device_t *get_pci_device(char addr[PCIADDR_MAX]);
 void free_device_list();
 void free_token_list();
 void free_buffer_list();
-vfio_token *get_token(const pci_device_t *p, uint32_t region, int type);
+vfio_token *get_token(pci_device_t *p, uint32_t region, int type);
 fpga_result get_guid(uint64_t* h, fpga_guid guid);
 #endif

--- a/plugins/vfio/plugin.c
+++ b/plugins/vfio/plugin.c
@@ -45,18 +45,12 @@ int __VFIO_API__ vfio_plugin_initialize(void)
 	if (res) {
 		OPAE_ERR("error with pci_discover\n");
 	}
-	res = features_discover();
-	if (res) {
-		OPAE_ERR("error discovering features\n");
-	}
-
 	return res;
 }
 
 int __VFIO_API__ vfio_plugin_finalize(void)
 {
 	free_buffer_list();
-	free_token_list();
 	free_device_list();
 	return 0;
 }


### PR DESCRIPTION
* Refactor enumeration in vfio plugin to match PCIe attributes (BDF, socket id)
  * Add functions, pci_matches_filters and pci_matches_filter that are called first during enumeration.
    * If the filters are empty or the the pci attributes in the filters match the device, it is considered for the rest of enumeration
    * Otherwise, it is skipped
  * Move token lists from a static token list into the static list of pci_device_t structures.
  * This helps prevent reading of CSR space by filtering on specific PCIe attributes read from sysfs
    IOW, given a specific PCIe address (segment, bus, device, function), the mmio space will be read only when the PCIe address is 
    set in the filter and it matches a device.
* Fix use of open_vfio_pair so that it is called only when a VF has a PF
physfn _AND_ that device is bound to the vfio-pci driver.
* Read afu_id for BAR0 when treating a whole device as an accelerator.