### PR TITLE
tools:(cherry-pcik) HSSI tools command line argument validation

### DIFF
--- a/tools/extra/hssi/ethernet/hssicommon.py
+++ b/tools/extra/hssi/ethernet/hssicommon.py
@@ -656,7 +656,7 @@ class hssi_eth_port_status(Union):
         return self.bits.eth_mode
 
 
-def veriy_pcie_address(pcie_address):
+def verify_pcie_address(pcie_address):
     m = BDF_PATTERN.match(pcie_address)
     if m is None:
         print("Invalid pcie address foramt",pcie_address)
@@ -750,7 +750,7 @@ class HSSICOMMON(object):
         and firmware version
         """
         try:
-            self.pyopaeuio_inst.open(hssi_uio)
+            self.open(hssi_uio)
             self.num_uio_regions = self.pyopaeuio_inst.numregions
             hssi_dfh = dfh(self.read32(0, 0))
             hssi_version = hssi_ver(self.read32(0, 0x8))
@@ -759,7 +759,7 @@ class HSSICOMMON(object):
             ctl_addr.sal_cmd = HSSI_SALCMD.FIRMWARE_VER.value
             firmware_version = self.read_reg(0, ctl_addr.value)
 
-            print("\n--------HSSI IINFO START-------")
+            print("\n--------HSSI INFO START-------")
             print("HSSI id: {0: >12}".format(hex(hssi_dfh.id)))
             print("HSSI version: {0: >12}".format(str(hssi_version)))
             print("HSSI num ports: {0: >12}"
@@ -771,10 +771,12 @@ class HSSICOMMON(object):
 
         except RuntimeError:
             print("opae uio module exception")
+            return False
         except ValueError:
             print("Invalid arguemnts")
+            return False
 
-        return 0
+        return True
 
     def open(self, hssi_uio):
         ret = self.pyopaeuio_inst.open(hssi_uio)

--- a/tools/extra/hssi/ethernet/hssiloopback.py
+++ b/tools/extra/hssi/ethernet/hssiloopback.py
@@ -108,7 +108,9 @@ class FPGAHSSILPBK(HSSICOMMON):
         enable/disable hssi loopback
         """
         print("----hssi_loopback_start----")
-        self.hssi_info(self._hssi_grps[0][0])
+        if not self.hssi_info(self._hssi_grps[0][0]):
+            print("Failed to read hssi information")
+            sys.exit(1)
         self.hssi_loopback_en()
 
 
@@ -135,6 +137,12 @@ def main():
                         default=0,
                         help='hssi port number')
 
+    # exit if no commad line argument
+    args = parser.parse_args()
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
+
     args, left = parser.parse_known_args()
 
     print("args", args)
@@ -143,7 +151,7 @@ def main():
     print("args.port:", args.port)
     print(args)
 
-    if not veriy_pcie_address(args.pcie_address):
+    if not verify_pcie_address(args.pcie_address.lower()):
         sys.exit(1)
 
     if args.loopback is None:
@@ -153,7 +161,7 @@ def main():
         op = 'enable' if args.loopback else 'disable'
         print('{} fpga loopback'.format(op))
 
-    f = FpgaFinder(args.pcie_address)
+    f = FpgaFinder(args.pcie_address.lower())
     devs = f.enum()
     for d in devs:
         print('sbdf: {segment:04x}:{bus:02x}:{dev:02x}.{func:x}'.format(**d))

--- a/tools/extra/hssi/ethernet/hssimac.py
+++ b/tools/extra/hssi/ethernet/hssimac.py
@@ -76,7 +76,9 @@ class FPGAHSSIMAC(HSSICOMMON):
         get mtu
         """
         print("----hssi_mtu_start----")
-        self.hssi_info(self._hssi_grps[0][0])
+        if not self.hssi_info(self._hssi_grps[0][0]):
+            print("Failed to read hssi information")
+            sys.exit(1)
         self.get_mac_mtu()
 
 
@@ -97,6 +99,12 @@ def main():
     parser.add_argument('--mtu', nargs='?', const='',
                         help='maximum allowable ethernet frame length')
 
+    # exit if no commad line argument
+    args = parser.parse_args()
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
+
     args, left = parser.parse_known_args()
 
     print("args", args)
@@ -104,10 +112,10 @@ def main():
     print("args.mtu:", args.mtu)
     print(args)
 
-    if not veriy_pcie_address(args.pcie_address):
+    if not verify_pcie_address(args.pcie_address.lower()):
         sys.exit(1)
 
-    f = FpgaFinder(args.pcie_address)
+    f = FpgaFinder(args.pcie_address.lower())
     devs = f.enum()
     for d in devs:
         print('sbdf: {segment:04x}:{bus:02x}:{dev:02x}.{func:x}'.format(**d))


### PR DESCRIPTION
* tools: HSSI tools command line argument validation

- Fix  HSSI tool without any command line parameters.
- Accept an uppercase or lower case bdf
- Gracefully exit HSSI tools in non-privilege mode
- Fix Bogus HSSI read stats

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>