### PR TITLE
opae-sdk: udpate opae-legacy release tag and fix spec file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ option(OPAE_BUILD_LEGACY "Enable building of OPAE legacy tools" OFF)
 mark_as_advanced(OPAE_BUILD_LEGACY)
 
 if(OPAE_BUILD_LEGACY)
-    set(OPAE_LEGACY_TAG "release/2.0.0" CACHE STRING "Desired branch for opae-legacy")
+    set(OPAE_LEGACY_TAG "2.0.0-2" CACHE STRING "Desired branch for opae-legacy")
     mark_as_advanced(OPAE_LEGACY_TAG)
 endif(OPAE_BUILD_LEGACY)
 

--- a/opae.spec.in
+++ b/opae.spec.in
@@ -121,16 +121,16 @@ mv %_topdir/tmpBRoot $RPM_BUILD_ROOT
 
 prev=$PWD
 pushd @CMAKE_SOURCE_DIR@/python/opae.admin
-%{__python3} setup.py install --single-version-externally-managed -O@CPACK_PACKAGE_RELEASE@ --root=$RPM_BUILD_ROOT --record=$prev/INSTALLED_FILES
+%{__python3} setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=$prev/INSTALLED_FILES
 popd
 
 pushd @CMAKE_SOURCE_DIR@/python/pacsign
-%{__python3} setup.py install --single-version-externally-managed -O@CPACK_PACKAGE_RELEASE@ --root=$RPM_BUILD_ROOT --record=$prev/INSTALLED_PACSIGN_FILES
+%{__python3} setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=$prev/INSTALLED_PACSIGN_FILES
 popd
 
 
 pushd @CMAKE_SOURCE_DIR@/tools/extra/fpgadiag/
-%{__python3} setup.py install --single-version-externally-managed -O@CPACK_PACKAGE_RELEASE@ --root=$RPM_BUILD_ROOT --record=$prev/INSTALLED_FPGADIAG_FILES
+%{__python3} setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=$prev/INSTALLED_FPGADIAG_FILES
 popd
 
 install -m 755 @CMAKE_SOURCE_DIR@/scripts/eth_group_mdev.sh %{buildroot}/usr/bin/eth_group_mdev.sh


### PR DESCRIPTION
  - udpate opae-legacy release tag 2.0.0-2
  - fix  release patch in spec file

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>