### PR TITLE
opae.admin: updates for sysfs path changes

### DIFF
--- a/python/opae.admin/opae/admin/tools/fpgaotsu.py
+++ b/python/opae.admin/opae/admin/tools/fpgaotsu.py
@@ -617,7 +617,7 @@ def main():
     errors = 0
     updaters = []
     for pac in pacs:
-        if pac.secure_dev:
+        if pac.upload_dev:
             LOG.info('%s %s is already secure.', json_cfg['product'],
                      pac.pci_node.pci_address)
             continue

--- a/python/opae.admin/opae/admin/tools/fpgasupdate.py
+++ b/python/opae.admin/opae/admin/tools/fpgasupdate.py
@@ -573,7 +573,7 @@ def update_fw_sysfs(infile, pac):
     payload_size = infile.tell() - orig_pos
     infile.close()
 
-    sec_dev = pac.secure_dev
+    sec_dev = pac.upload_dev
     error = sec_dev.find_one(os.path.join('update', 'error'))
     filename = sec_dev.find_one(os.path.join('update', 'filename'))
     size = sec_dev.find_one(os.path.join('update', 'remaining_size'))
@@ -775,7 +775,7 @@ def main():
                     sys.exit(1)
 
     # Check for 'update/filename' to determine if we use sysfs or ioctl
-    if pac.secure_dev.find_one(os.path.join('update', 'filename')):
+    if pac.upload_dev.find_one(os.path.join('update', 'filename')):
         use_ioctl = False
 
     LOG.warning('Update starting. Please do not interrupt.')
@@ -787,7 +787,7 @@ def main():
         stat, mesg = do_partial_reconf(pac.pci_node.pci_address,
                                        args.file.name)
     elif blk0 is not None:
-        sec_dev = pac.secure_dev
+        sec_dev = pac.upload_dev
         if not sec_dev:
             LOG.error('Failed to find secure '
                       'device for PAC %s', pac.pci_node.pci_address)

--- a/python/opae.admin/opae/admin/tools/rsu.py
+++ b/python/opae.admin/opae/admin/tools/rsu.py
@@ -105,13 +105,13 @@ def fpga_defaults_valid(pci_id, value):
 
 
 def set_fpga_default(device, args):
-    security = device.security
-    if not security:
+    secure_update = device.secure_update
+    if not secure_update:
         logging.error('failed to find secure '
                       'attributes for {}'.format(device.pci_node.pci_address))
         raise IOError
 
-    power_on_image = security.find_one('power_on_image')
+    power_on_image = secure_update.find_one('control/power_on_image')
 
     if not args.page and not args.fallback:
         # Print the power_on_image value.


### PR DESCRIPTION
*-secure.*.auto becomes *-sec-update.*.auto, so update the glob
to *-sec*.*.auto to account for both.

Rename the 'security' property accessor to 'secure_update'. This
corresponds to the base of the *-sec*.*.auto directory tree.

Rename the 'secure_dev' property accessor to 'upload_dev',
reflecting that it is the means by which to determine the
/dev/fpga_image_load* for loading secure images.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>