### PR TITLE
(cherry-pick) Squashed 'opae-libs/' changes from 3098f92e..5117a9b8

### DIFF
--- a/opae-libs/plugins/xfpga/sysfs.c
+++ b/opae-libs/plugins/xfpga/sysfs.c
@@ -2144,10 +2144,51 @@ out_free:
 	return res;
 }
 
+#define MAX_SYSOBJECT_FILESIZE 0x40000
+static ssize_t find_eof(int fd)
+{
+	uint64_t pg_size = (uint64_t)sysconf(_SC_PAGE_SIZE);
+	char buffer[pg_size];
+	ssize_t bytes_read = 0, total_read = 0;
+	while (total_read <= MAX_SYSOBJECT_FILESIZE) {
+		bytes_read = read(fd, buffer, pg_size);
+		if (bytes_read < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			lseek(fd, 0, SEEK_SET);
+			return bytes_read;
+		} else if (bytes_read == 0) {
+			break;
+		} else {
+			total_read += bytes_read;
+		}
+	}
+	lseek(fd, 0, SEEK_SET);
+	return total_read;
+}
+
+static fpga_result sync_object_size(struct _fpga_object *_obj, int fd)
+{
+	off_t size;
+	uint8_t *buffer;
+	size = find_eof(fd);
+	if (size > 0) {
+		buffer = realloc(_obj->buffer, size);
+		if (!buffer) {
+			return FPGA_NO_MEMORY;
+		}
+		_obj->buffer = buffer;
+		_obj->max_size = size;
+	}
+	return FPGA_OK;
+}
+
 fpga_result sync_object(fpga_object obj)
 {
 	struct _fpga_object *_obj;
 	int fd = -1;
+	fpga_result res = FPGA_OK;
 	ssize_t bytes_read = 0;
 	ASSERT_NOT_NULL(obj);
 	_obj = (struct _fpga_object *)obj;
@@ -2156,6 +2197,14 @@ fpga_result sync_object(fpga_object obj)
 		OPAE_ERR("Error opening %s: %s", _obj->path, strerror(errno));
 		return FPGA_EXCEPTION;
 	}
+
+	if (_obj->max_size == 0) {
+		res = sync_object_size(_obj, fd);
+		if (res != FPGA_OK) {
+			 return res;
+		}
+	}
+
 	bytes_read = eintr_read(fd, _obj->buffer, _obj->max_size);
 	if (bytes_read < 0) {
 		close(fd);


### PR DESCRIPTION
5117a9b8 plugins: xfpga: support sysfs file size 0 (#242)

git-subtree-dir: opae-libs
git-subtree-split: 5117a9b813ac4800897ee457c5931f6fe3c8486f