### PR TITLE
Tools: CP add fpgainfo phy  link status up/down

### DIFF
--- a/tools/libboard/board_n6000/board_n6000.c
+++ b/tools/libboard/board_n6000/board_n6000.c
@@ -74,6 +74,7 @@
 #define HSSI_FEATURE_LIST                       0xC
 #define HSSI_PORT_ATTRIBUTE                     0x10
 #define HSSI_VERSION                            0x8
+#define HSSI_PORT_STATUS                        0x818
 
 // boot page info sysfs
 #define DFL_SYSFS_BOOT_GLOB "*dfl*/**/fpga_boot_image"
@@ -141,6 +142,20 @@ struct hssi_port_attribute {
 			uint32_t dynamic_pr : 1;
 			uint32_t sub_profile : 5;
 			uint32_t reserved : 11;
+		};
+	};
+};
+
+//HSSI Ethernet Port Status
+//Byte Offset: 0x818
+struct hssi_port_status {
+	union {
+		uint64_t csr;
+		struct {
+			uint64_t txplllocked : 16;
+			uint64_t txlanestable : 16;
+			uint64_t rxpcsready : 16;
+			uint64_t reserved : 16;
 		};
 	};
 };
@@ -623,6 +638,7 @@ fpga_result print_phy_info(fpga_token token)
 	struct hssi_port_attribute port_profile;
 	struct hssi_feature_list  feature_list;
 	struct hssi_version  hssi_ver;
+	struct hssi_port_status port_status;
 	uint8_t *mmap_ptr = NULL;
 	uint32_t i = 0;
 
@@ -647,6 +663,8 @@ fpga_result print_phy_info(fpga_token token)
 
 	feature_list.csr = *((uint32_t *) (mmap_ptr + HSSI_FEATURE_LIST));
 	hssi_ver.csr = *((uint32_t *)(mmap_ptr + HSSI_VERSION));
+	port_status.csr = *((volatile uint64_t *)(mmap_ptr
+		+ HSSI_PORT_STATUS));
 
 	printf("//****** HSSI information ******//\n");
 	printf("%-32s : %d.%d  \n", "HSSI version", hssi_ver.major, hssi_ver.minor);
@@ -659,7 +677,7 @@ fpga_result print_phy_info(fpga_token token)
 			continue;
 		}
 
-		port_profile.csr = *((uint32_t *)(mmap_ptr +
+		port_profile.csr = *((volatile uint32_t *)(mmap_ptr +
 			HSSI_PORT_ATTRIBUTE + i * 4));
 
 		if (port_profile.profile > HSS_PORT_PROFILE_SIZE) {
@@ -669,7 +687,17 @@ fpga_result print_phy_info(fpga_token token)
 
 		for (int j = 0; j < HSS_PORT_PROFILE_SIZE; j++) {
 			if (hssi_port_profiles[j].port_index == port_profile.profile) {
-				printf("Port%-28d :%s\n", i, hssi_port_profiles[j].profile);
+				// lock, tx, rx bits set - link status UP
+				// lock, tx, rx bits not set - link status DOWN
+				if ((GET_BIT(port_status.txplllocked, i) == 1) &&
+					(GET_BIT(port_status.txlanestable, i) == 1) &&
+					(GET_BIT(port_status.rxpcsready, i) == 1)) {
+					printf("Port%-28d :%-12s %s\n", i,
+						hssi_port_profiles[j].profile, "UP");
+				} else {
+					printf("Port%-28d :%-12s %s\n", i,
+						hssi_port_profiles[j].profile, "DOWN");
+				}
 				break;
 			}
 		 }


### PR DESCRIPTION
* Tools: add fpgainfo phy  link status up/down

- add fpga Ethernet ports link status

  HSSI Link status CSR offset 0x818:

  reserved (63:48) -- Reserved
  rxpcsready (47:32) -- bit0 for port0
  txlanestable (31:16) -- bit0 for port0
  txplllocked (15:00) – bit0 for port0

   if TX PLL locked, RX PCS ready and TX lanes are set   means links Status UP
   if TX PLL locked, RX PCS ready and TX lanes are not set   means links Status DOWN

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>