### PR TITLE
hssi: loop when --he-loopback=on

### DIFF
--- a/samples/hssi/hssi_10g_cmd.h
+++ b/samples/hssi/hssi_10g_cmd.h
@@ -190,6 +190,16 @@ public:
 
     if (he_loopback_ != "none") {
         hafu->mbox_write(CSR_MAC_LOOP, (he_loopback_ == "on") ? 1 : 0);
+
+        if (he_loopback_ != "on") // don't loop for "off"
+            return test_afu::success;
+
+        std::cout << "HE loopback enabled. Use Ctrl+C to exit." << std::endl;
+
+        while (running_) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        }
+
         return test_afu::success;
     }
 


### PR DESCRIPTION
When --he-loopback=on is given, keep the process alive by entering
a busy/wait loop. Break out of the loop on Ctrl+C. This is to avoid
any register reset (FLR) that may occur when the process exits.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>