### PR TITLE
packaging, rpm: remove exclude clause from tar

### DIFF
--- a/packaging/opae/rpm/create-tarball.sh
+++ b/packaging/opae/rpm/create-tarball.sh
@@ -21,7 +21,6 @@ tar --transform=$trans \
   --exclude=build \
   --exclude=.* \
   --exclude=*~ \
-  --exclude=*.so \
   --exclude=doc/sphinx \
   --exclude=external/gtest \
   --exclude=external/opae-legacy/tests \


### PR DESCRIPTION
Preserves any .so's archived in the repo so that they can be
properly distributed with python projects.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>