### PR TITLE
tools: HSSI tools command line argument validation

### DIFF
--- a/tools/extra/hssi/ethernet/hssicommon.py
+++ b/tools/extra/hssi/ethernet/hssicommon.py
@@ -750,7 +750,7 @@ class HSSICOMMON(object):
         and firmware version
         """
         try:
-            self.pyopaeuio_inst.open(hssi_uio)
+            self.open(hssi_uio)
             self.num_uio_regions = self.pyopaeuio_inst.numregions
             hssi_dfh = dfh(self.read32(0, 0))
             hssi_version = hssi_ver(self.read32(0, 0x8))
@@ -759,7 +759,7 @@ class HSSICOMMON(object):
             ctl_addr.sal_cmd = HSSI_SALCMD.FIRMWARE_VER.value
             firmware_version = self.read_reg(0, ctl_addr.value)
 
-            print("\n--------HSSI IINFO START-------")
+            print("\n--------HSSI INFO START-------")
             print("HSSI id: {0: >12}".format(hex(hssi_dfh.id)))
             print("HSSI version: {0: >12}".format(str(hssi_version)))
             print("HSSI num ports: {0: >12}"
@@ -771,10 +771,12 @@ class HSSICOMMON(object):
 
         except RuntimeError:
             print("opae uio module exception")
+            return False
         except ValueError:
             print("Invalid arguemnts")
+            return False
 
-        return 0
+        return True
 
     def open(self, hssi_uio):
         ret = self.pyopaeuio_inst.open(hssi_uio)

--- a/tools/extra/hssi/ethernet/hssicommon.py
+++ b/tools/extra/hssi/ethernet/hssicommon.py
@@ -656,7 +656,7 @@ class hssi_eth_port_status(Union):
         return self.bits.eth_mode
 
 
-def veriy_pcie_address(pcie_address):
+def verify_pcie_address(pcie_address):
     m = BDF_PATTERN.match(pcie_address)
     if m is None:
         print("Invalid pcie address foramt",pcie_address)

--- a/tools/extra/hssi/ethernet/hssiloopback.py
+++ b/tools/extra/hssi/ethernet/hssiloopback.py
@@ -151,7 +151,7 @@ def main():
     print("args.port:", args.port)
     print(args)
 
-    if not veriy_pcie_address(args.pcie_address.lower()):
+    if not verify_pcie_address(args.pcie_address.lower()):
         sys.exit(1)
 
     if args.loopback is None:

--- a/tools/extra/hssi/ethernet/hssiloopback.py
+++ b/tools/extra/hssi/ethernet/hssiloopback.py
@@ -108,7 +108,9 @@ class FPGAHSSILPBK(HSSICOMMON):
         enable/disable hssi loopback
         """
         print("----hssi_loopback_start----")
-        self.hssi_info(self._hssi_grps[0][0])
+        if not self.hssi_info(self._hssi_grps[0][0]):
+            print("Failed to read hssi information")
+            sys.exit(1)
         self.hssi_loopback_en()
 
 
@@ -135,6 +137,12 @@ def main():
                         default=0,
                         help='hssi port number')
 
+    # exit if no commad line argument
+    args = parser.parse_args()
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
+
     args, left = parser.parse_known_args()
 
     print("args", args)
@@ -143,7 +151,7 @@ def main():
     print("args.port:", args.port)
     print(args)
 
-    if not veriy_pcie_address(args.pcie_address):
+    if not veriy_pcie_address(args.pcie_address.lower()):
         sys.exit(1)
 
     if args.loopback is None:
@@ -153,7 +161,7 @@ def main():
         op = 'enable' if args.loopback else 'disable'
         print('{} fpga loopback'.format(op))
 
-    f = FpgaFinder(args.pcie_address)
+    f = FpgaFinder(args.pcie_address.lower())
     devs = f.enum()
     for d in devs:
         print('sbdf: {segment:04x}:{bus:02x}:{dev:02x}.{func:x}'.format(**d))

--- a/tools/extra/hssi/ethernet/hssimac.py
+++ b/tools/extra/hssi/ethernet/hssimac.py
@@ -112,7 +112,7 @@ def main():
     print("args.mtu:", args.mtu)
     print(args)
 
-    if not veriy_pcie_address(args.pcie_address.lower()):
+    if not verify_pcie_address(args.pcie_address.lower()):
         sys.exit(1)
 
     f = FpgaFinder(args.pcie_address.lower())

