### PR TITLE
Samples:Host Exerciser Enhancement

### DIFF
--- a/samples/fpgaperf_counter/fpgaperf_counter.c
+++ b/samples/fpgaperf_counter/fpgaperf_counter.c
@@ -148,6 +148,7 @@ STATIC fpga_result parse_perf_attributes(struct udev_device *dev,
 			if (!fpga_perf->format_type) {
 				fpga_perf->num_format = 0;
 				OPAE_ERR("Failed to allocate Memory");
+				globfree(&pglob);
 				return FPGA_NO_MEMORY;
 			}
 		}

--- a/samples/fpgaperf_counter/fpgaperf_counter.c
+++ b/samples/fpgaperf_counter/fpgaperf_counter.c
@@ -104,119 +104,31 @@ STATIC fpga_result fpga_perf_check_and_lock(fpga_perf_counter *fpga_perf)
 	return FPGA_OK;
 }
 
-/* parse the each format and get the shift val */
-STATIC fpga_result parse_perf_format(struct udev_device *dev,
-		fpga_perf_counter *fpga_perf, const char *attr)
+/* parse the each format and get the shift val
+ * parse the events for the particular device directory */
+STATIC fpga_result parse_perf_attributes(struct udev_device *dev,
+			fpga_perf_counter *fpga_perf, const char *attr)
 {
 	regex_t re;
-	regmatch_t matches[3]			= { {0} };
 	char err[128] 				= { 0 };
 	int reg_res 				= 0;
 	uint64_t loop 				= 0;
+	uint64_t inner_loop			= 0;
 	uint64_t value 				= 0;
 	char attr_path[DFL_PERF_STR_MAX]	= { 0,};
 	char attr_value[128]			= { 0,};
 	int  gres				= 0;
-	size_t inner_loop			= 0;
+	size_t i				= 0;
 	FILE *file				= NULL;
 	glob_t pglob;
+	regmatch_t f_matches[3]			= { {0} };
+	regmatch_t e_matches[4]			= { {0} };
 
 	if (!dev || !fpga_perf) {
 		OPAE_ERR("Invalid input parameters");
 		return FPGA_INVALID_PARAM;
 	}
-	
-	if (snprintf(attr_path, sizeof(attr_path), "%s/%s/*",
-				udev_device_get_syspath(dev), attr) < 0) {
-		OPAE_ERR("snprintf buffer overflow");
-		return FPGA_EXCEPTION;
-	}
-	gres = glob(attr_path, GLOB_NOSORT, NULL, &pglob);
-	if (gres || !pglob.gl_pathc) {
-		OPAE_ERR("Failed pattern match %s", attr_path);
-		globfree(&pglob);
-		return FPGA_EXCEPTION;
-	}
 
-	fpga_perf->num_format = pglob.gl_pathc;
-
-	if (!fpga_perf->format_type) {
-		fpga_perf->format_type = calloc(fpga_perf->num_format,
-			sizeof(perf_format_type));
-		if (!fpga_perf->format_type) {
-			fpga_perf->num_format = 0;
-			OPAE_ERR("Failed to allocate Memory");
-			return FPGA_NO_MEMORY;
-		}
-	}
-
-	for (inner_loop = 0; inner_loop < pglob.gl_pathc; inner_loop++) {
-		reg_res = regcomp(&re, PERF_CONFIG_PATTERN,
-				REG_EXTENDED | REG_ICASE);
-		if (reg_res) {
-			OPAE_ERR("Error compiling regex");
-			return FPGA_EXCEPTION;
-		}
-		file = fopen(pglob.gl_pathv[inner_loop], "r");
-		if (!file) {
-			OPAE_ERR("fopen(%s) failed\n", pglob.gl_pathv[inner_loop]);
-			globfree(&pglob);
-			return FPGA_EXCEPTION;
-		}
-		if (fscanf(file, "%s", attr_value) != 1) {
-			OPAE_ERR("Failed to read %s", pglob.gl_pathv[inner_loop]);
-			goto out;
-		}
-		reg_res = regexec(&re, attr_value, 4, matches, 0);
-		if (reg_res) {
-			regerror(reg_res, &re, err, sizeof(err));
-			OPAE_ERR("Error executing regex: %s", err);
-			goto out;
-		} else {
-			PARSE_MATCH_INT(attr_value, matches[1].rm_so, value, 10);
-			fpga_perf->format_type[loop].shift = value;
-			if (snprintf(fpga_perf->format_type[loop].format_name,
-				sizeof(fpga_perf->format_type[loop].format_name),
-				"%s", (strstr(pglob.gl_pathv[inner_loop], attr)+strlen(attr)+1)) < 0) {
-				OPAE_ERR("snprintf buffer overflow");
-				goto out;
-			}
-			loop++;
-		}
-		fclose(file);
-	}
-
-	globfree(&pglob);
-	return FPGA_OK;
-
-out:
-	fclose(file);
-	globfree(&pglob);
-	return FPGA_EXCEPTION;
-}
-
-/* parse the events for the particular device directory */
-STATIC fpga_result parse_perf_event(struct udev_device *dev,
-		fpga_perf_counter *fpga_perf, const char *attr)
-{	
-	regex_t re;
-	regmatch_t matches[4]			= { {0} };
-	char err[128]				= { 0 };
-	int reg_res				= 0;
-	uint64_t loop 				= 0;
-	uint64_t inner_loop			= 0;
-	char attr_path[DFL_PERF_STR_MAX]	= { 0,};
-	char attr_value[128]			= { 0,};
-	int  gres				= 0;
-	size_t i 				= 0;
-	FILE *file				= NULL;
-	glob_t pglob;
-
-	if (!dev || !fpga_perf) {
-		OPAE_ERR("Invalid input parameters");
-		return FPGA_INVALID_PARAM;
-	}
-	
 	if (snprintf(attr_path, sizeof(attr_path), "%s/%s/*",
 			udev_device_get_syspath(dev), attr) < 0) {
 		OPAE_ERR("snprintf buffer overflow");
@@ -228,26 +140,32 @@ STATIC fpga_result parse_perf_event(struct udev_device *dev,
 		globfree(&pglob);
 		return FPGA_EXCEPTION;
 	}
-
-	fpga_perf->num_perf_events = pglob.gl_pathc;
-	if (!fpga_perf->perf_events) {
-		fpga_perf->perf_events = calloc(fpga_perf->num_perf_events,
-			sizeof(perf_events_type));
+	if (strcmp(attr, "format") == 0 ) {
+		fpga_perf->num_format = pglob.gl_pathc;
+		if (!fpga_perf->format_type) {
+			fpga_perf->format_type = calloc(fpga_perf->num_format,
+						sizeof(perf_format_type));
+			if (!fpga_perf->format_type) {
+				fpga_perf->num_format = 0;
+				OPAE_ERR("Failed to allocate Memory");
+				return FPGA_NO_MEMORY;
+			}
+		}
+	} else {
+		fpga_perf->num_perf_events = pglob.gl_pathc;
 		if (!fpga_perf->perf_events) {
-			fpga_perf->num_perf_events = 0;
-			OPAE_ERR("Failed to allocate Memory");
-			globfree(&pglob);
-			return FPGA_NO_MEMORY;
+			fpga_perf->perf_events = calloc(fpga_perf->num_perf_events,
+							sizeof(perf_events_type));
+			if (!fpga_perf->perf_events) {
+				fpga_perf->num_perf_events = 0;
+				OPAE_ERR("Failed to allocate Memory");
+				globfree(&pglob);
+				return FPGA_NO_MEMORY;
+			}
 		}
 	}
+
 	for (i = 0; i < pglob.gl_pathc; i++) {
-		reg_res = regcomp(&re, PERF_EVENT_PATTERN,
-				REG_EXTENDED | REG_ICASE);
-		if (reg_res) {
-			OPAE_ERR("Error compiling regex");
-			globfree(&pglob);
-			return FPGA_EXCEPTION;
-		}
 		file = fopen(pglob.gl_pathv[i], "r");
 		if (!file) {
 			OPAE_ERR("fopen(%s) failed\n", pglob.gl_pathv[i]);
@@ -258,26 +176,58 @@ STATIC fpga_result parse_perf_event(struct udev_device *dev,
 			OPAE_ERR("Failed to read %s", pglob.gl_pathv[i]);
 			goto out;
 		}
-		reg_res = regexec(&re, attr_value, 4, matches, 0);
-		if (reg_res) {
-			regerror(reg_res, &re, err, sizeof(err));
-			OPAE_MSG("Error executing regex: %s", err);
-		} else {
-			uint64_t config = 0;
-			uint64_t event = 0;
-			if (snprintf(fpga_perf->perf_events[inner_loop].event_name,
-				sizeof(fpga_perf->perf_events[inner_loop].event_name),
-				"%s", (strstr(pglob.gl_pathv[i], attr) + strlen(attr)+1)) < 0) {
-				OPAE_ERR("snprintf buffer overflow");
+		if (strcmp(attr, "format") == 0 ) {
+			reg_res = regcomp(&re, PERF_CONFIG_PATTERN,
+				REG_EXTENDED | REG_ICASE);
+			if (reg_res) {
+				OPAE_ERR("Error compiling regex");
 				goto out;
 			}
-			for (loop = 0; loop < fpga_perf->num_format; loop++) {
-				PARSE_MATCH_INT(attr_value,
-						matches[loop + 1].rm_so, event, 16);
-				config |= event << fpga_perf->format_type[loop].shift;
+			reg_res = regexec(&re, attr_value, 4, f_matches, 0);
+			if (reg_res) {
+				regerror(reg_res, &re, err, sizeof(err));
+				OPAE_MSG("Error executing regex: %s", err);
+			} else {
+				PARSE_MATCH_INT(attr_value, f_matches[1].rm_so, value, 10);
+				fpga_perf->format_type[loop].shift = value;
+				if (snprintf(fpga_perf->format_type[loop].format_name,
+					sizeof(fpga_perf->format_type[loop].format_name),
+						"%s", (strstr(pglob.gl_pathv[i], attr)
+							+ strlen(attr)+1)) < 0) {
+					OPAE_ERR("snprintf buffer overflow");
+					goto out;
+				}
+				loop++;
 			}
-			fpga_perf->perf_events[inner_loop].config = config;
-			inner_loop++;
+		} else {
+			reg_res = regcomp(&re, PERF_EVENT_PATTERN,
+				REG_EXTENDED | REG_ICASE);
+			if (reg_res) {
+				OPAE_ERR("Error compiling regex");
+				goto out;
+			}
+			reg_res = regexec(&re, attr_value, 4, e_matches, 0);
+			if (reg_res) {
+				regerror(reg_res, &re, err, sizeof(err));
+				OPAE_MSG("Error executing regex: %s", err);
+			} else {
+				uint64_t config = 0;
+				uint64_t event = 0;
+				if (snprintf(fpga_perf->perf_events[inner_loop].event_name,
+					sizeof(fpga_perf->perf_events[inner_loop].event_name),
+					"%s", (strstr(pglob.gl_pathv[i], attr)
+						+ strlen(attr) + 1)) < 0) {
+					OPAE_ERR("snprintf buffer overflow");
+					goto out;
+				}
+				for (loop = 0; loop < fpga_perf->num_format; loop++) {
+					PARSE_MATCH_INT(attr_value,
+						e_matches[loop + 1].rm_so, event, 16);
+					config |= event << fpga_perf->format_type[loop].shift;
+				}
+				fpga_perf->perf_events[inner_loop].config = config;
+				inner_loop++;
+			}
 		}
 		fclose(file);
 	}
@@ -325,11 +275,11 @@ STATIC fpga_result fpga_perf_events(char* perf_sysfs_path, fpga_perf_counter *fp
 		PARSE_MATCH_INT(ptr, 0, fpga_perf->type, 10);
 
 	/* parse the format value */
-	ret = parse_perf_format(dev, fpga_perf, "format");
+	ret = parse_perf_attributes(dev, fpga_perf, "format");
 	if (ret != FPGA_OK)
 		goto out;
 	/* parse the event value */
-	ret = parse_perf_event(dev, fpga_perf, "events");
+	ret = parse_perf_attributes(dev, fpga_perf, "events");
 	if (ret != FPGA_OK)
 		goto out;
 


### PR DESCRIPTION
Modified the source to access the sysfs path for formats and events
using glob instead of udev library.
With udev library in Centos8 machine not able to get events and format attributes for dfl fme.  

Signed-off-by: ramyavv <ramyax.venkatesha@intel.com>