### PR TITLE
cpeng: add heartbeat command

### DIFF
--- a/ofs/umd/cpeng/ofs_cpeng.yml
+++ b/ofs/umd/cpeng/ofs_cpeng.yml
@@ -24,6 +24,8 @@ api: |
     return CSR_HPS2HOST_RSP_SHDW.KERNEL_VFY_SHDW
   def hps_ssbl_verify() -> int:
     return CSR_HPS2HOST_RSP_SHDW.SSBL_VFY_SHDW
+  def hps2host_rsp() -> uint64_t:
+    return CSR_HPS2HOST_RSP_SHDW.value
   def ce_soft_reset():
     CSR_CE_SFTRST.CE_SFTRST = 1
   def image_complete():


### PR DESCRIPTION
Add 'heartbeat' command to hps program.
This command reads the value of the hps2host_rsp register once a second
and verifies that it's incrementing in value. It will log if it detects
a heartbeat or not.
This also adds 'hps2host_rsp' API function in the umd spec.


Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>