### PR TITLE
ci: remove python 2.7,3.5 from ci checks

### DIFF
--- a/.github/workflows/python-static-analysis.yml
+++ b/.github/workflows/python-static-analysis.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>