### PR TITLE
opae-sdk: fix fedora rpmlint errors

### DIFF
--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -13,11 +13,9 @@ Requires:       uuid
 Requires:	json-c
 Requires:	python3
 Requires:	systemd
-Requires:	libcap
 Requires:	tbb
 Requires:	hwloc
 Requires:	spdlog
-Requires:	libedit
 
 URL:            https://github.com/OPAE/%{name}-sdk
 Source0:        https://github.com/OPAE/opae-sdk/releases/download/%{version}-%{opae_release}/%{name}-%{version}-%{opae_release}.tar.gz
@@ -163,7 +161,7 @@ popd
 
 # Make rpmlint happy about install permissions
 # admin tools
-for file in %{buildroot}%{python3_sitelib}/opae/admin/tools/{fpgaflash,fpgaotsu,fpgaport,fpgasupdate,ihex2ipmi,rsu,super_rsu,bitstream_info,opaevfio,pci_device}.py; do
+for file in %{buildroot}%{python3_sitelib}/opae/admin/tools/{fpgaflash,fpgaotsu,fpgaport,fpgasupdate,ihex2ipmi,rsu,super_rsu,bitstream_info,opaevfio,pci_device,fpgareg}.py; do
    chmod a+x $file
 done
 # ethernet
@@ -223,6 +221,7 @@ done
 
 %post
 %systemd_post fpgad.service
+/sbin/ldconfig
 
 %preun
 %systemd_preun fpgad.service

--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -9,14 +9,14 @@ ExclusiveArch:  x86_64
 
 Group:          Development/Libraries
 Vendor:         Intel Corporation
-Requires:   uuid
-Requires:	json-c
-Requires:	python3
-Requires:	systemd
-Requires:	tbb
-Requires:	hwloc
-Requires:	spdlog
-Requires:	libedit
+Requires:  uuid
+Requires:  json-c
+Requires:  python3
+Requires:	 systemd
+Requires:	 tbb
+Requires:	 hwloc
+Requires:	 spdlog
+Requires:	 libedit
 
 URL:            https://github.com/OPAE/%{name}-sdk
 Source0:        https://github.com/OPAE/opae-sdk/releases/download/%{version}-%{opae_release}/%{name}-%{version}-%{opae_release}.tar.gz
@@ -36,7 +36,6 @@ BuildRequires:  python3-setuptools
 BuildRequires:  python3-pyyaml
 BuildRequires:  rpm-build
 BuildRequires:  systemd-devel
-BuildRequires:  libcap-devel
 BuildRequires:  tbb-devel
 BuildRequires:  hwloc-devel
 BuildRequires:  pybind11-devel

--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -16,6 +16,8 @@ Requires:	systemd
 Requires:	tbb
 Requires:	hwloc
 Requires:	spdlog
+Requires:	cap
+Requires:	edit
 
 URL:            https://github.com/OPAE/%{name}-sdk
 Source0:        https://github.com/OPAE/opae-sdk/releases/download/%{version}-%{opae_release}/%{name}-%{version}-%{opae_release}.tar.gz

--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -12,11 +12,11 @@ Vendor:         Intel Corporation
 Requires:  uuid
 Requires:  json-c
 Requires:  python3
-Requires:	 systemd
-Requires:	 tbb
-Requires:	 hwloc
-Requires:	 spdlog
-Requires:	 libedit
+Requires:  systemd
+Requires:  tbb
+Requires:  hwloc
+Requires:  spdlog
+Requires:  libedit
 
 URL:            https://github.com/OPAE/%{name}-sdk
 Source0:        https://github.com/OPAE/opae-sdk/releases/download/%{version}-%{opae_release}/%{name}-%{version}-%{opae_release}.tar.gz

--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -9,15 +9,14 @@ ExclusiveArch:  x86_64
 
 Group:          Development/Libraries
 Vendor:         Intel Corporation
-Requires:       uuid
+Requires:   uuid
 Requires:	json-c
 Requires:	python3
 Requires:	systemd
 Requires:	tbb
 Requires:	hwloc
 Requires:	spdlog
-Requires:	cap
-Requires:	edit
+Requires:	libedit
 
 URL:            https://github.com/OPAE/%{name}-sdk
 Source0:        https://github.com/OPAE/opae-sdk/releases/download/%{version}-%{opae_release}/%{name}-%{version}-%{opae_release}.tar.gz


### PR DESCRIPTION
rpmlint opae-2.0.9-1.fc33.x86_64.rpm
opae.x86_64: E: explicit-lib-dependency libcap
opae.x86_64: E: explicit-lib-dependency libedit
opae.x86_64: E: non-executable-script /usr/lib/python3.9/site-packages/opae/admin/tools/fpgareg.py 644 /usr/bin/env python3
opae.x86_64: E: postin-without-ldconfig /usr/lib64/libbitstream.so.2.0.10
opae.x86_64: E: postin-without-ldconfig /usr/lib64/libfpgad-api.so.2.0.10
opae.x86_64: E: postin-without-ldconfig /usr/lib64/libmml-srv.so.2.0.10
opae.x86_64: E: postin-without-ldconfig /usr/lib64/libmml-stream.so.2.0.10
opae.x86_64: E: postin-without-ldconfig /usr/lib64/libofs.so.2.0.10
opae.x86_64: E: postin-without-ldconfig /usr/lib64/libopae-c++-nlb.so.2.0.10
opae.x86_64: E: postin-without-ldconfig /usr/lib64/libopae-c++-utils.so.2.0.10
opae.x86_64: E: postin-without-ldconfig /usr/lib64/libopae-c.so.2.0.10
opae.x86_64: E: postin-without-ldconfig /usr/lib64/libopae-cxx-core.so.2.0.10
opae.x86_64: E: postin-without-ldconfig /usr/lib64/libopaemem.so.2.0.10
opae.x86_64: E: postin-without-ldconfig /usr/lib64/libopaeuio.so.2.0.10
opae.x86_64: E: postin-without-ldconfig /usr/lib64/libopaevfio.so.2.0.10

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>