### PR TITLE
tools: support fpgainfo for iofs bitstream deviceid

### DIFF
--- a/tools/fpgainfo/board.c
+++ b/tools/fpgainfo/board.c
@@ -62,6 +62,7 @@ static platform_data platform_data_table[] = {
 	{ 0x8086, 0x0b31, "libboard_n3000.so", NULL },
 	{ 0x8086, 0x0b2b, "libboard_d5005.so", NULL },
 	{ 0x8086, 0x0b2c, "libboard_d5005.so", NULL },
+	{ 0x8086, 0xaf00, "libboard_d5005.so", NULL },
 	{ 0,      0,          NULL, NULL },
 };
 

--- a/tools/fpgainfo/errors.c
+++ b/tools/fpgainfo/errors.c
@@ -500,7 +500,7 @@ fpga_result errors_command(fpga_token *tokens, int num_tokens, int argc,
 
 	int i = 0;
 	for (i = 0; i < num_tokens; ++i) {
-		uint32_t num_errors;
+		uint32_t num_errors = 0;
 
 		res = fpgaGetProperties(tokens[i], &props);
 		if (res == FPGA_OK) {


### PR DESCRIPTION
 - add support 0xaf00 deviceid to fpgainfo board enumeration  list
 - iofs release1 bitstream can program on D5005 card

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>