### PR TITLE
tools: update fpgainfo security key  sysfs path

### DIFF
--- a/tools/libboard/board_common/board_common.c
+++ b/tools/libboard/board_common/board_common.c
@@ -45,7 +45,7 @@
 
 #include "board_common.h"
 
-#define DFL_SYSFS_SEC_GLOB "*dfl*/*spi*/*spi*/*spi*/**/security/"
+#define DFL_SYSFS_SEC_GLOB "*dfl*/**/security/"
 #define DFL_SYSFS_SEC_USER_FLASH_COUNT         DFL_SYSFS_SEC_GLOB "*flash_count"
 #define DFL_SYSFS_SEC_BMC_CANCEL               DFL_SYSFS_SEC_GLOB "bmc_canceled_csks"
 #define DFL_SYSFS_SEC_BMC_ROOT                 DFL_SYSFS_SEC_GLOB "bmc_root_entry_hash"


### PR DESCRIPTION
 - change sysfs "*dfl*/*spi*/*spi*/*spi*/**/security/"  to "*dfl*/**/security/"
 - update recursive search path for sec keys

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>