### PR TITLE
host_exerciser updates

### DIFF
--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -213,7 +213,7 @@ public:
 
         // In atomic mode, at most the first 8 bytes of each line will be
         // updated and copied. In the source buffer, write a function of
-        // the value at the start of each line to the second postion so
+        // the value at the start of each line to the second position so
         // it can be used as a check later.
         if (he_lpbk_cfg_.AtomicFunc != HOSTEXE_ATOMIC_OFF) {
             for (uint32_t i = 0; i < buffer->size()/CL; i += 1) {


### PR DESCRIPTION
- Read the AFU frequency from a new CSR.
- Add tests for PCIe atomic functions, including validating that each function
  is performed properly.
- Fill the source buffer with random data instead of the same pattern over
  and over so that read errors are more likely to be found.
- Make the log level work. Dump a few lines of the buffers in some modes.