### PR TITLE
qpafilter: fix --output, add doc

### DIFF
--- a/tools/extra/qpafilter/qpafilter.md
+++ b/tools/extra/qpafilter/qpafilter.md
@@ -14,13 +14,16 @@ sensor thresholds. In addition to creating this binary file,
 qpafilter can parse it and dump it in a human-readable format.
 
 ## SUB-COMMANDS ##
-create
- Transform qpa text file into a binary format for the BMC FW.
 
-dump
- Parse an existing binary file and dump in a human-readable format.
+`create`
 
-### Mode 1: create ###
+&nbsp;&nbsp;&nbsp;&nbsp;Transform qpa text file into a binary format for the BMC FW.
+
+`dump`
+
+&nbsp;&nbsp;&nbsp;&nbsp;Parse an existing binary file and dump in a human-readable format.
+
+### Mode 1: `create` ###
 
 ```console
 qpafilter create [-t MIN_TEMP] [-f VIRT_FATAL_TEMP] [-w VIRT_WARN_TEMP] [-O OVERRIDE_TEMP] [-o OUTPUT] [file]
@@ -44,14 +47,11 @@ value and units.
 ; HSSI_0_1 dts4 Temperature                     ; 90.7 °<br>
 +-----------------------------------------------+-----------+<br>
 
-#### Mode 1: create POSITIONAL ARGUMENTS ####
-`create`
-selects create mode
-
+#### `create` POSITIONAL ARGUMENTS ####
 `file`
 the input sensors text file
 
-#### Mode 1: create OPTIONAL ARGUMENTS ####
+#### `create` OPTIONAL ARGUMENTS ####
 `-t,--min-temp MIN_TEMP`
 select the minimum temperature for the input temperature data.
 If an individual temperature is below the minimum temperature
@@ -98,7 +98,7 @@ FPGA Core dts11 Temperature: 9<br>
 <br>
 HSSI_0_1 dts4 Temperature: 5<br>
 
-#### Mode 1: examples ####
+#### `create` examples ####
 
 ```console
 $ qpafilter create thermal.txt
@@ -114,7 +114,7 @@ $ qpafilter create --override-temp='FPGA Core dts11 Temperature:75' -o qpafilter
  temperature for sensor "FPGA Core dts11 Temperature" as 75% of the
  Upper Fatal value.
 
-### Mode 2: dump ###
+### Mode 2: `dump` ###
 
 ```console
 qpafilter dump [-o OUTPUT] [-F {csv,json,yaml}] [file]
@@ -124,12 +124,12 @@ Convert the input binary file to human-readable output. The
 input binary file must have been previously created by a
 qpafilter create ... command.
 
-#### Mode 2: dump POSITIONAL ARGUMENTS ####
+#### `dump` POSITIONAL ARGUMENTS ####
 `file`
 the input binary file. This file must have been created by
 using qpafilter create ...
 
-#### Mode 2: dump OPTIONAL ARGUMENTS ####
+#### `dump` OPTIONAL ARGUMENTS ####
 `-o,--output OUTPUT`
 specify the output human-readable file name.
 
@@ -150,7 +150,7 @@ FPGA Core dts11 Temperature: 9<br>
 <br>
 HSSI_0_1 dts4 Temperature: 5<br>
 
-#### Mode 2: examples ####
+#### `dump` examples ####
 
 ```console
 qpafilter dump qpafilter.blob

--- a/tools/extra/qpafilter/qpafilter.md
+++ b/tools/extra/qpafilter/qpafilter.md
@@ -118,8 +118,7 @@ using qpafilter create ...
 
 ### Mode 2: dump OPTIONAL ARGUMENTS ###
 `-o,--output OUTPUT`
-specify the output binary file name. The default OUTPUT value is
-qpafilter.blob.
+specify the output binary file name.
 
 `-F,--format (csv|json|yaml)`
 

