### PR TITLE
opae.admin: update path to secure device for D5005

### DIFF
--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -210,9 +210,12 @@ class fme(region):
     @property
     def spi_bus(self):
         if os.path.basename(self.sysfs_path).startswith('dfl'):
-            return self.find_one('dfl*.*/'
-                                 '*spi*/'
-                                 'spi_master/spi*/spi*')
+            patterns = ['dfl*.*/*spi*/spi_master/spi*/spi*',
+                        'dfl*.*/spi_master/spi*/spi*']
+            for pattern in patterns:
+                spi = self.find_one(pattern)
+                if spi:
+                    return spi
         return self.find_one('spi*/spi_master/spi*/spi*')
 
     @property


### PR DESCRIPTION
Recent driver changes have removed one layer from the secure
device path for D5005 devices. The remaining devices retain the
original pattern. Add the new path pattern for D5005.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>