### PR TITLE
CP tools: remove second print Accelerator id

### DIFF
--- a/tools/fpgainfo/fpgainfo.c
+++ b/tools/fpgainfo/fpgainfo.c
@@ -62,7 +62,6 @@ void fpgainfo_print_common(const char *hdr, fpga_properties props)
 	fpga_objtype objtype;
 	fpga_properties pprops = props;
 	fpga_token par = NULL;
-	int is_accelerator = 0;
 	bool has_parent = true;
 
 	res = fpgaPropertiesGetObjectID(props, &object_id);
@@ -91,8 +90,6 @@ void fpgainfo_print_common(const char *hdr, fpga_properties props)
 
 	if (objtype != FPGA_DEVICE) {
 		res = fpgaPropertiesGetGUID(props, &port_guid);
-		if (res == FPGA_OK)
-			is_accelerator = 1;
 	}
 
 	// Go up the tree until we find the device
@@ -164,11 +161,6 @@ void fpgainfo_print_common(const char *hdr, fpga_properties props)
 			bbs_version.major, bbs_version.minor, bbs_version.patch);
 		uuid_unparse(guid, guid_str);
 		printf("%-32s : %s\n", "Pr Interface Id", guid_str);
-	}
-
-	if (is_accelerator) {
-		uuid_unparse(port_guid, guid_str);
-		printf("%-32s : %s\n", "Accelerator Id", guid_str);
 	}
 
 }


### PR DESCRIPTION
* tools: remove second print Accelerator id

- fpgainfo prints GUID 2 times

[root@PG16WVAW0272_SuperMicro_14 ALPHA]# fpgainfo port
//****** PORT ******//
Object Id                        : 0xEE00000
PCIe s:b:d.f                     : 0000:B1:00.0
Device Id                        : 0xBCCE
Socket Id                        : 0x00
//****** PORT ******//
Object Id                        : 0x20B1000000000000
PCIe s:b:d.f                     : 0000:B1:00.1
Device Id                        : 0xBCCE
Socket Id                        : 0x01
Accelerator Id                   : 1aae155c-acc5-4210-b9ab-efbd90b970c4
Accelerator GUID                 : 1aae155c-acc5-4210-b9ab-efbd90b970c4

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>