### PR TITLE
opae.io: use opae_python_install in cmake

### DIFF
--- a/opae.spec.in
+++ b/opae.spec.in
@@ -122,13 +122,6 @@ pushd @CMAKE_SOURCE_DIR@/python/pacsign
 %{__python3} setup.py install --single-version-externally-managed -O@CPACK_PACKAGE_RELEASE@ --root=$RPM_BUILD_ROOT --record=$prev/INSTALLED_PACSIGN_FILES
 popd
 
-
-pushd @CMAKE_SOURCE_DIR@/python/opae.io
-%{__python3} setup.py install --single-version-externally-managed %-O@CPACK_PACKAGE_RELEASE@ --root=$RPM_BUILD_ROOT --record=$prev/OPAEIO_INSTALLED_FILES
-cat $prev/OPAEIO_INSTALLED_FILES >> $prev/devel-files.txt
-popd
-
-
 %clean
 
 

--- a/python/opae.io/CMakeLists.txt
+++ b/python/opae.io/CMakeLists.txt
@@ -28,10 +28,10 @@ if(PLATFORM_SUPPORTS_VFIO)
 
     set(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/timestamp)
     file(GLOB_RECURSE PKG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/opae/*)
-    
+
     set(INCLUDE_DIRS "${OPAE_INCLUDE_PATH}:${pybind11_ROOT}/include:${OPAE_SDK_SOURCE}/tools/extra/opae.io")
     set(LINK_DIRS "${LIBRARY_OUTPUT_PATH}")
-    
+
     add_custom_command(
         OUTPUT ${OUTPUT}
         COMMAND ${PYTHON_EXECUTABLE} setup.py build_ext -I ${INCLUDE_DIRS} -L ${LINK_DIRS}
@@ -39,14 +39,12 @@ if(PLATFORM_SUPPORTS_VFIO)
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         DEPENDS setup.py ${PKG_FILES}
     )
-    
-    add_custom_target(opae.io-package ALL DEPENDS opaevfio opae.io ${OUTPUT})
-    install(
-        CODE "execute_process(
-            COMMAND ${PYTHON_EXECUTABLE} setup.py install
-    	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    	)"
-        COMPONENT opae.io
-    )
 
+    add_custom_target(opae.io-build ALL DEPENDS opaevfio opae.io ${OUTPUT})
+    opae_python_install(
+        COMPONENT opae.io
+        RECORD_FILE opae.io-install.txt
+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+        RPM_PACKAGE devel
+    )
 endif(PLATFORM_SUPPORTS_VFIO)

--- a/tools/extra/opae.io/CMakeLists.txt
+++ b/tools/extra/opae.io/CMakeLists.txt
@@ -38,7 +38,7 @@ if(PLATFORM_SUPPORTS_VFIO)
     else()
         target_link_libraries(opae.io PRIVATE ${PYTHON_LIBRARIES} dl util ${libedit_LIBRARIES} opaevfio)
     endif()
-    
+
     target_include_directories(opae.io
         PUBLIC ${OPAE_INCLUDE_DIR}
         PRIVATE ${PYTHON_INCLUDE_DIRS}
@@ -51,5 +51,5 @@ if(PLATFORM_SUPPORTS_VFIO)
             RUNTIME DESTINATION bin
             COMPONENT opae.io
     )
-    
+
 endif(PLATFORM_SUPPORTS_VFIO)


### PR DESCRIPTION
* Replace regular cmake install directive with opae_python_install
* Remove install step in legacy RPM spec file template (opae.spec.in)
* Cleanup whitespace...