### PR TITLE
bitstreaminfo: fix one-off error

### DIFF
--- a/python/opae.admin/opae/admin/utils/verifier.py
+++ b/python/opae.admin/opae/admin/utils/verifier.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019-2021, Intel Corporation
+# Copyright(c) 2019-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -202,7 +202,7 @@ class Block_0:
         self.content_type = bits[8]
         self.cert_type = bits[9]
         self.slot_num = bits[10] & 0xF
-        self.bitstream_version = bytearray(bits[96:127]).decode()
+        self.bitstream_version = bytearray(bits[96:128]).decode()
         self.sha256 = int_from_bytes(bits[16:48], byteorder="big")
         self.sha384 = int_from_bytes(bits[48:96], byteorder="big")
         self.calc_sha256 = int_from_bytes(


### PR DESCRIPTION
When printing the Bitstream Version field, the slice specifier
was chopping off the last valid byte. Increment it by one to fix.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>