### PR TITLE
opae-sdk: disable fpga image info in fpgainfo

### DIFF
--- a/tools/fpgainfo/fmeinfo.c
+++ b/tools/fpgainfo/fmeinfo.c
@@ -56,7 +56,8 @@ static void print_fme_info(fpga_token token)
 	fpgainfo_board_info(token);
 	fpgainfo_print_common("//****** FME ******//", props);
 	fpga_boot_info(token);
-	fpga_image_info(token);
+	//TODO enable after fixing BMC log driver
+	//fpga_image_info(token);
 
 	res = fpgaDestroyProperties(&props);
 	ON_FPGAINFO_ERR_GOTO(res, out_exit,


### PR DESCRIPTION
Signed-off-by: anandaravuri <ananda.ravuri@intel.com>