### PR TITLE
opae.io: update copyright date to include 2021

### DIFF
--- a/tools/extra/opae.io/main.cpp
+++ b/tools/extra/opae.io/main.cpp
@@ -46,7 +46,7 @@ struct mmio_region *the_region = nullptr;
 const char *program = "opae.io";
 const int major = 0;
 const int minor = 2;
-const int patch = 1;
+const int patch = 2;
 
 py::tuple version()
 {

--- a/tools/extra/opae.io/main.h
+++ b/tools/extra/opae.io/main.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2020, Intel Corporation
+// Copyright(c) 2020-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:

--- a/tools/extra/opae.io/opae/io/utils.py
+++ b/tools/extra/opae.io/opae/io/utils.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2020, Intel Corporation
+# Copyright(c) 2020-2021, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -25,7 +25,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import contextlib
-import glob
 import grp
 import json
 import os
@@ -326,7 +325,7 @@ class feature(object):
         finally:
             if not err:
                 csr.commit()
-            
+
 fpga_devices = {(0x8086, 0x09c4) : "Intel PAC A10 GX",
                 (0x8086, 0x09c5) : "Intel PAC A10 GX VF",
                 (0x8086, 0x0b2b) : "Intel PAC D5005",
@@ -377,7 +376,7 @@ def lsfpga(**kwargs):
                 print('error with vendor/device: {}'.format(k))
             else:
                 conf_ids[(int(vstr, 16), int(dstr, 16))] = v
-            
+
         if conf.get('override', False):
             device_ids.update(conf_ids)
         else:
@@ -436,7 +435,7 @@ def find_device(pci_addr=None):
             LOG.error(errstr)
             raise OSError(os.EX_OSERR, errstr)
         return d
-        
+
     for pci_addr, vid, did, name, driver in lsfpga():
         if driver == 'vfio-pci':
             iommu_group = read_link('/sys/bus/pci/devices', pci_addr, 'iommu_group')

--- a/tools/extra/opae.io/pymain.h
+++ b/tools/extra/opae.io/pymain.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2020, Intel Corporation
+// Copyright(c) 2020-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:

--- a/tools/extra/opae.io/setup.py
+++ b/tools/extra/opae.io/setup.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2020, Intel Corporation
+# Copyright(c) 2020-2021, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -29,7 +29,7 @@ from distutils.core import Extension, setup
 
 setup(
     name="opae.io",
-    version="0.1",
+    version="0.2",
     packages=find_packages(include=['opae.*']),
     entry_points={
         'console_scripts': []

--- a/tools/extra/opae.io/setup.py
+++ b/tools/extra/opae.io/setup.py
@@ -29,7 +29,7 @@ from distutils.core import Extension, setup
 
 setup(
     name="opae.io",
-    version="0.2",
+    version="0.2.2",
     packages=find_packages(include=['opae.*']),
     entry_points={
         'console_scripts': []

--- a/tools/extra/opae.io/vfiobindings.cpp
+++ b/tools/extra/opae.io/vfiobindings.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2020, Intel Corporation
+// Copyright(c) 2020-2021, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
* update copyright date to include 2021
* remove unnecessary import in utils.py
* 
Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>