### PR TITLE
afu_test: use CLI11 default_str

### DIFF
--- a/afu-test/afu_test.h
+++ b/afu-test/afu_test.h
@@ -155,14 +155,14 @@ public:
   , current_command_(nullptr)
   {
     if (!afu_id_.empty())
-      app_.add_option("-g,--guid", afu_id_, "GUID")->default_val(afu_id_);
+      app_.add_option("-g,--guid", afu_id_, "GUID")->default_str(afu_id_);
     app_.add_option("-p,--pci-address", pci_addr_,
                     "[<domain>:]<bus>:<device>.<function>");
     app_.add_option("-l,--log-level", log_level_, "stdout logging level")->
-      default_val(log_level_)->
+      default_str(log_level_)->
       check(CLI::IsMember(SPDLOG_LEVEL_NAMES));
     app_.add_flag("-s,--shared", shared_, "open in shared mode, default is off");
-    app_.add_option("-t,--timeout", timeout_msec_, "test timeout (msec)")->default_val(timeout_msec_);
+    app_.add_option("-t,--timeout", timeout_msec_, "test timeout (msec)")->default_str(std::to_string(timeout_msec_));
   }
   virtual ~afu() {
     if (logger_)

--- a/ofs/apps/cpeng/hps.cpp
+++ b/ofs/apps/cpeng/hps.cpp
@@ -66,7 +66,7 @@ public:
   {
     std::map<std::string, uint32_t> units = {{"s", 1E6}, {"ms", 1E3}, {"us", 1}};
     app->add_option("-f,--filename", filename_, "Image file to copy")
-      ->default_val("hps.img")
+      ->default_val(filename_)
       ->check(CLI::ExistingFile);
     app->add_option("-d,--destination", destination_offset_, "HPS DDR Offset")
       ->default_str(std::to_string(destination_offset_));

--- a/ofs/apps/cpeng/hps.cpp
+++ b/ofs/apps/cpeng/hps.cpp
@@ -69,12 +69,12 @@ public:
       ->default_val("hps.img")
       ->check(CLI::ExistingFile);
     app->add_option("-d,--destination", destination_offset_, "HPS DDR Offset")
-      ->default_val(destination_offset_);
+      ->default_str(std::to_string(destination_offset_));
     app->add_option("-t,--timeout", timeout_usec_, "Timeout")
-      ->default_val(timeout_usec_)
+      ->default_str(std::to_string(timeout_usec_))
       ->transform(CLI::AsNumberWithUnit(units));
     app->add_option("-c,--chunk", chunk_, "Chunk size. 0 indicates no chunks")
-      ->default_val(chunk_);
+      ->default_str(std::to_string(chunk_));
   }
 
   virtual int run(opae::afu_test::afu *afu, __attribute__((unused)) CLI::App *app)

--- a/samples/dummy_afu/dummy_afu.h
+++ b/samples/dummy_afu/dummy_afu.h
@@ -186,7 +186,7 @@ public:
   : test_afu("dummy_afu", afu_id)
   , count_(1)
   {
-    app_.add_option("-c,--count", count_, "Number of times to run test")->default_val(count_);
+    app_.add_option("-c,--count", count_, "Number of times to run test")->default_str(std::to_string(count_));
   }
 
   virtual int run(CLI::App *app, test_command::ptr_t test) override

--- a/samples/dummy_afu/mmio.h
+++ b/samples/dummy_afu/mmio.h
@@ -117,15 +117,15 @@ public:
   {
     app->add_option("-c,--count",
                     count_,
-                    "number of repititions")->default_val(1);
+                    "number of repititions")->default_str(std::to_string(1));
     app->add_option("-s,--scratchpad-index",
                     sp_index_,
                     "index in the scratchpad array")->check(CLI::Range(0, 63));
     app->add_flag("--perf", perf_, "get mmio performace numbers");
     auto opt = app->add_option("-w,--width", width_, "mmio width for mmio performance stats");
-    opt->check(CLI::IsMember({8, 16, 32, 64}))->default_val(64);
+    opt->check(CLI::IsMember({8, 16, 32, 64}))->default_str(std::to_string(64));
     opt = app->add_option("--op", op_, "operation for mmio performance stats");
-    opt->check(CLI::IsMember({"rd", "wr"}))->default_val("rd");
+    opt->check(CLI::IsMember({"rd", "wr"}))->default_str("rd");
   }
 
   virtual int run(test_afu *afu, CLI::App *app)

--- a/samples/dummy_afu/mmio.h
+++ b/samples/dummy_afu/mmio.h
@@ -117,15 +117,15 @@ public:
   {
     app->add_option("-c,--count",
                     count_,
-                    "number of repititions")->default_str(std::to_string(1));
+                    "number of repititions")->default_str(std::to_string(count_));
     app->add_option("-s,--scratchpad-index",
                     sp_index_,
                     "index in the scratchpad array")->check(CLI::Range(0, 63));
     app->add_flag("--perf", perf_, "get mmio performace numbers");
     auto opt = app->add_option("-w,--width", width_, "mmio width for mmio performance stats");
