### PR TITLE
fpgainfo: security command to be compatible with sysfs subdirectory i…

### DIFF
--- a/tools/libboard/board_common/board_common.c
+++ b/tools/libboard/board_common/board_common.c
@@ -44,8 +44,8 @@
 
 #include "board_common.h"
 
-#define DFL_SYSFS_SEC_GLOB "dfl*/*spi*/spi_master/spi*/spi*/*/*/*/security/"
-#define DFL_SYSFS_SEC_USER_FLASH_COUNT         DFL_SYSFS_SEC_GLOB "user_flash_count"
+#define DFL_SYSFS_SEC_GLOB "dfl*/*spi*/spi_master/spi*/spi*/*/security/"
+#define DFL_SYSFS_SEC_USER_FLASH_COUNT         DFL_SYSFS_SEC_GLOB "flash_count"
 #define DFL_SYSFS_SEC_BMC_CANCEL               DFL_SYSFS_SEC_GLOB "bmc_canceled_csks"
 #define DFL_SYSFS_SEC_BMC_ROOT                 DFL_SYSFS_SEC_GLOB "bmc_root_entry_hash"
 #define DFL_SYSFS_SEC_PR_CANCEL                DFL_SYSFS_SEC_GLOB "pr_canceled_csks"


### PR DESCRIPTION
…n linux-dfl 5.10.16

In linux-dfl branch fpga-ofs-dev-5.10-lts, the security subdirectory moved out of the class driver and into the
device-specific parent driver. The sysfs path and flash_count is modified to support kernel modifications.

Signed-off-by: dbiswas-dev <debaratix.biswas@intel.com>