### PR TITLE
pacsign: swizzle SDM and SDM_TEST

### DIFF
--- a/python/pacsign/pacsign/reader.py
+++ b/python/pacsign/pacsign/reader.py
@@ -775,7 +775,9 @@ class UPDATE_reader(_READER_BASE):
         log.debug(self.bitstream_type)
         should_swizzle = self.bitstream_type in [database.CONTENT_SR,
                                                  database.CONTENT_FACTORY,
-                                                 database.CONTENT_SR_TEST]
+                                                 database.CONTENT_SR_TEST,
+                                                 database.CONTENT_SDM,
+                                                 database.CONTENT_SDM_TEST]
         log.debug("should_swizzle={}".format(should_swizzle))
 
         if should_swizzle and not prev_sig:


### PR DESCRIPTION
Add SDM and SDM_TEST to the list of collateral types that need to
have the bits swizzled in the output image.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>