### PR TITLE
Tools: CP fpgainfo errors  all output reformat

### DIFF
--- a/tools/fpgainfo/errors.c
+++ b/tools/fpgainfo/errors.c
@@ -282,7 +282,8 @@ static void print_errors_info(fpga_token token, fpga_properties props,
 	if (((VERB_ALL == errors_config.which)
 	     || (VERB_FME == errors_config.which))
 	    && (FPGA_DEVICE == objtype)) {
-		fpgainfo_print_common("//****** FME ERRORS ******//", props);
+		fpgainfo_print_common("//****** FME ******//", props);
+		printf("//****** FME ERRORS ******// \n");
 
 		for (i = 0; i < (int)num_errors; i++) {
 			uint64_t error_value = 0;
@@ -310,7 +311,11 @@ static void print_errors_info(fpga_token token, fpga_properties props,
 	} else if (((VERB_ALL == errors_config.which)
 		    || (VERB_PORT == errors_config.which))
 		   && (FPGA_ACCELERATOR == objtype)) {
-		fpgainfo_print_common("//****** PORT ERRORS ******//", props);
+
+		if (VERB_PORT == errors_config.which)
+			fpgainfo_print_common("//****** PORT ******//", props);
+
+		printf("//****** PORT ERRORS ******// \n");
 
 		for (i = 0; i < (int)num_errors; i++) {
 			uint64_t error_value = 0;


### PR DESCRIPTION
-fpgainfo errors  all output reformatting, remove duplicate output Object Id, PCIe s:b:d.f, Device Id, Socket Id. Ports Num, Bitstream Id, Bitstream Version, Pr Interface Id

After Reformat:
sudo ./bin/fpgainfo  errors all
//****** FME ******//
Object Id                        : 0xEF00000
PCIe s:b:d.f                     : 0000:B1:00.0
Device Id                        : 0xBCCE
Socket Id                        : 0x00
Ports Num                        : 01
Bitstream Id                     : 0x501020283CF60D7
Bitstream Version                : 5.0.1
Pr Interface Id                  : 43c10034-ed73-5816-8ed9-67944c5b53c0
//****** FME ERRORS ******//
PCIe0 Errors                     : 0x0
PCIe1 Errors                     : 0x0
Catfatal Errors                  : 0x0
Inject Errors                    : 0x0
Next Error                       : 0x0
First Error                      : 0x0
Fme Errors                       : 0x0
Nonfatal Errors                  : 0x0
//****** PORT ERRORS ******//
First Malformed Req              : 0x0
First Error                      : 0x0
Errors                           : 0x0

Before Reformat:
sudo ./bin/fpgainfo  errors all
//****** FME ERRORS ******//
Object Id                        : 0xEF00000
PCIe s:b:d.f                     : 0000:B1:00.0
Device Id                        : 0xBCCE
Socket Id                        : 0x00
Ports Num                        : 01
Bitstream Id                     : 0x501020283CF60D7
Bitstream Version                : 5.0.1
Pr Interface Id                  : 43c10034-ed73-5816-8ed9-67944c5b53c0
PCIe0 Errors                     : 0x0
PCIe1 Errors                     : 0x0
Catfatal Errors                  : 0x0
Inject Errors                    : 0x0
Next Error                       : 0x0
First Error                      : 0x0
Fme Errors                       : 0x0
Nonfatal Errors                  : 0x0
//****** PORT ERRORS ******//
Object Id                        : 0xEE00000
PCIe s:b:d.f                     : 0000:B1:00.0
Device Id                        : 0xBCCE
Socket Id                        : 0x00
Ports Num                        : 01
Bitstream Id                     : 0x501020283CF60D7
Bitstream Version                : 5.0.1
Pr Interface Id                  : 43c10034-ed73-5816-8ed9-67944c5b53c0
First Malformed Req              : 0x0
First Error                      : 0x0
Errors                           : 0x0

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>