### PR TITLE
(cherry-pick) fpgasupdate: format time display / fix bug (#2346)

### DIFF
--- a/python/opae.admin/opae/admin/tools/fpgasupdate.py
+++ b/python/opae.admin/opae/admin/tools/fpgasupdate.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-# Copyright(c) 2019-2020, Intel Corporation
+# Copyright(c) 2019-2021, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -698,6 +698,17 @@ def sig_handler(signum, frame):
     raise SecureUpdateError((1, 'Caught SIGTERM'))
 
 
+class MyLogFormatter(logging.Formatter):
+    '''Custom logging.Formatter object.
+       Overrides formatTime() to limit the fractional seconds
+       field to hundredths.'''
+    def formatTime(self, record, datefmt=None):
+        dt = super().formatTime(record, datefmt)
+        front = dt[:-4]
+        end = dt[-4:]
+        return front + '.' + end[1:3]
+
+
 def main():
     """The main entry point."""
     parser, args = parse_args()
@@ -712,7 +723,7 @@ def main():
     log_fmt = ('[%(asctime)-15s] [%(levelname)-8s] '
                '%(message)s')
     log_hndlr = logging.StreamHandler(sys.stdout)
-    log_hndlr.setFormatter(logging.Formatter(log_fmt))
+    log_hndlr.setFormatter(MyLogFormatter(log_fmt))
     log_hndlr.setLevel(LOG_NAMES_TO_LEVELS[args.log_level])
     LOG.addHandler(log_hndlr)
 
@@ -831,7 +842,9 @@ def main():
     else:
         LOG.info(mesg)
 
-    LOG.info('Total time: %s', datetime.now() - start)
+    total = datetime.now() - start
+    total_str = str(total)[:-4] # limit to hundredths
+    LOG.info('Total time: %s', total_str)
     sys.exit(stat)
 
 

--- a/python/opae.admin/opae/admin/utils/progress.py
+++ b/python/opae.admin/opae/admin/utils/progress.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019-2020, Intel Corporation
+# Copyright(c) 2019-2021, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -28,8 +28,7 @@ import codecs
 import os
 import sys
 import threading
-import time
-from datetime import timedelta
+from datetime import timedelta, datetime
 
 from opae.admin.utils.log import loggable
 
@@ -78,7 +77,7 @@ class progress(loggable):
         self._units = kwargs.get('units', 'bytes')
         self._bar = kwargs.get('bar', self.BAR)
         self._logfn = kwargs.get('log')
-        self._start_time = time.time()
+        self._start_time = datetime.now()
         self._last_pct = 0
         self._line_ending = '\r'
         label = kwargs.get('label', '')
@@ -129,8 +128,9 @@ class progress(loggable):
         if ratio is not None and len(ratio) == 2:
             text += u' [{}/{} {}]'.format(ratio[0], ratio[1], self._units)
 
-        elapsed = timedelta(seconds=time.time() - self._start_time)
-        text += u'[Elapsed Time: {}]'.format(elapsed)
+        elapsed = datetime.now() - self._start_time
+        elapsed_str = str(elapsed)[:-4] # limit to hundredths
+        text += u'[Elapsed Time: {}]'.format(elapsed_str)
         if self._label:
             text += u'[{}]'.format(self._label)
 
@@ -160,13 +160,13 @@ class progress(loggable):
         """tick Update elapsed time by getting the current time."""
         if self._total_time is None:
             raise RuntimeError('progress not configured with "time" value')
-        elapsed = time.time() - self._start_time
-        pct = elapsed/self._total_time
+        elapsed = datetime.now() - self._start_time
+        pct = elapsed.total_seconds() / self._total_time
         return self.update_percent(pct)
 
     def begin(self):
         """begin Initialize the progress bar (reset time to zero)"""
-        self._start_time = time.time()
+        self._start_time = datetime.now()
         return self.update_percent(0)
 
     def end(self):


### PR DESCRIPTION
Format each time display to limit the precision to 2 digits
(hundredths of a second). This includes the standard logging
package output.

Use datetime.now() for timestamps in progress.py to correct an
accuracy error caused by using time.time() with datetime.timedelta.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>