--- a/tools/extra/qpafilter/qpafilter.md
+++ b/tools/extra/qpafilter/qpafilter.md
@@ -20,16 +20,16 @@ Analyzer. Following is a brief example input file. The temperature
 sensor label is followed by the temperature sensor Upper Fatal
 value and units.
 
-+-----------------------------------------------------------+
-; Temperature and Cooling                                   ;
-+-----------------------------------------------+-----------+
-; FPGA Core dts01 Temperature                   ; 55.0 °C  
-; FPGA Core dts11 Temperature                   ; 54.5 °C  
-
-...
-
-; HSSI_0_1 dts4 Temperature                     ; 90.7 °C  
-+-----------------------------------------------+-----------+
++-----------------------------------------------------------+<br>
+; Temperature and Cooling                                   ;<br>
++-----------------------------------------------+-----------+<br>
+; FPGA Core dts01 Temperature                   ; 55.0 °<br>
+; FPGA Core dts11 Temperature                   ; 54.5 °<br>
+<br>
+...<br>
+<br>
+; HSSI_0_1 dts4 Temperature                     ; 90.7 °<br>
++-----------------------------------------------+-----------+<br>
 
 ### Mode 1: create POSITIONAL ARGUMENTS ###
 `create`
@@ -78,12 +78,12 @@ specify the name of the input sensors map file. The default value
 is n5010_bmc_sensors.yml. This file contains the mapping from
 sensor labels to sensor IDs. A sample input follows:
 
-FPGA Core dts01 Temperature: 8
-FPGA Core dts11 Temperature: 9
-
-...
-
-HSSI_0_1 dts4 Temperature: 5
+FPGA Core dts01 Temperature: 8<br>
+FPGA Core dts11 Temperature: 9<br>
+<br>
+...<br>
+<br>
+HSSI_0_1 dts4 Temperature: 5<br>
 
 ### Mode 1: examples ###
 
@@ -131,12 +131,12 @@ specify the name of the input sensors map file. The default value
 is n5010_bmc_sensors.yml. This file contains the mapping from
 sensor labels to sensor IDs. A sample input follows:
 
-FPGA Core dts01 Temperature: 8
-FPGA Core dts11 Temperature: 9
-
-...
-
-HSSI_0_1 dts4 Temperature: 5
+FPGA Core dts01 Temperature: 8<br>
+FPGA Core dts11 Temperature: 9<br>
+<br>
+...<br>
+<br>
+HSSI_0_1 dts4 Temperature: 5<br>
 
 ### Mode 2: examples ###
 

--- a/tools/extra/qpafilter/qpafilter.md
+++ b/tools/extra/qpafilter/qpafilter.md
@@ -7,7 +7,20 @@ qpafilter [-h] [-v] [-s SENSOR_MAP] {create,dump} ...
 
 ## DESCRIPTION ##
 
-### Mode 1: create ##
+qpafilter is a tool that, given sensor values as determined by
+Quartus Power Analyzer, creates a binary file that can be used
+by the FPGA BMC (Board Management Controller) firmware to set
+sensor thresholds. In addition to creating this binary file,
+qpafilter can parse it and dump it in a human-readable format.
+
+## SUB-COMMANDS ##
+create
+ Transform qpa text file into a binary format for the BMC FW.
+
+dump
+ Parse an existing binary file and dump in a human-readable format.
+
+### Mode 1: create ###
 
 ```console
 qpafilter create [-t MIN_TEMP] [-f VIRT_FATAL_TEMP] [-w VIRT_WARN_TEMP] [-O OVERRIDE_TEMP] [-o OUTPUT] [file]
@@ -31,14 +44,14 @@ value and units.
 ; HSSI_0_1 dts4 Temperature                     ; 90.7 °<br>
 +-----------------------------------------------+-----------+<br>
 
-### Mode 1: create POSITIONAL ARGUMENTS ###
+#### Mode 1: create POSITIONAL ARGUMENTS ####
 `create`
 selects create mode
 
 `file`
 the input sensors text file
 
-### Mode 1: create OPTIONAL ARGUMENTS ###
+#### Mode 1: create OPTIONAL ARGUMENTS ####
 `-t,--min-temp MIN_TEMP`
 select the minimum temperature for the input temperature data.
 If an individual temperature is below the minimum temperature
@@ -85,7 +98,7 @@ FPGA Core dts11 Temperature: 9<br>
 <br>
 HSSI_0_1 dts4 Temperature: 5<br>
 
-### Mode 1: examples ###
+#### Mode 1: examples ####
 
 ```console
 $ qpafilter create thermal.txt
