### PR TITLE
opae.io: don't set attrs to nullptr

### DIFF
--- a/tools/extra/opae.io/main.cpp
+++ b/tools/extra/opae.io/main.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2020, Intel Corporation
+// Copyright(c) 2020-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -400,8 +400,6 @@ int main(int argc, char *argv[])
   py::module builtins = import_builtins();
   globals["builtins"] = builtins;
 
-  builtins.attr("the_device") = the_device;
-  builtins.attr("the_region") = the_region;
   builtins.attr("peek") = opae_io.attr("peek");
   builtins.attr("read_csr") = opae_io.attr("read_csr");
   builtins.attr("write_csr") = opae_io.attr("write_csr");


### PR DESCRIPTION
The globals the_device and the_region are initialized to
nullptr at program start. Attempting to set Python attributes
to nullptr proves problematic for some combinations of Python
and PyBind11. Removing the initial update of these attr's
solved the observed exception/abort.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>