### PR TITLE
opae.io: make 'walk' interpreter independent

### DIFF
--- a/tools/extra/opae.io/pymain.h
+++ b/tools/extra/opae.io/pymain.h
@@ -158,7 +158,7 @@ class walk_action(base_action):
     open_device = True
 
     def add_args(self):
-        self.parser.add_argument('offset', nargs='?', type=utils.hex_int)
+        self.parser.add_argument('offset', nargs='?', type=utils.hex_int, default=0)
         self.parser.add_argument('-u', '--show-uuid', action='store_true', default=False)
 
     def execute(self, args):
@@ -168,11 +168,7 @@ class walk_action(base_action):
             raise SystemExit('walk requires region.')
 
         offset = 0 if args.offset is None else args.offset
-        for offset, dfh in utils.dfh_walk(offset=offset):
-            print('offset: 0x{:04x}, value: 0x{:04x}'.format(offset, dfh.value))
-            print('    dfh: {}'.format(dfh))
-            if args.show_uuid:
-                print('    uuid: {}'.format(utils.read_guid(offset+0x8)))
+        utils.walk(self.region, args.offset, args.show_uuid)
 
 
 class no_action(base_action):


### PR DESCRIPTION
* refactor 'opae_register' class, 'read_guid' and 'dfh_walk' functions
  * parameterize region
  * remove reference to opae.io builtins
    * use region read64|write64
* add 'walk' function to opae.io.utils
  * walk the dfl and print out offset, value, uuid
* change 'walk_action' in pymain.h
  * use 'walk' function in opae.io.utils
  * default region argument to 0

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>