### PR TITLE
docs: remove opaeuio doc

### DIFF
--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -178,7 +178,7 @@ man_pages = [
     ("docs/fpga_tools/mmlink/mmlink", 'mmlink', u'Enable remote SignalTAP debugging', [author], 8),
     ("docs/fpga_tools/hssi/hssi", 'hssi', u'High Speed Serial Interface', [author], 8),
     ("docs/fpga_tools/opaevfio/opaevfio", 'opaevfio', u'Bind/Unbind accelerator to/from vfio-pci', [author], 8),
-    ("docs/fpga_tools/opaeuio/opaeuio", 'opaeuio', u'Bind/Unbind DFL device to/from dfl-uio-pdev', [author], 8),
+    #("docs/fpga_tools/opaeuio/opaeuio", 'opaeuio', u'Bind/Unbind DFL device to/from dfl-uio-pdev', [author], 8),
     ("docs/fpga_tools/userclk/userclk", 'userclk', u'Set AFU high and low clock frequency', [author], 8),
     ("docs/fpga_tools/pci_device/pci_device", 'pci_device', u'Common operations for PCIe devices', [author], 8),
     ("docs/fpga_tools/opae.io/opae.io", 'opae.io', u'User space access to PCIe devices', [author], 8),

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -129,14 +129,11 @@ latex_elements = {
 quick_start_doc = 'docs/fpga_api/quick_start/readme'
 prog_guide_doc = 'docs/fpga_api/prog_guide/readme'
 drv_arch_doc = 'docs/drv_arch/drv_arch'
-#hssi_config_doc = 'docs/fpga_tools/hssi_config/readme'
-#hssi_loopback_doc = 'docs/fpga_tools/hssi_loopback/readme'
 hssi_tuner_doc = 'docs/fpga_tools/mhssi_tuner/readme'
 alaska_fw_loader_doc = 'docs/fpga_tools/alaska_fw_loader/readme'
 fpga_tools_doc = 'docs/fpga_tools/readme'
 ase_userguide_doc = 'docs/ase_userguide/ase_userguide'
 api_build_doc = 'docs/build_chain/fpga_api/api_build'
-#driver_build_doc = 'docs/build_chain/fpga_driver/driver_build'
 install_guide_doc = 'docs/install_guide/installation_guide'
 
 
@@ -144,14 +141,10 @@ latex_documents = [
     (quick_start_doc, 'quick_start.tex', u'Intel FPGA Quick Start Guide', u'FPT SW Development Team', 'howto'),
     (prog_guide_doc, 'prog_guide.tex', u'Intel FPGA Programming Guide', u'FPT SW Development Team', 'howto'),
     (fpga_tools_doc, 'fpga_tools.tex', u'Intel FPGA Tools', u'FPT SW Development Team', 'howto'),
-    # (fpgainfo_doc, 'fpgainfo.tex', u'fpgainfo', u'FPT SW Development Team', 'howto'),
     (ase_userguide_doc, 'ase_userguide.tex', u'Intel AFU Simulation Environment (ASE) User Guide', u'FPT SW Development Team', 'howto'),
     (api_build_doc, 'api_build.tex', u'apiBuild', u'FPT SW Development Team', 'howto'),
-    # (driver_build_doc, 'driver_build.tex', u'Building the Intel FPGA driver', u'FPT SW Development Team', 'howto'),
     (install_guide_doc, 'install_guide.tex', u'Intel FPGA Software Stack Installation Guide', u'FPT SW Development Team', 'howto'),
     (drv_arch_doc, 'drv_arch.tex', u'FPGA Driver Architecture', u'FPT SW Development Team', 'manual'),
-    # (hssi_config_doc, 'hssi_config.tex', u'HSSI config manual', u'FPT SW Development Team', 'howto'),
-    # (hssi_loopback_doc, 'hssi_loopback.tex', u'HSSI loopback manual', u'FPT SW Development Team', 'manual'),
     ]
 
 # -- Options for manual page output ---------------------------------------
@@ -163,22 +156,15 @@ man_pages = [
 #     [author], 1),
     ("docs/fpga_tools/fpgabist/fpgabist", 'fpgabist', u'Perform self-diagnostic tests on supported FPGA platforms', [author], 8),
     ("docs/fpga_tools/fpgaport/fpgaport", 'fpgaport', u'Enable/Disable virtualization', [author], 8),
-    #("docs/fpga_tools/fpgaflash/fpgaflash", 'fpgaflash', u'Update static FIM image loaded from flash at power-on', [author], 8),
-    #("docs/fpga_tools/fpgaflash/superrsu", 'super-rsu', u'Flash image files and command an Intel PAC device to perform RSU', [author], 8),
-    #("docs/fpga_tools/coreidle/coreidle", 'coreidle', u'Adjust number of active cores to account for FPGA power consumption', [author], 8),
     ("docs/fpga_tools/fpgaconf/fpgaconf", 'fpgaconf', u'Configure green bitstreams to an FPGA', [author], 8),
     ("docs/fpga_tools/fpgad/fpgad", 'fpgad', u'Log errors and generate events', [author], 8),
     ("docs/fpga_tools/fpgadiag/README", 'fpgadiag', u'FPGA diagnosis and testing tool', [author], 8),
     ("docs/fpga_tools/fpgainfo/fpgainfo", 'fpgainfo', u'FPGA information tool', [author], 8),
     ("docs/fpga_tools/fpgasupdate/fpgasupdate", 'fpgasupdate', u'FPGA Secure Update tool', [author], 8),
-    #("docs/fpga_tools/fpgamux/fpgamux", 'fpgamux', u'Software MUX for running multiple AFU tests in one GBS', [author], 8),
     ("docs/fpga_tools/pac_hssi_config/pac_hssi_config", 'pac_hssi_config', u'Access Ethernet transceivers for designs', [author], 8),
-    #("docs/fpga_tools/hssi_loopback/readme", 'hssi_loopback', u'Interact with a packet generator GBS', [author], 8),
-    #("docs/fpga_tools/hssi_config/readme", 'hssi_config', u'Read from or write to HSSI registers', [author], 8),
     ("docs/fpga_tools/mmlink/mmlink", 'mmlink', u'Enable remote SignalTAP debugging', [author], 8),
     ("docs/fpga_tools/hssi/hssi", 'hssi', u'High Speed Serial Interface', [author], 8),
     ("docs/fpga_tools/opaevfio/opaevfio", 'opaevfio', u'Bind/Unbind accelerator to/from vfio-pci', [author], 8),
-    #("docs/fpga_tools/opaeuio/opaeuio", 'opaeuio', u'Bind/Unbind DFL device to/from dfl-uio-pdev', [author], 8),
     ("docs/fpga_tools/userclk/userclk", 'userclk', u'Set AFU high and low clock frequency', [author], 8),
     ("docs/fpga_tools/pci_device/pci_device", 'pci_device', u'Common operations for PCIe devices', [author], 8),
     ("docs/fpga_tools/opae.io/opae.io", 'opae.io', u'User space access to PCIe devices', [author], 8),

--- a/doc/sphinx/index.rst.in
+++ b/doc/sphinx/index.rst.in
@@ -61,7 +61,6 @@ The main documentation for the site is organized into following sections:
    docs/fpga_tools/userclk/userclk
    docs/fpga_tools/hssi/hssi
    docs/fpga_tools/opaevfio/opaevfio
-   docs/fpga_tools/opaeuio/opaeuio
    docs/fpga_tools/pci_device/pci_device
    docs/fpga_tools/opae.io/opae.io
    


### PR DESCRIPTION
The opaeuio script is no longer needed, as the driver has switched
to hard-coding the UIO device IDs in the source code.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>