### PR TITLE
Tools: add  hssi stats clear command and print active port stats (#2219)

### DIFF
--- a/tools/extra/hssi/ethernet/hssicommon.py
+++ b/tools/extra/hssi/ethernet/hssicommon.py
@@ -58,6 +58,8 @@ HSSI_POLL_TIMEOUT = 1
 
 HSSI_FEATURE_ID = 0x15
 
+# Max port count
+HSSI_PORT_COUNT = 16
 
 class HSSI_CSR(Enum):
     """
@@ -241,8 +243,9 @@ class hssi_feature_bits(Structure):
     """
     _fields_ = [
                    ("axi4_support", c_uint32, 1),
-                   ("num_hssi_ports", c_uint32, 4),
-                   ("reserved", c_uint32, 26)
+                   ("num_hssi_ports", c_uint32, 5),
+                   ("port_enable", c_uint32, 16),
+                   ("reserved", c_uint32, 10)
     ]
 
 
@@ -266,28 +269,13 @@ class hssi_feature(Union):
     def num_hssi_ports(self):
         return self.bits.num_hssi_ports
 
+    @property
+    def port_enable(self):
+        return self.bits.port_enable
+
     @num_hssi_ports.setter
     def num_hssi_ports(self, value):
         self.bits.num_hssi_ports = value
-
-
-class HSSI_PORT_BUSWIDTH(Enum):
-    """
-    HSSI DFH CSR offset
-    """
-    HSSI_400GAUI_8 = 0x0
-    HSSI_400GAUI_4 = 0x1
-    HSSI_VERSION = 0x8
-    HSSI_FEATURE_LIST = 0xC
-    HSSI_INTER_ATTRIB_PORT = 0x10
-    HSSI_CTL_STS = 0x50
-    HSSI_CTL_ADDRESS = 0x54
-    HSSI_WR_DATA = 0x58
-    HSSI_RD_DATA = 0x5C
-    HSSI_GM_TX_LATENCY = 0x60
-    HSSI_GM_RX_LATENCY = 0x64
-    HSSI_ETH_PORT_STATUS = 0x68
-    HSSI_TSE_CONTROL = 0xA8
 
 
 class hssi_port_attribute_bits(Structure):
@@ -300,7 +288,8 @@ class hssi_port_attribute_bits(Structure):
                    ("port_databus_width", c_uint32, 3),
                    ("low_speed_eth", c_uint32, 2),
                    ("dyn_reconf", c_uint32, 1),
-                   ("reserved", c_uint32, 16)
+                   ("port_sub_profiles", c_uint32, 5),
+                   ("reserved", c_uint32, 11)
     ]
 
 
@@ -320,7 +309,8 @@ class hssi_port_attribute(Union):
                           (4, 512),
                           (5, 1024))
 
-    HSSI_PORT_PROFILES = ((32, '400GAUI-8'),
+    HSSI_PORT_PROFILES = ((33, 'CRI'),
+                          (32, '400GAUI-8'),
                           (31, '400GAUI-4'),
                           (30, '200GAUI-8'),
                           (29, '200GAUI-4'),
@@ -331,7 +321,7 @@ class hssi_port_attribute(Union):
                           (24, '50GAUI-1'),
                           (23, '50GAUI-2'),
                           (22, '40GCAUI-4'),
-                          (21, '5GbE'),
+                          (21, '25GbE'),
                           (20, '10GbE'),
                           (19, 'Ethernet PMA-Direct'),
                           (18, 'Ethernet FEC-Direct'),
@@ -342,15 +332,45 @@ class hssi_port_attribute(Union):
                           (13, 'General PCS-Direct'),
                           (12, 'OTN'),
                           (11, 'Flex-E'),
-                          (10, 'General FEC-Direct'),
-                          (9, 'TSE MAC'))
+                          (10, 'TSE MAC'),
+                          (9, 'TSE PCS'),
+                          (8, 'LL10G'),
+                          (7, 'MRPHY'),
+                          (6, '10_25G'),
+                          (5, '25_50G'),
+                          (4, 'Ultra40G'),
+                          (3, 'LL40G'),
+                          (2, 'LL50G'),
+                          (1, 'Ultra100G'),
+                          (0, 'LL100G'))
 
     HSSI_SPEED_ETH_INTER = ((0, 'MII'),
                             (1, 'GMII'),
                             (2, 'XGMII'))
 
+    HSSI_PORT_SUBPROFILES = ((15, '24G PCS'),
+                             (14, '12G PCS'),
+                             (13, '10G PCS'),
+                             (12, '9.8G PMA'),
+                             (11, '8.1G PMA'),
+                             (10, '6.1G PMA'),
+                             (9, '4.9G PMA'),
+                             (8, '3.0G PMA'),
+                             (7, '2.4G PMA'),
+                             (6, '1.2G PMA'),
+                             (5, '0.6G PMA'),
+                             (4, 'MAC + PCS'),
+                             (3, 'PCS'),
+                             (2, 'Flex-E'),
+                             (1, 'OTN'),
+                             (0, 'None'))
+
     def __init__(self, value):
         self.value = value
