### PR TITLE
opae.admin: CP add support to aer clear subcommand (#2296)

### DIFF
--- a/python/opae.admin/opae/admin/tools/pci_device.py
+++ b/python/opae.admin/opae/admin/tools/pci_device.py
@@ -26,8 +26,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import re
 import sys
+import subprocess
 from argparse import ArgumentParser, FileType
 from opae.admin.sysfs import pcie_device, pci_node
+from opae.admin.utils.process import call_process
 
 
 PCI_ADDRESS_PATTERN = (r'^(?P<pci_address>'
@@ -116,6 +118,17 @@ class aer(object):
         action = myargs.action or 'dump'
         getattr(self, action)(device, *rest)
 
+    def clear(self, device):
+        """
+        clear aer errors and print error status.
+        """
+        try:
+            cmd = f'setpci -s {device} ECAP_AER+0x10.L'
+            call_process(f'{cmd}=0xFFFFFFFF')
+            output = call_process(cmd)
+            print("aer clear errors:", output)
+        except (subprocess.CalledProcessError, OSError):
+            print("Failed to clear aer errors")
 
     def dump(self, device):
         for key in ['aer_dev_correctable', 'aer_dev_fatal', 'aer_dev_nonfatal']:


### PR DESCRIPTION
* opae.admin:add support to aer clear subcommand

- add new clear function to class aer
  AER error clear command:  setpci -s  0000:b1:00.0 ECAP_AER+0x10.L=0xFFFFFFFF
  AER error status command: setpci -s  0000:b1:00.0 ECAP_AER+0x10.L

* opae.admin:  add exception handling to clear subcommand
 -add clear function in  try / except block  to catch setpci command failures
* opae.admin: foramt aer error clear command string

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>