### PR TITLE
opae-sdk: generic name for fpgainfo bmc   and fpga card

### DIFF
--- a/tests/board/test_board_n6000.cpp
+++ b/tests/board/test_board_n6000.cpp
@@ -362,7 +362,7 @@ void board_dfl_n6000_c_p::test_bom_info(
 TEST_P(board_dfl_n6000_c_p, board_n6000_11) {
 
 	const char * const bom_info_nvmem = "dfl_dev*/*/bom_info0/nvmem";
-	const char * const last_board_info = ".*Board Management Controller, MAX10 Build version:.*\n";
+	const char * const last_board_info = ".*Board Management Controller Build version:.*\n";
 	const size_t FPGA_BOM_INFO_NVMEM_SIZE = 0x2000;
 	static char bom_info_in[FPGA_BOM_INFO_NVMEM_SIZE];
 	static char bom_info_out[2 * FPGA_BOM_INFO_NVMEM_SIZE];

--- a/tools/libboard/board_n6000/board_n6000.c
+++ b/tools/libboard/board_n6000/board_n6000.c
@@ -623,9 +623,9 @@ fpga_result print_board_info(fpga_token token)
 		resval = res;
 	}
 
-	printf("Intel N6000 Acceleration Development Platform\n");
-	printf("Board Management Controller, MAX10 NIOS FW version: %s \n", bmc_ver);
-	printf("Board Management Controller, MAX10 Build version: %s \n", max10_ver);
+	printf("Intel Acceleration Development Platform\n");
+	printf("Board Management Controller NIOS FW version: %s \n", bmc_ver);
+	printf("Board Management Controller Build version: %s \n", max10_ver);
 
 	res = print_bom_info(token);
 	if (res != FPGA_OK) {


### PR DESCRIPTION
Device id & vendor id is same for Intel fpga N6000 & N6100 cards
Make generic name for fpga bmc version  and fpga card

Example:
 Intel Acceleration Development Platform
 Board Management Controller NIOS FW version: 1.0.4
 Board Management Controller Build version: 1.0.6

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>