### PR TITLE
qpafilter: add entries back to sensors map

### DIFF
--- a/tools/extra/qpafilter/n5010_bmc_sensors.yml
+++ b/tools/extra/qpafilter/n5010_bmc_sensors.yml
@@ -26,5 +26,11 @@ HSSI_0_1 dts1 Temperature:
   adjustment: -1.5
 - id: 5
   adjustment: -1.5
+HSSI_0_1 dts2 Temperature:
+- id: 3
+HSSI_0_1 dts3 Temperature:
+- id: 4
+HSSI_0_1 dts4 Temperature:
+- id: 5
 FPGA Virtual Temperature Sensor 0:
 - id: 0x8000


### PR DESCRIPTION
Per request from stakeholders, add
HSSI_0_1 dts2 Temperature
HSSI_0_1 dts3 Temperature
HSSI_0_1 dts4 Temperature

back to the sensors map file.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>