### PR TITLE
continuing with rpm building

### DIFF
--- a/opae-libs/cmake/modules/OPAEGit.cmake
+++ b/opae-libs/cmake/modules/OPAEGit.cmake
@@ -33,7 +33,7 @@
 
 find_program(OPAE_GIT_EXECUTABLE git)
 
-if(EXISTS ${OPAE_GIT_EXECUTABLE})
+if((EXISTS ${OPAE_GIT_EXECUTABLE}) AND (EXISTS ".git"))
     # Find the abbreviated git commit hash.
     execute_process(COMMAND ${OPAE_GIT_EXECUTABLE} log -1 --format=%h
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -59,7 +59,7 @@ if(EXISTS ${OPAE_GIT_EXECUTABLE})
             set(OPAE_GIT_SRC_TREE_DIRTY 0)
         endif()
     endif()
-else(EXISTS ${OPAE_GIT_EXECUTABLE})
+else()
     set(OPAE_GIT_COMMIT_HASH unknown)
     set(OPAE_GIT_SRC_TREE_DIRTY 0)
-endif(EXISTS ${OPAE_GIT_EXECUTABLE})
+endif()

--- a/opae.spec
+++ b/opae.spec
@@ -27,6 +27,7 @@ BuildRequires:  doxygen
 BuildRequires:  systemd
 BuildRequires:  pybind11-devel
 BuildRequires:  python3-setuptools
+BuildRequires:  spdlog-devel
 BuildRequires:  tbb-devel
 BuildRequires:  git
 BuildRequires:  python3-jsonschema

--- a/opae.spec
+++ b/opae.spec
@@ -113,20 +113,6 @@ cp samples/n5010-ddr-test/n5010-ddr-test.c %{buildroot}%{_usr}/src/opae/samples/
   %cmake_install
 %endif
 
-prev=$PWD
-pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/python/opae.admin/
-%{__python3} setup.py install --single-version-externally-managed  --root=%{buildroot} 
-popd
-
-pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/python/pacsign
-%{__python3} setup.py install --single-version-externally-managed --root=%{buildroot} 
-popd
-
-for file in %{buildroot}%{python3_sitelib}/opae/admin/tools/{fpgaflash,fpgaotsu,fpgaport,fpgasupdate,ihex2ipmi,rsu,super_rsu,bitstream_info}.py; do
-   chmod a+x $file
-done
-
-
 %files
 %dir %{_datadir}/opae
 %doc %{_datadir}/opae/RELEASE_NOTES.md

--- a/opae.spec
+++ b/opae.spec
@@ -154,6 +154,7 @@ cp samples/n5010-ddr-test/n5010-ddr-test.c %{buildroot}%{_usr}/src/opae/samples/
 %{_libdir}/opae/libboard_n3000.so*
 %{_libdir}/opae/libboard_d5005.so*
 %{_libdir}/opae/libboard_n5010.so*
+%{_libdir}/opae/libboard_n6010.so*
 %{_libdir}/opae/libfpgad-xfpga.so*
 %{_libdir}/opae/libopae-v.so*
 %{_libdir}/libopae-c++-nlb.so

--- a/opae.spec
+++ b/opae.spec
@@ -17,6 +17,7 @@ Source0:        https://github.com/OPAE/opae-sdk/releases/download/%{version}-%{
 
 BuildRequires:  gcc, gcc-c++
 BuildRequires:  cmake
+BuildRequires:  cli11-devel
 BuildRequires:  python3-devel
 BuildRequires:  json-c-devel
 BuildRequires:  libuuid-devel

--- a/opae.spec
+++ b/opae.spec
@@ -66,7 +66,7 @@ OPAE headers, tools, sample source, and documentation
 %setup -q -n %{name}-%{version}-%{opae_release}
 
 %build
-%cmake -DCMAKE_INSTALL_PREFIX=/usr  -DOPAE_PRESERVE_REPOS=ON -DOPAE_BUILD_LEGACY=ON -DOPAE_BUILD_SAMPLES=ON -DOPAE_BUILD_EXTRA_TOOLS_FPGABIST=ON .
+%cmake -DCMAKE_INSTALL_PREFIX=/usr  -DOPAE_PRESERVE_REPOS=ON -DOPAE_BUILD_LEGACY=ON -DOPAE_BUILD_EXTRA_TOOLS_FPGABIST=ON .
 %if 0%{?rhel}
   %make_build
 %else

--- a/opae.spec
+++ b/opae.spec
@@ -211,7 +211,7 @@ cp samples/n5010-ddr-test/n5010-ddr-test.c %{buildroot}%{_usr}/src/opae/samples/
 %{_bindir}/fpga_dma_test
 %{_bindir}/n5010-ddr-test
 %{_bindir}/PACSign*
-%{_bindir}/fpgad*
+%{_bindir}/fpgad
 %{_bindir}/host_exerciser*
 %{_bindir}/opaevfio*
 %{_bindir}/pci_device*

--- a/packaging/opae/rpm/create
+++ b/packaging/opae/rpm/create
@@ -59,6 +59,7 @@ for pkg in 'make' \
            'python3-pip' \
 	   'python3-virtualenv' \
            'rpm-build' \
+	   'spdlog-devel' \
            'systemd' \
            'rpmdevtools'
 do

--- a/packaging/opae/rpm/create
+++ b/packaging/opae/rpm/create
@@ -45,6 +45,7 @@ SDK_DIR="$(cd "${SCRIPT_DIR}/../../../" && pwd)"
 # Check for prerequisite packages.
 for pkg in 'make' \
            'cmake' \
+           'cli11-devel' \
            'git' \
            'gcc' \
            'gcc-c++' \

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -39,5 +39,16 @@ find_package(PythonLibs ${OPAE_PYTHON_VERSION})
 
 set(INTEL_SECURITY_TOOLS_VERSION 1.0.3 CACHE STRING "Security Tools Version string")
 
-add_subdirectory(opae.admin)
-add_subdirectory(pacsign)
+option(OPAE_BUILD_OPAE_ADMIN "Enable building opae.admin" ON)
+mark_as_advanced(OPAE_BUILD_OPAE_ADMIN)
+
+option(OPAE_BUILD_PACSIGN "Enable building pacsign" ON)
+mark_as_advanced(OPAE_BUILD_PACSIGN)
+
+if(OPAE_BUILD_OPAE_ADMIN)
+  add_subdirectory(opae.admin)
+endif()
+
+if(OPAE_BUILD_PACSIGN)
+  add_subdirectory(pacsign)
+endif()


### PR DESCRIPTION
The first commit addresses a lot of noise in the build log when the .git directory is not there.
The second disables pacsign building so other rpm errors can be addressed
