### PR TITLE
cmake: set minimum version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 3.10)
 project(opae)
 
 set(OPAE_SDK_SOURCE ${CMAKE_CURRENT_SOURCE_DIR} CACHE PATH "Root directory of opae-sdk project" FORCE)

--- a/afu-test/CMakeLists.txt
+++ b/afu-test/CMakeLists.txt
@@ -26,23 +26,18 @@
 cmake_minimum_required (VERSION  3.10)
 
 project(afu-test)
-opae_add_shared_library(TARGET afu-test
-    SOURCE afu_test.cpp
-    VERSION ${OPAE_VERSION}
-    SOVERSION ${OPAE_VERSION_MAJOR}
-    COMPONENT afutest
-)
+add_library(afu-test INTERFACE)
 
-target_include_directories(afu-test PUBLIC
+target_include_directories(afu-test INTERFACE
     ${OPAE_INCLUDE_PATHS}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CLI11_ROOT}/include
     ${spdlog_ROOT}/include
 )
-target_link_libraries(afu-test PUBLIC
+target_link_libraries(afu-test INTERFACE
     opae-c opae-cxx-core
 )
-target_compile_options(afu-test PUBLIC
+target_compile_options(afu-test INTERFACE
     -Wno-unused-result
 )
 

--- a/afu-test/CMakeLists.txt
+++ b/afu-test/CMakeLists.txt
@@ -23,7 +23,7 @@
 ## CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION  3.10)
 
 project(afu-test)
 opae_add_shared_library(TARGET afu-test

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION  3.10)
 
 set(CLI11_URL
     https://github.com/CLIUtils/CLI11.git

--- a/opae.spec.in
+++ b/opae.spec.in
@@ -173,7 +173,6 @@ ldconfig
 @CMAKE_INSTALL_PREFIX@/@OPAE_LIB_INSTALL_DIR@/opae/libxfpga.so*
 @CMAKE_INSTALL_PREFIX@/@OPAE_LIB_INSTALL_DIR@/opae/libmodbmc.so
 @CMAKE_INSTALL_PREFIX@/@OPAE_LIB_INSTALL_DIR@/libbitstream.so*
-@CMAKE_INSTALL_PREFIX@/@OPAE_LIB_INSTALL_DIR@/libafu-test.so*
 
 
 %files devel -f devel-files.txt

--- a/platforms/scripts/CMakeLists.txt
+++ b/platforms/scripts/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION  3.10)
 #include(packaging)
 
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION  3.10)
 
 project(python)
 

--- a/python/opae.admin/CMakeLists.txt
+++ b/python/opae.admin/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION  3.10)
 
 # projectname is the same as the main-executable
 project(opae.admin)

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -7,7 +7,7 @@ mkdir -p unittests
 cd unittests
 
 if [ ! -f CMakeCache.txt ]; then
-    cmake .. -DOPAE_PYTHON_VERSION=3.6 \
+    cmake .. -DOPAE_PYTHON_VERSION=3 \
              -DCMAKE_BUILD_TYPE=Coverage \
              -DOPAE_BUILD_LIBOPAE_CXX=ON \
              -DOPAE_BUILD_TESTS=ON \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION  3.10)
 
 project(testing)
 

--- a/tools/extra/packager/CMakeLists.txt
+++ b/tools/extra/packager/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION  3.10)
 #include(packaging)
 
 ## Install target for jsonschema files


### PR DESCRIPTION
* set cmake minimum version to 3.10
* change afu-test to an interface (header-only) library where client libraries/applications inherit compiler/linker options when linking with afu-test.