### PR TITLE
docs: build docker image instead of pulling

### DIFF
--- a/.github/workflows/ccpp-tests.yml
+++ b/.github/workflows/ccpp-tests.yml
@@ -91,7 +91,7 @@ jobs:
     - name: update
       run: sudo apt-get update -y
     - name: Build Docker image
-        run: docker build . -f docker/docs/Dockerfile -t opae/docs-builder
+      run: docker build . -f docker/docs/Dockerfile -t opae/docs-builder
     - name: Build Documentation
       run: docker run --rm -v ${{ github.workspace }}:/root opae/docs-builder ./scripts/build-documentation.sh
     - name: Upload latest to github.io

--- a/.github/workflows/ccpp-tests.yml
+++ b/.github/workflows/ccpp-tests.yml
@@ -90,8 +90,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: update
       run: sudo apt-get update -y
-    - name: Pull opae/docs-builder docker image
-      run: docker pull opae/docs-builder
+    - name: Build Docker image
+        run: docker build . -f docker/docs/Dockerfile -t opae/docs-builder
     - name: Build Documentation
       run: docker run --rm -v ${{ github.workspace }}:/root opae/docs-builder ./scripts/build-documentation.sh
     - name: Upload latest to github.io

--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -1,8 +1,10 @@
 FROM ubuntu:latest
-RUN apt update
-RUN apt install apt-utils
-RUN apt install -y tzdata && dpkg-reconfigure --frontend noninteractive tzdata
-RUN apt install -y build-essential cmake git libjson-c-dev uuid-dev git python3-dev python3-wheel python3-pip doxygen libedit-dev
+RUN apt-get update -y
+RUN apt-get install -y apt-utils
+RUN apt-get install -y tzdata && dpkg-reconfigure --frontend noninteractive tzdata
+RUN apt-get install -y build-essential cmake git libjson-c-dev uuid-dev git \
+	               python3-dev python3-wheel python3-pip doxygen libedit-dev \
+		       libcap-dev libudev-dev
 WORKDIR /root
 ENTRYPOINT [ "/bin/bash", "-c" ]
 


### PR DESCRIPTION
* change github workflow job to build the docker image from the
Dockerfile instead of pulling it
* fix the docs/Dockerfile to
  * use "-y"
  * include package for libudev and libcap

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>