-    opt->check(CLI::IsMember({8, 16, 32, 64}))->default_str(std::to_string(64));
+    opt->check(CLI::IsMember({8, 16, 32, 64}))->default_str(std::to_string(width_));
     opt = app->add_option("--op", op_, "operation for mmio performance stats");
-    opt->check(CLI::IsMember({"rd", "wr"}))->default_str("rd");
+    opt->check(CLI::IsMember({"rd", "wr"}))->default_str(op_);
   }
 
   virtual int run(test_afu *afu, CLI::App *app)

--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -304,20 +304,20 @@ public:
   {
     // Mode
     app_.add_option("-m,--mode", he_modes_, "host exerciser mode {lpbk,read, write, trput}")
-      ->transform(CLI::CheckedTransformer(he_modes))->default_val("lpbk");
+      ->transform(CLI::CheckedTransformer(he_modes))->default_str("lpbk");
 
     // Cache line
     app_.add_option("--cls", he_req_cls_len_, "number of CLs per request{cl_1, cl_2, cl_3, cl_4}")
-       ->transform(CLI::CheckedTransformer(he_req_cls_len))->default_val("cl_1");
+       ->transform(CLI::CheckedTransformer(he_req_cls_len))->default_str("cl_1");
 
     // Configures test rollover or test termination
-    app_.add_option("--continuousmode", he_continuousmode_, "test rollover or test termination")->default_val(false);
+    app_.add_option("--continuousmode", he_continuousmode_, "test rollover or test termination")->default_str(std::to_string(false));
 
     // Delay
-    app_.add_option("-d,--delay", he_delay_, "Enables random delay insertion between requests")->default_val(false);
+    app_.add_option("-d,--delay", he_delay_, "Enables random delay insertion between requests")->default_str(std::to_string(false));
 
     // Configure interleave requests in Throughput mode
-    app_.add_option("--interleave", he_interleave_, interleave_help)->default_val(0);
+    app_.add_option("--interleave", he_interleave_, interleave_help)->default_str(std::to_string(0));
 
   }
 

--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -304,20 +304,20 @@ public:
   {
     // Mode
     app_.add_option("-m,--mode", he_modes_, "host exerciser mode {lpbk,read, write, trput}")
-      ->transform(CLI::CheckedTransformer(he_modes))->default_str("lpbk");
+      ->transform(CLI::CheckedTransformer(he_modes))->default_val("lpbk");
 
     // Cache line
     app_.add_option("--cls", he_req_cls_len_, "number of CLs per request{cl_1, cl_2, cl_3, cl_4}")
-       ->transform(CLI::CheckedTransformer(he_req_cls_len))->default_str("cl_1");
+       ->transform(CLI::CheckedTransformer(he_req_cls_len))->default_val("cl_1");
 
     // Configures test rollover or test termination
-    app_.add_option("--continuousmode", he_continuousmode_, "test rollover or test termination")->default_str(std::to_string(false));
+    app_.add_option("--continuousmode", he_continuousmode_, "test rollover or test termination")->default_val("false");
 
     // Delay
-    app_.add_option("-d,--delay", he_delay_, "Enables random delay insertion between requests")->default_str(std::to_string(false));
+    app_.add_option("-d,--delay", he_delay_, "Enables random delay insertion between requests")->default_val("false");
 
     // Configure interleave requests in Throughput mode
-    app_.add_option("--interleave", he_interleave_, interleave_help)->default_str(std::to_string(0));
+    app_.add_option("--interleave", he_interleave_, interleave_help)->default_val("0");
 
   }
 

--- a/samples/hssi/hssi_100g_cmd.h
+++ b/samples/hssi/hssi_100g_cmd.h
@@ -63,31 +63,31 @@ public:
   {
     auto opt = app->add_option("--port", port_,
                                "QSFP port");
-    opt->check(CLI::Range(0, 7))->default_val(port_);
+    opt->check(CLI::Range(0, 7))->default_str(std::to_string(port_));
 
     opt = app->add_option("--eth-loopback", eth_loopback_,
                     "whether to enable loopback on the eth interface");
-    opt->check(CLI::IsMember({"on", "off"}))->default_val(eth_loopback_);
+    opt->check(CLI::IsMember({"on", "off"}))->default_str(eth_loopback_);
 
     opt = app->add_option("--num-packets", num_packets_,
                           "number of packets");
-    opt->default_val(num_packets_);
+    opt->default_str(std::to_string(num_packets_));
 
     opt = app->add_option("--gap", gap_,
                           "inter-packet gap");
-    opt->check(CLI::IsMember({"random", "none"}))->default_val(gap_);
+    opt->check(CLI::IsMember({"random", "none"}))->default_str(gap_);
 
     opt = app->add_option("--pattern", pattern_,
                           "pattern mode");
-    opt->check(CLI::IsMember({"random", "fixed", "increment"}))->default_val(pattern_);
+    opt->check(CLI::IsMember({"random", "fixed", "increment"}))->default_str(pattern_);
 
     opt = app->add_option("--src-addr", src_addr_,
                           "source MAC address");
-    opt->default_val(src_addr_);
+    opt->default_str(src_addr_);
 
     opt = app->add_option("--dest-addr", dest_addr_,
                           "destination MAC address");
-    opt->default_val(dest_addr_);
+    opt->default_str(dest_addr_);
   }
 
   virtual int run(test_afu *afu, CLI::App *app) override

