### PR TITLE
qpafilter: add sensors map file

### DIFF
--- a/tools/extra/qpafilter/n5010_bmc_sensors.yml
+++ b/tools/extra/qpafilter/n5010_bmc_sensors.yml
@@ -1,0 +1,14 @@
+FPGA Core dts01 Temperature: 8
+FPGA Core dts11 Temperature: 9
+FPGA Core dts12 Temperature: 13
+FPGA Core dts21 Temperature: 10
+FPGA Core dts22 Temperature: 14
+FPGA Core dts31 Temperature: 11
+FPGA Core dts32 Temperature: 15
+FPGA Core dts41 Temperature: 12
+FPGA Core dts42 Temperature: 16
+HSSI_0_0 dts1 Temperature: 6
+HSSI_0_1 dts1 Temperature: 2
+HSSI_0_1 dts2 Temperature: 3
+HSSI_0_1 dts3 Temperature: 4
+HSSI_0_1 dts4 Temperature: 5

--- a/tools/extra/qpafilter/qpafilter.py
+++ b/tools/extra/qpafilter/qpafilter.py
@@ -136,7 +136,7 @@ class two_way_map:
         self.str_to_int = str_to_int
         self.int_to_str = {v: k for k,v in str_to_int.items()}
 
-    def get(self, i):
+    def __getitem__(self, i):
         if isinstance(i, str):
             return self.str_to_int[i]
         elif isinstance(i, int):

--- a/tools/extra/qpafilter/qpafilter.py
+++ b/tools/extra/qpafilter/qpafilter.py
@@ -211,6 +211,14 @@ def dump_blob(args):
     pass
 
 
+def read_sensors(fname):
+    """Given the name of a yaml file containing the sensor
+       label to ID mapping, return a two_way_map containing
+       the data."""
+    with open(fname, 'r') as infile:
+        return two_way_map(yaml.load(infile, Loader=yaml.SafeLoader))
+
+
 def parse_args():
     """Parses command line arguments"""
     parser = argparse.ArgumentParser()
@@ -228,7 +236,7 @@ def parse_args():
                         help='display version information and exit')
 
     parser.add_argument('-s', '--sensor-file',
-                        type=argparse.FileType('r'),
+                        type=read_sensors, dest='sensor_map',
                         default='n5010_bmc_sensors.yml',
                         help='BMC sensor to id file')
 
@@ -283,9 +291,6 @@ def main():
     log_hndlr.setFormatter(logging.Formatter(log_fmt))
     log_hndlr.setLevel(logging.getLevelName(args.log_level.upper()))
     LOG.addHandler(log_hndlr)
-
-    setattr(args, 'sensor_map',
-            two_way_map(yaml.load(args.sensor_file, Loader=yaml.SafeLoader)))
 
     setattr(args, 'threshold_map',
             two_way_map({'Upper Warning': 0,

--- a/tools/extra/qpafilter/qpafilter.py
+++ b/tools/extra/qpafilter/qpafilter.py
@@ -131,18 +131,18 @@ def get_filter(category):
     return filters[category]
 
 
-class sensors_map:
-    def __init__(self, label_to_id):
-        self.label_to_id = label_to_id
-        self.id_to_label = {v: k for k,v in label_to_id.items()}
+class two_way_map:
+    def __init__(self, str_to_int):
+        self.str_to_int = str_to_int
+        self.int_to_str = {v: k for k,v in str_to_int.items()}
 
     def get(self, i):
         if isinstance(i, str):
-            return self.label_to_id[i]
+            return self.str_to_int[i]
         elif isinstance(i, int):
-            return self.id_to_label[i]
+            return self.int_to_str[i]
         else:
-            raise TypeError('sensors_map index must be str or int')
+            raise TypeError('two_way_map index must be str or int')
 
 
 def read_qpa(in_file, temp_overrides):
@@ -285,7 +285,15 @@ def main():
     LOG.addHandler(log_hndlr)
 
     setattr(args, 'sensor_map',
-            sensors_map(yaml.load(args.sensor_file, Loader=yaml.SafeLoader)))
+            two_way_map(yaml.load(args.sensor_file, Loader=yaml.SafeLoader)))
+
+    setattr(args, 'threshold_map',
+            two_way_map({'Upper Warning': 0,
+                         'Upper Critical': 1,
+                         'Upper Fatal': 2,
+                         'Lower Warning': 3,
+                         'Lower Critical': 4,
+                         'Lower Fatal': 5}))
 
     if hasattr(args, 'func'):
         args.func(args)


### PR DESCRIPTION
Add class two_way_map - given a dictionary mapping strings
to integer IDs, create the inverse mapping and store for later use
with member get(). When given a str, get() returns the integer ID
corresponding to the given string. When given an int, get() returns
the string corresponding to the given ID.

Load the sensors data as command argument -s, --sensor-file.