### PR TITLE
Tools: Update Host Exerciser sample with DSM  performance counter.

### DIFF
--- a/opae.spec.in
+++ b/opae.spec.in
@@ -120,10 +120,6 @@ mv %_topdir/tmpBRoot $RPM_BUILD_ROOT
 mkdir -p /etc/ld.so.conf.d
 echo "@LDCONFIG_DIR@" > /etc/ld.so.conf.d/opae-c.conf
 ldconfig
-if [ -x %{_sbindir}/setcap ];
-then
-  %{_sbindir}/setcap "38,cap_sys_ptrace,cap_syslog+eip" %{_bindir}/host_exerciser
-fi
 
 %postun
 @CPACK_RPM_SPEC_POSTUNINSTALL@

--- a/samples/host_exerciser/CMakeLists.txt
+++ b/samples/host_exerciser/CMakeLists.txt
@@ -30,14 +30,7 @@ opae_add_executable(TARGET host_exerciser
         opae-c
         opae-cxx-core
         afu-test
-        fpgaperf_counter
         ${libjson-c_LIBRARIES}
         ${libuuid_LIBRARIES}
-        ${LIBCAP_LIBRARIES}
     COMPONENT samplebin
-)
-
-target_include_directories(host_exerciser
-    PRIVATE
-        ${OPAE_SDK_SOURCE}/samples/fpgaperf_counter
 )

--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -42,8 +42,8 @@ static const uint64_t KB = 1024;
 static const uint64_t MB = KB * 1024;
 static const uint64_t LOG2_CL = 6;
 static const size_t LPBK1_DSM_SIZE = 2 * KB;
-static const size_t LPBK1_BUFFER_SIZE = 2 * KB;
-static const size_t LPBK1_BUFFER_ALLOCATION_SIZE = 2 * KB;
+static const size_t LPBK1_BUFFER_SIZE = 64 * KB;
+static const size_t LPBK1_BUFFER_ALLOCATION_SIZE = 64 * KB;
 static const uint32_t DSM_STATUS_TEST_COMPLETE = 0x40;
 
 // Host execiser CSR Offset

--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -264,6 +264,24 @@ union he_stride {
   };
 };
 
