### PR TITLE
cmake: link with fmt if spdlog is found

### DIFF
--- a/afu-test/CMakeLists.txt
+++ b/afu-test/CMakeLists.txt
@@ -28,6 +28,13 @@ cmake_minimum_required (VERSION  3.10)
 project(afu-test)
 add_library(afu-test INTERFACE)
 
+if (fmt_LIBRARIES)
+    # if we found fmt before (from external/CMakeLists.txt)
+    # then we need to find it again from this directory
+    # so we can "import" the fmt::fmt link target
+    find_package(fmt)
+endif (fmt_LIBRARIES)
+
 target_include_directories(afu-test INTERFACE
     ${OPAE_INCLUDE_PATHS}
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -38,6 +45,7 @@ target_include_directories(afu-test INTERFACE
 target_link_libraries(afu-test INTERFACE
     opae-c opae-cxx-core
     ${spdlog_LIBRARIES}
+    ${fmt_LIBRARIES}
 )
 
 target_compile_options(afu-test INTERFACE

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -58,13 +58,7 @@ if(NOT spdlog_FOUND)
     find_package(spdlog 1.8)
 endif(NOT spdlog_FOUND)
 
-if(spdlog_FOUND)
-    string(REGEX MATCH "-DSPDLOG_FMT_EXTERNAL" have_fmt ${spdlog_DEFINITIONS})
-    if (have_fmt)
-        find_package(fmt)
-        set(fmt_LIBRARIES "fmt::fmt" CACHE STRING "fmt library link interface")
-    endif (have_fmt)
-else(spdlog_FOUND)
+if(NOT spdlog_FOUND)
     set(SPDLOG_URL
         https://github.com/gabime/spdlog.git
         CACHE STRING "URL for spdlog Project")
@@ -86,7 +80,15 @@ else(spdlog_FOUND)
     set(spdlog_DEFINITIONS ""
         CACHE STRING "Do not link against spdlog library, using header-only" FORCE)
     set(spdlog_FOUND TRUE CACHE BOOL "spdlog found as external")
-endif(spdlog_FOUND)
+else(NOT spdlog_FOUND)
+    if(spdlog_DEFINITIONS)
+        string(REGEX MATCH "-DSPDLOG_FMT_EXTERNAL" have_fmt ${spdlog_DEFINITIONS})
+        if (have_fmt)
+            find_package(fmt)
+            set(fmt_LIBRARIES "fmt::fmt" CACHE STRING "fmt library link interface")
+        endif (have_fmt)
+    endif(spdlog_DEFINITIONS)
+endif(NOT spdlog_FOUND)
 
 if(OPAE_BUILD_LEGACY)
     opae_external_project_add(PROJECT_NAME opae-legacy

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -56,6 +56,11 @@ endif(NOT CLI11_FOUND)
 
 if(NOT spdlog_FOUND)
     find_package(spdlog 1.8)
+    string(REGEX MATCH "-DSPDLOG_FMT_EXTERNAL" have_fmt ${spdlog_DEFINITIONS})
+    if (have_fmt)
+        find_package(fmt)
+        set(fmt_LIBRARIES "fmt::fmt" CACHE STRING "fmt library link interface")
+    endif (have_fmt)
 endif(NOT spdlog_FOUND)
 
 if(NOT spdlog_FOUND)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -56,14 +56,15 @@ endif(NOT CLI11_FOUND)
 
 if(NOT spdlog_FOUND)
     find_package(spdlog 1.8)
+endif(NOT spdlog_FOUND)
+
+if(spdlog_FOUND)
     string(REGEX MATCH "-DSPDLOG_FMT_EXTERNAL" have_fmt ${spdlog_DEFINITIONS})
     if (have_fmt)
         find_package(fmt)
         set(fmt_LIBRARIES "fmt::fmt" CACHE STRING "fmt library link interface")
     endif (have_fmt)
-endif(NOT spdlog_FOUND)
-
-if(NOT spdlog_FOUND)
+else(spdlog_FOUND)
     set(SPDLOG_URL
         https://github.com/gabime/spdlog.git
         CACHE STRING "URL for spdlog Project")
@@ -85,7 +86,7 @@ if(NOT spdlog_FOUND)
     set(spdlog_DEFINITIONS ""
         CACHE STRING "Do not link against spdlog library, using header-only" FORCE)
     set(spdlog_FOUND TRUE CACHE BOOL "spdlog found as external")
-endif(NOT spdlog_FOUND)
+endif(spdlog_FOUND)
 
 if(OPAE_BUILD_LEGACY)
     opae_external_project_add(PROJECT_NAME opae-legacy


### PR DESCRIPTION
Some distros include spdlog that uses format operations from an external
fmt library. When this is the case, finding spdlog will set
-DSPDLOG_FMT_EXTERNAL in its definitions.
This change checks for this when it finds the spdlog package that comes
as part of the distro. If it detects fmt is external, it will set
FMT_LIBRARIES to "fmt::fmt" which is the link interface used when
find_package(fmt) finds fmt on the system. When linking afu_test with
spdlog, it will check if FMT_LIBRARIES is defined and call
find_package(fmt) again from its directory so that it will import the
link target, "fmt::fmt"

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>