### PR TITLE
Tools:  fpgainfo load board specific modules using vendor, device and…

### DIFF
--- a/tests/fpgainfo/CMakeLists.txt
+++ b/tests/fpgainfo/CMakeLists.txt
@@ -51,9 +51,11 @@ target_include_directories(fpgainfo-static
 opae_test_add(TARGET test_fpgainfo_c
     SOURCE test_fpgainfo_c.cpp
     LIBS fpgainfo-static
+         board-common-static
 )
 
 opae_test_add(TARGET test_fpgainfo_board_c 
     SOURCE test_board_c.cpp
     LIBS fpgainfo-static
+         board-common-static
 )

--- a/tests/fpgainfo/test_board_c.cpp
+++ b/tests/fpgainfo/test_board_c.cpp
@@ -37,6 +37,7 @@ fpga_result phy_filter(fpga_properties *filter, int argc, char *argv[]);
 fpga_result phy_command(fpga_token *tokens, int num_tokens, int argc, char *argv[]);
 fpga_result mac_info(fpga_token token);
 fpga_result phy_group_info(fpga_token token);
+fpga_result find_dev_feature(fpga_token token, uint32_t feature_id, char *dfl_dev_str);
 }
 
 using namespace opae::testing;

--- a/tools/fpgainfo/CMakeLists.txt
+++ b/tools/fpgainfo/CMakeLists.txt
@@ -39,6 +39,7 @@ opae_add_executable(TARGET fpgainfo
     LIBS
         argsfilter
         opae-c
+        board_common
         ${libjson-c_LIBRARIES}
     COMPONENT toolfpgainfo
 )

--- a/tools/fpgainfo/board.c
+++ b/tools/fpgainfo/board.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2020, Intel Corporation
+// Copyright(c) 2019-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -49,6 +49,7 @@
 #include <dlfcn.h>
 #include <pthread.h>
 
+#include "../libboard/board_common/board_common.h"
 #include "board.h"
 
 
@@ -56,17 +57,23 @@ static pthread_mutex_t board_plugin_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_N
 
 // Board plug-in table
 static platform_data platform_data_table[] = {
-	{ 0x1c2c, 0x1000, "libboard_n5010.so", NULL },
-	{ 0x1c2c, 0x1001, "libboard_n5010.so", NULL },
-	{ 0x8086, 0x09c4, "libboard_a10gx.so", NULL },
-	{ 0x8086, 0x09c5, "libboard_a10gx.so", NULL },
-	{ 0x8086, 0x0b30, "libboard_n3000.so", NULL },
-	{ 0x8086, 0x0b31, "libboard_n3000.so", NULL },
-	{ 0x8086, 0x0b2b, "libboard_d5005.so", NULL },
-	{ 0x8086, 0x0b2c, "libboard_d5005.so", NULL },
-	{ 0x8086, 0xaf00, "libboard_d5005.so", NULL },
-	{ 0x8086, 0xbcce, "libboard_d5005.so", NULL },
-	{ 0,      0,          NULL, NULL },
+	{ 0x1c2c, 0x1000,  -1,  "libboard_n5010.so", NULL },
+	{ 0x1c2c, 0x1001,  -1,  "libboard_n5010.so", NULL },
+	{ 0x8086, 0x09c4,  -1,  "libboard_a10gx.so", NULL },
+	{ 0x8086, 0x09c5,  -1,  "libboard_a10gx.so", NULL },
+	{ 0x8086, 0x0b30,  -1,  "libboard_n3000.so", NULL },
+	{ 0x8086, 0x0b31,  -1,  "libboard_n3000.so", NULL },
+	{ 0x8086, 0x0b2b,  -1,  "libboard_d5005.so", NULL },
+	{ 0x8086, 0x0b2c,  -1,  "libboard_d5005.so", NULL },
+	// Max10 SPI feature id 0xe
+	{ 0x8086, 0xaf00, 0xe,  "libboard_d5005.so", NULL },
+	{ 0x8086, 0xbcce, 0xe,  "libboard_d5005.so", NULL },
+	// Max10 PMCI feature id 0x12
+	{ 0x8086, 0xaf00, 0x12, "libboard_n6010.so", NULL },
+	{ 0x8086, 0xbcce, 0x12, "libboard_n6010.so", NULL },
+
+
+	{ 0,      0, -1,         NULL, NULL },
 };
 
 void *find_plugin(const char *libpath)
