### PR TITLE
tools: CP fix n6000 static code analysis issue -Buffer Overflow

### DIFF
--- a/tools/libboard/board_n6000/board_n6000.c
+++ b/tools/libboard/board_n6000/board_n6000.c
@@ -563,6 +563,9 @@ fpga_result print_bom_info(const fpga_token token)
 		return res;
 	}
 
+	// Terminated by a null character '\0'
+	bom_info[FPGA_BOM_INFO_BUF_LEN] = '\0';
+
 	res = reformat_bom_info(bom_info, FPGA_BOM_INFO_BUF_LEN, max_result_len);
 	if (res != FPGA_OK) {
 		OPAE_ERR("Failed to reformat BOM info");


### PR DESCRIPTION
- Array 'bom_info' of size 16384 may use index value(s) 16384..INT_MAX
- bom_info terminate with null character '\0'

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>