### PR TITLE
tools: fix fpgainfo errors port command return error code

### DIFF
--- a/tools/fpgainfo/errors.c
+++ b/tools/fpgainfo/errors.c
@@ -183,6 +183,11 @@ fpga_result errors_filter(fpga_properties *filter, int argc, char *argv[])
 							  FPGA_ACCELERATOR);
 			ON_FPGAINFO_ERR_GOTO(
 				res, out, "setting type to FPGA_ACCELERATOR");
+
+			res = fpgaPropertiesSetInterface(*filter,
+				FPGA_IFC_DFL);
+			ON_FPGAINFO_ERR_GOTO(
+				res, out, "setting type to FPGA_IFC_DFL");
 			break;
 		case VERB_ALL:
 		default:


### PR DESCRIPTION
- fpgainfo errors -c port returns errno 70 if one or more functions are bound to vfio-pci, Errors are supported by DFL driver port, so set fpgaPropertiesSetInterface to FPGA_IFC_DFL.

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>