### PR TITLE
ofs: add umd driver and hps app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ opae_add_subdirectory(afu-test)
 opae_add_subdirectory(platforms)
 opae_add_subdirectory(tools)
 opae_add_subdirectory(python)
+opae_add_subdirectory(ofs)
 
 option(OPAE_BUILD_SAMPLES "Enable building of OPAE samples" ON)
 mark_as_advanced(OPAE_BUILD_SAMPLES)

--- a/ofs/CMakeLists.txt
+++ b/ofs/CMakeLists.txt
@@ -24,8 +24,6 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required (VERSION  3.10)
-
 opae_add_subdirectory(umd)
 opae_add_subdirectory(apps)
 

--- a/ofs/CMakeLists.txt
+++ b/ofs/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2017-2020, Intel Corporation
+## Copyright(c) 2021, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -26,16 +26,6 @@
 
 cmake_minimum_required (VERSION  3.10)
 
-project(testing)
+opae_add_subdirectory(umd)
+opae_add_subdirectory(apps)
 
-add_subdirectory(argsfilter)
-add_subdirectory(board)
-add_subdirectory(dummy_afu)
-add_subdirectory(fpgaconf)
-add_subdirectory(fpgainfo)
-add_subdirectory(hello_events)
-add_subdirectory(hello_fpga)
-add_subdirectory(object_api)
-add_subdirectory(userclk)
-add_subdirectory(fpgametrics)
-add_subdirectory(ofs_cpeng)

--- a/ofs/apps/CMakeLists.txt
+++ b/ofs/apps/CMakeLists.txt
@@ -24,7 +24,5 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required (VERSION  3.10)
-
 opae_add_subdirectory(cpeng)
 

--- a/ofs/apps/CMakeLists.txt
+++ b/ofs/apps/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2017-2020, Intel Corporation
+## Copyright(c) 2021, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -26,16 +26,5 @@
 
 cmake_minimum_required (VERSION  3.10)
 
-project(testing)
+opae_add_subdirectory(cpeng)
 
-add_subdirectory(argsfilter)
-add_subdirectory(board)
-add_subdirectory(dummy_afu)
-add_subdirectory(fpgaconf)
-add_subdirectory(fpgainfo)
-add_subdirectory(hello_events)
-add_subdirectory(hello_fpga)
-add_subdirectory(object_api)
-add_subdirectory(userclk)
-add_subdirectory(fpgametrics)
-add_subdirectory(ofs_cpeng)

--- a/ofs/apps/cpeng/CMakeLists.txt
+++ b/ofs/apps/cpeng/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2017-2020, Intel Corporation
+## Copyright(c) 2021, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -24,18 +24,10 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required (VERSION  3.10)
-
-project(testing)
-
-add_subdirectory(argsfilter)
-add_subdirectory(board)
-add_subdirectory(dummy_afu)
-add_subdirectory(fpgaconf)
-add_subdirectory(fpgainfo)
-add_subdirectory(hello_events)
-add_subdirectory(hello_fpga)
-add_subdirectory(object_api)
-add_subdirectory(userclk)
-add_subdirectory(fpgametrics)
-add_subdirectory(ofs_cpeng)
+opae_add_executable(TARGET hps
+    SOURCE hps.cpp
+    LIBS
+        ofs_cpeng
+        afu-test
+    COMPONENT cpeng
+)

--- a/ofs/apps/cpeng/hps.cpp
+++ b/ofs/apps/cpeng/hps.cpp
@@ -136,3 +136,4 @@ int main(int argc, char *argv[])
   hps.main(argc, argv);
   return 0;
 }
+