--- a/tools/extra/hssi/ethernet/hssimac.py
+++ b/tools/extra/hssi/ethernet/hssimac.py
@@ -76,7 +76,9 @@ class FPGAHSSIMAC(HSSICOMMON):
         get mtu
         """
         print("----hssi_mtu_start----")
-        self.hssi_info(self._hssi_grps[0][0])
+        if not self.hssi_info(self._hssi_grps[0][0]):
+            print("Failed to read hssi information")
+            sys.exit(1)
         self.get_mac_mtu()
 
 
@@ -97,6 +99,12 @@ def main():
     parser.add_argument('--mtu', nargs='?', const='',
                         help='maximum allowable ethernet frame length')
 
+    # exit if no commad line argument
+    args = parser.parse_args()
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
+
     args, left = parser.parse_known_args()
 
     print("args", args)
@@ -104,10 +112,10 @@ def main():
     print("args.mtu:", args.mtu)
     print(args)
 
-    if not veriy_pcie_address(args.pcie_address):
+    if not veriy_pcie_address(args.pcie_address.lower()):
         sys.exit(1)
 
-    f = FpgaFinder(args.pcie_address)
+    f = FpgaFinder(args.pcie_address.lower())
     devs = f.enum()
     for d in devs:
         print('sbdf: {segment:04x}:{bus:02x}:{dev:02x}.{func:x}'.format(**d))

--- a/tools/extra/hssi/ethernet/hssistats.py
+++ b/tools/extra/hssi/ethernet/hssistats.py
@@ -188,7 +188,7 @@ def main():
 
     print(args)
     print("pcie_address:", args.pcie_address)
-    if not veriy_pcie_address(args.pcie_address.lower()):
+    if not verify_pcie_address(args.pcie_address.lower()):
          sys.exit(1)
 
     f = FpgaFinder(args.pcie_address.lower())

--- a/tools/extra/hssi/ethernet/hssistats.py
+++ b/tools/extra/hssi/ethernet/hssistats.py
@@ -37,6 +37,9 @@ import struct
 import mmap
 from ethernet.hssicommon import *
 
+# Invalid  hssi stats value
+HSSI_INAVLID_STATS = 0xfffffff1
+
 
 class FPGAHSSISTATS(HSSICOMMON):
     hssi_eth_stats = (('tx_packets', 0),
@@ -121,11 +124,19 @@ class FPGAHSSISTATS(HSSICOMMON):
                 ctl_addr.value = self.register_field_set(ctl_addr.value,
                                                          31, 1, 1)
                 value_lsb = self.read_reg(0, ctl_addr.value)
+                if value_lsb  >= HSSI_INAVLID_STATS :
+                    stats_list[port_index] += "{}|".format("N/A").rjust(20, ' ')
+                    port_index = port_index + 1
+                    continue
 
                 # Read MSB value
                 ctl_addr.value = self.register_field_set(ctl_addr.value,
                                                          31, 1, 0)
                 value_msb = self.read_reg(0, ctl_addr.value)
+                if value_msb  >= HSSI_INAVLID_STATS :
+                    stats_list[port_index] += "{}|".format("N/A").rjust(20, ' ')
+                    port_index = port_index + 1
+                    continue
 
                 # 64 bit value
                 value = (value_msb << 32) | (value_lsb)
@@ -147,7 +158,9 @@ class FPGAHSSISTATS(HSSICOMMON):
         get hssi stats
         """
         print("----hssi_stats_start----")
-        self.hssi_info(self._hssi_grps[0][0])
+        if not self.hssi_info(self._hssi_grps[0][0]):
+            print("Failed to read hssi information")
+            sys.exit(1)
         self.get_hssi_stats()
 
 
@@ -165,14 +178,20 @@ def main():
     parser.add_argument('--pcie-address', '-P',
                         default=None, help=pcieaddress_help)
 
+    # exit if no commad line argument
+    args = parser.parse_args()
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
+
     args, left = parser.parse_known_args()
 
     print(args)
     print("pcie_address:", args.pcie_address)
-    if not veriy_pcie_address(args.pcie_address):
+    if not veriy_pcie_address(args.pcie_address.lower()):
          sys.exit(1)
 
-    f = FpgaFinder(args.pcie_address)
+    f = FpgaFinder(args.pcie_address.lower())
     devs = f.enum()
     for d in devs:
         print('sbdf: {segment:04x}:{bus:02x}:{dev:02x}.{func:x}'.format(**d))


### PR DESCRIPTION
- Fix  HSSI tool without any command line parameters.
- Accept an uppercase or lower case bdf
- Gracefully exit HSSI tools in non-privilege mode
- Fix Bogus HSSI read stats


**fix HSSI tool without any command line parameters:**
hssistats
usage: hssistats.py [-h] [--pcie-address PCIE_ADDRESS]

optional arguments:
  -h, --help            show this help message and exit
  --pcie-address PCIE_ADDRESS, -P PCIE_ADDRESS
                        sbdf of device to program (e.g. 0000:04:00.0).
                        Optional when one device in system.

