### PR TITLE
logging: deprecate FPGA_MSG and FPGA_ERR macros

### DIFF
--- a/tests/hello_fpga/test_hello_fpga_c.cpp
+++ b/tests/hello_fpga/test_hello_fpga_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -78,19 +78,19 @@ int mmio_ioctl(mock_object * m, int request, va_list argp){
     UNUSED_PARAM(request);
     struct fpga_port_region_info *rinfo = va_arg(argp, struct fpga_port_region_info *);
     if (!rinfo) {
-      FPGA_MSG("rinfo is NULL");
+      OPAE_MSG("rinfo is NULL");
       goto out_EINVAL;
     }
     if (rinfo->argsz != sizeof(*rinfo)) {
-      FPGA_MSG("wrong structure size");
+      OPAE_MSG("wrong structure size");
       goto out_EINVAL;
     }
     if (rinfo->index > 1 ) {
-      FPGA_MSG("unsupported MMIO index");
+      OPAE_MSG("unsupported MMIO index");
       goto out_EINVAL;
     }
     if (rinfo->padding != 0) {
-      FPGA_MSG("unsupported padding");
+      OPAE_MSG("unsupported padding");
       goto out_EINVAL;
     }
     rinfo->flags = FPGA_REGION_READ | FPGA_REGION_WRITE | FPGA_REGION_MMAP;

--- a/tools/libboard/board_n3000/board_n3000.c
+++ b/tools/libboard/board_n3000/board_n3000.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2020, Intel Corporation
+// Copyright(c) 2019-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -103,7 +103,7 @@ fpga_result read_bmcfw_version(fpga_token token, char *bmcfw_ver, size_t len)
 	char buf[FPGA_VAR_BUF_LEN]     = { 0 };
 
 	if (bmcfw_ver == NULL) {
-		FPGA_ERR("Invalid Input parameters");
+		OPAE_ERR("Invalid Input parameters");
 		return FPGA_INVALID_PARAM;
 	}
 
@@ -130,7 +130,7 @@ fpga_result parse_fw_ver(char *buf, char *fw_ver, size_t len)
 	char *endptr               = NULL;
 	if (buf == NULL ||
 		fw_ver == NULL) {
-		FPGA_ERR("Invalid Input parameters");
+		OPAE_ERR("Invalid Input parameters");
 		return FPGA_INVALID_PARAM;
 	}
 
@@ -157,7 +157,7 @@ fpga_result parse_fw_ver(char *buf, char *fw_ver, size_t len)
 	if ((rev >= 'A') && (rev <= 'Z')) {// range from 'A' to 'Z'
 		retval = snprintf(fw_ver, len, "%c.%u.%u.%u", (char)rev, (var >> 16) & 0xff, (var >> 8) & 0xff, var & 0xff);
 		if (retval < 0) {
-			FPGA_ERR("error in formatting version");
+			OPAE_ERR("error in formatting version");
 			return FPGA_EXCEPTION;
 		}
 	} else {
@@ -175,7 +175,7 @@ fpga_result read_max10fw_version(fpga_token token, char *max10fw_ver, size_t len
 	char buf[FPGA_VAR_BUF_LEN]           = { 0 };
 
 	if (max10fw_ver == NULL) {
-		FPGA_ERR("Invalid input parameters");
+		OPAE_ERR("Invalid input parameters");
 		return FPGA_INVALID_PARAM;
 	}
 	res = read_sysfs(token, DFL_SYSFS_MAX10_VER, buf, FPGA_VAR_BUF_LEN - 1);
@@ -217,7 +217,7 @@ fpga_result print_pkvl_version(fpga_token token)
 
 	retval = snprintf(ver_a_buf, FPGA_VAR_BUF_LEN, "%lx.%lx", sub_ver, serdes_ver);
 	if (retval < 0) {
-		FPGA_ERR("error in formatting version");
+		OPAE_ERR("error in formatting version");
 		return FPGA_EXCEPTION;
 	}
 
@@ -234,7 +234,7 @@ fpga_result print_pkvl_version(fpga_token token)
 
 	retval = snprintf(ver_b_buf, FPGA_VAR_BUF_LEN, "%lx.%lx", sub_ver, serdes_ver);
 	if (retval < 0) {
-		FPGA_ERR("error in formatting version");
+		OPAE_ERR("error in formatting version");
 		return FPGA_EXCEPTION;
 	}
 


### PR DESCRIPTION
Use OPAE_MSG and OPAE_ERR instead.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>