### PR TITLE
opae.admin: rsu: fix secure_update for pmci

### DIFF
--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019-2021, Intel Corporation
+# Copyright(c) 2019-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -481,9 +481,8 @@ class fpga_base(sysfs_device):
                 return secure_update(sec.sysfs_path, self.pci_node)
         else:
             pmci = f.pmci_bus
-            sec = pmci.find_one('*-sec*.*.auto')
-            if sec:
-                return secure_update(sec.sysfs_path, self.pci_node)
+            if pmci:
+                return secure_update(pmci.sysfs_path, self.pci_node)
 
     @property
     def port(self):


### PR DESCRIPTION
The pmci_bus attribute returns a path that is rooted at
'*-sec*.*.auto', so there is no need to search further.
Searching further within that directory yields no result, causing
the script to error out.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>