### PR TITLE
rsu: add sdm image type

### DIFF
--- a/doc/src/fpga_tools/rsu/rsu.md
+++ b/doc/src/fpga_tools/rsu/rsu.md
@@ -2,7 +2,7 @@
 
 ## SYNOPSIS ##
 ```console
-rsu [-h] [-d] {bmcimg,retimer,fpga,fpgadefault} [PCIE_ADDR]
+rsu [-h] [-d] {bmc,bmcimg,retimer,fpga,sdm,fpgadefault} [PCIE_ADDR]
 
 ```
 
@@ -11,17 +11,18 @@ rsu [-h] [-d] {bmcimg,retimer,fpga,fpgadefault} [PCIE_ADDR]
 ### Mode 1: RSU ###
 
 ```console
-rsu bmcimg --page=(user|factory) [PCIE_ADDR]
+rsu bmc --page=(user|factory) [PCIE_ADDR]
 rsu retimer [PCIE_ADDR]
 rsu fpga --page=(user1|user2|factory) [PCIE_ADDR]
+rsu sdm [PCIE_ADDR]
 ```
 
 Perform RSU (remote system update) operation on PAC device
 given its PCIe address.
 An RSU operation sends an instruction to the device to trigger
 a power cycle of the card only. This will force reconfiguration
-from flash for either BMC image (on devices that support it) or the
-FPGA.
+from flash for either BMC, Retimer, SDM, (on devices that support these)
+or the FPGA.
 
 ### Mode 2: Default FPGA Image ###
 
@@ -34,7 +35,7 @@ the primary FPGA boot image. The --fallback option allows a comma-separated
 list of values to specify fallback images.
 
 ## POSITIONAL ARGUMENTS ##
-`{bmcimg,retimer,fpga,fpgadefault}`
+`{bmc,bmcimg,retimer,fpga,sdm,fpgadefault}`
 
 type of RSU operation or set Default FPGA Image operation.
    
@@ -51,14 +52,14 @@ log debug statements
 ## EXAMPLE ##
 
 ```console
-# rsu bmcimg --page=user 25:00.0
+# rsu bmc --page=user 25:00.0
 ```
 
  Triggers a boot of the BMC image (user page) for the device with PCIe
  address 25:00.0.
 
 ```console
-# rsu bmcimg --page=factory 25:00.0
+# rsu bmc --page=factory 25:00.0
 ```
 
  Triggers a factory boot of the BMC image for the device with
@@ -77,6 +78,13 @@ log debug statements
 
  Triggers a factory reconfiguration of the FPGA for the device
  with PCIe address 25:00.0.
+
+```console
+# rsu sdm 25:00.0
+```
+
+ Triggers a reconfiguration of the SDM for the device with
+ PCIE address 25:00.0.
 
 ```console
 # rsu fpgadefault --page=factory --fallback=user1,user2 25:00.0

--- a/python/opae.admin/opae/admin/tools/rsu.py
+++ b/python/opae.admin/opae/admin/tools/rsu.py
@@ -56,13 +56,13 @@ from flash for the given image.
 EPILOG = '''
 Example usage:
 
-     %(prog)s bmcimg 25:00.0
+     %(prog)s bmc 25:00.0
      This will trigger a boot of the BMC image for the device with PCIe
      address 25:00.0.
      NOTE: The BMC image will be reconfigured from user bank and the
            FPGA image will be reconfigured using the default setting.
 
-     %(prog)s bmcimg 25:00.0 --page=factory
+     %(prog)s bmc 25:00.0 --page=factory
      This will trigger a factory boot of the BMC image for the device
      with PCIe address 25:00.0.
      NOTE: The BMC image will be reconfigured from factory bank and the
@@ -157,6 +157,10 @@ def device_rsu_fpga(device, args):
     device_rsu(device, 'fpga_' + args.page)
 
 
+def device_rsu_sdm(device, args):
+    device_rsu(device, 'sdm')
+
+
 def parse_args():
     fc_ = argparse.RawDescriptionHelpFormatter
     parser = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG,
@@ -166,7 +170,8 @@ def parse_args():
 
     subparser = parser.add_subparsers(dest='which')
 
-    bmcimg = subparser.add_parser('bmcimg', help='RSU BMC Image')
+    bmcimg = subparser.add_parser('bmc', aliases=['bmcimg'],
+                                  help='RSU BMC Image')
     bmcimg.add_argument('bdf', nargs='?',
                         help=('PCIe address '
                               '(eg 04:00.0 or 0000:04:00.0)'))
@@ -188,6 +193,12 @@ def parse_args():
                           choices=['user1', 'user2', 'factory'],
                           default='user1', help='select FPGA page')
     fpga_img.set_defaults(func=device_rsu_fpga)
+
+    sdm = subparser.add_parser('sdm', help='RSU SDM Image')
+    sdm.add_argument('bdf', nargs='?',
+                     help=('PCIe address '
+                           '(eg 04:00.0 or 0000:04:00.0)'))
+    sdm.set_defaults(func=device_rsu_sdm)
 
     fpgadefault = subparser.add_parser('fpgadefault',
                                        help='Set default FPGA image')


### PR DESCRIPTION
Add bmc keyword with an alias of bmcimg. Changing to bmc follows
suit with the other image types. Preserving bmcimg allows client
scripts to remain unchanged.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>