### PR TITLE
tools: CP fix static code analysis  overflow of the buffer

### DIFF
--- a/samples/fpgaperf_counter/fpgaperf_counter.c
+++ b/samples/fpgaperf_counter/fpgaperf_counter.c
@@ -173,7 +173,7 @@ STATIC fpga_result parse_perf_attributes(struct udev_device *dev,
 			globfree(&pglob);
 			return FPGA_EXCEPTION;
 		}
-		if (fscanf(file, "%s", attr_value) != 1) {
+		if (fscanf(file, "%127s", attr_value) != 1) {
 			OPAE_ERR("Failed to read %s", pglob.gl_pathv[i]);
 			goto out;
 		}


### PR DESCRIPTION
-  Width is not specified for 's' conversion specifier.
   This can result in an overflow of the buffer provided in argument 3 of a call to 'fscanf'

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>