### PR TITLE
fpgasupdate: display error messages from fpgaconf

### DIFF
--- a/python/opae.admin/opae/admin/tools/fpgasupdate.py
+++ b/python/opae.admin/opae/admin/tools/fpgasupdate.py
@@ -252,7 +252,7 @@ def do_partial_reconf(addr, filename):
     LOG.debug('command: %s', ' '.join(conf_args))
 
     try:
-        output = subprocess.check_output(conf_args)
+        output = subprocess.check_output(conf_args, stderr=subprocess.STDOUT)
         output = output.decode(sys.getdefaultencoding())
     except subprocess.CalledProcessError as exc:
         return (exc.returncode,


### PR DESCRIPTION
L255 calls fpgaconf.
L259 prepends fpgaconf's stdout to "\nPartial Reconfiguration failed".
However, fpgaconf uses stderr for readable error messages (see https://github.com/OPAE/opae-sdk/blob/5ebcb4cfc0602fdc68dbe509fcd8dbefc907083c/tools/fpgaconf/fpgaconf.c#L92)