### PR TITLE
Tools: CP fix fpgainfo memory leak

### DIFF
--- a/tools/fpgainfo/board.c
+++ b/tools/fpgainfo/board.c
@@ -317,6 +317,10 @@ fpga_result mac_command(fpga_token *tokens, int num_tokens, int argc,
 			printf("mac info is not supported\n");
 		}
 
+		res = fpgaDestroyProperties(&props);
+		if (res != FPGA_OK) {
+			OPAE_ERR("Failed to destroy properties");
+		}
 	}
 
 	return FPGA_OK;
@@ -432,6 +436,11 @@ fpga_result phy_command(fpga_token *tokens, int num_tokens, int argc,
 		res = phy_group_info(tokens[i]);
 		if (res != FPGA_OK) {
 			printf("phy group info is not supported\n");
+		}
+
+		res = fpgaDestroyProperties(&props);
+		if (res != FPGA_OK) {
+			OPAE_ERR("Failed to destroy properties");
 		}
 
 	}
@@ -603,6 +612,11 @@ fpga_result sec_command(fpga_token *tokens, int num_tokens, int argc,
 		res = sec_info(tokens[i]);
 		if (res != FPGA_OK) {
 			printf("Sec info is not supported\n");
+		}
+
+		res = fpgaDestroyProperties(&props);
+		if (res != FPGA_OK) {
+			OPAE_ERR("Failed to destroy properties");
 		}
 
 	}

--- a/tools/libboard/board_common/board_common.c
+++ b/tools/libboard/board_common/board_common.c
@@ -392,6 +392,7 @@ fpga_result get_fpga_sbdf(fpga_token token,
 {
 	fpga_result res = FPGA_OK;
 	fpga_properties props = NULL;
+	fpga_result resval = FPGA_OK;
 
 	if (!segment || !bus ||
 		!device || !function) {
@@ -407,27 +408,37 @@ fpga_result get_fpga_sbdf(fpga_token token,
 	res = fpgaPropertiesGetBus(props, bus);
 	if (res != FPGA_OK) {
 		OPAE_ERR("Failed to get bus ");
-		return res;
+		resval = res;
+		goto out_destroy;
 	}
 
 	res = fpgaPropertiesGetSegment(props, segment);
 	if (res != FPGA_OK) {
 		OPAE_ERR("Failed to get Segment ");
-		return res;
+		resval = res;
+		goto out_destroy;
 	}
 	res = fpgaPropertiesGetDevice(props, device);
 	if (res != FPGA_OK) {
 		OPAE_ERR("Failed to get Device ");
-		return res;
+		resval = res;
+		goto out_destroy;
 	}
 
 	res = fpgaPropertiesGetFunction(props, function);
 	if (res != FPGA_OK) {
 		OPAE_ERR("Failed to get Function ");
-		return res;
+		resval = res;
+		goto out_destroy;
 	}
 
-	return res;
+out_destroy:
+	res = fpgaDestroyProperties(&props);
+	if (res != FPGA_OK) {
+		OPAE_ERR("Failed to destroy properties");
+	}
+
+	return resval;
 }
 
 


### PR DESCRIPTION
- add fpgaDestroyProperties to free Properties object

Signed-off-by: lab <lab@psera2-dell21.ra.intel.com>

Co-authored-by: lab <lab@psera2-dell21.ra.intel.com>