### PR TITLE
(cherry pick) vabtool: fix status array definition (#2445)

### DIFF
--- a/tools/extra/vabtool/vabtool
+++ b/tools/extra/vabtool/vabtool
@@ -1,5 +1,5 @@
 #!/bin/bash
-## Copyright(c) 2021, Intel Corporation
+## Copyright(c) 2021-2022, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -25,7 +25,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-declare -r VERSION='1.0.0'
+declare -r VERSION='1.0.1'
 
 oops() {
   printf "fatal: %s\n" "$*"
@@ -54,12 +54,12 @@ declare -ra SDM_SR_PROVISION_STATUS=(\
 'SDM device busy during PUBKEY_PROGRAM command to SDM.' \
 'SR Key Hash program failed with recoverable errors after max retry.' \
 'SR Key Hash program failed with likely permanent device damage.' \
-'SR Key program failed with recoverable errors because of invalid SDM command. (Note: Refer register SDM SR Key Program status @ 0x81C for more information.)'\
+'SR Key program failed with recoverable errors because of invalid SDM command. (Note: Refer register SDM SR Key Program status @ 0x81C for more information.)' \
 'SDM Provisioning Image configuration Failed; Shell image configured.' \
 'SR Key Hash provision ignored because SR Key Hash not programmed to BMC.' \
 'SDM Response mismatch during SDM Provisioning Image CONFIG_STATUS Check.' \
 'SDM Response mismatch during PUBKEY_PROGRAM command to SDM.' \
-'SR Key Hash provision request ignored because BMC is busy.' \
+'SR Key Hash provision request ignored because BMC is busy.'\
 )
 
 declare -r SDM_SR_PROVISION_STATUS_GLOB="/sys/bus/pci/devices/ssss:bb:dd.f/fpga_region/region*/dfl-fme.*/dfl_dev.*/*-sec*.*.auto/security/sdm_sr_provision_status"


### PR DESCRIPTION
Fix error in SDM status array definition. The previous change
caused two error messages to be concatenated instead of occupying
two unique indexes.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>