### PR TITLE
rsu: allow uppercase ssss:bb:dd.f

### DIFF
--- a/python/opae.admin/opae/admin/tools/rsu.py
+++ b/python/opae.admin/opae/admin/tools/rsu.py
@@ -264,7 +264,7 @@ def main():
     Path(RSU_LOCK_DIR).mkdir(parents=True, exist_ok=True)
 
     for device in compatible:
-        if device.pci_node.pci_address == bdf:
+        if device.pci_node.pci_address.lower() == bdf.lower():
             exit_code = os.EX_IOERR
             with open(RSU_LOCK_FILE, 'w') as flock:
                 fcntl.flock(flock.fileno(), fcntl.LOCK_EX)


### PR DESCRIPTION
Convert the sbdf to lowercase when comparing the two values
to allow both uppercase and lowercase.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>