### PR TITLE
rpm: install hssi_pkt_filt_*.h

### DIFF
--- a/opae.spec.rhel
+++ b/opae.spec.rhel
@@ -232,6 +232,8 @@ done
 %{_usr}/src/opae/samples/hssi/hssi.cpp
 %{_usr}/src/opae/samples/hssi/hssi_100g_cmd.h
 %{_usr}/src/opae/samples/hssi/hssi_10g_cmd.h
+%{_usr}/src/opae/samples/hssi/hssi_pkt_filt_100g_cmd.h
+%{_usr}/src/opae/samples/hssi/hssi_pkt_filt_10g_cmd.h
 %{_usr}/src/opae/samples/hssi/hssi_afu.h
 %{_usr}/src/opae/samples/hssi/hssi_cmd.h
 %{_usr}/src/opae/samples/opae.io/main.cpp


### PR DESCRIPTION
Fixes this error on rhel 8.5

error: Installed (but unpackaged) file(s) found:
   /usr/src/opae/samples/hssi/hssi_pkt_filt_100g_cmd.h
   /usr/src/opae/samples/hssi/hssi_pkt_filt_10g_cmd.h

Signed-off-by: Tom Rix <trix@redhat.com>