### PR TITLE
(cherry-pick) PACSign: allow SR/PR keys to apply to *_TEST (#2344)

### DIFF
--- a/python/pacsign/pacsign/reader.py
+++ b/python/pacsign/pacsign/reader.py
@@ -588,6 +588,26 @@ class _READER_BASE(object):
                     bit_index <<= 1
         return (crc32 ^ xor)
 
+    def assert_types_match(self, msg, key_type, bits_type):
+        sr_types = [database.CONTENT_SR, database.CONTENT_SR_TEST, database.CONTENT_SR_CERT]
+        pr_types = [database.CONTENT_PR, database.CONTENT_PR_TEST]
+
+        if key_type in sr_types:
+            common_util.assert_in_error(
+                bits_type in sr_types,
+                f"{msg} content type mismatch: key={key_type}, type={bits_type}"
+            )
+        elif key_type in pr_types:
+            common_util.assert_in_error(
+                bits_type in pr_types,
+                f"{msg} content type mismatch: key={key_type}, type={bits_type}"
+            )
+        else:
+            common_util.assert_in_error(
+                key_type == bits_type,
+                f"{msg} content type mismatch: key={key_type}, type={bits_type}"
+            )
+
 
 class CANCEL_reader(_READER_BASE):
     def __init__(self, args, hsm_manager, config):
@@ -617,11 +637,9 @@ class CANCEL_reader(_READER_BASE):
         log.debug("FOO: {}".format(self.pub_root_key_type))
         common_util.assert_in_error(self.pub_root_key_type is not None,
                                     "Cannot retrieve root public key type")
-        common_util.assert_in_error(
-            self.pub_root_key_type == self.bitstream_type,
-            "Root key content type mismatch: key={}, type={}".format(
-                self.pub_root_key_type, self.bitstream_type),
-        )
+        self.assert_types_match('Root key',
+                                self.pub_root_key_type,
+                                self.bitstream_type)
 
     def run(self):
         # Put the key ID into the payload and pad
@@ -677,11 +695,9 @@ class UPDATE_reader(_READER_BASE):
             common_util.assert_in_error(
                 self.pub_root_key_type is not None,
                 "Cannot retrieve root public key type")
-            common_util.assert_in_error(
-                self.pub_root_key_type == self.bitstream_type,
-                "Root key content type mismatch: key={}, type={}".format(
-                    self.pub_root_key_type, self.bitstream_type),
-            )
+            self.assert_types_match('Root key',
+                                    self.pub_root_key_type,
+                                    self.bitstream_type)
         else:
             self.pub_root_key = common_util.BYTE_ARRAY()
             while self.pub_root_key.size() < 96:
@@ -702,11 +718,9 @@ class UPDATE_reader(_READER_BASE):
                     self.pub_CSK_type].ENUM
             common_util.assert_in_error(self.pub_CSK_type is not None,
                                         "Cannot retrieve CSK type")
-            common_util.assert_in_error(
-                self.pub_CSK_type == self.bitstream_type,
-                "CSK content type mismatch: key={}, type={}".format(
-                    self.pub_CSK_type, self.bitstream_type),
-            )
+            self.assert_types_match('CSK',
+                                    self.pub_CSK_type,
+                                    self.bitstream_type)
         else:
             self.pub_CSK = common_util.BYTE_ARRAY()
             while self.pub_CSK.size() < 96:
@@ -895,11 +909,9 @@ class RHP_reader(_READER_BASE):
                 self.pub_root_key_type].ENUM
         common_util.assert_in_error(self.pub_root_key_type is not None,
                                     "Cannot retrieve root public key type")
-        common_util.assert_in_error(
-            self.pub_root_key_type == self.bitstream_type,
-            "Root key content type mismatch: key={}, type={}".format(
-                self.pub_root_key_type, self.bitstream_type),
-        )
+        self.assert_types_match('Root key',
+                                self.pub_root_key_type,
+                                self.bitstream_type)
         self.fuse_info = args.fuse_info
 
     def run(self):


### PR DESCRIPTION
Updates the key checking logic to relax the requirement on key naming
for SR/SR_TEST and PR/PR_TEST.

Previously, the strings '_fim_'/'_sr_test_' were required to appear in
the key names for SR/SR_TEST. This change relaxes the restriction so
that a key with '_fim_' can also be used for SR_TEST and vice-versa.

Likewise, the strings '_pr_'/'_pr_test_' were required to appear in
the key names for PR/PR_TEST. This change relaxes the restriction so
that a key with '_pr_' can also be used for PR_TEST and vice-versa.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>