### PR TITLE
qpafilter: update input sensors map file

### DIFF
--- a/tools/extra/qpafilter/n5010_bmc_sensors.yml
+++ b/tools/extra/qpafilter/n5010_bmc_sensors.yml
@@ -1,51 +1,30 @@
 FPGA Core dts01 Temperature:
-  id:
-    - 8
-  adjustment: 0.0
+- id: 8
 FPGA Core dts11 Temperature:
-  id:
-    - 9
-  adjustment: 0.0
+- id: 9
 FPGA Core dts12 Temperature:
-  id:
-    - 13
-  adjustment: 0.0
+- id: 13
 FPGA Core dts21 Temperature:
-  id:
-    - 10
-  adjustment: 0.0
+- id: 10
 FPGA Core dts22 Temperature:
-  id:
-    - 14
-  adjustment: 0.0
+- id: 14
 FPGA Core dts31 Temperature:
-  id:
-    - 11
-  adjustment: 0.0
+- id: 11
 FPGA Core dts32 Temperature:
-  id:
-    - 15
-  adjustment: 0.0
+- id: 15
 FPGA Core dts41 Temperature:
-  id:
-    - 12
-  adjustment: 0.0
+- id: 12
 FPGA Core dts42 Temperature:
-  id:
-    - 16
-  adjustment: 0.0
+- id: 16
 HSSI_0_0 dts1 Temperature:
-  id:
-    - 6
-  adjustment: 0.0
+- id: 6
 HSSI_0_1 dts1 Temperature:
-  id:
-    - 2
-    - 3
-    - 4
-    - 5
+- id: 2
+- id: 3
+  adjustment: -1.5
+- id: 4
+  adjustment: -1.5
+- id: 5
   adjustment: -1.5
 FPGA Virtual Temperature Sensor 0:
-  id:
-    - 0x8000
-  adjustment: 0.0
+- id: 0x8000

--- a/tools/extra/qpafilter/qpafilter.md
+++ b/tools/extra/qpafilter/qpafilter.md
@@ -2,7 +2,7 @@
 
 ## SYNOPSIS ##
 ```console
-qpafilter [-h] [-v] [-s SENSOR_MAP] {create,dump} ...
+qpafilter [-h] [-v] [-s SENSOR_MAP] {create,dump,show} ...
 ```
 
 ## DESCRIPTION ##
@@ -99,27 +99,22 @@ sensor labels to sensor IDs. A sample input follows:
 
 <pre>
 FPGA Core dts01 Temperature:
-  id:
-    - 8
-  adjustment: 0.0
+- id: 8
 FPGA Core dts11 Temperature:
-  id:
-    - 9
-  adjustment: 0.0
+- id: 9
 
 ...
 
 HSSI_0_1 dts1 Temperature:
-  id:
-    - 2
-    - 3
-    - 4
-    - 5
+- id: 2
+- id: 3
+  adjustment: -1.5
+- id: 4
+  adjustment: -1.5
+- id: 5
   adjustment: -1.5
 FPGA Virtual Temperature Sensor 0:
-  id:
-    - 0x8000
-  adjustment: 0.0
+- id: 0x8000
 </pre>
 
 #### `create` examples ####
@@ -169,27 +164,22 @@ sensor labels to sensor IDs. A sample input follows:
 
 <pre>
 FPGA Core dts01 Temperature:
-  id:
-    - 8
-  adjustment: 0.0
+- id: 8
 FPGA Core dts11 Temperature:
-  id:
-    - 9
-  adjustment: 0.0
+- id: 9
 
 ...
 
 HSSI_0_1 dts1 Temperature:
-  id:
-    - 2
-    - 3
-    - 4
-    - 5
+- id: 2
+- id: 3
+  adjustment: -1.5
+- id: 4
+  adjustment: -1.5
+- id: 5
   adjustment: -1.5
 FPGA Virtual Temperature Sensor 0:
-  id:
-    - 0x8000
-  adjustment: 0.0
+- id: 0x8000
 </pre>
 
 #### `dump` examples ####


### PR DESCRIPTION
Updates the format of the input senors map file so that each
sensor ID may specify an adjustment value, for example:

Sensor0:
- id: 2
- id: 3
  adjustment: -1.5
- id: 4

Previously, only one adjustment value could be specified per sensor
label. Now, there is an adjustment value per sensor integer ID.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>