### PR TITLE
Cherry-pick opae.admin: fix 'rsu fpga' command 

### DIFF
--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -555,12 +555,8 @@ class fpga_base(sysfs_device):
     def safe_rsu_boot(self, available_image, **kwargs):
         wait_time = kwargs.pop('wait', 10)
 
-        if available_image[:4] == 'fpga':
-            to_remove = self.pci_node.root.endpoints
-            to_disable = [ep.parent for ep in to_remove]
-        else:
-            to_remove = [self.pci_node.root]
-            to_disable = [self.pci_node.root]
+        to_remove = [self.pci_node.root]
+        to_disable = [self.pci_node.root]
         # rescan at the pci bus, if found
         # if for some reason it can't be found, do a full system rescan
         to_rescan = self.pci_node.pci_bus


### PR DESCRIPTION
Change the logic to always remove/disable AER on the root port.
When 'fpga' type is chosen, the flow will remove/disable AER on the
endpoints (including the target endpoint). Because the PCIe topology is
part of the 'fpga', then we should remove the root port no matter what.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>