### PR TITLE
cmake: fix OPAEGit.cmake

### DIFF
--- a/opae-libs/cmake/modules/OPAEGit.cmake
+++ b/opae-libs/cmake/modules/OPAEGit.cmake
@@ -1,5 +1,5 @@
 #!/usr/bin/cmake -P
-## Copyright(c) 2017-2020, Intel Corporation
+## Copyright(c) 2017-2021, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -33,7 +33,7 @@
 
 find_program(OPAE_GIT_EXECUTABLE git)
 
-if((EXISTS ${OPAE_GIT_EXECUTABLE}) AND (EXISTS "${CMAKE_SOURCE_DIR}/.git"))
+if(EXISTS ${OPAE_GIT_EXECUTABLE})
     # Find the abbreviated git commit hash.
     execute_process(COMMAND ${OPAE_GIT_EXECUTABLE} log -1 --format=%h
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
https://github.com/OPAE/opae-sdk/pull/2051 errantly changed this
opae-libs file in the opae-sdk tree. Bringing the two back into
sync..

The change in 2051 broke our application --version output. This
change corrects it.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>