### PR TITLE
host_exerciser: fix build on g++ 11.2.1

### DIFF
--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -66,11 +66,17 @@ public:
         he_status0.value = host_exe_->read64(HE_STATUS0);
         he_status1.value = host_exe_->read64(HE_STATUS1);
 
-        host_exe_->logger_->info("Host Exerciser numReads: {0}", he_status0.numReads);
-        host_exe_->logger_->info("Host Exerciser numWrites: {0}", he_status0.numWrites);
+	uint64_t tmp;
 
-        host_exe_->logger_->info("Host Exerciser numPendReads: {0}", he_status1.numPendReads);
-        host_exe_->logger_->info("Host Exerciser numPendWrites: {0}", he_status1.numPendWrites);
+	tmp = he_status0.numReads;
+        host_exe_->logger_->info("Host Exerciser numReads: {0}", tmp);
+	tmp = he_status0.numWrites;
+        host_exe_->logger_->info("Host Exerciser numWrites: {0}", tmp);
+
+	tmp = he_status1.numPendReads;
+        host_exe_->logger_->info("Host Exerciser numPendReads: {0}", tmp);
+	tmp = he_status1.numPendWrites;
+        host_exe_->logger_->info("Host Exerciser numPendWrites: {0}", tmp);
     }
 
     void host_exerciser_errors()
@@ -139,9 +145,14 @@ public:
             host_exerciser_status();
         }
 
-        host_exe_->logger_->info("Number of clocks: {0}", dsm_status->num_ticks);
-        host_exe_->logger_->info("Total number of Reads sent: {0}", dsm_status->num_reads);
-        host_exe_->logger_->info("Total number of Writes sent: {0}", dsm_status->num_writes);
+	uint64_t tmp;
+
+	tmp = dsm_status->num_ticks;
+        host_exe_->logger_->info("Number of clocks: {0}", tmp);
+	tmp = dsm_status->num_reads;
+        host_exe_->logger_->info("Total number of Reads sent: {0}", tmp);
+	tmp = dsm_status->num_writes;
+        host_exe_->logger_->info("Total number of Writes sent: {0}", tmp);
 
         // print bandwidth
         if (dsm_status->num_ticks > 0) {

--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -68,14 +68,14 @@ public:
 
 	uint64_t tmp;
 
-	tmp = he_status0.numReads;
+        tmp = he_status0.numReads;
         host_exe_->logger_->info("Host Exerciser numReads: {0}", tmp);
-	tmp = he_status0.numWrites;
+        tmp = he_status0.numWrites;
         host_exe_->logger_->info("Host Exerciser numWrites: {0}", tmp);
 
-	tmp = he_status1.numPendReads;
+        tmp = he_status1.numPendReads;
         host_exe_->logger_->info("Host Exerciser numPendReads: {0}", tmp);
-	tmp = he_status1.numPendWrites;
+        tmp = he_status1.numPendWrites;
         host_exe_->logger_->info("Host Exerciser numPendWrites: {0}", tmp);
     }
 
@@ -147,11 +147,11 @@ public:
 
 	uint64_t tmp;
 
-	tmp = dsm_status->num_ticks;
+        tmp = dsm_status->num_ticks;
         host_exe_->logger_->info("Number of clocks: {0}", tmp);
-	tmp = dsm_status->num_reads;
+        tmp = dsm_status->num_reads;
         host_exe_->logger_->info("Total number of Reads sent: {0}", tmp);
-	tmp = dsm_status->num_writes;
+        tmp = dsm_status->num_writes;
         host_exe_->logger_->info("Total number of Writes sent: {0}", tmp);
 
         // print bandwidth

--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -66,7 +66,7 @@ public:
         he_status0.value = host_exe_->read64(HE_STATUS0);
         he_status1.value = host_exe_->read64(HE_STATUS1);
 
-	uint64_t tmp;
+        uint64_t tmp;
 
         tmp = he_status0.numReads;
         host_exe_->logger_->info("Host Exerciser numReads: {0}", tmp);
@@ -145,7 +145,7 @@ public:
             host_exerciser_status();
         }
 
-	uint64_t tmp;
+        uint64_t tmp;
 
         tmp = dsm_status->num_ticks;
         host_exe_->logger_->info("Number of clocks: {0}", tmp);


### PR DESCRIPTION
Assign bitfields to a temporary variable before logging in order
to appease spdlog.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>