### PR TITLE
qpafilter: use min temperature for invalid fatal

### DIFF
--- a/tools/extra/qpafilter/qpafilter.py
+++ b/tools/extra/qpafilter/qpafilter.py
@@ -242,6 +242,7 @@ class temp_verifier:
                 LOG.info(f'is lower than the platform\'s recommended '
                          f'minimum of {self.args.min_temp} {DEGREES_C}.')
                 min_temp_failures += 1
+                i['fatal'] = str(self.args.min_temp)
 
         if min_temp_failures == len(items):
             LOG.warning(f'WARNING: All threshold values are below the '


### PR DESCRIPTION
When any of the input fatal temperature values is less than the
minimum of 90C, set that fatal value to 90C.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>