### PR TITLE
PACSign: remove "print" subparser..

### DIFF
--- a/python/pacsign/pacsign/pacsign.py
+++ b/python/pacsign/pacsign/pacsign.py
@@ -181,18 +181,6 @@ def main():
     add_common_options(parser_therm_sr)
     add_common_options(parser_therm_pr)
 
-    parser_print = subparsers.add_parser("print", help="Print header information")
-
-    parser_print.add_argument(
-        "files", nargs="+", help="List of files whose contents" " are to be printed"
-    )
-    parser_print.add_argument(
-        "-v",
-        "--verbose",
-        help="Increase verbosity.  Can be specified multiple times",
-        action="count",
-    )
-
     args = parser.parse_args()
     if len(sys.argv) == 1:
         parser.print_help()
@@ -206,9 +194,6 @@ def main():
     common_util.assert_in_error(args.slot_num < 0x10, "Slot number must be <= 15")
 
     log.handlers[0].setLevel(LOGLEVELS[args.verbose])
-
-    if args.main_command == "print":
-        return reader.print_file_contents(args.files)
 
     manager = args.HSM_manager.rstrip('_manager')
     # Load HSM handler


### PR DESCRIPTION
Also remove related optional args, and the call to the
reader module.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>