--- a/ofs/apps/cpeng/hps.cpp
+++ b/ofs/apps/cpeng/hps.cpp
@@ -1,0 +1,138 @@
+// Copyright(c) 2021, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include <chrono>
+#include <fstream>
+#include <thread>
+#include "afu_test.h"
+#include "ofs_cpeng.h"
+
+
+const char *cpeng_guid = "44bfc10d-b42a-44e5-bd42-57dc93ea7f91";
+
+using opae::fpga::types::shared_buffer;
+using usec = std::chrono::microseconds;
+
+class cpeng : public opae::afu_test::command
+{
+public:
+  cpeng()
+    : filename_("hps.img")
+    , destination_offset_(0)
+    , timeout_usec_(60000000)
+    , chunk_(0)
+  {
+    log_ = spdlog::get(this->name());
+  }
+  virtual ~cpeng(){}
+  virtual const char *name() const
+  {
+    return "cpeng";
+  }
+
+  virtual const char *description() const
+  {
+    return "Run copy engine commands";
+  }
+
+  virtual const char *afu_id() const
+  {
+    return cpeng_guid;
+  }
+
+  virtual void add_options(CLI::App *app)
+  {
+    std::map<std::string, uint32_t> units = {{"s", 1E6}, {"ms", 1E3}, {"us", 1}};
+    app->add_option("-f,--filename", filename_, "Image file to copy")
+      ->default_val("hps.img")
+      ->check(CLI::ExistingFile);
+    app->add_option("-d,--destination", destination_offset_, "HPS DDR Offset")
+      ->default_val(destination_offset_);
+    app->add_option("-t,--timeout", timeout_usec_, "Timeout")
+      ->default_val(timeout_usec_)
+      ->transform(CLI::AsNumberWithUnit(units));
+    app->add_option("-c,--chunk", chunk_, "Chunk size. 0 indicates no chunks")
+      ->default_val(chunk_);
+  }
+
+  virtual int run(opae::afu_test::afu *afu, __attribute__((unused)) CLI::App *app)
+  {
+    ofs_cpeng cpeng;
+
+    // Initialize cpeng driver
+    ofs_cpeng_init(&cpeng, afu->handle()->c_type());
+    if (ofs_cpeng_wait_for_hps_ready(&cpeng, timeout_usec_)) {
+      log_->warn("HPS is not ready");
+      return 1;
+    }
+
+    // Read file into shared buffer
+    std::ifstream inp(filename_, std::ios::binary | std::ios::ate);
+    auto sz = inp.tellg();
+    inp.seekg(0, std::ios::beg);
+    auto buffer = shared_buffer::allocate(afu->handle(), sz);
+    auto ptr = reinterpret_cast<char*>(const_cast<uint8_t*>(buffer->c_type()));
+    if (!inp.read(ptr, sz)){
+      log_->error("error reading file: {}", filename_);
+      return 2;
+    }
+    log_->info("opened file {} with size {}", filename_, sz);
+
+    // Call cpeng driver copy_buffer
+    auto copy_status =
+      ofs_cpeng_copy_image(&cpeng,
+          buffer->io_address(), destination_offset_, sz, chunk_, timeout_usec_);
+    if (copy_status) {
+      log_->error("Erro calling ofs_cpeng_copy_image");
+      if (ofs_cpeng_dma_status_error(&cpeng)) {
+        uint64_t axist_cpl = ofs_cpeng_ce_axist_cpl_sts(&cpeng);
+        uint64_t acelite_bresp = ofs_cpeng_ce_acelite_bresp_sts(&cpeng);
+        if (axist_cpl) {
+          log_->error("CE_AXIST_CPL_STS: {:x}", axist_cpl);
+        }
+        if (acelite_bresp) {
+          log_->error("CE_ACELITE_BRESP_STS: {:x}", acelite_bresp);
+        }
+      }
+    }
+    return copy_status;
+  }
+
+
+private:
+  std::string filename_;
+  uint64_t destination_offset_;
+  uint32_t timeout_usec_;
+  uint32_t chunk_;
+  std::shared_ptr<spdlog::logger> log_;
+};
+
+int main(int argc, char *argv[])
+{
+  opae::afu_test::afu hps(cpeng_guid);
+  hps.register_command<cpeng>();
+  hps.main(argc, argv);
+  return 0;
+}

--- a/ofs/umd/CMakeLists.txt
+++ b/ofs/umd/CMakeLists.txt
@@ -25,3 +25,4 @@
 ## POSSIBILITY OF SUCH DAMAGE.
 
 opae_add_subdirectory(cpeng)
+

--- a/ofs/umd/CMakeLists.txt
+++ b/ofs/umd/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2017-2020, Intel Corporation
+## Copyright(c) 2021, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -24,18 +24,4 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required (VERSION  3.10)
-
-project(testing)
-
-add_subdirectory(argsfilter)
-add_subdirectory(board)
-add_subdirectory(dummy_afu)
-add_subdirectory(fpgaconf)
-add_subdirectory(fpgainfo)
-add_subdirectory(hello_events)
-add_subdirectory(hello_fpga)
-add_subdirectory(object_api)
-add_subdirectory(userclk)
-add_subdirectory(fpgametrics)
-add_subdirectory(ofs_cpeng)
+opae_add_subdirectory(cpeng)

