### PR TITLE
fpgadiag: fix finding of entrypoint dir

### DIFF
--- a/tools/extra/fpgadiag/opae/diag/fpgadiag.py
+++ b/tools/extra/fpgadiag/opae/diag/fpgadiag.py
@@ -28,9 +28,10 @@
 import os
 import argparse
 import subprocess
+import sys
 from subprocess import CalledProcessError
 
-cwd = os.path.dirname(os.path.realpath(__file__))
+cwd = os.path.dirname(sys.argv[0])
 cmd_list = ['lpbk1', 'read', 'write', 'trput', 'sw',
             'fvlbypass', 'fpgalpbk', 'mactest', 'fpgastats', 'fpgamac']
 cmd_map = {'lpbk1': ['nlb0'],


### PR DESCRIPTION
now that fpgadiag is installed as a Python package, the fpgadiag
entrypoint calls the fpgadiag module which in turns calls the underlying
executable. Because the fpgadiag module is installed in the Python
site-pacakges area, we can't rely on using dirname of __file__ anymore.
We should instead use sys.argv[0] to determine the entrypoint and then
get its directory.