+
+    @property
+    def port_profiles(self):
+        return self.bits.port_profiles
 
     @property
     def port_read_latency(self):
@@ -367,6 +387,10 @@ class hssi_port_attribute(Union):
     @property
     def dyn_reconf(self):
         return self.bits.dyn_reconf
+		
+    @property
+    def port_sub_profiles(self):
+        return self.bits.port_sub_profiles
 
 
 class hssi_cmd_sts_bits(Structure):
@@ -437,6 +461,7 @@ class HSSI_SALCMD(Enum):
     GET_SCR = 0x6
     ENABLE_LOOPBACK = 0x7
     DISABLE_LOOPBACK = 0x8
+    RESET_MAC_STATISTIC = 0x9
     FIRMWARE_VER = 0xFF
 
 
@@ -760,11 +785,20 @@ class HSSICOMMON(object):
             firmware_version = self.read_reg(0, ctl_addr.value)
 
             print("\n--------HSSI INFO START-------")
-            print("HSSI id: {0: >12}".format(hex(hssi_dfh.id)))
-            print("HSSI version: {0: >12}".format(str(hssi_version)))
-            print("HSSI num ports: {0: >12}"
-                  .format(hssi_feature_list.num_hssi_ports))
-            print("Firmware Version: {0: >12}".format(firmware_version))
+            print("{0: <24}:{1}".format("HSSI ID",hex(hssi_dfh.id)))
+            print("{0: <24}:{1}".format("HSSI version",str(hssi_version)))
+            print("{0: <24}:{1}".format("HSSI num ports",hssi_feature_list.num_hssi_ports))
+            print("{0: <24}:{1}".format("Firmware Version",firmware_version))
+            print("--------Port profile-------")
+            for port in range(0, HSSI_PORT_COUNT):
+               enable = self.register_field_get(hssi_feature_list.port_enable,
+                                             port);
+               if enable == 0:
+                    continue
+               port_attribute = hssi_port_attribute(self.read32(0, 0x10 + port * 4))
+               for profile, pro_str in hssi_port_attribute.HSSI_PORT_PROFILES:
+                  if port_attribute.port_profiles == profile:
+                     print("Port{0:<20}:{1:<25}".format(port,pro_str))
             print("--------HSSI INFO END------- \n")
 
             self.close()
@@ -951,6 +985,10 @@ class HSSICOMMON(object):
         reg_data &= ~(mask << idx)
         reg_data |= (value << idx)
         return reg_data
+
+    def register_field_get(self, reg_data, idx):
+        value = ((reg_data >> idx) & (1))
+        return value
 
 
 def main():

--- a/tools/extra/hssi/ethernet/hssiloopback.py
+++ b/tools/extra/hssi/ethernet/hssiloopback.py
@@ -59,8 +59,15 @@ class FPGAHSSILPBK(HSSICOMMON):
         self.open(self._hssi_grps[0][0])
 
         hssi_feature_list = hssi_feature(self.read32(0, 0xC))
-        if (self._port >= hssi_feature_list.num_hssi_ports):
+        if (self._port >= HSSI_PORT_COUNT):
             print("Invalid Input port number")
+            self.close()
+            return -1
+
+        enable = self.register_field_get(hssi_feature_list.port_enable,
+                                             self._port);
+        if enable == 0:
+            print("Input port is not enabled")
             self.close()
             return -1
 

--- a/tools/extra/hssi/ethernet/hssistats.py
+++ b/tools/extra/hssi/ethernet/hssistats.py
@@ -37,9 +37,10 @@ import struct
 import mmap
 from ethernet.hssicommon import *
 
+# Sleep 50 milliseconds after clearing stats.
+HSSI_STATS_CLEAR_SLEEP_TIME = 50/1000
 # Invalid  hssi stats value
 HSSI_INAVLID_STATS = 0xfffffff1
