### PR TITLE
cmake, rpm spec: fix straggling BUILD_ASE usage

### DIFF
--- a/opae.spec.in
+++ b/opae.spec.in
@@ -1,5 +1,5 @@
 # -*- rpm-spec -*-
-%define with_ase "@BUILD_ASE@"
+%define with_ase "@OPAE_BUILD_SIM@"
 
 BuildRoot:      %_topdir/@CPACK_PACKAGE_FILE_NAME@
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -60,9 +60,9 @@ endif()
 ######################################################################
 # Client application #################################################
 ######################################################################
-if(BUILD_ASE)
+if(OPAE_BUILD_SIM)
   add_definitions(-DTEST_TIMEOUT=130000000)
-endif()
+endif(OPAE_BUILD_SIM)
 
 opae_add_subdirectory(hello_fpga)
 opae_add_subdirectory(hello_events)


### PR DESCRIPTION
Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>