### PR TITLE
tools: fix fpgainfo security key sysfs path

### DIFF
--- a/tools/libboard/board_common/board_common.c
+++ b/tools/libboard/board_common/board_common.c
@@ -45,7 +45,7 @@
 
 #include "board_common.h"
 
-#define DFL_SYSFS_SEC_GLOB "dfl*/*spi*/spi_master/spi*/spi*/**/security/"
+#define DFL_SYSFS_SEC_GLOB "*dfl*/*spi*/*spi*/*spi*/**/security/"
 #define DFL_SYSFS_SEC_USER_FLASH_COUNT         DFL_SYSFS_SEC_GLOB "*flash_count"
 #define DFL_SYSFS_SEC_BMC_CANCEL               DFL_SYSFS_SEC_GLOB "bmc_canceled_csks"
 #define DFL_SYSFS_SEC_BMC_ROOT                 DFL_SYSFS_SEC_GLOB "bmc_root_entry_hash"


### PR DESCRIPTION
  -max10/bmc sysfs path are different  for n3000 and d5005 cards

   d5005 sysfspath  dfl*/*spi*/spi_master/spi*/spi*/**/security/
   n3000 sysfspath  dfl*/*spi*/spi_master/spi*/**/security/

   recursive search path *dfl*/*spi*/*spi*/*spi*/**/security/

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>