### PR TITLE
cpeng: fix API functions to use correct registers

### DIFF
--- a/ofs/umd/cpeng/ofs_cpeng.yml
+++ b/ofs/umd/cpeng/ofs_cpeng.yml
@@ -21,9 +21,9 @@ api: |
   def ce_fifo2_status() -> int:
     return CSR_CE2HOST_STATUS.CE_FIFO2_STS
   def hps_kernel_verify() -> int:
-    return CSR_HPS2HOST_RSP.KERNEL_VFY
+    return CSR_HPS2HOST_RSP_SHDW.KERNEL_VFY_SHDW
   def hps_ssbl_verify() -> int:
-    return CSR_HPS2HOST_RSP.SSBL_VFY
+    return CSR_HPS2HOST_RSP_SHDW.SSBL_VFY_SHDW
   def ce_soft_reset():
     CSR_CE_SFTRST.CE_SFTRST = 1
   def image_complete():


### PR DESCRIPTION
Fix the following API functions to reference the shadow
registers/fields:
* hps_kernel_verify()
* hps_ssbl_verify()

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>