+// HE DSM status
+struct he_dms_status {
+	uint64_t test_completed : 1;
+	uint64_t dsm_number : 15;
+	uint64_t res1 : 16;
+	uint64_t err_vector : 32;
+	uint64_t num_ticks : 40;
+	uint64_t res2 : 24;
+	uint64_t num_reads : 32;
+	uint64_t num_writes : 32;
+	uint64_t penalty_start : 16;
+	uint64_t res3 : 16;
+	uint64_t penalty_end : 8;
+	uint64_t res4 : 24;
+	uint64_t ab_error_info : 32;
+	uint32_t res5[7];
+};
+
 const std::map<std::string, uint32_t> he_modes = {
   { "lpbk", HOST_EXEMODE_LPBK1},
   { "read", HOST_EXEMODE_READ},

--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -25,12 +25,10 @@
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <sys/capability.h>
 #include <unistd.h>
 
 #include "afu_test.h"
 #include "host_exerciser.h"
-#include "fpgaperf_counter.h"
 
 using test_afu = opae::afu_test::afu;
 using opae::fpga::types::shared_buffer;
@@ -38,46 +36,6 @@ using opae::fpga::types::token;
 
 namespace host_exerciser {
 
-class fpgaperf {
-public:
-  typedef std::shared_ptr<fpgaperf> ptr_t;
-  static std::shared_ptr<fpgaperf> get(token::ptr_t token)
-  {
-    std::shared_ptr<fpgaperf> p(new fpgaperf());
-    if (fpgaPerfCounterGet(token->c_type(), p->counter_) != FPGA_OK) {
-        p.reset();
-    }
-    return p;
-  }
-  ~fpgaperf()
-  {
-    if (fpgaPerfCounterDestroy(counter_) != FPGA_OK) {
-        std::cout << "Failed to destroy the fpga perf counter" << std::endl;
-    }
-    if(counter_) {
-        delete counter_;
-        counter_ = nullptr;
-    }
-  }
-  fpga_result start()
-  {
-      return fpgaPerfCounterStartRecord(counter_);
-  }
-  fpga_result stop()
-  {
-      return fpgaPerfCounterStopRecord(counter_);
-  }
-  fpga_result print()
-  {
-      return fpgaPerfCounterPrint(stdout, counter_);
-  }
-private:
-  fpgaperf() {
-      counter_ = new fpga_perf_counter;
-  }
-  fpgaperf(const fpgaperf &);
-  fpga_perf_counter *counter_ = nullptr;
-};
 
 class host_exerciser_cmd : public test_command
 {
@@ -133,6 +91,20 @@ public:
         return num >> LOG2_CL;
     }
 
+    void host_exerciser_perf_counters(uint8_t *status_ptr)
+    {
+        if (!status_ptr)
+            return;
+        struct he_dms_status *dms_status;
+        dms_status = reinterpret_cast<he_dms_status *>(status_ptr);
+        std::cout << "Number of clocks:" <<
+                    dms_status->num_ticks << std::endl;
+        std::cout << "Total number of Reads sent:" <<
+                    dms_status->num_reads << std::endl;
+        std::cout << "Total number of Writes sent :" <<
+                    dms_status->num_writes << std::endl;
+    }
+
     int parse_input_options()
     {
 
@@ -170,45 +142,11 @@ public:
     virtual int run(test_afu *afu, CLI::App *app)
     {
         (void)app;
-        cap_t caps;
-        cap_flag_value_t cap_flag_value;
-        int res 				= 0;
-        char file_name[DFL_PERF_STR_MAX]	= { 0 };
 
         auto d_afu = dynamic_cast<host_exerciser*>(afu);
         host_exe_ = dynamic_cast<host_exerciser*>(afu);
 
         token_ = d_afu->get_token();
-
-        fpgaperf::ptr_t perf(nullptr);
-        if (host_exe_->perf_) {
-            uid_t uid = getuid();
-            if (uid != 0) {
-                if (readlink("/proc/self/exe", file_name, DFL_PERF_STR_MAX) == -1) {
-                    std::cerr << "Failed to get the binary path" << std::endl;
-                    return -1;
-                }
-                caps = cap_get_file(file_name);
-                if (caps != 0)
-                    res =  cap_get_flag(caps, CAP_PERFMON, CAP_EFFECTIVE, &cap_flag_value);
-                if (res == 0) {
-                    std::cout << std::endl;
-                    std::cout <<"Failed to read Perf counter due to unprivileged user access"<<std::endl
-                    <<"=> check --help for more information on setting the capabilities for binary" <<std::endl << std::endl;
-                    return -1;
-                }
-            }
-            //fpga perf counter initialization
-            perf = fpgaperf::get(token_);
-            if (!perf) {
-                std::cout << "Failed to get the fpgaperf object" << std::endl;
-                return -1;
-            }
-            //start the fpga perf counter
-            if (perf->start() != FPGA_OK) {
-                std::cout << "Failed to start the fpga perf counter" << std::endl;
-            }
-        }
 
         auto ret = parse_input_options();
         if (ret != 0) {
@@ -300,26 +238,19 @@ public:
              }
          }
 
-        if (perf) {
-            //stop performance counter
-            if (perf->stop() != FPGA_OK) {
-                std::cout << "Failed to stop the fpga perf counter" << std::endl;
-            }
-        }
-
         std::cout << "Test Completed" << std::endl;
         host_exerciser_swtestmsg();
-        host_exerciser_status();
 
         /* Compare buffer contents only loopback test mode*/
         if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_LPBK1)
             d_afu->compare(source_, destination_);
 
-        if (perf) {
-            //print the performace counter values
-            if (perf->print() != FPGA_OK) {
-                std::cout << "Failed to print the fpga perf counter" << std::endl;
-            }
+        if (host_exe_->perf_) {
+            //print the Performance  counter values
+            std::cout <<"\n****Host Exerciser Performance Counter****"
+                      << std::endl;
+            host_exerciser_status();
+            host_exerciser_perf_counters((uint8_t *)status_ptr);
         }
 
         return 0;

--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -97,12 +97,20 @@ public:
             return;
         struct he_dms_status *dms_status;
         dms_status = reinterpret_cast<he_dms_status *>(status_ptr);
+
+        uint64_t num_cache_lines = (LPBK1_BUFFER_SIZE / (1 * CL));
         std::cout << "Number of clocks:" <<
                     dms_status->num_ticks << std::endl;
         std::cout << "Total number of Reads sent:" <<
                     dms_status->num_reads << std::endl;
         std::cout << "Total number of Writes sent :" <<
                     dms_status->num_writes << std::endl;
+
+        double  perf_data = (double)(num_cache_lines * 64) /
+                            (4 * (dms_status->num_ticks));
+        std::cout << "Bandwidth: " << std::setprecision(3) <<
+                   perf_data << " GB/s"<< std::endl;
+
     }
 
     int parse_input_options()


### PR DESCRIPTION
 -OFS release doesn’t support any global perf counters, so removed global perf counters code from Host Exerciser.

  -Host Exerciser  reads Performance Counter  from DSM Status buffer.
      DSM Status fromat:
	Field Name	Range	Width	Description
	Reserved	[511:288]	224	Reserved
	Ab_error_info	[287:256]	32	Arbiter error info field
	Reserved	[255:232]	24	Reserved
	Penalty_end	[231:224]	8	Test end overhead in # clks
	Reserved	[223:208]	16	Reserved
	Penalty_start	[207:192]	16	Test start overhead in # clks
	Num_writes	[191:160]	32	Total number of Writes sent / Total Num CX sent
	Num_reads	[159:128]	32	Total number of Reads sent
	Reserved	[127:104]	24	Reserved
	Num_ticks	[103:64]	40	Number of clocks
	ErrorVector	[63:32]	32	Errors detected
	Reserved	[31:16]	16	Reserved
	Dsm_number	[15:1]	15	Unique id for each dsm status write
	TestCompleted	[0]	1	Test completion flag

	host_exerciser  --perf true  lpbk
	[2021-08-23 14:14:36.624] [lpbk] [info] starting test run, count of 1
	Input Config:0
	Allocate SRC Buffer
	Allocate DST Buffer
	Allocate DSM Buffer
	Start Test
	Test Completed
	Host Exerciser swtest msg:0

	****Host Exerciser Performance Counter****
        Host Exerciser numReads:1024
        Host Exerciser numWrites:1025
        Host Exerciser numPendReads:0
       Host Exerciser numPendWrites:0
       Number of clocks:7283
       Total number of Reads sent:1024
       Total number of Writes sent :1022
       Bandwidth: 2.25 GB/s

       [2021-08-23 14:14:36.626] [lpbk] [info] Test lpbk(1): PASS

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>