-
 
 class FPGAHSSISTATS(HSSICOMMON):
     hssi_eth_stats = (('tx_packets', 0),
@@ -102,8 +103,12 @@ class FPGAHSSISTATS(HSSICOMMON):
         port_str = "{0: <32} |".format('HSSI Ports')
         hssi_feature_list = hssi_feature(self.read32(0, 0xC))
         print("HSSI num ports:", hssi_feature_list.num_hssi_ports)
-        for port in range(0, hssi_feature_list.num_hssi_ports):
-            port_str += "port:{}|".format(port).rjust(20, ' ')
+        for port in range(0, HSSI_PORT_COUNT):
+            # add active ports
+            enable = self.register_field_get(hssi_feature_list.port_enable,
+                                             port);
+            if enable == 1:
+                port_str += "port:{}|".format(port).rjust(20, ' ')
 
         print(port_str)
 
@@ -111,8 +116,13 @@ class FPGAHSSISTATS(HSSICOMMON):
         for str, reg in self.hssi_eth_stats:
             stats_list.append("{0: <32} |".format(str))
 
-        for port in range(0, hssi_feature_list.num_hssi_ports):
+        for port in range(0, HSSI_PORT_COUNT):
             port_index = 0
+            # add active ports
+            enable = self.register_field_get(hssi_feature_list.port_enable,
+                                             port);
+            if enable == 0:
+                 continue
             for str, reg in self.hssi_eth_stats:
 
                 ctl_addr.value = 0
@@ -152,6 +162,63 @@ class FPGAHSSISTATS(HSSICOMMON):
 
         return 0
 
+    def clear_hssi_stats(self):
+        """
+        clear ctl address and ctl sts CSR
+        write 0x3 value ctl address and address bit
+        write read cmd 0x1 value ctl sts csr
+        poll for status
+        read LSB stats
+        clear ctl address and ctl sts CSR
+        write 0x3 value ctl address , address bit  and set 31 bit
+        write read 0x1 value ctl sts csr
+        poll for status
+        read MSB stats
+        print stats
+        """
+        self.open(self._hssi_grps[0][0])
+        ctl_addr = hssi_ctl_addr(0)
+        ctl_addr.sal_cmd = HSSI_SALCMD.RESET_MAC_STATISTIC.value
+        value = 0
+
+        print("------------HSSI stats clear start------------")
+
+        port_str = "{0: <32} |".format('HSSI Ports')
+        hssi_feature_list = hssi_feature(self.read32(0, 0xC))
+        print("HSSI num ports:", hssi_feature_list.num_hssi_ports)
+        print("HSSI stats clearing ...")
+        for port in range(0, HSSI_PORT_COUNT):
+            # add active ports
+            enable = self.register_field_get(hssi_feature_list.port_enable,
+                                             port);
+            if enable == 0:
+                 continue
+            ctl_addr.value = 0
+            ctl_addr.sal_cmd = HSSI_SALCMD.RESET_MAC_STATISTIC.value
+            ctl_addr.port_address = port
+            # set bit 16 and 17
+            ctl_addr.value = self.register_field_set(ctl_addr.value,
+                                                         16, 1, 1)
+            ctl_addr.value = self.register_field_set(ctl_addr.value,
+                                                         17, 1, 1)
+            ret = self.clear_ctl_sts_reg(0)
+            if not ret:
+                 print("Failed to clear HSSI CTL STS csr")
+                 return False
+            self.write32(0, HSSI_CSR.HSSI_CTL_ADDRESS.value, ctl_addr.value)
+            # write to ctl sts reg
+            cmd_sts = hssi_cmd_sts(0x2)
+            self.write32(0,  HSSI_CSR.HSSI_CTL_STS.value, cmd_sts.value)
+            time.sleep(HSSI_STATS_CLEAR_SLEEP_TIME)
+            ret = self.clear_ctl_sts_reg(0)
+            if not ret:
+                 print("Failed to clear HSSI CTL STS csr")
+                 return False
+        print("-------------HSSI stats cleared------------")
+
+        self.close()
+        return True
+
     def hssi_stats_start(self):
         """
         print hssi info
@@ -162,6 +229,17 @@ class FPGAHSSISTATS(HSSICOMMON):
             print("Failed to read hssi information")
             sys.exit(1)
         self.get_hssi_stats()
+
+    def hssi_stats_clear(self):
+        """
+        print hssi info
+        get hssi stats
+        """
+        print("----hssi_stats_clear----")
+        self.hssi_info(self._hssi_grps[0][0])
+        if self.clear_hssi_stats() == False:
+           print("hssi stats clearing failed")
+           sys.exit(1)
 
 
 def main():
@@ -178,6 +256,8 @@ def main():
     parser.add_argument('--pcie-address', '-P',
                         default=None, help=pcieaddress_help)
 
+    parser.add_argument('--clear','-C', action='store_true',
+                        help='clears hssi statistics')
     # exit if no commad line argument
     args = parser.parse_args()
     if len(sys.argv) == 1:
@@ -213,7 +293,11 @@ def main():
 
     print("fpga uid dev:", args.hssi_grps[0][0])
     lp = FPGAHSSISTATS(args)
-    lp.hssi_stats_start()
+    if args.clear:
+        lp.hssi_stats_clear()
+        sys.exit(0)
+    else:
+        lp.hssi_stats_start()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Tools: add  hssi stats clear command and print active port stats

- add hssi stats command line argument  --clear or -C ,  reset MAC statistics
   SAL command to clear MAC statistic registers value per port. User can choose to reset either Tx or Rx MAC statistic only or reset both Tx and Rx MAC statistic together by setting bit 16 (Tx) and 17 (Rx) on HSSI Control/Address Register.

- added new CSR field enabled ports  to HSSI Sub system feature list CSR
   Bit 21:6
   Physical Port Enable
   [6] - Port 0 Enable
   [7] - Port 1 Enable
   :
   [21] - Port 15 Enable

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>

* Tools: Fixed bugs during integration with bitstream

User issuing reset MAC statistic SAL command to clear MAC statistic registers value per port. User can choose to reset either Tx or Rx MAC statistic only or reset both Tx and Rx MAC statistic together by setting bit 16 (Tx) and 17 (Rx) on HSSI Control/Address Register.

Co-authored-by: Tim Whisonant <tim.whisonant@intel.com>