### PR TITLE
opae.io: fix dump for binary format

### DIFF
--- a/tools/extra/opae.io/opae/io/utils.py
+++ b/tools/extra/opae.io/opae/io/utils.py
@@ -310,7 +310,7 @@ def dump(region, start=0, output=sys.stdout, fmt='hex', count=None):
         if fmt == 'hex':
             output.write(f'0x{offset:04x}: 0x{value:016x}\n')
         else:
-            output.write(value)
+            output.write(value.to_bytes(8, 'little'))
         offset += 8
 
 


### PR DESCRIPTION
Convert register values to bytes when dumping to binary format.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>