### PR TITLE
(cherry pick) rsu: support old and new sysfs paths

### DIFF
--- a/python/opae.admin/opae/admin/tools/rsu.py
+++ b/python/opae.admin/opae/admin/tools/rsu.py
@@ -281,7 +281,7 @@ def main():
 
     logging.error('PCIe address (%s) does not identify a compatible device',
                   args.bdf)
-    raise SystemExit(os.EX_NOTFOUND)
+    raise SystemExit(os.EX_UNAVAILABLE)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The previous driver implementation provided
fpga_sec_mgr/fpga_secX/update/available_images and
fpga_sec_mgr/fpga_secX/update/image_load.

The new implementation uses
control/available_images and
control/image_load

Add support for both flavors.

Fix bug in rsu.py: os.EX_NOTFOUND not defined.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>