### PR TITLE
tools: remove second print Accelerator id

### DIFF
--- a/tools/extra/qpafilter/qpafilter.py
+++ b/tools/extra/qpafilter/qpafilter.py
@@ -252,9 +252,9 @@ class temp_verifier:
                 return False
             if not self.verify_min_temp(fatal):
                 LOG.info(f'QPA threshold value for sensor '
-                         f'{label}: {fatal} {units}')
+                         f'{label}: {fatal:.2f} {units}')
                 LOG.info(f'is lower than the platform\'s recommended '
-                         f'minimum of {self.args.min_temp} {DEGREES_C}.')
+                         f'minimum of {self.args.min_temp:.2f} {DEGREES_C}.')
                 min_temp_failures += 1
                 i['fatal'] = str(self.args.min_temp)
 
@@ -376,8 +376,8 @@ class qpamap:
             self.id_map[ident]['filtered_warning'] = filtered_warning
             self.id_map[ident]['filtered_fatal'] = filtered_fatal
 
-            msg = (f'{item["label"]} warning: {warning} {item["units"]} '
-                   f'fatal: {fatal} {item["units"]} -> {filtered_warning} '
+            msg = (f'{item["label"]} warning: {warning:.2f} {item["units"]} '
+                   f'fatal: {fatal:.2f} {item["units"]} -> {filtered_warning} '
                    f'{filtered_fatal}')
             if adjustment != 0.0:
                 msg += f' (adjustment {adjustment}{item["units"]})'

--- a/tools/fpgainfo/fpgainfo.c
+++ b/tools/fpgainfo/fpgainfo.c
@@ -166,11 +166,6 @@ void fpgainfo_print_common(const char *hdr, fpga_properties props)
 		printf("%-32s : %s\n", "Pr Interface Id", guid_str);
 	}
 
-	if (is_accelerator) {
-		uuid_unparse(port_guid, guid_str);
-		printf("%-32s : %s\n", "Accelerator Id", guid_str);
-	}
-
 }
 
 // Replace occurrences of character within string

--- a/tools/fpgainfo/fpgainfo.c
+++ b/tools/fpgainfo/fpgainfo.c
@@ -62,7 +62,6 @@ void fpgainfo_print_common(const char *hdr, fpga_properties props)
 	fpga_objtype objtype;
 	fpga_properties pprops = props;
 	fpga_token par = NULL;
-	int is_accelerator = 0;
 	bool has_parent = true;
 
 	res = fpgaPropertiesGetObjectID(props, &object_id);
@@ -91,8 +90,6 @@ void fpgainfo_print_common(const char *hdr, fpga_properties props)
 
 	if (objtype != FPGA_DEVICE) {
 		res = fpgaPropertiesGetGUID(props, &port_guid);
-		if (res == FPGA_OK)
-			is_accelerator = 1;
 	}
 
 	// Go up the tree until we find the device


### PR DESCRIPTION
- fpgainfo prints GUID 2 times

[root@PG16WVAW0272_SuperMicro_14 ALPHA]# fpgainfo port
//****** PORT ******//
Object Id                        : 0xEE00000
PCIe s:b:d.f                     : 0000:B1:00.0
Device Id                        : 0xBCCE
Socket Id                        : 0x00
//****** PORT ******//
Object Id                        : 0x20B1000000000000
PCIe s:b:d.f                     : 0000:B1:00.1
Device Id                        : 0xBCCE
Socket Id                        : 0x01
Accelerator Id                   : 1aae155c-acc5-4210-b9ab-efbd90b970c4
Accelerator GUID                 : 1aae155c-acc5-4210-b9ab-efbd90b970c4