### PR TITLE
argsfilter: refactor to accept PCIe address

### DIFF
--- a/tests/argsfilter/test_argsfilter_c.cpp
+++ b/tests/argsfilter/test_argsfilter_c.cpp
@@ -80,22 +80,18 @@ TEST_P(argsfilter_c_p, bdf) {
     char seven[20];
     char eight[20];
     char nine[20];
-    char ten[20];
-    char eleven[20];
     char *argv[] = { zero, one, two, three, four, five,
-                     six, seven, eight, nine, ten, eleven };
-    int argc = 12;
+                     six, seven, eight, nine };
+    int argc = 10;
     fpga_result result;
-    char bus[10];
-    char device[10];
-    char function[10];
-    char socket_id[10];
-    char segment[10];
+    char bus[20];
+    char device[20];
+    char function[20];
+    char segment[20];
 
     sprintf(bus, "0x%x", platform_.devices[0].bus);
     sprintf(device, "0x%x", platform_.devices[0].device);
     sprintf(function, "0x%x", platform_.devices[0].function);
-    sprintf(socket_id, "0x%x", platform_.devices[0].socket_id);
     sprintf(segment, "0x%x", platform_.devices[0].segment);
 
     fpga_properties filter = NULL;
@@ -110,9 +106,7 @@ TEST_P(argsfilter_c_p, bdf) {
     strcpy(six, "-F");
     strcpy(seven, function);
     strcpy(eight, "-S");
-    strcpy(nine, socket_id);
-    strcpy(ten, "--segment");
-    strcpy(eleven, segment);
+    strcpy(nine, segment);
     EXPECT_EQ(set_properties_from_args(filter, &result, &argc, argv), 0);
     EXPECT_EQ(fpgaDestroyProperties(&filter), FPGA_OK);
     EXPECT_EQ(result, 0);
@@ -287,62 +281,6 @@ TEST_P(argsfilter_c_p, function_neg) {
 }
 
 /**
- * @test       socket_id
- * @brief      Test: set_properties_from_args
- * @details    When passed with valid argument for the socket_id, <br>
- *             the function returns 0. <br>
- */
-TEST_P(argsfilter_c_p, socket_id) {
-    char zero[20];
-    char one[20];
-    char two[20];
-    char three[20];
-    char *argv[] = { zero, one, two, three };
-    int argc = 4;
-    fpga_result result;
-    char socket_id[10];
-
-    sprintf(socket_id, "0x%x", platform_.devices[0].socket_id);
-
-    fpga_properties filter = NULL;
-    ASSERT_EQ(fpgaGetProperties(NULL, &filter), FPGA_OK);
-
-    strcpy(zero, "fpgainfo");
-    strcpy(one, "fme");
-    strcpy(two, "-S");
-    strcpy(three, socket_id);
-    EXPECT_EQ(set_properties_from_args(filter, &result, &argc, argv), 0);
-    EXPECT_EQ(fpgaDestroyProperties(&filter), FPGA_OK);
-    EXPECT_EQ(result, 0);
-}
-
-/**
- * @test       socket_neg
- * @brief      Test: set_properties_from_args
- * @details    When passed with invalid argument for the socket, <br>
- *             the function returns an error. <br>
- */
-TEST_P(argsfilter_c_p, socket_neg) {
-    char zero[20];
-    char one[20];
-    char two[20];
-    char three[20];
-    char *argv[] = { zero, one, two, three };
-    int argc = 4;
-    fpga_result result;
-
-    fpga_properties filter = NULL;
-    ASSERT_EQ(fpgaGetProperties(NULL, &filter), FPGA_OK);
-
-    strcpy(zero, "fpgainfo");
-    strcpy(one, "fme");
-    strcpy(two, "-S");
-    strcpy(three, "zxyw");
-    EXPECT_NE(set_properties_from_args(filter, &result, &argc, argv), 0);
-    EXPECT_EQ(fpgaDestroyProperties(&filter), FPGA_OK);
-}
-
-/**
  * @test       segment
  * @brief      Test: set_properties_from_args
  * @details    When passed with valid argument for the segment, <br>
@@ -356,7 +294,7 @@ TEST_P(argsfilter_c_p, segment) {
     char *argv[] = { zero, one, two, three };
     int argc = 4;
     fpga_result result;
-    char segment[10];
+    char segment[20];
 
     sprintf(segment, "0x%x", platform_.devices[0].segment);
 
@@ -375,8 +313,8 @@ TEST_P(argsfilter_c_p, segment) {
 /**
  * @test       segment_neg
  * @brief      Test: set_properties_from_args
- * @details    When passed with valid argument for the segment, <br>
- *             the function returns 0. <br>
+ * @details    When passed an invalid argument for the segment, <br>
+ *             the function returns non-zero. <br>
  */
 TEST_P(argsfilter_c_p, segment_neg) {
     char zero[20];
@@ -420,6 +358,133 @@ TEST_P(argsfilter_c_p, argsfilter_neg) {
     strcpy(two, "-B");
     EXPECT_NE(set_properties_from_args(filter, &result, &argc, argv), 0);
     EXPECT_EQ(fpgaDestroyProperties(&filter), FPGA_OK);
+}
+
+/**
+ * @test       addr_sbdf
+ * @brief      Test: set_properties_from_args
+ * @details    When the arguments to the function contain<br>
+ *             a properly formatted ssss:bb:dd.f, then the<br>
+ *             properties are set appropriately.
+ */
+TEST_P(argsfilter_c_p, addr_sbdf) {
+    char zero[20];
+    char one[20];
+    char two[20];
+    char three[20];
+    char four[20];
+    char five[20];
+    char six[20];
+    char seven[20];
+    char eight[20];
+    char nine[20];
+    char ten[20];
+    char *argv[] = { zero, one, two, three,
+                     four, five, six, seven,
+                     eight, nine, ten };
+    int argc = 11;
+    fpga_result result;
+
+    fpga_properties filter = NULL;
+    ASSERT_EQ(fpgaGetProperties(NULL, &filter), FPGA_OK);
+
+    strcpy(zero, "fpgainfo");
+    strcpy(one, "fme");
+    strcpy(two, "-S");
+    strcpy(three, "0xff");
+    strcpy(four, "-B");
+    strcpy(five, "0xff");
+    strcpy(six, "-D");
+    strcpy(seven, "0xff");
+    strcpy(eight, "-F");
+    strcpy(nine, "7");
+    strcpy(ten, "1234:56:78.7");
+
+    EXPECT_EQ(set_properties_from_args(filter, &result, &argc, argv), 0);
+
+    uint16_t segment = 0;
+    uint8_t bus = 0;
+    uint8_t device = 0;
+    uint8_t function = 0;
+
+    EXPECT_EQ(fpgaPropertiesGetSegment(filter, &segment), FPGA_OK);
+    EXPECT_EQ(segment, 0x1234);
+
+    EXPECT_EQ(fpgaPropertiesGetBus(filter, &bus), FPGA_OK);
+    EXPECT_EQ(bus, 0x56);
+
+    EXPECT_EQ(fpgaPropertiesGetDevice(filter, &device), FPGA_OK);
+    EXPECT_EQ(device, 0x78);
+
+    EXPECT_EQ(fpgaPropertiesGetFunction(filter, &function), FPGA_OK);
+    EXPECT_EQ(function, 7);
+
+    EXPECT_EQ(fpgaDestroyProperties(&filter), FPGA_OK);
+    EXPECT_EQ(result, 0);
+}
+
+/**
+ * @test       addr_bdf
+ * @brief      Test: set_properties_from_args
+ * @details    When the arguments to the function contain<br>
+ *             a properly formatted bb:dd.f, then the<br>
+ *             properties are set appropriately. The segment<br>
+ *             field is set to 0.
+ */
+TEST_P(argsfilter_c_p, addr_bdf) {
+    char zero[20];
+    char one[20];
+    char two[20];
+    char three[20];
+    char four[20];
+    char five[20];
+    char six[20];
+    char seven[20];
+    char eight[20];
+    char nine[20];
+    char ten[20];
+    char *argv[] = { zero, one, two, three,
+                     four, five, six, seven,
+                     eight, nine, ten };
+    int argc = 11;
+    fpga_result result;
+
+    fpga_properties filter = NULL;
+    ASSERT_EQ(fpgaGetProperties(NULL, &filter), FPGA_OK);
+
+    strcpy(zero, "fpgainfo");
+    strcpy(one, "fme");
+    strcpy(two, "-S");
+    strcpy(three, "0xff");
+    strcpy(four, "-B");
+    strcpy(five, "0xff");
+    strcpy(six, "-D");
+    strcpy(seven, "0xff");
+    strcpy(eight, "-F");
+    strcpy(nine, "7");
+    strcpy(ten, "56:78.7");
+
+    EXPECT_EQ(set_properties_from_args(filter, &result, &argc, argv), 0);
+
+    uint16_t segment = 0xff;
+    uint8_t bus = 0;
+    uint8_t device = 0;
+    uint8_t function = 0;
+
+    EXPECT_EQ(fpgaPropertiesGetSegment(filter, &segment), FPGA_OK);
+    EXPECT_EQ(segment, 0);
+
+    EXPECT_EQ(fpgaPropertiesGetBus(filter, &bus), FPGA_OK);
+    EXPECT_EQ(bus, 0x56);
+
+    EXPECT_EQ(fpgaPropertiesGetDevice(filter, &device), FPGA_OK);
+    EXPECT_EQ(device, 0x78);
+
+    EXPECT_EQ(fpgaPropertiesGetFunction(filter, &function), FPGA_OK);
+    EXPECT_EQ(function, 7);
+
+    EXPECT_EQ(fpgaDestroyProperties(&filter), FPGA_OK);
+    EXPECT_EQ(result, 0);
 }
 
 INSTANTIATE_TEST_CASE_P(argsfilter_c, argsfilter_c_p,

--- a/tools/argsfilter/argsfilter.c
+++ b/tools/argsfilter/argsfilter.c
@@ -119,8 +119,7 @@ STATIC bool get_pci_address(const char *addr,
 		if ((res) != FPGA_OK) {                                        \
 			optind = 1;                                            \
 			opterr = old_opterr;                                   \
-			fprintf(stderr, "Error %s: %s\n", (desc),              \
-				fpgaErrStr(res));                              \
+			OPAE_ERR("%s: %s\n", (desc), fpgaErrStr(res));         \
 			return EX_SOFTWARE;                                    \
 		}                                                              \
 	} while (0)
@@ -172,8 +171,7 @@ int set_properties_from_args(fpga_properties filter, fpga_result *result,
 			args_filter_config.bus =
 				(int)strtoul(tmp_optarg, &endptr, 0);
 			if (endptr != tmp_optarg + strlen(tmp_optarg)) {
-				fprintf(stderr, "invalid bus: %s\n",
-					tmp_optarg);
+				OPAE_ERR("invalid bus: %s\n", tmp_optarg);
 				return EX_USAGE;
 			}
 			found_opts[next_found++] = optind - 2;
@@ -186,8 +184,7 @@ int set_properties_from_args(fpga_properties filter, fpga_result *result,
 			args_filter_config.device =
 				(int)strtoul(tmp_optarg, &endptr, 0);
 			if (endptr != tmp_optarg + strlen(tmp_optarg)) {
-				fprintf(stderr, "invalid device: %s\n",
-					tmp_optarg);
+				OPAE_ERR("invalid device: %s\n", tmp_optarg);
 				return EX_USAGE;
 			}
 			found_opts[next_found++] = optind - 2;
@@ -200,8 +197,7 @@ int set_properties_from_args(fpga_properties filter, fpga_result *result,
 			args_filter_config.function =
 				(int)strtoul(tmp_optarg, &endptr, 0);
 			if (endptr != tmp_optarg + strlen(tmp_optarg)) {
-				fprintf(stderr, "invalid function: %s\n",
-					tmp_optarg);
+				OPAE_ERR("invalid function: %s\n", tmp_optarg);
 				return EX_USAGE;
 			}
 			found_opts[next_found++] = optind - 2;
@@ -214,14 +210,13 @@ int set_properties_from_args(fpga_properties filter, fpga_result *result,
 			args_filter_config.segment =
 				(int)strtoul(tmp_optarg, &endptr, 0);
 			if (endptr != tmp_optarg + strlen(tmp_optarg)) {
-				fprintf(stderr, "invalid segment: %s\n",
-					tmp_optarg);
+				OPAE_ERR("invalid segment: %s\n", tmp_optarg);
 				return EX_USAGE;
 			}
 			found_opts[next_found++] = optind - 2;
 			break;
 		case ':': /* missing option argument */
-			fprintf(stderr, "Missing option argument\n");
+			OPAE_ERR("Missing option argument\n");
 			return EX_USAGE;
 
 		case '?':
@@ -229,7 +224,7 @@ int set_properties_from_args(fpga_properties filter, fpga_result *result,
 		case 1:
 			break;
 		default: /* invalid option */
-			fprintf(stderr, "Invalid cmdline options\n");
+			OPAE_ERR("Invalid cmdline options\n");
 			return EX_USAGE;
 		}
 	}

--- a/tools/argsfilter/argsfilter.c
+++ b/tools/argsfilter/argsfilter.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -23,10 +23,18 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
 #include "argsfilter.h"
 #include <getopt.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
+#include <regex.h>
+
 #ifdef _WIN32
 #define EX_OK 0
 #define EX_USAGE (-1)
@@ -34,6 +42,106 @@
 #else
 #include <sysexits.h>
 #endif
+
+struct _args_filter_config {
+	int segment;
+	int bus;
+	int device;
+	int function;
+};
+
+STATIC bool get_pci_address(const char *addr,
+			    struct _args_filter_config *c)
+{
+	regex_t re;
+	regmatch_t matches[5];
+
+	//           11
+	// 012345678901
+	// ssss:bb:dd.f
+	char address[32];
+
+	const char *sbdf = "([0-9a-fA-F]{4}):"
+			   "([0-9a-fA-F]{2}):"
+			   "([0-9a-fA-F]{2})\\."
+			   "([0-7])";
+
+	const char *bdf = "([0-9a-fA-F]{2}):"
+			  "([0-9a-fA-F]{2})\\."
+			  "([0-7])";
+
+	bool is_match = false;
+
+	size_t len = strlen(addr);
+
+	if (len > 12)
+		return false;
+
+	memcpy(address, addr, len + 1);
+	address[len] = '\0';
+
+	memset(matches, 0, sizeof(matches));
+	regcomp(&re, sbdf, REG_EXTENDED);
+
+	if (regexec(&re,
+		    address,
+		    sizeof(matches) / sizeof(matches[0]),
+		    matches,
+		    0) == 0) {
+		is_match = true;
+	}
+
+	regfree(&re);
+
+	if (is_match) {
+		address[matches[1].rm_eo] = '\0';
+		c->segment = (int) strtoul(&address[matches[1].rm_so],
+					   NULL, 16);
+
+		address[matches[2].rm_eo] = '\0';
+		c->bus = (int) strtoul(&address[matches[2].rm_so],
+				       NULL, 16);
+
+		address[matches[3].rm_eo] = '\0';
+		c->device = (int) strtoul(&address[matches[3].rm_so],
+					  NULL, 16);
+
+		c->function = (int) strtoul(&address[matches[4].rm_so],
+					    NULL, 10);
+		return true;
+	}
+
+	memset(matches, 0, sizeof(matches));
+	regcomp(&re, bdf, REG_EXTENDED);
+
+	if (regexec(&re,
+		    address,
+		    sizeof(matches) / sizeof(matches[0]),
+		    matches,
+		    0) == 0) {
+		is_match = true;
+	}
+
+	regfree(&re);
+
+	if (is_match) {
+		c->segment = 0;
+
+		address[matches[1].rm_eo] = '\0';
+		c->bus = (int) strtoul(&address[matches[1].rm_so],
+				       NULL, 16);
+
+		address[matches[2].rm_eo] = '\0';
+		c->device = (int) strtoul(&address[matches[2].rm_so],
+					  NULL, 16);
+
+		c->function = (int) strtoul(&address[matches[3].rm_so],
+					    NULL, 10);
+		return true;
+	}
+
+	return false;
+}
 
 #define RETURN_ON_ERR(res, desc)                                               \
 	do {                                                                   \
@@ -53,30 +161,29 @@ int set_properties_from_args(fpga_properties filter, fpga_result *result,
 	// ignored
 	const char *short_opts = "-:B:D:F:S:";
 	struct option longopts[] = {
-		{"bus", required_argument, NULL, 'B'},
-		{"device", required_argument, NULL, 'D'},
-		{"function", required_argument, NULL, 'F'},
-		{"socket-id", required_argument, NULL, 'S'},
-		{"segment", required_argument, NULL, 0xe},
+		{ "segment",  required_argument, NULL, 'S'},
+		{ "bus",      required_argument, NULL, 'B'},
+		{ "device",   required_argument, NULL, 'D'},
+		{ "function", required_argument, NULL, 'F'},
 		{0, 0, 0, 0},
 	};
 	int supported_options = sizeof(longopts) / sizeof(longopts[0]) - 1;
 	int getopt_ret = -1;
 	int option_index = 0;
 	char *endptr = NULL;
-	int found_opts[] = {0, 0, 0, 0, 0};
+	int found_opts[] = {0, 0, 0, 0 };
 	int next_found = 0;
-	int old_opterr = opterr;
+	int old_opterr;
+
+	struct _args_filter_config args_filter_config = {
+		.segment = -1,
+		.bus = -1,
+		.device = -1,
+		.function = -1
+	};
+
+	old_opterr = opterr;
 	opterr = 0;
-	struct _args_filter_config {
-		int bus;
-		int device;
-		int function;
-		int socket_id;
-		int segment;
-	} args_filter_config = {
-		.bus = -1, .device = -1, .function = -1, .socket_id = -1,
-		.segment = -1 };
 
 	while (-1
 	       != (getopt_ret = getopt_long(*argc, argv, short_opts, longopts,
@@ -129,20 +236,7 @@ int set_properties_from_args(fpga_properties filter, fpga_result *result,
 			found_opts[next_found++] = optind - 2;
 			break;
 
-		case 'S': /* socket */
-			if (NULL == tmp_optarg)
-				break;
-			endptr = NULL;
-			args_filter_config.socket_id =
-				(int)strtoul(tmp_optarg, &endptr, 0);
-			if (endptr != tmp_optarg + strlen(tmp_optarg)) {
-				fprintf(stderr, "invalid socket: %s\n",
-					tmp_optarg);
-				return EX_USAGE;
-			}
-			found_opts[next_found++] = optind - 2;
-			break;
-		case 0xe: /* segment */
+		case 'S': /* segment */
 			if (NULL == tmp_optarg)
 				break;
 			endptr = NULL;
@@ -169,33 +263,6 @@ int set_properties_from_args(fpga_properties filter, fpga_result *result,
 		}
 	}
 
-	if (-1 != args_filter_config.bus) {
-		*result = fpgaPropertiesSetBus(filter, args_filter_config.bus);
-		RETURN_ON_ERR(*result, "setting bus");
-	}
-	if (-1 != args_filter_config.device) {
-		*result = fpgaPropertiesSetDevice(filter,
-						  args_filter_config.device);
-		RETURN_ON_ERR(*result, "setting device");
-	}
-
-	if (-1 != args_filter_config.function) {
-		*result = fpgaPropertiesSetFunction(
-			filter, args_filter_config.function);
-		RETURN_ON_ERR(*result, "setting function");
-	}
-
-	if (-1 != args_filter_config.socket_id) {
-		*result = fpgaPropertiesSetSocketID(
-			filter, args_filter_config.socket_id);
-		RETURN_ON_ERR(*result, "setting socket id");
-	}
-
-	if (-1 != args_filter_config.segment) {
-		*result = fpgaPropertiesSetSegment(
-			filter, args_filter_config.segment);
-		RETURN_ON_ERR(*result, "setting segment");
-	}
 	// using the list of optind values
 	// shorten the argv vector starting with a decrease
 	// of 2 and incrementing that amount by two for each option found
@@ -212,6 +279,35 @@ int set_properties_from_args(fpga_properties filter, fpga_result *result,
 		}
 	}
 	*argc -= removed;
+
+	for (i = 0 ; i < *argc ; ++i) {
+		if (get_pci_address(argv[i], &args_filter_config)) {
+			break;
+		}
+	}
+
+	if (-1 != args_filter_config.segment) {
+		*result = fpgaPropertiesSetSegment(
+			filter, args_filter_config.segment);
+		RETURN_ON_ERR(*result, "setting segment");
+	}
+
+	if (-1 != args_filter_config.bus) {
+		*result = fpgaPropertiesSetBus(filter, args_filter_config.bus);
+		RETURN_ON_ERR(*result, "setting bus");
+	}
+	if (-1 != args_filter_config.device) {
+		*result = fpgaPropertiesSetDevice(filter,
+						  args_filter_config.device);
+		RETURN_ON_ERR(*result, "setting device");
+	}
+
+	if (-1 != args_filter_config.function) {
+		*result = fpgaPropertiesSetFunction(
+			filter, args_filter_config.function);
+		RETURN_ON_ERR(*result, "setting function");
+	}
+
 	// restore getopt variables
 	// setting optind to zero will cause getopt to reinitialize for future
 	// calls within the program

--- a/tools/argsfilter/argsfilter.c
+++ b/tools/argsfilter/argsfilter.c
@@ -50,7 +50,7 @@ struct _args_filter_config {
 	int function;
 };
 
- bool get_pci_address(const char *addr,
+STATIC bool get_pci_address(const char *addr,
 			    struct _args_filter_config *c)
 {
 	regex_t re;


### PR DESCRIPTION
In addition to allowing -S, -B, -D, -F, refactor
set_properties_from_args() so that it also recognizes the PCIe
address forms ssss:bb:dd.f and bb:dd.f. The address forms
are given precedence over the options.

eg fpgainfo fme -B 0xff -D 0xff -F 7 12:34.5
will set the properties as
segment  == 0
bus      == 0x12
device   == 0x34
function == 5

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>