**Accept an uppercase or lower case bdf:**
hssistats.py  -P  0000:B1:00.0
Namespace(pcie_address='0000:B1:00.0')
pcie_address: 0000:B1:00.0
sbdf: 0000:b1:00.0
FPGA dev: {'segment': 0, 'bus': 177, 'dev': 0, 'func': 0, 'path': '/sys/class/fpga_region/region0', 'pcie_address': '0000:b1:00.0'}
devs[0] {'segment': 0, 'bus': 177, 'dev': 0, 'func': 0, 'path': '/sys/class/fpga_region/region0', 'pcie_address': '0000:b1:00.0'}
args.hssi_grps {0: ['dfl_dev.6', ['/sys/bus/pci/devices/0000:b1:00.0/fpga_region/region0/dfl-fme.0/dfl_dev.6/uio/uio0']]}
fpga uid dev: dfl_dev.6
----hssi_stats_start----

--------HSSI INFO START-------
HSSI id:         0x15
HSSI version:          1.0
HSSI num ports:            8
Firmware Version:            1
--------HSSI INFO END-------



**Fix Bogus HSSI read stats:**
hssistats.py  -P  0000:B1:00.0
Namespace(pcie_address='0000:B1:00.0')
pcie_address: 0000:B1:00.0
sbdf: 0000:b1:00.0
FPGA dev: {'segment': 0, 'bus': 177, 'dev': 0, 'func': 0, 'path': '/sys/class/fpga_region/region0', 'pcie_address': '0000:b1:00.0'}
devs[0] {'segment': 0, 'bus': 177, 'dev': 0, 'func': 0, 'path': '/sys/class/fpga_region/region0', 'pcie_address': '0000:b1:00.0'}
args.hssi_grps {0: ['dfl_dev.6', ['/sys/bus/pci/devices/0000:b1:00.0/fpga_region/region0/dfl-fme.0/dfl_dev.6/uio/uio0']]}
fpga uid dev: dfl_dev.6
----hssi_stats_start----

--------HSSI INFO START-------
HSSI id:         0x15
HSSI version:          1.0
HSSI num ports:            4
Firmware Version:            1
--------HSSI INFO END-------

------------HSSI stats------------
HSSI num ports: 4
HSSI Ports                       |             port:0|             port:1|             port:2|             port:3|


tx_packets                       |                  0|                N/A|                N/A|                N/A|
rx_packets                       |                  0|                N/A|                N/A|                N/A|
rx_crc_errors                    |                  0|                N/A|                N/A|                N/A|
rx_align_errors                  |                  0|                  0|                  0|                  0|
tx_bytes                         |                  0|                N/A|                N/A|                N/A|
rx_bytes                         |                  0|                N/A|                N/A|                N/A|
tx_pause                         |                  0|                N/A|                N/A|                N/A|
rx_pause                         |                  0|                N/A|                N/A|                N/A|
rx_errors                        |                  0|                N/A|                N/A|                N/A|
tx_errors                        |                  0|                N/A|                N/A|                N/A|
rx_unicast                       |                  0|                N/A|                N/A|                N/A|
rx_multicast                     |                  0|                N/A|                N/A|                N/A|
rx_broadcast                     |                  0|                N/A|                N/A|                N/A|
tx_discards                      |                  0|                  0|                  0|                  0|
tx_unicast                       |                  0|                N/A|                N/A|                N/A|
tx_multicast                     |                  0|                N/A|                N/A|                N/A|
tx_broadcast                     |                  0|                N/A|                N/A|                N/A|
ether_drops                      |                  0|                N/A|                N/A|                N/A|
rx_total_packets                 |                  0|                N/A|                N/A|                N/A|
rx_undersize                     |                  0|                N/A|                N/A|                N/A|
rx_oversize                      |                  0|                N/A|                N/A|                N/A|
rx_64_bytes                      |                  0|                N/A|                N/A|                N/A|
rx_65_127_bytes                  |                  0|                N/A|                N/A|                N/A|
rx_128_255_bytes                 |                  0|                N/A|                N/A|                N/A|
rx_256_511_bytes                 |                  0|                N/A|                N/A|                N/A|
rx_512_1023_bytes                |                  0|                N/A|                N/A|                N/A|
rx_1024_1518_bytes               |                  0|                N/A|                N/A|                N/A|
rx_gte_1519_bytes                |                  0|                N/A|                N/A|                N/A|
rx_jabbers                       |                  0|                N/A|                N/A|                N/A|
rx_runts                         |                  0|                N/A|                N/A|                N/A|


Signed-off-by: anandaravuri <ananda.ravuri@intel.com>