### PR TITLE
opae-sdk: fix hssi setup.py installation

### DIFF
--- a/tools/extra/hssi/dummy/dummy.cpp
+++ b/tools/extra/hssi/dummy/dummy.cpp
@@ -1,0 +1,34 @@
+// Copyright(c) 2021, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <string.h>
+#include <iostream>
+#include <stdexcept>
+
+void dummy(void)
+{
+ std::cout<<"---test--------"<< std::endl;
+}

--- a/tools/extra/hssi/hssiloopback.py
+++ b/tools/extra/hssi/hssiloopback.py
@@ -35,7 +35,7 @@ import fcntl
 import stat
 import struct
 import mmap
-from hssicommon import *
+from hssi.hssicommon import *
 
 
 class FPGAHSSILPBK(HSSICOMMON):

--- a/tools/extra/hssi/hssimac.py
+++ b/tools/extra/hssi/hssimac.py
@@ -31,7 +31,7 @@ import glob
 import argparse
 import sys
 import struct
-from hssicommon import *
+from hssi.hssicommon import *
 
 
 class FPGAHSSIMAC(HSSICOMMON):

--- a/tools/extra/hssi/hssistats.py
+++ b/tools/extra/hssi/hssistats.py
@@ -35,7 +35,7 @@ import fcntl
 import stat
 import struct
 import mmap
-from hssicommon import *
+from hssi.hssicommon import *
 
 
 class FPGAHSSISTATS(HSSICOMMON):

--- a/tools/extra/hssi/setup.py
+++ b/tools/extra/hssi/setup.py
@@ -44,6 +44,14 @@ def override_build_extensions(self):
 # replace build_extensions with our custom version
 build_ext.build_extensions = override_build_extensions
 
+extensions = [
+            Extension("dummy",
+                      sources=['dummy/dummy.cpp'],
+                      language="c++",
+                      extra_compile_args=["-std=c++11"],
+                      extra_link_args=["-std=c++11"]
+                      )
+]
 
 class pybind_include_dirs(object):
     def __init__(self, user=False):
@@ -57,19 +65,22 @@ class pybind_include_dirs(object):
 setup(
     name='hssi',
     version="2.0",
-    packages=find_packages(include=['*']),
+    package_dir={'hssi': '.'},
+    packages=['hssi', 'hssi.'],
+    platforms='linux-x86_x64',
     include_dirs=[pybind_include_dirs()],
     entry_points={
         'console_scripts': [
-            'hssistats = hssistats:main',
-            'hssimac = hssimac:main',
-            'hssiloopback = hssiloopback:main',
-            'hssicommon = hssiloopback:main',
+            'hssistats = hssi.hssistats:main',
+            'hssimac = hssi.hssimac:main',
+            'hssiloopback = hssi.hssiloopback:main',
+            'hssicommon = hssi.hssicommon:main',
         ]
     },
     description="hssi eth tools"
     "for ethernet UIO",
     license="BSD3",
+    ext_modules=extensions,
     keywords="OPAE hssi tools ",
     url="https://01.org/OPAE",
     include_package_data=True,


### PR DESCRIPTION
 - added dummy.cpp file to install python  files to /usr/lib64/python3.9/site-packages/hssi/
  Without dummy.cpp python  files install into folder  /usr/lib/python3.9/site-packages/hssi/

  -fix setupy package

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>