@@ -135,6 +142,15 @@ fpga_result load_board_plugin(fpga_token token, void **dl_handle)
 		if (platform_data_table[i].device_id == device_id &&
 			platform_data_table[i].vendor_id == vendor_id) {
 
+			// load plugin with matching featureid
+			if (platform_data_table[i].feature_id > 0) {
+				res = find_dev_feature(token,
+					platform_data_table[i].feature_id,
+					NULL);
+					if (res != FPGA_OK) {
+						continue;
+					}
+			}
 			// Loaded lib or found
 			if (platform_data_table[i].dl_handle) {
 				*dl_handle = platform_data_table[i].dl_handle;

--- a/tools/fpgainfo/board.h
+++ b/tools/fpgainfo/board.h
@@ -41,7 +41,7 @@ extern "C" {
 typedef struct _platform_data {
 	uint16_t vendor_id;
 	uint16_t device_id;
-	uint32_t feature_id;
+	int32_t feature_id;
 	char *board_plugin;
 	void *dl_handle;
 } platform_data;

--- a/tools/fpgainfo/board.h
+++ b/tools/fpgainfo/board.h
@@ -41,6 +41,7 @@ extern "C" {
 typedef struct _platform_data {
 	uint16_t vendor_id;
 	uint16_t device_id;
+	uint32_t feature_id;
 	char *board_plugin;
 	void *dl_handle;
 } platform_data;

--- a/tools/libboard/board_common/board_common.c
+++ b/tools/libboard/board_common/board_common.c
@@ -59,8 +59,9 @@
 #define IFCONFIG_STR             "ifconfig"
 #define IFCONFIG_UP_STR          "up"
 
-#define SYSFS_FEATURE_ID "/sys/bus/pci/devices/*%x*:*%x*:*%x*.*%x*/" \
-                       "fpga_region/region*/dfl-fme*/dfl_dev*/feature_id"
+#define SYSFS_FEATURE_ID "/sys/bus/pci/devices/*%x*:*%x*:*%x*.*%x*/"\
+			"fpga_region/region*/dfl-fme*/dfl_dev*/feature_id"
+
 // Read sysfs
 fpga_result read_sysfs(fpga_token token, char *sysfs_path,
 		char *sysfs_name, size_t len)

--- a/tools/libboard/board_common/board_common.c
+++ b/tools/libboard/board_common/board_common.c
@@ -445,10 +445,10 @@ fpga_result find_dev_feature(fpga_token token,
 	glob_t pglob;
 	char feature_path[SYSFS_PATH_MAX] = { 0 };
 
-	res = get_fpga_sbdf(token, &segment, &bus, &device, &function);
-	if (res != FPGA_OK) {
+	retval = get_fpga_sbdf(token, &segment, &bus, &device, &function);
+	if (retval != FPGA_OK) {
 		OPAE_ERR("Failed to get sbdf ");
-		return res;
+		return retval;
 	}
 
 	if (snprintf(feature_path, sizeof(feature_path),

--- a/tools/libboard/board_common/board_common.c
+++ b/tools/libboard/board_common/board_common.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2020, Intel Corporation
+// Copyright(c) 2019-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -59,6 +59,8 @@
 #define IFCONFIG_STR             "ifconfig"
 #define IFCONFIG_UP_STR          "up"
 
+#define SYSFS_FEATURE_ID "/sys/bus/pci/devices/*%x*:*%x*:*%x*.*%x*/" \
+                       "fpga_region/region*/dfl-fme*/dfl_dev*/feature_id"
 // Read sysfs
 fpga_result read_sysfs(fpga_token token, char *sysfs_path,
 		char *sysfs_name, size_t len)
@@ -422,5 +424,72 @@ fpga_result get_fpga_sbdf(fpga_token token,
 		return res;
 	}
 
+	return res;
+}
+
+
+fpga_result find_dev_feature(fpga_token token,
+	 uint32_t feature_id,
+	 char *dfl_dev_str)
+{
+	fpga_result res          = FPGA_NOT_FOUND;
+	fpga_result retval       = FPGA_OK;
+	int gres                 = 0;
+	size_t i                 = 0;
+	uint64_t value           = 0;
+	uint16_t segment         = 0;
+	uint8_t bus              = 0;
+	uint8_t device           = 0;
+	uint8_t function         = 0;
+	glob_t pglob;
+	char feature_path[SYSFS_PATH_MAX] = { 0 };
+
+	res = get_fpga_sbdf(token, &segment, &bus, &device, &function);
+	if (res != FPGA_OK) {
+		OPAE_ERR("Failed to get sbdf ");
+		return res;
+	}
+
+	if (snprintf(feature_path, sizeof(feature_path),
+		SYSFS_FEATURE_ID,
+		segment, bus, device, function) < 0) {
+		OPAE_ERR("snprintf buffer overflow");
+		return FPGA_EXCEPTION;
+	}
+
+	gres = glob(feature_path, GLOB_NOSORT, NULL, &pglob);
+	if (gres) {
+		OPAE_ERR("Failed pattern match %s: %s",
+			feature_path, strerror(errno));
+		globfree(&pglob);
+		return FPGA_NOT_FOUND;
+	}
+	for (i = 0; i < pglob.gl_pathc; i++) {
+		retval = sysfs_read_u64(pglob.gl_pathv[i], &value);
+		if (retval != FPGA_OK) {
+			OPAE_MSG("Failed to read sysfs value");
+			continue;
+		}
+
+		if (value == feature_id) {
+			res = FPGA_OK;
+			if (dfl_dev_str) {
+				char *p = strstr(pglob.gl_pathv[i], "dfl_dev");
+				if (p == NULL) {
+					res = FPGA_NOT_FOUND;
+				}
+
+				if (snprintf(dfl_dev_str, SYSFS_PATH_MAX,
+					"%s", p) < 0) {
+					OPAE_ERR("snprintf buffer overflow");
+					res = FPGA_EXCEPTION;
+				}
+			}
+			break;
+		}
+
+	}
+	if (gres)
+		globfree(&pglob);
 	return res;
 }

--- a/tools/libboard/board_common/board_common.h
+++ b/tools/libboard/board_common/board_common.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2020, Intel Corporation
+// Copyright(c) 2019-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -109,6 +109,21 @@ fpga_result get_fpga_sbdf(fpga_token token,
 *
 */
 fpga_result sysfs_read_u64(const char *path, uint64_t *u);
+
+/**
+* find fpga feature id.
+*
+* @param[in] token           fpga_token object for device (FPGA_DEVICE type)
+* @param[in] feature_id      fpga dev feature id
+* @param[inout] dev_str      returns fpga dev str
+* FPGA_INVALID_PARAM if invalid parameters were provided
+* FPGA_NOT_FOUND if feature_id not found
+*
+*/
+fpga_result find_dev_feature(fpga_token token,
+	uint32_t feature_id,
+	char *dfl_dev_str);
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
… feature id

IOFS Release 1 And Arrow Creek Have same vendor id and device id,  fpgainfo board loads wrong module
IOFS Release 1 : Vendor ID 0x8086  Device ID : 0xbcce
Arrow Creek : Vendor ID 0x8086  Device ID : 0xbcce

fpgainfo board module enumerates  PMCI or SPI feature id  and loads proper module

PMCI feature id 0x12 -> loads n6010

SPI  feature id 0xe -> loads D5005

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>