### PR TITLE
opae.admin: fix msg when no devices found

### DIFF
--- a/python/opae.admin/opae/admin/tools/pci_device.py
+++ b/python/opae.admin/opae/admin/tools/pci_device.py
@@ -191,7 +191,7 @@ def main():
 
 
     if not args.devices:
-        raise SystemExit(f'{args.device} not found')
+        raise SystemExit(f'{sys.argv[1]} not found')
 
     for dev in args.devices:
         actions[args.action or 'topology'](dev, args, *rest)


### PR DESCRIPTION
Original code referenced a typo of the argparse namespace variable
called 'devices'. Upon further review, the value in this variable is a
list because the 'type' function (pci_deivce) returns a list.
Instead of using this, use argv[1] as the filter is the first
positional argument.

This is a fix for #2278 

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>