### PR TITLE
PACSign: OpenSSL: verify with public key

### DIFF
--- a/python/pacsign/pacsign/hsm_managers/openssl/key_manager.py
+++ b/python/pacsign/pacsign/hsm_managers/openssl/key_manager.py
@@ -100,7 +100,7 @@ class HSM_MANAGER(object):
     def sign(self, sha, key):
         private_key = self.get_private_key(key)
         data = common_util.BYTE_ARRAY()
-        private_key.sign(sha, data)
+        private_key.sign(sha, data, self.get_public_key(key))
         log.debug("Signature len={}".format(data.size()))
         log.debug("".join("{:02x} ".format(x) for x in data.data))
 
@@ -558,7 +558,7 @@ class _PRIVATE_KEY(_KEY):
         self.key = self.openssl.read_private_key(self.file)
         self.retrive_key_info()
 
-    def sign(self, sha, data, fixed_RS_size=0):
+    def sign(self, sha, data, public_key, fixed_RS_size=0):
         log.debug("Sign: sha_size:{}".format(len(sha)))
         common_util.assert_in_error(
             len(sha) == 32 or len(sha) == 48 or len(sha) == 64,
@@ -572,7 +572,7 @@ class _PRIVATE_KEY(_KEY):
         common_util.assert_in_error(
             self.openssl.lib.ECDSA_do_verify(
                 sha, len(sha),
-                signature, self.key),
+                signature, public_key.key),
             "Fail to verify after the signing",)
 
         r = c_void_p(None)

--- a/python/pacsign/tests/test_key_manager.py
+++ b/python/pacsign/tests/test_key_manager.py
@@ -63,8 +63,9 @@ def test_sign():
     _PRIVATE_KEY_test = _PRIVATE_KEY(init_file, init_openssl, init_key_info)
     sign_sha = mock.MagicMock()
     sign_data = mock.MagicMock()
+    public_key = mock.MagicMock()
     sign_fixed_RS_size = mock.MagicMock()
-    _PRIVATE_KEY_test.sign(sign_sha, sign_data, sign_fixed_RS_size)
+    _PRIVATE_KEY_test.sign(sign_sha, sign_data, public_key, fixed_RS_size=sign_fixed_RS_size)
 
 '''test_get_private_key'''
 


### PR DESCRIPTION
Change the verification step after the signing process to verify
with the public key. Apparently, the API will take either the public
or the private key, but the public key is the correct choice.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>