### PR TITLE
hssi: 100G test updates

### DIFF
--- a/samples/hssi/hssi_100g_cmd.h
+++ b/samples/hssi/hssi_100g_cmd.h
@@ -27,7 +27,8 @@
 #include "hssi_cmd.h"
 
 #define CSR_SCRATCH     0x1000
-#define CSR_FEATURES    0x1002
+#define CSR_BLOCK_ID    0x1001
+#define CSR_PKT_SIZE    0x1008
 #define CSR_CTRL0       0x1009
 #define CSR_CTRL1       0x1010
 #define CSR_DST_ADDR_LO 0x1011
@@ -35,6 +36,7 @@
 #define CSR_SRC_ADDR_LO 0x1013
 #define CSR_SRC_ADDR_HI 0x1014
 #define CSR_MLB_RST     0x1016
+#define CSR_TX_COUNT    0x1017
 
 class hssi_100g_cmd : public hssi_cmd
 {
@@ -48,6 +50,9 @@ public:
     , src_addr_("11:22:33:44:55:66")
     , dest_addr_("77:88:99:aa:bb:cc")
     , eth_ifc_("none")
+    , start_size_(64)
+    , end_size_(9600)
+    , end_select_("pkt_num")
   {}
 
   virtual const char *name() const override
@@ -93,6 +98,18 @@ public:
     opt = app->add_option("--eth-ifc", eth_ifc_,
                           "ethernet interface name");
     opt->default_str(eth_ifc_);
+
+    opt = app->add_option("--start-size", start_size_,
+                          "packet size in bytes (lower limit for incr mode)");
+    opt->default_str(std::to_string(start_size_));
+
+    opt = app->add_option("--end-size", end_size_,
+                          "upper limit of packet size in bytes");
+    opt->default_str(std::to_string(end_size_));
+
+    opt = app->add_option("--end-select", end_select_,
+                          "end of packet generation control");
+    opt->check(CLI::IsMember({"pkt_num", "gen_idle"}))->default_str(end_select_);
   }
 
   virtual int run(test_afu *afu, CLI::App *app) override
@@ -127,6 +144,9 @@ public:
               << "  dest_address: " << dest_addr_ << std::endl
               << "    (bits): 0x" << std::hex << bin_dest_addr << std::endl
               << "  pattern: " << pattern_ << std::endl
+              << "  start size: " << start_size_ << std::endl
+              << "  end size: " << end_size_ << std::endl
+              << "  end select: " << end_select_ << std::endl
               << "  eth: " << eth_ifc << std::endl
               << std::endl;
 
@@ -140,9 +160,16 @@ public:
         enable_eth_loopback(eth_ifc, false);
     }
 
+    hafu->mbox_write(CSR_CTRL1, 0xa);
+
     hafu->write64(TRAFFIC_CTRL_PORT_SEL, port_);
 
-    uint32_t reg = num_packets_;
+    uint32_t reg;
+
+    reg = start_size_ | (end_size_ << 16);
+    hafu->mbox_write(CSR_PKT_SIZE, reg);
+
+    reg = num_packets_;
     if (reg)
       reg |= 0x80000000;
     hafu->mbox_write(CSR_CTRL0, reg);
@@ -155,6 +182,9 @@ public:
 
     reg = 0;
     if (gap_ == "random")
+      reg |= 1 << 7;
+
+    if (end_select_ == "pkt_num")
       reg |= 1 << 6;
 
     if (pattern_ == "fixed")
@@ -162,9 +192,26 @@ public:
     else if (pattern_ == "increment")
       reg |= 2 << 4;
 
+    if (eth_loopback_ == "off")
+      reg |= 1 << 3;
+
     hafu->mbox_write(CSR_CTRL1, reg);
 
     print_registers(std::cout, hafu);
+
+    uint32_t count;
+    const uint64_t interval = 100ULL;
+    do
+    {
+      count = hafu->mbox_read(CSR_TX_COUNT);
+
+      if (!running_) {
+        hafu->mbox_write(CSR_CTRL1, 0xa);
+        return test_afu::error;
+      }
+
+      std::this_thread::sleep_for(std::chrono::microseconds(interval));
+    } while(count < num_packets_);
 
     std::cout << std::endl;
 
@@ -207,8 +254,10 @@ public:
 
     os << "0x1000 " << std::setw(22) << "scratch" << ": " <<
       int_to_hex(hafu->mbox_read(CSR_SCRATCH)) << std::endl;
-    os << "0x1002 " << std::setw(22) << "features" << ": " <<
-      int_to_hex(hafu->mbox_read(CSR_FEATURES)) << std::endl;
+    os << "0x1001 " << std::setw(22) << "block_ID" << ": " <<
+      int_to_hex(hafu->mbox_read(CSR_BLOCK_ID)) << std::endl;
+    os << "0x1008 " << std::setw(22) << "pkt_size" << ": " <<
+      int_to_hex(hafu->mbox_read(CSR_PKT_SIZE)) << std::endl;
     os << "0x1009 " << std::setw(22) << "ctrl0" << ": " <<
       int_to_hex(hafu->mbox_read(CSR_CTRL0)) << std::endl;
     os << "0x1010 " << std::setw(22) << "ctrl1" << ": " <<
@@ -223,6 +272,8 @@ public:
       int_to_hex(hafu->mbox_read(CSR_SRC_ADDR_HI)) << std::endl;
     os << "0x1016 " << std::setw(22) << "mlb_rst" << ": " <<
       int_to_hex(hafu->mbox_read(CSR_MLB_RST)) << std::endl;
+    os << "0x1017 " << std::setw(22) << "tx_count" << ": " <<
+      int_to_hex(hafu->mbox_read(CSR_TX_COUNT)) << std::endl;
 
     return os;
   }
@@ -236,4 +287,7 @@ protected:
   std::string src_addr_;
   std::string dest_addr_;
   std::string eth_ifc_;
+  uint32_t start_size_;
+  uint32_t end_size_;
+  std::string end_select_;
 };

--- a/samples/hssi/hssi_100g_cmd.h
+++ b/samples/hssi/hssi_100g_cmd.h
@@ -38,6 +38,8 @@
 #define CSR_MLB_RST     0x1016
 #define CSR_TX_COUNT    0x1017
 
+#define STOP_BITS       0xa
+
 class hssi_100g_cmd : public hssi_cmd
 {
 public:
@@ -160,7 +162,7 @@ public:
         enable_eth_loopback(eth_ifc, false);
     }
 
-    hafu->mbox_write(CSR_CTRL1, 0xa);
+    hafu->mbox_write(CSR_CTRL1, STOP_BITS);
 
     hafu->write64(TRAFFIC_CTRL_PORT_SEL, port_);
 
@@ -206,7 +208,7 @@ public:
       count = hafu->mbox_read(CSR_TX_COUNT);
 
       if (!running_) {
-        hafu->mbox_write(CSR_CTRL1, 0xa);
+        hafu->mbox_write(CSR_CTRL1, STOP_BITS);
         return test_afu::error;
       }
 


### PR DESCRIPTION
* Loop on (new) PKT_TX_COUNT CSR before ending test.
* Display new BlockID CSR in dump.
* Implement controls for PKG_GEN_CTRL register.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>