### PR TITLE
cpeng: add api to set data req. limit

### DIFF
--- a/ofs/apps/cpeng/hps.cpp
+++ b/ofs/apps/cpeng/hps.cpp
@@ -133,6 +133,8 @@ public:
     log_->info("starting copy of file:{}, size: {}, chunk size: {}",
                filename_, sz, chunk);
     uint32_t n_chunks = 0;
+    // set the data req. limit to 512 (default is 1k)
+    ofs_cpeng_set_data_req_limit(&cpeng, 0b10);
     while (written < sz) {
         inp.read(ptr, chunk);
         if (ofs_cpeng_copy_chunk(

--- a/ofs/umd/cpeng/ofs_cpeng.yml
+++ b/ofs/umd/cpeng/ofs_cpeng.yml
@@ -28,6 +28,8 @@ api: |
     CSR_CE_SFTRST.CE_SFTRST = 1
   def image_complete():
     CSR_HOST2HPS_IMG_XFR.HOST2HPS_IMG_XFR = 0x1
+  def set_data_req_limit(value: uint8_t):
+    CSR_CE2HOST_DATA_REQ_LIMIT.DATA_REQ_LIMIT = value
   def copy_chunk(iova: uint64_t, offset: uint64_t, size: uint32_t, timeout_usec: uint64_t) -> int:
     CSR_SRC_ADDR.CSR_SRC_ADDR = iova
     CSR_DST_ADDR.CSR_DST_ADDR = offset
@@ -82,7 +84,7 @@ registers:
     - - [HOST_SCRATCHPAD, [63, 0], RW, 0x0, Scratchpad register used during board bring up]
   - - [CSR_CE2HOST_DATA_REQ_LIMIT, 0x0108, 0x0000000000000000, "Data request limit"]
     - - [Reserved, [63, 2], RsvdZ, 0x0, Reserved]
-      - [DATA_REQ_LIMIT, [0], RO, 0x0, "00: 64 Bytes\n
+      - [DATA_REQ_LIMIT, [1,0], RO, 0x0, "00: 64 Bytes\n
                                         01: 128 Bytes\n
                                         10: 512 Bytes\n
                                         11: 1024 Bytes\n


### PR DESCRIPTION
Data request limit is dependent on PCIe read request.
Setting it to 512 is safer for PCIe cores that don't support reads
higher than 512.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>