### PR TITLE
Tools: Fix hssiloopback incorrectly prints and exit error code.

### DIFF
--- a/tools/extra/hssi/ethernet/hssiloopback.py
+++ b/tools/extra/hssi/ethernet/hssiloopback.py
@@ -54,22 +54,20 @@ class FPGAHSSILPBK(HSSICOMMON):
         poll for status
         clear ctl address and ctl sts CSR
         """
-        print("eth_group_loopback_en", self._loopback)
-
         self.open(self._hssi_grps[0][0])
 
         hssi_feature_list = hssi_feature(self.read32(0, 0xC))
         if (self._port >= HSSI_PORT_COUNT):
             print("Invalid Input port number")
             self.close()
-            return -1
+            return False
 
         enable = self.register_field_get(hssi_feature_list.port_enable,
-                                             self._port);
+                                         self._port)
         if enable == 0:
-            print("Input port is not enabled")
+            print("Input port is not enabled or active")
             self.close()
-            return -1
+            return False
 
         ctl_addr = hssi_ctl_addr(0)
         if (self._loopback):
@@ -87,7 +85,7 @@ class FPGAHSSILPBK(HSSICOMMON):
         if not ret:
             print("Failed to clear HSSI CTL STS csr")
             self.close()
-            return 0
+            return False
 
         self.write32(0, HSSI_CSR.HSSI_CTL_ADDRESS.value, ctl_addr.value)
         self.write32(0, HSSI_CSR.HSSI_CTL_STS.value, cmd_sts.value)
@@ -97,17 +95,16 @@ class FPGAHSSILPBK(HSSICOMMON):
                                       0x2):
             print("HSSI ctl sts csr fails to update ACK")
             self.close()
-            return 0
+            return False
 
         ret = self.clear_ctl_sts_reg(0)
         if not ret:
             print("Failed to clear HSSI CTL STS csr")
             self.close()
-            return 0
+            return False
 
         self.close()
-
-        return 0
+        return True
 
     def hssi_loopback_start(self):
         """
@@ -117,8 +114,10 @@ class FPGAHSSILPBK(HSSICOMMON):
         print("----hssi_loopback_start----")
         if not self.hssi_info(self._hssi_grps[0][0]):
             print("Failed to read hssi information")
-            sys.exit(1)
-        self.hssi_loopback_en()
+            return False
+        if not self.hssi_loopback_en():
+            return False
+        return True
 
 
 def main():
@@ -181,7 +180,6 @@ def main():
         print('no FPGA found')
         sys.exit(1)
 
-
     args.hssi_grps = f.find_hssi_group(devs[0].get('pcie_address'))
     print("args.hssi_grps", args.hssi_grps)
     if len(args.hssi_grps) == 0:
@@ -191,7 +189,10 @@ def main():
     print("fpga uid dev:", args.hssi_grps[0][0])
 
     lp = FPGAHSSILPBK(args)
-    lp.hssi_loopback_start()
+    if not lp.hssi_loopback_start():
+        print("Failed to Enable loopback")
+        sys.exit(1)
+    print("hssi loopback enabled")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Fix hssiloopback incorrectly print to console that loopback has been enabled/disabled even if there are errors
- Exit  with error code 1 if error
- Exit  with error code 0 if  no error

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>