@@ -111,12 +124,12 @@ Convert the input binary file to human-readable output. The
 input binary file must have been previously created by a
 qpafilter create ... command.
 
-### Mode 2: dump POSITIONAL ARGUMENTS ###
+#### Mode 2: dump POSITIONAL ARGUMENTS ####
 `file`
 the input binary file. This file must have been created by
 using qpafilter create ...
 
-### Mode 2: dump OPTIONAL ARGUMENTS ###
+#### Mode 2: dump OPTIONAL ARGUMENTS ####
 `-o,--output OUTPUT`
 specify the output human-readable file name.
 
@@ -137,7 +150,7 @@ FPGA Core dts11 Temperature: 9<br>
 <br>
 HSSI_0_1 dts4 Temperature: 5<br>
 
-### Mode 2: examples ###
+#### Mode 2: examples ####
 
 ```console
 qpafilter dump qpafilter.blob

--- a/tools/extra/qpafilter/qpafilter.md
+++ b/tools/extra/qpafilter/qpafilter.md
@@ -1,0 +1,153 @@
+# qpafilter #
+
+## SYNOPSIS ##
+```console
+qpafilter [-h] [-v] [-s SENSOR_MAP] {create,dump} ...
+```
+
+## DESCRIPTION ##
+
+### Mode 1: create ##
+
+```console
+qpafilter create [-t MIN_TEMP] [-f VIRT_FATAL_TEMP] [-w VIRT_WARN_TEMP] [-O OVERRIDE_TEMP] [-o OUTPUT] [file]
+```
+
+Convert the input sensors text file to a binary file suitable for
+consumption by the Board Management Controller. The format of the
+input sensors text file is that produced by the Quartus Power
+Analyzer. Following is a brief example input file. The temperature
+sensor label is followed by the temperature sensor Upper Fatal
+value and units.
+
++-----------------------------------------------------------+
+; Temperature and Cooling                                   ;
++-----------------------------------------------+-----------+
+; FPGA Core dts01 Temperature                   ; 55.0 °C  
+; FPGA Core dts11 Temperature                   ; 54.5 °C  
+
+...
+
+; HSSI_0_1 dts4 Temperature                     ; 90.7 °C  
++-----------------------------------------------+-----------+
+
+### Mode 1: create POSITIONAL ARGUMENTS ###
+`create`
+selects create mode
+
+`file`
+the input sensors text file
+
+### Mode 1: create OPTIONAL ARGUMENTS ###
+`-t,--min-temp MIN_TEMP`
+select the minimum temperature for the input temperature data.
+If an individual temperature is below the minimum temperature
+value, qpafilter displays a warning. If all of the input
+temperatures are below the minimum, qpafilter displays an
+error and halts execution.
+
+`-f,--virt-fatal-temp VIRT_FATAL_TEMP`
+specify the virtual sensor Upper Fatal value. The sensor
+Upper Warning threshold values are calcuated from the ratio of
+the virtual sensor Upper Warning threshold:the virtual sensor
+Upper Fatal threshold.
+
+`-w,--virt-warn-temp VIRT_WARN_TEMP`
+specify the virtual sensor Upper Warning value. The sensor
+Upper Warning threshold values are calculated from the ratio of
+the virtual sensor Upper Warning threshold:the virtual sensor
+Upper Fatal threshold.
+
+`-O,--override-temp OVERRIDE_TEMP`
+specify a temperature sensor override of the form label:percentage,
+where label is the label given to the temperature sensor in the
+input sensor text file; and percentage is a number between 0 and
+100.
+
+example: --override-temp='HSSI_0_1 dts4 Temperature:50'
+
+This will calculate the Upper Warning value of the sensor labeled
+"HSSI_0_1 dts4 Temperature" as 50% of the input Upper Fatal value.
+
+`-o,--output OUTPUT`
+specify the output binary file name. The default OUTPUT value is
+qpafilter.blob.
+
+`-s,--sensor-file SENSOR_MAP`
+specify the name of the input sensors map file. The default value
+is n5010_bmc_sensors.yml. This file contains the mapping from
+sensor labels to sensor IDs. A sample input follows:
+
+FPGA Core dts01 Temperature: 8
+FPGA Core dts11 Temperature: 9
+
+...
+
+HSSI_0_1 dts4 Temperature: 5
+
+### Mode 1: examples ###
+
+```console
+$ qpafilter create thermal.txt
+```
+
+ Uses default settings to create qpafilter.blob from thermal.txt.
+
+```console
+$ qpafilter create --override-temp='FPGA Core dts11 Temperature:75' -o qpafilter.bin thermal.txt
+```
+
+ Create qpafilter.bin from thermal.txt, calculating the Upper Warning
+ temperature for sensor "FPGA Core dts11 Temperature" as 75% of the
+ Upper Fatal value.
+
+### Mode 2: dump ###
+
+```console
+qpafilter dump [-o OUTPUT] [-F {csv,json,yaml}] [file]
+```
+
+Convert the input binary file to human-readable output. The
+input binary file must have been previously created by a
+qpafilter create ... command.
+
+### Mode 2: dump POSITIONAL ARGUMENTS ###
+`file`
+the input binary file. This file must have been created by
+using qpafilter create ...
+
+### Mode 2: dump OPTIONAL ARGUMENTS ###
+`-o,--output OUTPUT`
+specify the output binary file name. The default OUTPUT value is
+qpafilter.blob.
+
+`-F,--format (csv|json|yaml)`
+
+specify the human-readable output format. The default is
+Comma-Separated Value (csv). JSON and YAML are also supported.
+
+`-s,--sensor-file SENSOR_MAP`
+specify the name of the input sensors map file. The default value
+is n5010_bmc_sensors.yml. This file contains the mapping from
+sensor labels to sensor IDs. A sample input follows:
+
+FPGA Core dts01 Temperature: 8
+FPGA Core dts11 Temperature: 9
+
+...
+
+HSSI_0_1 dts4 Temperature: 5
+
+### Mode 2: examples ###
+
+```console
+qpafilter dump qpafilter.blob
+```
+
+ uses default settings to produce csv output for binary qpafilter.blob.
+
+```console
+qpafilter dump --format=yaml qpafilter.bin
+```
+
+ displays the sensor data found in qpafilter.bin in yaml format.

--- a/tools/extra/qpafilter/qpafilter.md
+++ b/tools/extra/qpafilter/qpafilter.md
@@ -118,7 +118,7 @@ using qpafilter create ...
 
 ### Mode 2: dump OPTIONAL ARGUMENTS ###
 `-o,--output OUTPUT`
-specify the output binary file name.
+specify the output human-readable file name.
 
 `-F,--format (csv|json|yaml)`
 

--- a/tools/extra/qpafilter/qpafilter.py
+++ b/tools/extra/qpafilter/qpafilter.py
@@ -466,7 +466,7 @@ def parse_args():
                       help='Input blob file')
 
     dump.add_argument('-o', '--output', type=argparse.FileType('w'),
-                      default=sys.stdout, nargs='?',
+                      default=sys.stdout,
                       help='Output text file (default=stdout)')
 
     dump.add_argument('-F', '--format',


### PR DESCRIPTION
The parameter to --output should not be optional, but required,
as it is invalid to run qpafilter as

$ qpafilter dump --output

Add qpafilter.md documentation.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>