### PR TITLE
Squashed 'opae-libs/' changes from 525b0e75..77c076bf

### DIFF
--- a/opae-libs/libopaevfio/opaevfio.c
+++ b/opae-libs/libopaevfio/opaevfio.c
@@ -734,8 +734,6 @@ opae_vfio_buffer_mmap(struct opae_vfio *v,
 	dma_map.flags = VFIO_DMA_MAP_FLAG_READ|VFIO_DMA_MAP_FLAG_WRITE;
 
 	if (ioctl(v->cont_fd, VFIO_IOMMU_MAP_DMA, &dma_map) < 0) {
-		ERR("ioctl(%d, VFIO_IOMMU_MAP_DMA, &dma_map)\n",
-		    v->cont_fd);
 		mem_alloc_put(&v->iova_alloc, ioaddr);
 		res = 4;
 		goto out_munmap;

--- a/opae-libs/plugins/vfio/opae_vfio.c
+++ b/opae-libs/plugins/vfio/opae_vfio.c
@@ -1276,7 +1276,7 @@ fpga_result vfio_fpgaPrepareBuffer(fpga_handle handle, uint64_t len,
 	else
 		sz = 4096;
 	if (opae_vfio_buffer_allocate_ex(v, &sz, &virt, &iova, flags)) {
-		OPAE_ERR("could not allocate buffer");
+		OPAE_DBG("could not allocate buffer");
 		return FPGA_EXCEPTION;
 	}
 	vfio_buffer *buffer = (vfio_buffer *)malloc(sizeof(vfio_buffer));


### PR DESCRIPTION
77c076bf VFIO: silence errors in prealloc mmap path (#249)

git-subtree-dir: opae-libs
git-subtree-split: 77c076bfc0e61aade41dbd5e8ce0439f4bab2400