### PR TITLE
(cherry-pick) Squashed 'opae-libs/' changes from 77c076bf..83a4312d

### DIFF
--- a/opae-libs/libopaevfio/opaevfio.c
+++ b/opae-libs/libopaevfio/opaevfio.c
@@ -55,9 +55,13 @@
 	p;                                                \
 })
 
+#ifdef LIBOPAE_DEBUG
 #define ERR(format, ...)                               \
 fprintf(stderr, "%s:%u:%s() **ERROR** [%s] : " format, \
 	__SHORT_FILE__, __LINE__, __func__, strerror(errno), ##__VA_ARGS__)
+#else
+#define ERR(format, ...) do { } while (0)
+#endif
 
 STATIC struct opae_vfio_sparse_info *
 opae_vfio_create_sparse_info(uint32_t index, uint32_t offset, uint32_t size)
@@ -734,6 +738,7 @@ opae_vfio_buffer_mmap(struct opae_vfio *v,
 	dma_map.flags = VFIO_DMA_MAP_FLAG_READ|VFIO_DMA_MAP_FLAG_WRITE;
 
 	if (ioctl(v->cont_fd, VFIO_IOMMU_MAP_DMA, &dma_map) < 0) {
+		ERR("ioctl(%d, VFIO_IOMMU_MAP_DMA, &dma_map)\n", v->cont_fd);
 		mem_alloc_put(&v->iova_alloc, ioaddr);
 		res = 4;
 		goto out_munmap;

--- a/opae-libs/plugins/vfio/opae_vfio.h
+++ b/opae-libs/plugins/vfio/opae_vfio.h
@@ -33,9 +33,13 @@
 #define __FILENAME__ (SLASHPTR ? SLASHPTR+1 : __FILE__)
 #endif
 
+#ifdef LIBOPAE_DEBUG
 #define ERR(format, ...)                                                       \
 	fprintf(stderr, "%s:%u:%s() [ERROR][%s] : " format,                    \
 	__FILENAME__, __LINE__, __func__, strerror(errno), ##__VA_ARGS__)
+#else
+#define ERR(format, ...) do { } while (0)
+#endif
 
 #ifndef ASSERT_NOT_NULL_MSG_RESULT
 #define ASSERT_NOT_NULL_MSG_RESULT(__arg, __msg, __res) \


### PR DESCRIPTION
83a4312d libopaevfio: fix coding style (#252)
3bc7308b libopaevfio: silence error output by default (#250)

git-subtree-dir: opae-libs
git-subtree-split: 83a4312df38adc8aeaad96a7cdbf8791c254be21