### PR TITLE
PACSign: change default hash size to 256

### DIFF
--- a/python/pacsign/PACSign.md
+++ b/python/pacsign/PACSign.md
@@ -117,9 +117,9 @@ specifies which of the slots to which this bitstream is to be acted upon.
 
 User-formatted version information. This can be any string up to 32 bytes in length.
 
-`-S, --SHA256`
+`-S, --SHA384`
 
-Used to specify that PACSign is to use 256-bit crypto.  Default is 384-bit.
+Used to specify that PACSign is to use 384-bit crypto.  Default is 256-bit.
 
 `-R, --ROOT_BITSTREAM <root_bitstream>`
 
@@ -218,3 +218,4 @@ images that CSK 4 signed.
  | 2019.10.04 | 2.0.1 Beta. <br>(Supported with Intel Quartus Prime Pro Edition 19.2.) | Editorial changes only. |
  | 2020.12.16 | 2.0.1 Beta. <br>(Supported with Intel Quartus Prime Pro Edition 19.2.) | Added -S; default SHA384. |
  | 2021.02.02 | 2.0.1 Beta. <br>(Supported with Intel Quartus Prime Pro Edition 19.2.) | Added -s, -b; Added more bitstream types. |
+ | 2021.02.17 | 2.0.1 Beta. <br>(Supported with Intel Quartus Prime Pro Edition 19.2.) | Default to 256-bit crypto. |

--- a/python/pacsign/pacsign/pacsign.py
+++ b/python/pacsign/pacsign/pacsign.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019, Intel Corporation
+# Copyright(c) 2019-2021, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -57,8 +57,8 @@ def get_manager_names(append_manager=True):
 def add_common_options(parser):
     parser.add_argument(
         "-S",
-        "--SHA256",
-        help="Generate 256-bit signatures (384-bit default)",
+        "--SHA384",
+        help="Generate 384-bit signatures (256-bit default)",
         action="store_true",
     )
     parser.add_argument(

--- a/python/pacsign/pacsign/reader.py
+++ b/python/pacsign/pacsign/reader.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019-2020, Intel Corporation
+# Copyright(c) 2019-2021, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -70,7 +70,7 @@ class _READER_BASE(object):
         log.debug(self.bitstream_type)
         self.root_hash = common_util.BYTE_ARRAY()
         self.s10_root_hash = common_util.BYTE_ARRAY()
-        cinfo = database.get_curve_info_from_name("secp256r1" if args.SHA256 else "secp384r1")
+        cinfo = database.get_curve_info_from_name("secp384r1" if args.SHA384 else "secp256r1")
         self.curve_magic_num = cinfo.curve_magic_num
         self.dc_curve_magic_num = cinfo.dc_curve_magic_num
         self.dc_sig_hash_magic_num = cinfo.dc_sig_hash_magic_num
@@ -195,15 +195,15 @@ class _READER_BASE(object):
         root_entry.append_data(root_body.data)
 
         log.info("Calculating Root Entry SHA")
-        if self.args.SHA256:
-            sha = sha256(root_body.data).digest()
-            self.root_hash.append_data(sha)
-            sha = sha256(pub_key.data).digest()
-            self.s10_root_hash.append_data(sha)
-        else:
+        if self.args.SHA384:
             sha = sha384(root_body.data).digest()
             self.root_hash.append_data(sha)
             sha = sha384(pub_key.data).digest()
+            self.s10_root_hash.append_data(sha)
+        else:
+            sha = sha256(root_body.data).digest()
+            self.root_hash.append_data(sha)
+            sha = sha256(pub_key.data).digest()
             self.s10_root_hash.append_data(sha)
         del sha
 
@@ -232,7 +232,7 @@ class _READER_BASE(object):
         xy_body.append_data(pub_key.data[-self.sigsize:])
 
         log.info("Calculating Root Entry SHA for DC PR")
-        sha = sha256(pub_key.data).digest() if self.args.SHA256 else sha384(pub_key.data).digest()
+        sha = sha384(pub_key.data).digest() if self.args.SHA384 else sha256(pub_key.data).digest()
         self.s10_root_hash.append_data(sha)
         sha_msb = sha[0:4]  # get first 4 bytes
         del sha
@@ -315,7 +315,7 @@ class _READER_BASE(object):
 
         log.info("Calculating Code Signing Key Entry SHA")
         if root_key is not None:
-            sha = sha256(csk_body.data).digest() if self.args.SHA256 else sha384(csk_body.data).digest()
+            sha = sha384(csk_body.data).digest() if self.args.SHA384 else sha256(csk_body.data).digest()
 
             rs = self.hsm_manager.sign(sha, root_key)
             del sha
@@ -405,7 +405,7 @@ class _READER_BASE(object):
 
         # Calculate the signature and append to the block
         if root_key is not None:
-            sha = sha256(csk_body.data).digest() if self.args.SHA256 else sha384(csk_body.data).digest()
+            sha = sha384(csk_body.data).digest() if self.args.SHA384 else sha256(csk_body.data).digest()
 
             rs = self.hsm_manager.sign(sha, root_key)
             del sha
@@ -431,7 +431,7 @@ class _READER_BASE(object):
 
         log.info("Calculating Block 0 Entry SHA")
         if CSK_key is not None:
-            sha = sha256(block0.data).digest() if self.args.SHA256 else sha384(block0.data).digest()
+            sha = sha384(block0.data).digest() if self.args.SHA384 else sha256(block0.data).digest()
 
             rs = self.hsm_manager.sign(sha, CSK_key)
             del sha
@@ -486,7 +486,7 @@ class _READER_BASE(object):
 
         # Signature R & S
         if CSK_key is not None:
-            sha = sha256(block0.data).digest() if self.args.SHA256 else sha384(block0.data).digest()
+            sha = sha384(block0.data).digest() if self.args.SHA384 else sha256(block0.data).digest()
             rs = self.hsm_manager.sign(sha, CSK_key)
             del sha
             b0_entry.append_data(rs.data[:self.sigsize])


### PR DESCRIPTION
Change -S,--SHA256 to -S,--SHA384. ie, the default is 256-bit
signatures. 384-bit signatures are enabled only by specifying
the flags -S or --SHA384.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>