### PR TITLE
tools: align fpgainfo mac for N5010 with N6000

### DIFF
--- a/tests/board/test_board_n5010.cpp
+++ b/tests/board/test_board_n5010.cpp
@@ -152,13 +152,11 @@ TEST_P(board_dfl_n5010_c_p, board_n5010_3) {
 /**
 * @test       board_n5010_4
 * @brief      Tests: print_mac_info
-* @details    Validates fpga board info  <br>
+* @details    Validates prints mac info <br>
 */
 TEST_P(board_dfl_n5010_c_p, board_n5010_4) {
 
-	struct ether_addr ea;
-
-	EXPECT_EQ(read_mac_info(tokens_[0], 0, &ea), FPGA_OK);
+	EXPECT_EQ(print_mac_info(tokens_[0]), FPGA_OK);
 }
 
 /**

--- a/tools/libboard/board_common/board_common.c
+++ b/tools/libboard/board_common/board_common.c
@@ -28,6 +28,7 @@
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
+#include <limits.h>
 #include <glob.h>
 #include <stdio.h>
 #include <errno.h>
@@ -558,4 +559,53 @@ pro_destroy:
 	}
 
 	return res;
+}
+
+static uint64_t macaddress_uint64(const struct ether_addr *eth_addr)
+{
+	uint64_t value   = 0;
+	const uint8_t *ptr = (uint8_t *) eth_addr;
+
+	for (int i = 5; i >= 0; i--) {
+		value |= (uint64_t)*ptr++ << (CHAR_BIT * i);
+	}
+	return value;
+}
+
+static void uint64_macaddress(const uint64_t value, struct ether_addr *eth_addr)
+{
+	uint8_t *ptr = (uint8_t *)eth_addr;
+	for (int i = 5; i >= 0; i--) {
+		*ptr++ = value >> (CHAR_BIT * i);
+	}
+}
+
+// print mac address
+void print_mac_address(struct ether_addr *eth_addr, int count)
+{
+	uint64_t value = 0;
+	if (eth_addr == NULL || count <= 0)
+		return;
+
+	printf("%s %-20d : %02X:%02X:%02X:%02X:%02X:%02X\n",
+		"MAC address", 0, eth_addr->ether_addr_octet[0],
+		eth_addr->ether_addr_octet[1], eth_addr->ether_addr_octet[2],
+		eth_addr->ether_addr_octet[3], eth_addr->ether_addr_octet[4],
+		eth_addr->ether_addr_octet[5]);
+
+	for (int i = 1; i < count; ++i) {
+
+		// convert MAC to uint64
+		value = macaddress_uint64(eth_addr);
+		++value;
+		// convert uint64 to MAC
+		uint64_macaddress(value, eth_addr);
+
+		printf("%s %-20d : %02X:%02X:%02X:%02X:%02X:%02X\n",
+			"MAC address", i, eth_addr->ether_addr_octet[0],
+			eth_addr->ether_addr_octet[1], eth_addr->ether_addr_octet[2],
+			eth_addr->ether_addr_octet[3], eth_addr->ether_addr_octet[4],
+			eth_addr->ether_addr_octet[5]);
+
+	}
 }

--- a/tools/libboard/board_common/board_common.h
+++ b/tools/libboard/board_common/board_common.h
@@ -27,6 +27,7 @@
 #ifndef __FPGA_BOARD_COMMON_H__
 #define __FPGA_BOARD_COMMON_H__
 
+#include <netinet/ether.h>
 #include <opae/types.h>
 
 #ifdef __cplusplus
@@ -134,6 +135,14 @@ fpga_result find_dev_feature(fpga_token token,
 */
 fpga_result print_common_boot_info(fpga_token token);
 
+/**
+ * Prints a number of incremented MAC addresses.
+ *
+ * @param[in] eth_addr pointer to MAC address in network byte order
+ * @param[in] count    number of MAC address to print
+ *
+ */
+void print_mac_address(struct ether_addr *eth_addr, int count);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/tools/libboard/board_n5010/board_n5010.h
+++ b/tools/libboard/board_n5010/board_n5010.h
@@ -85,20 +85,6 @@ fpga_result read_bmcfw_version(fpga_token token, char *bmcfw_var, size_t len);
 fpga_result parse_fw_ver(char *buf, char *fw_ver, size_t len);
 
 /**
-* Get mac address.
-*
-* @param[in] token           fpga_token object for device (FPGA_DEVICE type)
-* @param[in] afu_channel_num afu channel number
-* @param[inout] mac_addr  pointer to struct ether_addr
-
-* @returns FPGA_OK on success. FPGA_NOT_FOUND if invalid MAC address.
-* FPGA_INVALID_PARAM if invalid parameters were provided
-*
-*/
-fpga_result read_mac_info(fpga_token token, uint32_t afu_channel_num,
-				struct ether_addr *mac_addr);
-
-/**
 * Prints Security information.
 *
 * @param[in] token            fpga_token object for device (FPGA_DEVICE type)

--- a/tools/libboard/board_n6000/board_n6000.c
+++ b/tools/libboard/board_n6000/board_n6000.c
@@ -295,55 +295,6 @@ fpga_result read_max10fw_version(fpga_token token, char *max10fw_ver, size_t len
 	return res;
 }
 
-uint64_t macaddress_uint64(const struct ether_addr *eth_addr)
-{
-	uint64_t value   = 0;
-	const uint8_t *ptr = (uint8_t *) eth_addr;
-
-	for (int i = 5; i >= 0; i--) {
-		value |= (uint64_t)*ptr++ << (CHAR_BIT * i);
-	}
-	return value;
-}
-
-void uint64_macaddress(const uint64_t value, struct ether_addr *eth_addr)
-{
-	uint8_t *ptr = (uint8_t *)eth_addr;
-	for (int i = 5; i >= 0; i--) {
-		*ptr++ = value >> (CHAR_BIT * i);
-	}
-}
-
-// print mac address
-void print_mac_address(struct ether_addr *eth_addr, int count)
-{
-	uint64_t value = 0;
-	if (eth_addr == NULL || count <= 0)
-		return;
-
-	printf("%s %-20d : %02X:%02X:%02X:%02X:%02X:%02X\n",
-		"MAC address", 0, eth_addr->ether_addr_octet[0],
-		eth_addr->ether_addr_octet[1], eth_addr->ether_addr_octet[2],
-		eth_addr->ether_addr_octet[3], eth_addr->ether_addr_octet[4],
-		eth_addr->ether_addr_octet[5]);
-
-	for (int i = 1; i < count; ++i) {
-
-		// convert MAC to uint64
-		value = macaddress_uint64(eth_addr);
-		++value;
-		// convert uint64 to MAC
-		uint64_macaddress(value, eth_addr);
-
-		printf("%s %-20d : %02X:%02X:%02X:%02X:%02X:%02X\n",
-			"MAC address", i, eth_addr->ether_addr_octet[0],
-			eth_addr->ether_addr_octet[1], eth_addr->ether_addr_octet[2],
-			eth_addr->ether_addr_octet[3], eth_addr->ether_addr_octet[4],
-			eth_addr->ether_addr_octet[5]);
-
-	}
-}
-
 // print mac information
 fpga_result print_mac_info(fpga_token token)
 {


### PR DESCRIPTION
Example:
Number of MACs                   : 2
MAC address 0                    : 00:E0:ED:5C:72:E0
MAC address 1                    : 00:E0:ED:5C:72:E1

Signed-off-by: Roger Christensen <rc@silicom.dk>