--- a/samples/hssi/hssi_10g_cmd.h
+++ b/samples/hssi/hssi_10g_cmd.h
@@ -83,55 +83,55 @@ public:
   {
     auto opt = app->add_option("--port", port_,
                                "QSFP port");
-    opt->check(CLI::Range(0, 7))->default_val(port_);
+    opt->check(CLI::Range(0, 7))->default_str(std::to_string(port_));
 
     opt = app->add_option("--eth-loopback", eth_loopback_,
                     "whether to enable loopback on the eth interface");
-    opt->check(CLI::IsMember({"on", "off"}))->default_val(eth_loopback_);
+    opt->check(CLI::IsMember({"on", "off"}))->default_str(eth_loopback_);
 
     opt = app->add_option("--he-loopback", he_loopback_,
                     "whether to enable loopback in the Hardware Exerciser (HE)");
-    opt->check(CLI::IsMember({"on", "off"}))->default_val(he_loopback_);
+    opt->check(CLI::IsMember({"on", "off"}))->default_str(he_loopback_);
 
     opt = app->add_option("--num-packets", num_packets_,
                           "number of packets");
-    opt->default_val(num_packets_);
+    opt->default_str(std::to_string(num_packets_));
 
     opt = app->add_option("--random-length", random_length_,
                           "packet length randomization");
-    opt->check(CLI::IsMember({"fixed", "random"}))->default_val(random_length_);
+    opt->check(CLI::IsMember({"fixed", "random"}))->default_str(random_length_);
 
     opt = app->add_option("--random-payload", random_payload_,
                           "payload randomization");
-    opt->check(CLI::IsMember({"incremental", "random"}))->default_val(random_payload_);
+    opt->check(CLI::IsMember({"incremental", "random"}))->default_str(random_payload_);
 
     opt = app->add_option("--packet-length", packet_length_,
                           "packet length");
-    opt->default_val(packet_length_);
+    opt->default_str(std::to_string(packet_length_));
 
     opt = app->add_option("--src-addr", src_addr_,
                           "source MAC address");
-    opt->default_val(src_addr_);
+    opt->default_str(src_addr_);
 
     opt = app->add_option("--dest-addr", dest_addr_,
                           "destination MAC address");
-    opt->default_val(dest_addr_);
+    opt->default_str(dest_addr_);
 
     opt = app->add_option("--eth-ifc", eth_ifc_,
                           "ethernet interface name");
-    opt->default_val(eth_ifc_);
+    opt->default_str(eth_ifc_);
 
     opt = app->add_option("--rnd-seed0", rnd_seed0_,
                           "prbs generator [31:0]");
-    opt->default_val(rnd_seed0_);
+    opt->default_str(std::to_string(rnd_seed0_));
 
     opt = app->add_option("--rnd-seed1", rnd_seed1_,
                           "prbs generator [47:32]");
-    opt->default_val(rnd_seed1_);
+    opt->default_str(std::to_string(rnd_seed1_));
 
     opt = app->add_option("--rnd-seed2", rnd_seed2_,
                           "prbs generator [91:64]");
-    opt->default_val(rnd_seed2_);
+    opt->default_str(std::to_string(rnd_seed2_));
   }
 
   virtual int run(test_afu *afu, CLI::App *app) override

--- a/tests/dummy_afu/test_dummy_afu.cpp
+++ b/tests/dummy_afu/test_dummy_afu.cpp
@@ -85,7 +85,7 @@ public:
   virtual void add_options(CLI::App *app) override
   {
     app->add_option("-s,--sleep",
-                    sleep_msec_, "sleep time (msec)")->default_val(sleep_msec_);
+                    sleep_msec_, "sleep time (msec)")->default_str(std::to_string(sleep_msec_));
 
   }
 


### PR DESCRIPTION
Use default_str instead of default_val to be compatible with older
versions of CLI11.

CLI11::Option::default_str is documented as affecting only how the
default is presented but does not actually set the variable bounded to
the option to that value.
Most of our uses of default_val have the bounded
variable defaulted but some do not.
This change does one of the
following:
* Uses the bounded valriable as the input to default_str
* Uses default_val with a string input

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>