### PR TITLE
dfh: add support for dumping registers in binary

### DIFF
--- a/cmake/modules/OFS.cmake
+++ b/cmake/modules/OFS.cmake
@@ -29,7 +29,7 @@ macro(ofs_add_driver yml_file driver)
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${driver}.h
 	COMMAND ${PYTHON_EXECUTABLE} ${OPAE_LIB_SOURCE}/scripts/ofs/ofs_parse.py
-        ${CMAKE_CURRENT_LIST_DIR}/${yml_file} headers c ${CMAKE_CURRENT_BINARY_DIR} --driver ${driver} --use-local-refs
+        ${CMAKE_CURRENT_LIST_DIR}/${yml_file} --use-local-refs headers c ${CMAKE_CURRENT_BINARY_DIR} --driver ${driver}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         DEPENDS
             ${CMAKE_CURRENT_LIST_DIR}/${yml_file}


### PR DESCRIPTION
This modifies ofs_parse to support dumping a register spec into binary
format. To support this:
* a dump and its parser were added
* schema and use-local-refs CLI args were moved to the main parser
* lo, hi, width methods were added to register structure
* bitfield64 method was added to create a union of bitfields dynamically

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>