--- a/ofs/umd/cpeng/CMakeLists.txt
+++ b/ofs/umd/cpeng/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2017-2020, Intel Corporation
+## Copyright(c) 2021, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -24,18 +24,4 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required (VERSION  3.10)
-
-project(testing)
-
-add_subdirectory(argsfilter)
-add_subdirectory(board)
-add_subdirectory(dummy_afu)
-add_subdirectory(fpgaconf)
-add_subdirectory(fpgainfo)
-add_subdirectory(hello_events)
-add_subdirectory(hello_fpga)
-add_subdirectory(object_api)
-add_subdirectory(userclk)
-add_subdirectory(fpgametrics)
-add_subdirectory(ofs_cpeng)
+ofs_add_driver(ofs_cpeng.yml ofs_cpeng ofs_cpeng.c)

--- a/ofs/umd/cpeng/ofs_cpeng.c
+++ b/ofs/umd/cpeng/ofs_cpeng.c
@@ -1,0 +1,27 @@
+// Copyright(c) 2021, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "ofs_cpeng.h"

--- a/ofs/umd/cpeng/ofs_cpeng.yml
+++ b/ofs/umd/cpeng/ofs_cpeng.yml
@@ -1,0 +1,160 @@
+%TAG !! tag:intel.com,2020:
+---
+drivers:
+  - name: ofs_cpeng
+    functions:
+      wait_for_hps_ready:
+        return: int
+        args: [uint64_t timeout_usec]
+        body:
+          return OFS_WAIT_FOR_EQ(CSR_HPS2HOST_RDY_STATUS.HPS_RDY, 1, timeout_usec, 100)
+      dma_status:
+        return: int
+        body:
+          return CSR_CE2HOST_STATUS.CE_DMA_STS
+      dma_status_success:
+        return: bool
+        body:
+          return dma_status() == 0b10
+      dma_status_error:
+        return: bool
+        body:
+          return CSR_CE2HOST_STATUS.CE_DMA_STS == 0b11
+      ce_axist_cpl_sts:
+        return: int
+        body:
+          return CSR_CE2HOST_STATUS.CE_AXIST_CPL_STS
+      ce_acelite_bresp_sts:
+        return: int
+        body:
+          return CSR_CE2HOST_STATUS.CE_ACELITE_BRESP_STS
+      image_complete:
+        body:
+          CSR_HOST2HPS_GPIO.HOST_HPS_CPL = 0x1
+      copy_chunk:
+        return: int
+        args: [uint64_t iova, uint64_t offset, uint32_t size, uint64_t timeout_usec]
+        body: |
+          CSR_SRC_ADDR.CSR_SRC_ADDR = iova
+          CSR_DST_ADDR.CSR_DST_ADDR = offset
+          CSR_DATA_SIZE.CSR_DATA_SIZE = size
+          CSR_HOST2CE_MRD_START.MRD_START = 1
+          if OFS_WAIT_FOR_NE(CSR_CE2HOST_STATUS.CE_DMA_STS, 0b01, timeout_usec, 100):
+            return 1
+          if dma_status_success():
+            return 0
+          return 1
+      copy_image:
+        return: int
+        args: [uint64_t iova, uint64_t offset, uint32_t size, uint32_t chunk, uint64_t timeout_usec]
+        body: |
+          if not chunk:
+            return copy_chunk(iova, offset, size, timeout_usec)
+          ptr: uint32_t = 0
+          local_timeout: uint64_t = timeout_usec/chunk
+          while ptr < size:
+            if copy_chunk(iova+ptr, offset+ptr, chunk, local_timeout):
+              return 1
+            ptr += chunk
+            if size-ptr < chunk:
+              chunk = size-ptr
+            if OFS_WAIT_FOR_EQ(CSR_HOST2CE_MRD_START.MRD_START, 0, local_timeout, 100):
+              return 1
+          image_complete()
+          return 0
+    registers:
+      - !!ofs/register
+        - [CSR_HPS2HOST_RDY_STATUS, 0x0110, 0x0000000000000000, "HPS Ready Status"]
+        - - [Reserved, [63, 1], RsvdZ, 0x0, Reserved]
+          - [HPS_RDY, [0], RO, 0x0, "0: Not ready/reset value\n
+                                     1: HPS is ready to accept the image to be downloaded\n
+                                     HPS ACE Ready signal is mapped to this CSR"]
+      - !!ofs/register
+        - [CSR_SRC_ADDR, 0x0118, 0x0000000000000000, Host DDR Address]
+        - - [Reserved, [63, 32], RsvdZ, 0x0, Reserved]
+          - [CSR_SRC_ADDR, [31, 0], RW, 0x0, Host DDR Physical Address]
+      - !!ofs/register
+        - [CSR_DST_ADDR, 0x0120, 0x0000000000000000, HPS DDR Offset]
+        - - [Reserved, [63, 32], RsvdZ, 0x0, Reserved]
+          - [CSR_DST_ADDR, [31, 0], RW, 0x0, HPS DDR Offset or Destination Offset]
+      - !!ofs/register
+        - [CSR_DATA_SIZE, 0x0128, 0x0000000000000000, Image size in bytes]
+        - - [Reserved, [63, 32], RsvdZ, 0x0, Reserved]
+          - [CSR_DATA_SIZE, [31, 0], RW, 0x0, "Data size in bytes\n
+                                               0x00- Default Value\n
+                                               0x01- 1 byte\n
+                                               0x02 - 2 bytes\n
+                                               and so on"]
+      - !!ofs/register
+        - [CSR_HOST2CE_MRD_START, 0x0130, 0x0000000000000000, Host DDR read start flag]
+        - - [Reserved, [63, 1], RsvdZ, 0x0, Reserved]
+          - [MRD_START, [0], RW, 0x0, "Programmed by host to start host DDR memory read by copy engine
+                                       after programming CSR_SRC_ADDR, CSR_DST_ADDR and CSR_DATA_SIZE"]
+      - !!ofs/register
+        - [CSR_CE2HOST_STATUS, 0x0138, 0x0000000000000000, DMA Status]
+        - - [Reserved, [63, 7], RsvdZ, 0x0, Reserved]
+          - [CE_AXIST_CPL_STS, [6, 4], RO, 0x0, "000- Successful completion\n
+                                                 001- Unsupported request\n
+                                                 010- Reserved\n
+                                                 011- Reserved\n
+                                                 100- completer abort\n
+                                                 101- Reserved\n
+                                                 110- Reserved\n
+                                                 111- Reserved\n
+                                                 Host DDR Read completion packet status at AXI Stream interface.\n
+                                                 Bit mapping is same as 'completion status' field in the completion header format.\n
+                                                 If the completion header packet has the status value other than '3'b000',\n
+                                                 copy engine treats as unsuccessful completion."]
+          - [CE_ACELITE_BRESP_STS, [3, 2], RO, 0x0, "00 -OKAY\n
+                                                     01 - EXOKAY - Exclusive Access Okay\n
+                                                     10 - SLVERR - Slave Error\n
+                                                     11- DECERR - Decode Error\n
+                                                     Acelite write response channle status for HPS DDR write.\n
+                                                     Bit mapping is same as the 'BRESP' signal bit mapping of write response channel.\n
+                                                     If the BRESP is not equal to 2'b00, copy engine treats as transfer failure."]
+          - [CE_DMA_STS, [1, 0], RO, 0x0, "Status of data movement from host to copy engine\n
+                                           00-idle\n
+                                           01-DMA in progress (Busy state)\n
+                                           10-Successfully tranfered data from Host to HPS (data size as programmed in CSR_DATA_SIZE)\n
+                                           11-Error in Transfer\n
+                                           This field gets updated for each descriptor programming.\n
+                                           When the copying is in progress, 0x1 is the status.\n
+                                           This field is marked successful only once the complete data as programmed in CSR_DATA_SIZE is transferred from Host to HPS\n
+                                           If any data packet is erroneous, this field is immediately mapped to 2'b11.\n
+                                           Host Software once seeing this field as 2'b11 can read bit[6, 4],\n
+                                           and bit[3, 2], of this CSR to know the source of error(AXI ST side or Acelite side)\n
+                                           Copy Engine expects a soft Reset if this field is 2'b11\n
+                                           Note: Once complete data as per CSR_DATA_SIZE is transferred,\n
+                                           copy engine will write '0' to CSR_HOST2CE_MRD_START.MRD_START"]
+      - !!ofs/register
+        - [CSR_HOST2HPS_GPIO, 0x0140, 0x0000000000000000, DMA Done Flag]
+        - - [Reserved, [63, 1], RsvdZ, 0x0, Reserved]
+          - [HOST_HPS_CPL, [0], RW, 0x0, "0: Complete Image size not copied from Host to HPS
+                                          1: Complete image size copied from Host to HPS. HPS can start SSBL verification. "]
+      - !!ofs/register
+        - [CSR_HPS2HOST_VFY_STATUS, 0x0148, 0x0000000000000000, HPS Verification Status]
+        - - [Reserved, [63, 5], RsvdZ, 0x0, Reserved]
+          - [HPS_RDY_TIMEOUT, [4], RO, 0x0, "HPS Ready Timeout This bit is asserted if hps2host_hps_rdy_gpio input pin\n
+                                             remains 1'b0 more than specified threshold value set (CE_RDY_LOW_THRESHOLD).\n
+                                             This threshold value is parameterized."]
+          - [KERNEL_VFY, [3, 2], RO, 0x0, "Kernel Verification\n
+                                           00: reset value\n
+                                           01: successful Kernel verification\n
+                                           10: Erroneous\n
+                                           11: Rsvd\n
+                                           The image that is downloaded from host includes the following:\n
+                                           * Second Stage bootloader / uBoot\n
+                                           * Linux kernel + rootFS (includes the 1588 application)\n
+                                           Host will send this complete package to HPS DDR using the copy engine\n
+                                           This field depicts the Kernel verification status. Kernel verification is done after SSBL"]
+          - [SSBL_VFY, [1, 0], RO, 0x0, "SSBL Verification\n
+                                         00: reset value\n
+                                         01: successful SSBL verification\n
+                                         10: Erroneous\n
+                                         11: Rsvd\n
+                                         The image that is downloaded from host includes the following:\n
+                                         * Second Stage bootloader / uBoot\n
+                                         * Linux kernel + rootFS (includes the 1588 application)\n
+                                         Host will send this complete package to HPS DDR using the copy engine\n
+                                         This field depicts the SSBL Verification status. Once HPS sees host2hps\n
+                                         gpio (input to HPS) as high, HPS can issue read to HPS DDR and then start SSBL verification"]

--- a/tests/ofs_cpeng/CMakeLists.txt
+++ b/tests/ofs_cpeng/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2017-2020, Intel Corporation
+## Copyright(c) 2021, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -24,18 +24,8 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required (VERSION  3.10)
-
-project(testing)
-
-add_subdirectory(argsfilter)
-add_subdirectory(board)
-add_subdirectory(dummy_afu)
-add_subdirectory(fpgaconf)
-add_subdirectory(fpgainfo)
-add_subdirectory(hello_events)
-add_subdirectory(hello_fpga)
-add_subdirectory(object_api)
-add_subdirectory(userclk)
-add_subdirectory(fpgametrics)
-add_subdirectory(ofs_cpeng)
+opae_test_add(
+    TARGET test_ofs_cpeng
+    SOURCE test_ofs_cpeng.cpp
+    LIBS ofs_cpeng
+)

--- a/tests/ofs_cpeng/test_ofs_cpeng.cpp
+++ b/tests/ofs_cpeng/test_ofs_cpeng.cpp
@@ -1,0 +1,95 @@
+// Copyright(c) 2021, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include <chrono>
+#include <future>
+#include <thread>
+#include <uuid/uuid.h>
+#include "gtest/gtest.h"
+#include "ofs_cpeng.h"
+
+
+/**
+ * @test    wait_for_hps_ready
+ * @brief   Tests: ofs_cpeng_wait_for_hps_ready
+ * @details Tests ofs_cpeng_wait_for_ready by setting the register pointer to
+ *          the address of a local variable of that type. First set the ready
+ *          bit to 0, call ofs_cpeng_wait_for_ready, and verify the result is
+ *          non-zero. Then set the ready bit to 1, call
+ *          ofs_cpeng_wait_for_ready and verify the result is 0.
+ * */
+TEST(ofs_cpeng, wait_for_hps_ready)
+{
+  ofs_cpeng otest;
+  CSR_HPS2HOST_RDY_STATUS ready;
+  otest.r_CSR_HPS2HOST_RDY_STATUS = &ready;
+
+  ready.f_HPS_RDY = 0;
+  EXPECT_EQ(ofs_cpeng_wait_for_hps_ready(&otest, 1000), 1);
+
+  ready.f_HPS_RDY = 1;
+  EXPECT_EQ(ofs_cpeng_wait_for_hps_ready(&otest, 1000), 0);
+}
+
+/**
+ * @test    copy_chunk
+ * @brief   Tests: copy_chunk
+ * @details Tests ofs_cpeng_copy_chunk by setting the register pointers in
+ * ofs_cpeng structure to local variables. Modify bit field variables in the
+ * test before calling ofs_cpeng_copy_chunk then verify that those bit fields
+ * are changed as expected by that call.
+ * */
+TEST(ofs_cpeng, copy_chunk)
+{
+  ofs_cpeng otest;
+  CSR_SRC_ADDR r_src = {0};
+  CSR_DST_ADDR r_dst = {0};
+  CSR_DATA_SIZE r_size = {0};
+  CSR_HOST2CE_MRD_START r_start = {0};
+  CSR_CE2HOST_STATUS r_status = {0};
+
+  otest.r_CSR_SRC_ADDR = &r_src;
+  otest.r_CSR_DST_ADDR = &r_dst;
+  otest.r_CSR_DATA_SIZE = &r_size;
+  otest.r_CSR_HOST2CE_MRD_START = &r_start;
+  otest.r_CSR_CE2HOST_STATUS = &r_status;
+
+  ASSERT_EQ(r_src.value, 0);
+  ASSERT_EQ(r_dst.value, 0);
+  ASSERT_EQ(r_size.value, 0);
+  ASSERT_EQ(r_start.value, 0);
+  ASSERT_EQ(r_status.value, 0);
+  EXPECT_EQ(ofs_cpeng_copy_chunk(&otest, 0x1000, 0x2000, 4096), 1);
+  EXPECT_EQ(r_src.f_CSR_SRC_ADDR, 0x1000);
+  EXPECT_EQ(r_dst.f_CSR_DST_ADDR, 0x2000);
+  EXPECT_EQ(r_size.f_CSR_DATA_SIZE, 4096);
+
+
+  r_status.f_CE_DMA_STS = 0b10;
+  EXPECT_EQ(ofs_cpeng_copy_chunk(&otest, 0x3000, 0x4000, 8192), 0);
+  EXPECT_EQ(r_src.f_CSR_SRC_ADDR, 0x3000);
+  EXPECT_EQ(r_dst.f_CSR_DST_ADDR, 0x4000);
+  EXPECT_EQ(r_size.f_CSR_DATA_SIZE, 8192);
+}

--- a/tests/ofs_cpeng/test_ofs_cpeng.cpp
+++ b/tests/ofs_cpeng/test_ofs_cpeng.cpp
@@ -81,14 +81,14 @@ TEST(ofs_cpeng, copy_chunk)
   ASSERT_EQ(r_size.value, 0);
   ASSERT_EQ(r_start.value, 0);
   ASSERT_EQ(r_status.value, 0);
-  EXPECT_EQ(ofs_cpeng_copy_chunk(&otest, 0x1000, 0x2000, 4096), 1);
+  EXPECT_EQ(ofs_cpeng_copy_chunk(&otest, 0x1000, 0x2000, 4096, 1000), 1);
   EXPECT_EQ(r_src.f_CSR_SRC_ADDR, 0x1000);
   EXPECT_EQ(r_dst.f_CSR_DST_ADDR, 0x2000);
   EXPECT_EQ(r_size.f_CSR_DATA_SIZE, 4096);
 
 
   r_status.f_CE_DMA_STS = 0b10;
-  EXPECT_EQ(ofs_cpeng_copy_chunk(&otest, 0x3000, 0x4000, 8192), 0);
+  EXPECT_EQ(ofs_cpeng_copy_chunk(&otest, 0x3000, 0x4000, 8192, 1000), 0);
   EXPECT_EQ(r_src.f_CSR_SRC_ADDR, 0x3000);
   EXPECT_EQ(r_dst.f_CSR_DST_ADDR, 0x4000);
   EXPECT_EQ(r_size.f_CSR_DATA_SIZE, 8192);


### PR DESCRIPTION
* Add ofs/umd/cpeng
  This contains ofs_cpeng.yml which contains register map and APIs
* Add ofs/apps/hps
  * This uses afu_test framework to reuse command line parsing to locate
    an AFU and give it to a command.
  * Add cpeng command that uses the ofs_cpeng driver to copy an image
    from a file.
* Add unit tests for ofs_cpeng driver

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>