### PR TITLE
add support for PCI device id bcce

### DIFF
--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -403,7 +403,8 @@ class fpga_base(sysfs_device):
                                       'factory': 0},
                            'retimer': {'user': 0,
                                        'factory': 0}},
-        (0x8086, 0xaf00): None
+        (0x8086, 0xaf00): None,
+        (0x8086, 0xbcce): None
     }
 
     def __init__(self, path):

--- a/python/opae.admin/opae/admin/tools/rsu.py
+++ b/python/opae.admin/opae/admin/tools/rsu.py
@@ -91,6 +91,14 @@ def fpga_defaults_valid(pci_id, value):
                                       'fpga_factory fpga_user2',
                                       'fpga_factory fpga_user1 fpga_user2',
                                       'fpga_factory fpga_user2 fpga_user1'
+                                    ],
+                  (0x8086, 0xbcce): [ 'fpga_user1',
+                                      'fpga_user2',
+                                      'fpga_factory',
+                                      'fpga_factory fpga_user1',
+                                      'fpga_factory fpga_user2',
+                                      'fpga_factory fpga_user1 fpga_user2',
+                                      'fpga_factory fpga_user2 fpga_user1'
                                     ]
                 }
     return value in sequences[pci_id]

--- a/tools/fpgainfo/board.c
+++ b/tools/fpgainfo/board.c
@@ -65,7 +65,7 @@ static platform_data platform_data_table[] = {
 	{ 0x8086, 0x0b2b, "libboard_d5005.so", NULL },
 	{ 0x8086, 0x0b2c, "libboard_d5005.so", NULL },
 	{ 0x8086, 0xaf00, "libboard_d5005.so", NULL },
-	{ 0x8086, 0xbcce, "libboard_n6010.so", NULL },
+	{ 0x8086, 0xbcce, "libboard_d5005.so", NULL },
 	{ 0,      0,          NULL, NULL },
 };
 


### PR DESCRIPTION
Add support for the officially reservered PCI device id
for OFS devices.

Signed-off-by: Matthew Gerlach <matthew.gerlach@linux.intel.com>