### PR TITLE
cpeng: cleanup

### DIFF
--- a/ofs/apps/cpeng/hps.cpp
+++ b/ofs/apps/cpeng/hps.cpp
@@ -89,8 +89,8 @@ public:
     app->add_option("-c,--chunk", chunk_, "Chunk size. 0 indicates no chunks")
       ->default_str(std::to_string(chunk_));
     app->add_flag("--soft-reset", soft_reset_, "Issue soft reset only");
-    app->add_flag("--no-ssbl-verify", skip_ssbl_verify_, "Do not wait for ssbl verify");
-    app->add_flag("--no-kernel-verify", skip_kernel_verify_, "Do not wait for kernel verify");
+    app->add_flag("--skip-ssbl-verify", skip_ssbl_verify_, "Do not wait for ssbl verify");
+    app->add_flag("--skip-kernel-verify", skip_kernel_verify_, "Do not wait for kernel verify");
   }
 
   virtual int run(opae::afu_test::afu *afu, __attribute__((unused)) CLI::App *app)


### PR DESCRIPTION
* set default timeout to 1 sec
* check that chunk size is cacheline aligned and error out if not
* Add skip_ssbl_verify and skip_kernel_verify flags to tell the program to
not wait for either ssbl or kernel verify.
* Abstracted the wait_for_verify function:
  * Take in the stage name (ssbl, kernel)  
  * Take in the cpeng driver API function to call