### PR TITLE
tools: update recursive  bmc and max10 version sysfs path

### DIFF
--- a/tools/libboard/board_d5005/board_d5005.c
+++ b/tools/libboard/board_d5005/board_d5005.c
@@ -49,11 +49,11 @@
 #define MACADDR_LEN 19
 
 // DFL SYSFS
-#define DFL_SYSFS_BMCFW_VER                     "dfl*/*spi*/spi_master/spi*/spi*/bmcfw_version"
-#define DFL_SYSFS_MAX10_VER                     "dfl*/*spi*/spi_master/spi*/spi*/bmc_version"
+#define DFL_SYSFS_BMCFW_VER                     "dfl*/**/*spi*/*spi*/bmcfw_version"
+#define DFL_SYSFS_MAX10_VER                     "dfl*/**/*spi*/*spi*/bmc_version"
 
-#define DFL_SYSFS_MACADDR_PATH                  "dfl*/*spi*/spi_master/spi*/spi*.*/mac_address"
-#define DFL_SYSFS_MACCNT_PATH                   "dfl*/*spi*/spi_master/spi*/spi*.*/mac_count"
+#define DFL_SYSFS_MACADDR_PATH                  "dfl*/**/*spi*/*spi*/*spi*/mac_address"
+#define DFL_SYSFS_MACCNT_PATH                   "dfl*/**/*spi*/*spi*/*spi*/mac_count"
 
 
 // Read BMC firmware version

--- a/tools/libboard/board_n3000/board_n3000.c
+++ b/tools/libboard/board_n3000/board_n3000.c
@@ -47,11 +47,11 @@
 #include "board_n3000.h"
 
 // DFL SYSFS
-#define DFL_SYSFS_BMCFW_VER                  "dfl*/**/*spi*/*spi*/bmcfw_version"
-#define DFL_SYSFS_MAX10_VER                  "dfl*/**/*spi*/*spi*/bmc_version"
+#define DFL_SYSFS_BMCFW_VER                  "dfl*/*spi*/spi_master/spi*/spi*/bmcfw_version"
+#define DFL_SYSFS_MAX10_VER                  "dfl*/*spi*/spi_master/spi*/spi*/bmc_version"
 
-#define DFL_SYSFS_MACADDR_PATH               "dfl*/**/*spi*/*spi*/mac_address"
-#define DFL_SYSFS_MACCNT_PATH                "dfl*/**/*spi*/*spi*/mac_count"
+#define DFL_SYSFS_MACADDR_PATH               "dfl*/*spi*/spi_master/spi*/spi*.*/mac_address"
+#define DFL_SYSFS_MACCNT_PATH                "dfl*/*spi*/spi_master/spi*/spi*.*/mac_count"
 
 #define DFL_BITSTREAM_ID                      "bitstream_id"
 

--- a/tools/libboard/board_n3000/board_n3000.c
+++ b/tools/libboard/board_n3000/board_n3000.c
@@ -47,11 +47,11 @@
 #include "board_n3000.h"
 
 // DFL SYSFS
-#define DFL_SYSFS_BMCFW_VER                  "dfl*/*spi*/spi_master/spi*/spi*/bmcfw_version"
-#define DFL_SYSFS_MAX10_VER                  "dfl*/*spi*/spi_master/spi*/spi*/bmc_version"
+#define DFL_SYSFS_BMCFW_VER                  "dfl*/**/*spi*/*spi*/bmcfw_version"
+#define DFL_SYSFS_MAX10_VER                  "dfl*/**/*spi*/*spi*/bmc_version"
 
-#define DFL_SYSFS_MACADDR_PATH               "dfl*/*spi*/spi_master/spi*/spi*.*/mac_address"
-#define DFL_SYSFS_MACCNT_PATH                "dfl*/*spi*/spi_master/spi*/spi*.*/mac_count"
+#define DFL_SYSFS_MACADDR_PATH               "dfl*/**/*spi*/*spi*/mac_address"
+#define DFL_SYSFS_MACCNT_PATH                "dfl*/**/*spi*/*spi*/mac_count"
 
 #define DFL_BITSTREAM_ID                      "bitstream_id"
 


### PR DESCRIPTION
 - change in fpga max10 dirver sysfs path

   current path: subdev_spi_altera.6.auto/spi_master/spi6/spi6.0
   new path : /spi_master/spi6/spi6.0

  Max10 sysfs path  dfl*/**/*spi*/*spi*/bmcfw_version