### PR TITLE
Add fmt to libraries to link with

### DIFF
--- a/ofs/apps/cpeng/CMakeLists.txt
+++ b/ofs/apps/cpeng/CMakeLists.txt
@@ -29,5 +29,6 @@ opae_add_executable(TARGET hps
     LIBS
         ofs_cpeng
         afu-test
+	fmt
     COMPONENT cpeng
 )

--- a/samples/dummy_afu/CMakeLists.txt
+++ b/samples/dummy_afu/CMakeLists.txt
@@ -32,6 +32,7 @@ opae_add_executable(TARGET dummy_afu
         afu-test
         ${libjson-c_LIBRARIES}
         ${libuuid_LIBRARIES}
+	fmt
     COMPONENT samplebin
 )
 

--- a/samples/host_exerciser/CMakeLists.txt
+++ b/samples/host_exerciser/CMakeLists.txt
@@ -32,5 +32,6 @@ opae_add_executable(TARGET host_exerciser
         afu-test
         ${libjson-c_LIBRARIES}
         ${libuuid_LIBRARIES}
+	fmt
     COMPONENT samplebin
 )

--- a/samples/hssi/CMakeLists.txt
+++ b/samples/hssi/CMakeLists.txt
@@ -30,5 +30,6 @@ opae_add_executable(TARGET hssi
     SOURCE hssi.cpp
     LIBS
         afu-test
+        fmt
     COMPONENT sampleshssi
 )


### PR DESCRIPTION
On RHEL 8.2, there is this repesentative build error

/usr/bin/ld: CMakeFiles/hssi.dir/hssi.cpp.o: undefined reference to symbol '_ZTVN3fmt2v612format_errorE'
//usr/lib64/libfmt.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status

So add the libfmt to the libraries to link with.

Signed-off-by: Tom Rix <trix@redhat.com>