### PR TITLE
qpafilter: adjust temps to min_temp when below

### DIFF
--- a/tools/extra/qpafilter/qpafilter.py
+++ b/tools/extra/qpafilter/qpafilter.py
@@ -242,6 +242,8 @@ class temp_verifier:
                 LOG.info(f'is lower than the platform\'s recommended '
                          f'minimum of {self.args.min_temp} {DEGREES_C}.')
                 min_temp_failures += 1
+                # Adjust the fatal value up to the minimum.
+                i['fatal'] = str(self.args.min_temp)
 
         if min_temp_failures == len(items):
             LOG.warning(f'WARNING: All threshold values are below the '


### PR DESCRIPTION
When a sensor fatal value is less than the prescribed 90C minimum,
set it to the 90C minimum.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>