### PR TITLE
test: upgrade gtest to 1.11.0

### DIFF
--- a/cmake/modules/OPAETest.cmake
+++ b/cmake/modules/OPAETest.cmake
@@ -34,7 +34,7 @@ function(opae_load_gtest)
     message(STATUS "Trying to fetch gtest through git...")
     opae_external_project_add(PROJECT_NAME gtest
                               GIT_URL https://github.com/google/googletest
-                              GIT_TAG release-1.10.0
+                              GIT_TAG release-1.11.0
                               PRESERVE_REPOS ${OPAE_PRESERVE_REPOS})
 endfunction()
 

--- a/tests/bitstream/test_bits_utils_c.cpp
+++ b/tests/bitstream/test_bits_utils_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2020, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -618,6 +618,7 @@ TEST_P(bits_utils_c_p, is_valid6) {
   ASSERT_EQ(unlink(tmpfile), 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(bits_utils_c_p);
 INSTANTIATE_TEST_CASE_P(bits_utils_c, bits_utils_c_p,
     ::testing::ValuesIn(test_platform::platforms({})));
 
@@ -649,5 +650,6 @@ TEST_P(mock_bits_utils_c_p, string_err2) {
   EXPECT_EQ(value, nullptr);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_bits_utils_c_p);
 INSTANTIATE_TEST_CASE_P(bits_utils_c, mock_bits_utils_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({})));

--- a/tests/bitstream/test_bitstream_c.cpp
+++ b/tests/bitstream/test_bitstream_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2020, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -359,6 +359,7 @@ TEST_P(bitstream_c_p, unload_err1) {
   free(save);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(bitstream_c_p);
 INSTANTIATE_TEST_CASE_P(bitstream_c, bitstream_c_p,
     ::testing::ValuesIn(test_platform::platforms({})));
 
@@ -398,5 +399,6 @@ TEST_P(mock_bitstream_c_p, resolve_err2) {
   EXPECT_EQ(opae_resolve_bitstream(&info), FPGA_NO_MEMORY);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_bitstream_c_p);
 INSTANTIATE_TEST_CASE_P(bitstream_c, mock_bitstream_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({})));

--- a/tests/bitstream/test_metadatav1_c.cpp
+++ b/tests/bitstream/test_metadatav1_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2020, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -801,6 +801,7 @@ TEST_P(metadatav1_c_p, parse_v1_ok) {
   opae_bitstream_release_metadata_v1(md);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metadatav1_c_p);
 INSTANTIATE_TEST_CASE_P(metadatav1_c, metadatav1_c_p,
     ::testing::ValuesIn(test_platform::platforms({})));
 
@@ -891,5 +892,6 @@ TEST_P(mock_metadatav1_c_p, parse_v1_err0) {
             nullptr);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_metadatav1_c_p);
 INSTANTIATE_TEST_CASE_P(metadatav1_c, mock_metadatav1_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({})));

--- a/tests/board/test_board_a10gx.cpp
+++ b/tests/board/test_board_a10gx.cpp
@@ -403,6 +403,8 @@ TEST_P(board_a10gx_invalid_c_p, board_a10gx_10) {
   char reset_cause[SYSFS_PATH_MAX];
   EXPECT_NE(read_bmc_reset_cause(tokens_[0], reset_cause), FPGA_OK);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_a10gx_invalid_c_p);
 INSTANTIATE_TEST_CASE_P(
     board_a10gx_invalid_c, board_a10gx_invalid_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"skx-p"})));

--- a/tests/board/test_board_a10gx.cpp
+++ b/tests/board/test_board_a10gx.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2020, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -363,6 +363,8 @@ TEST_P(board_a10gx_c_p, board_a10gx_7) {
   char pwr_down_cause[SYSFS_PATH_MAX];
   EXPECT_NE(read_bmc_pwr_down_cause(tokens_[0], pwr_down_cause), FPGA_OK);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_a10gx_c_p);
 INSTANTIATE_TEST_CASE_P(
     baord_a10gx_c, board_a10gx_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"dcp-a10gx"})));

--- a/tests/board/test_board_d5005.cpp
+++ b/tests/board/test_board_d5005.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2020, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -340,6 +340,7 @@ TEST_P(board_dfl_d5005_c_p, board_d5005_9) {
 	EXPECT_EQ(read_mac_info(tokens_[0], 100, &mac_addr), FPGA_INVALID_PARAM);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_dfl_d5005_c_p);
 INSTANTIATE_TEST_CASE_P(baord_d5005_c, board_dfl_d5005_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-d5005" })));
 
@@ -367,5 +368,7 @@ TEST_P(board_d5005_invalid_c_p, invalid_board_d5005_1) {
 	EXPECT_EQ(read_mac_info(tokens_[0], 0, &mac_addr), FPGA_NOT_FOUND);
 
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_d5005_invalid_c_p);
 INSTANTIATE_TEST_CASE_P(board_d5005_invalid_c, board_d5005_invalid_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/tests/board/test_board_n3000.cpp
+++ b/tests/board/test_board_n3000.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2020, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -443,6 +443,8 @@ TEST_P(board_dfl_n3000_c_p, board_n3000_20) {
 		&value), FPGA_NOT_FOUND);
 
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_dfl_n3000_c_p);
 INSTANTIATE_TEST_CASE_P(board_dfl_n3000_c, board_dfl_n3000_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000" })));
 
@@ -487,5 +489,7 @@ TEST_P(board_n3000_invalid_c_p, board_n3000_9) {
 	EXPECT_EQ(print_pkvl_version(tokens_[0]), FPGA_NOT_FOUND);
 	EXPECT_NE(print_phy_info(tokens_[0]), FPGA_EXCEPTION);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_n3000_invalid_c_p);
 INSTANTIATE_TEST_CASE_P(board_n3000_invalid_c, board_n3000_invalid_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/tests/board/test_board_n5010.cpp
+++ b/tests/board/test_board_n5010.cpp
@@ -209,5 +209,7 @@ TEST_P(board_n5010_invalid_c_p, board_n5010_9) {
 
 	EXPECT_EQ(print_sec_info(tokens_[0]), FPGA_NOT_FOUND);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_n5010_invalid_c_p);
 INSTANTIATE_TEST_CASE_P(board_n5010_invalid_c, board_n5010_invalid_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/tests/board/test_board_n5010.cpp
+++ b/tests/board/test_board_n5010.cpp
@@ -1,4 +1,4 @@
-// Original work Copyright(c) 2019-2020, Intel Corporation
+// Original work Copyright(c) 2019-2022, Intel Corporation
 // Modifications Copyright(c) 2021, Silicom Denmark A/S
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
@@ -97,7 +97,7 @@ class board_dfl_n5010_c_p : public board_n5010_c_p { };
 * @brief      Tests: print_board_info
 * @details    Validates fpga board info  <br>
 */
-TEST_P(board_dfl_n5010_c_p, board_n5010_0) {
+TEST_P(board_dfl_n5010_c_p, DISABLED_board_n5010_0) {
 
 	EXPECT_EQ(print_board_info(tokens_[0]), FPGA_OK);
 }
@@ -107,7 +107,7 @@ TEST_P(board_dfl_n5010_c_p, board_n5010_0) {
 * @brief      Tests: read_max10fw_version
 * @details    Validates max10 firmware version  <br>
 */
-TEST_P(board_dfl_n5010_c_p, board_n5010_1) {
+TEST_P(board_dfl_n5010_c_p, DISABLED_board_n5010_1) {
 
 	char max10fw_ver[SYSFS_PATH_MAX];
 
@@ -123,7 +123,7 @@ TEST_P(board_dfl_n5010_c_p, board_n5010_1) {
 * @brief      Tests: read_bmcfw_version
 * @details    Validates bmc firmware version  <br>
 */
-TEST_P(board_dfl_n5010_c_p, board_n5010_2) {
+TEST_P(board_dfl_n5010_c_p, DISABLED_board_n5010_2) {
 
 	char bmcfw_ver[SYSFS_PATH_MAX];
 
@@ -154,7 +154,7 @@ TEST_P(board_dfl_n5010_c_p, board_n5010_3) {
 * @brief      Tests: print_mac_info
 * @details    Validates prints mac info <br>
 */
-TEST_P(board_dfl_n5010_c_p, board_n5010_4) {
+TEST_P(board_dfl_n5010_c_p, DISABLED_board_n5010_4) {
 
 	EXPECT_EQ(print_mac_info(tokens_[0]), FPGA_OK);
 }
@@ -164,7 +164,7 @@ TEST_P(board_dfl_n5010_c_p, board_n5010_4) {
 * @brief      Tests: print_sec_info
 * @details    Validates fpga board info  <br>
 */
-TEST_P(board_dfl_n5010_c_p, board_n5010_5) {
+TEST_P(board_dfl_n5010_c_p, DISABLED_board_n5010_5) {
 
 	EXPECT_EQ(print_sec_info(tokens_[0]), FPGA_OK);
 }
@@ -174,10 +174,14 @@ TEST_P(board_dfl_n5010_c_p, board_n5010_5) {
 * @brief      Tests: print_mac_info
 * @details    Validates prints mac info  <br>
 */
-TEST_P(board_dfl_n5010_c_p, board_n5010_6) {
+TEST_P(board_dfl_n5010_c_p, DISABLED_board_n5010_6) {
 
 	EXPECT_EQ(print_mac_info(tokens_[0]), FPGA_OK);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_dfl_n5010_c_p);
+INSTANTIATE_TEST_CASE_P(board_n5010_c, board_dfl_n5010_c_p,
+	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n6000" })));
 
 // test invalid sysfs attributes
 class board_n5010_invalid_c_p : public board_n5010_c_p { };

--- a/tests/board/test_board_n6000.cpp
+++ b/tests/board/test_board_n6000.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2021, Intel Corporation
+// Copyright(c) 2021-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -504,6 +504,8 @@ TEST_P(board_dfl_n6000_c_p, board_n6000_12) {
 	EXPECT_EQ(print_mac_info(tokens_[0]), FPGA_OK);
 
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_dfl_n6000_c_p);
 INSTANTIATE_TEST_CASE_P(board_dfl_n6000_c, board_dfl_n6000_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n6000" })));
 
@@ -535,5 +537,7 @@ TEST_P(board_n6000_invalid_c_p, board_n6000_11) {
 
 	EXPECT_NE(print_phy_info(tokens_[0]), FPGA_EXCEPTION);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_n6000_invalid_c_p);
 INSTANTIATE_TEST_CASE_P(board_n6000_invalid_c, board_n6000_invalid_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/tests/dummy_afu/test_dummy_afu.cpp
+++ b/tests/dummy_afu/test_dummy_afu.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -263,6 +263,7 @@ TEST_P(dummy_afu_p, main_invalid_guid) {
             app_->main(args_.size(), const_cast<char**>(args_.data())));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(dummy_afu_p);
 INSTANTIATE_TEST_CASE_P(dummy_afu, dummy_afu_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"dfl-d5005"})));
 

--- a/tests/fpgaconf/test_fpgaconf_c.cpp
+++ b/tests/fpgaconf/test_fpgaconf_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -818,6 +818,7 @@ TEST_P(fpgaconf_c_p, circular_symlink) {
   remove("link2");
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgaconf_c_p);
 INSTANTIATE_TEST_CASE_P(fpgaconf_c, fpgaconf_c_p,
                         ::testing::ValuesIn(test_platform::platforms({"skx-p"})));
 
@@ -999,6 +1000,7 @@ TEST_P(fpgaconf_c_mock_p, prog_bs2) {
   EXPECT_EQ(fpgaDestroyProperties(&filter), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgaconf_c_mock_p);
 INSTANTIATE_TEST_CASE_P(fpgaconf_c, fpgaconf_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"skx-p"})));
 

--- a/tests/fpgad/test_api_device_monitoring_c.cpp
+++ b/tests/fpgad/test_api_device_monitoring_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2021, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -134,5 +134,6 @@ TEST_P(fpgad_device_monitoring_c_p, mon02) {
   EXPECT_EQ(d.num_error_occurrences, 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_device_monitoring_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_c, fpgad_device_monitoring_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_api_logging_c.cpp
+++ b/tests/fpgad/test_api_logging_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -101,5 +101,6 @@ TEST_P(fpgad_log_c_p, log02) {
   EXPECT_STREQ(captured.c_str(), "abc");
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_log_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_log_c, fpgad_log_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_api_opae_events_api_c.cpp
+++ b/tests/fpgad/test_api_opae_events_api_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2021, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -178,5 +178,6 @@ TEST_P(fpgad_opae_events_api_c_p, events03) {
   EXPECT_EQ(event_registry_list, (void *)NULL);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_opae_events_api_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_c, fpgad_opae_events_api_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_api_sysfs_c.cpp
+++ b/tests/fpgad/test_api_sysfs_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2021, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -126,5 +126,6 @@ TEST_P(fpgad_sysfs_c_p, dup02) {
   free(s);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_sysfs_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_c, fpgad_sysfs_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_command_line_c.cpp
+++ b/tests/fpgad/test_command_line_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2021, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -423,5 +423,6 @@ TEST_P(fpgad_command_line_c_p, symlink4) {
   free(d);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_command_line_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_command_line_c, fpgad_command_line_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_config_file_c.cpp
+++ b/tests/fpgad/test_config_file_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2021, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -455,6 +455,7 @@ TEST_P(fpgad_config_file_c_p, process_plugin8) {
   EXPECT_NE(cfg_load_config(&config_), 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_config_file_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_config_file_c, fpgad_config_file_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));
 
@@ -681,6 +682,7 @@ TEST_P(fpgad_config_file_devices_p, process_plugin_devices9) {
   free(ids);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_config_file_devices_p);
 INSTANTIATE_TEST_CASE_P(fpgad_config_file_c, fpgad_config_file_devices_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));
 
@@ -820,6 +822,7 @@ TEST_P(mock_fpgad_config_file_c_p, process_plugin10) {
   EXPECT_NE(cfg_load_config(&config_), 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_fpgad_config_file_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_config_file_c, mock_fpgad_config_file_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));
 
@@ -871,5 +874,6 @@ TEST_P(mock_fpgad_config_file_devices_p, process_plugin_devices8) {
   EXPECT_EQ(cfg_process_plugin_devices("a", devices), nullptr);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_fpgad_config_file_devices_p);
 INSTANTIATE_TEST_CASE_P(fpgad_config_file_c, mock_fpgad_config_file_devices_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/tests/fpgad/test_daemonize_c.cpp
+++ b/tests/fpgad/test_daemonize_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -138,5 +138,6 @@ TEST_P(fpgad_daemonize_c_p, test) {
 
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_daemonize_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_daemonize_c, fpgad_daemonize_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_event_dispatcher_thread_c.cpp
+++ b/tests/fpgad/test_event_dispatcher_thread_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2021, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -163,5 +163,6 @@ TEST_P(fpgad_evt_c_p, normal_dispatch) {
   dispatch_thr.join();
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_evt_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_evt_c, fpgad_evt_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_events_api_thread_c.cpp
+++ b/tests/fpgad/test_events_api_thread_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2021, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -123,5 +123,6 @@ TEST_P(fpgad_events_api_c_p, remove0) {
   num_fds = 1;
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_events_api_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_events_api_c, fpgad_events_api_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_fpgad_c.cpp
+++ b/tests/fpgad/test_fpgad_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -317,5 +317,6 @@ TEST_P(fpgad_fpgad_c_p, main_valid) {
   EXPECT_EQ(main_returned, 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_fpgad_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_fpgad_c, fpgad_fpgad_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_monitor_thread_c.cpp
+++ b/tests/fpgad/test_monitor_thread_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2021, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -204,5 +204,6 @@ TEST_P(fpgad_monitor_c_p, null_response0) {
   normal_queue.tail = 0;
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_monitor_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_monitor_c, fpgad_monitor_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_monitored_device_c.cpp
+++ b/tests/fpgad/test_monitored_device_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2021, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -108,6 +108,7 @@ TEST_P(fpgad_monitored_device_c_p, enum_err) {
   EXPECT_NE(mon_enumerate(&cfg), 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_monitored_device_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_monitored_device_c, fpgad_monitored_device_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));
 
@@ -148,5 +149,6 @@ TEST_P(mock_fpgad_monitored_device_c_p, enum_err0) {
   EXPECT_NE(mon_enumerate(&cfg), 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_fpgad_monitored_device_c_p);
 INSTANTIATE_TEST_CASE_P(mock_fpgad_monitored_device_c, mock_fpgad_monitored_device_c_p,
   ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/tests/fpgad/test_plugin_fpgad_xfpga_c.cpp
+++ b/tests/fpgad/test_plugin_fpgad_xfpga_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2020, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -479,6 +479,7 @@ TEST_P(mock_port_fpgad_xfpga_c_p, configure) {
   fpgad_plugin_destroy(&d);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_port_fpgad_xfpga_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_c, mock_port_fpgad_xfpga_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));
 
@@ -690,5 +691,6 @@ TEST_P(mock_fme_fpgad_xfpga_c_p, configure) {
   fpgad_plugin_destroy(&d);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_fme_fpgad_xfpga_c_p);
 INSTANTIATE_TEST_CASE_P(fpgad_c, mock_fme_fpgad_xfpga_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/tests/fpgainfo/test_board_c.cpp
+++ b/tests/fpgainfo/test_board_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2021, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -305,6 +305,7 @@ TEST_P(fpgainfo_board_c_p, phy_group_info) {
     EXPECT_EQ(phy_group_info(tokens), FPGA_INVALID_PARAM);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgainfo_board_c_p);
 INSTANTIATE_TEST_CASE_P(fpgainfo_c, fpgainfo_board_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p","dcp-rc","dcp-vc" })));
 

--- a/tests/fpgainfo/test_fpgainfo_c.cpp
+++ b/tests/fpgainfo/test_fpgainfo_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -1505,5 +1505,7 @@ TEST_P(fpgainfo_c_p, main_7) {
 
 	EXPECT_EQ(fpgainfo_main(3, argv), 0);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgainfo_c_p);
 INSTANTIATE_TEST_CASE_P(fpgainfo_c, fpgainfo_c_p,
         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000" })));

--- a/tests/fpgametrics/test_fpgametrics_c.cpp
+++ b/tests/fpgametrics/test_fpgametrics_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -256,5 +256,6 @@ TEST_P(fpga_metrics_c_p, main2) {
 
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpga_metrics_c_p);
 INSTANTIATE_TEST_CASE_P(fpgametrics_c, fpga_metrics_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000" })));

--- a/tests/hello_events/test_hello_events_c.cpp
+++ b/tests/hello_events/test_hello_events_c.cpp
@@ -240,6 +240,7 @@ TEST_P(hello_events_c_p, main1) {
   EXPECT_NE(hello_events_main(3, argv), 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(hello_events_c_p);
 INSTANTIATE_TEST_CASE_P(hello_events_c, hello_events_c_p,
                         ::testing::ValuesIn(test_platform::keys(true)));
 
@@ -296,6 +297,7 @@ TEST_P(mock_hello_events_c_fpgad_p, main2) {
   EXPECT_NE(hello_events_main(3, argv), 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_hello_events_c_fpgad_p);
 INSTANTIATE_TEST_CASE_P(mock_hello_events_c_fpgad, mock_hello_events_c_fpgad_p,
   ::testing::ValuesIn(test_platform::mock_platforms()));
 

--- a/tests/hello_events/test_hello_events_c.cpp
+++ b/tests/hello_events/test_hello_events_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -325,5 +325,6 @@ TEST_P(hw_hello_events_c_fpgad_p, main2) {
   EXPECT_EQ(hello_events_main(3, argv), 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(hw_hello_events_c_fpgad_p);
 INSTANTIATE_TEST_CASE_P(hw_hello_events_c_fpgad, hw_hello_events_c_fpgad_p,
   ::testing::ValuesIn(test_platform::hw_platforms({}, fpga_driver::linux_intel)));

--- a/tests/hello_fpga/test_hello_fpga_c.cpp
+++ b/tests/hello_fpga/test_hello_fpga_c.cpp
@@ -251,6 +251,7 @@ TEST_P(hello_fpga_c_p, main0) {
   EXPECT_NE(hello_fpga_main(2, argv), 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(hello_fpga_c_p);
 INSTANTIATE_TEST_CASE_P(hello_fpga_c, hello_fpga_c_p,
                         ::testing::ValuesIn(test_platform::keys(true)));
 
@@ -283,6 +284,7 @@ TEST_P(mock_hello_fpga_c_p, main1) {
   EXPECT_EQ(hello_fpga_main(3, argv), FPGA_EXCEPTION);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_hello_fpga_c_p);
 INSTANTIATE_TEST_CASE_P(mock_hello_fpga_c, mock_hello_fpga_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"skx-p", "dcp-rc"})));
 

--- a/tests/hello_fpga/test_hello_fpga_c.cpp
+++ b/tests/hello_fpga/test_hello_fpga_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -311,5 +311,6 @@ TEST_P(hw_hello_fpga_c_p, main1) {
   EXPECT_EQ(hello_fpga_main(3, argv), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(hw_hello_fpga_c_p);
 INSTANTIATE_TEST_CASE_P(hw_hello_fpga_c, hw_hello_fpga_c_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({"skx-p","dcp-rc"})));

--- a/tests/object_api/test_object_api_c.cpp
+++ b/tests/object_api/test_object_api_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -194,6 +194,7 @@ TEST_P(object_api_c_mcp_hw_p, main1) {
   EXPECT_EQ(object_api_main(3, argv), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(object_api_c_mcp_hw_p);
 INSTANTIATE_TEST_CASE_P(object_api_c, object_api_c_mcp_hw_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({"skx-p"})));
 
@@ -222,5 +223,6 @@ TEST_P(object_api_c_dcp_hw_p, main1) {
   EXPECT_NE(object_api_main(3, argv), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(object_api_c_dcp_hw_p);
 INSTANTIATE_TEST_CASE_P(object_api_c, object_api_c_dcp_hw_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({"dcp-rc"})));

--- a/tests/object_api/test_object_api_c.cpp
+++ b/tests/object_api/test_object_api_c.cpp
@@ -137,6 +137,7 @@ TEST_P(object_api_c_p, main0) {
   EXPECT_NE(object_api_main(2, argv), 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(object_api_c_p);
 INSTANTIATE_TEST_CASE_P(object_api_c, object_api_c_p,
                         ::testing::ValuesIn(test_platform::platforms({})));
 
@@ -167,6 +168,7 @@ TEST_P(object_api_c_mock_p, main1) {
   EXPECT_EQ(object_api_main(3, argv), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(object_api_c_mock_p);
 INSTANTIATE_TEST_CASE_P(object_api_c, object_api_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));
 

--- a/tests/opae-c/test_buffer_c.cpp
+++ b/tests/opae-c/test_buffer_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -162,5 +162,6 @@ TEST_P(buffer_c_p, neg_test2) {
 }
 
 // TODO: re-enable these for n6000
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(buffer_c_p);
 INSTANTIATE_TEST_CASE_P(buffer_c, buffer_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000", "dfl-d5005" })));

--- a/tests/opae-c/test_enum_c.cpp
+++ b/tests/opae-c/test_enum_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -728,6 +728,7 @@ TEST(wrapper, validate) {
   EXPECT_EQ(NULL, opae_validate_wrapped_object(NULL));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_c_p);
 INSTANTIATE_TEST_CASE_P(enum_c, enum_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000", "dfl-d5005" })));
 
@@ -745,6 +746,7 @@ TEST_P(enum_c_mock_p, clone_token02) {
   EXPECT_EQ(fpgaCloneToken(src, &dst), FPGA_NO_MEMORY);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_c_mock_p);
 INSTANTIATE_TEST_CASE_P(enum_c, enum_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000", "dfl-d5005" })));
 
@@ -782,6 +784,7 @@ TEST_P(enum_c_err_p, num_errors) {
   EXPECT_EQ(num_matches_, 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_c_err_p);
 INSTANTIATE_TEST_CASE_P(enum_c, enum_c_err_p,
                         ::testing::ValuesIn(test_platform::platforms({"dfl-n3000", "dfl-d5005" })));
 
@@ -805,5 +808,6 @@ TEST_P(enum_c_socket_p, socket_id) {
   EXPECT_EQ(num_matches_, 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_c_socket_p);
 INSTANTIATE_TEST_CASE_P(enum_c, enum_c_socket_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/opae-c/test_error_c.cpp
+++ b/tests/opae-c/test_error_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -162,5 +162,6 @@ TEST_P(error_c_p, clear_all) {
   EXPECT_EQ(fpgaClearAllErrors(tokens_[0]), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(error_c_p);
 INSTANTIATE_TEST_CASE_P(error_c, error_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/opae-c/test_event_c.cpp
+++ b/tests/opae-c/test_event_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -251,6 +251,7 @@ TEST_P(event_c_p, destroy_err) {
 			  event_handle_), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(event_c_p);
 INSTANTIATE_TEST_CASE_P(event_c, event_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({})));
 
@@ -377,5 +378,6 @@ TEST_P(events_handle_p, manual_ap6) {
   EXPECT_EQ(FPGA_OK, fpgaUnregisterEvent(handle_accel_, FPGA_EVENT_POWER_THERMAL, eh_));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(events_handle_p);
 INSTANTIATE_TEST_CASE_P(events, events_handle_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"skx-p"})));

--- a/tests/opae-c/test_hostif_c.cpp
+++ b/tests/opae-c/test_hostif_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -119,6 +119,7 @@ TEST_P(hostif_c_p, release_from_ifc) {
 		     FPGA_NOT_SUPPORTED);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(hostif_c_p);
 INSTANTIATE_TEST_CASE_P(hostif_c, hostif_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({})));
 
@@ -138,6 +139,7 @@ TEST_P(hostif_c_mock_p, assign_port) {
 			  0, 0), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(hostif_c_mock_p);
 INSTANTIATE_TEST_CASE_P(hostif_c, hostif_c_mock_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({})));
 

--- a/tests/opae-c/test_metrics_c.cpp
+++ b/tests/opae-c/test_metrics_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2021, Intel Corporation
+// Copyright(c) 2021-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -159,5 +159,6 @@ TEST_P(metrics_c_p, threshold0) {
 
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_c_p);
 INSTANTIATE_TEST_CASE_P(metrics_c, metrics_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));

--- a/tests/opae-c/test_mmio_c.cpp
+++ b/tests/opae-c/test_mmio_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -254,5 +254,6 @@ TEST_P(mmio_c_p, mmio512_neg_test) {
 }
 #endif // TEST_SUPPORTS_AVX512
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mmio_c_p);
 INSTANTIATE_TEST_CASE_P(mmio_c, mmio_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/opae-c/test_object_c.cpp
+++ b/tests/opae-c/test_object_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -394,7 +394,7 @@ TEST_P(object_c_p, obj_close) {
   EXPECT_EQ(fpgaClose(nullptr), FPGA_INVALID_PARAM);
 }
 
-
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(object_c_p);
 INSTANTIATE_TEST_CASE_P(object_c, object_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
@@ -452,6 +452,7 @@ TEST_P(object_c_mock_p, obj_get_obj_err) {
   EXPECT_EQ(fpgaDestroyObject(&errors_obj), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(object_c_mock_p);
 INSTANTIATE_TEST_CASE_P(object_c, object_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 

--- a/tests/opae-c/test_open_c.cpp
+++ b/tests/opae-c/test_open_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -95,5 +95,6 @@ TEST_P(open_c_p, mallocfails) {
     EXPECT_EQ(accel_, nullptr);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(open_c_p);
 INSTANTIATE_TEST_CASE_P(open_c, open_c_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({})));

--- a/tests/opae-c/test_props_c.cpp
+++ b/tests/opae-c/test_props_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -3483,6 +3483,7 @@ TEST_P(properties_c_p, validate01) {
   p->magic = FPGA_PROPERTY_MAGIC;
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(properties_c_p);
 INSTANTIATE_TEST_CASE_P(properties_c, properties_c_p,
                         ::testing::ValuesIn(test_platform::platforms({})));
 
@@ -3532,6 +3533,7 @@ TEST_P(properties_c_mock_p, fpga_clone_properties02) {
   ASSERT_EQ(fpgaCloneProperties(filter_, &clone), FPGA_EXCEPTION);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(properties_c_mock_p);
 INSTANTIATE_TEST_CASE_P(properties_c, properties_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({})));
 

--- a/tests/opae-c/test_reconf_c.cpp
+++ b/tests/opae-c/test_reconf_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -109,5 +109,6 @@ TEST_P(reconf_c_p, pr) {
 		  bitstream, 5, 0), FPGA_INVALID_PARAM);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c_p);
 INSTANTIATE_TEST_CASE_P(reconf_c, reconf_c_p,
                         ::testing::ValuesIn(test_platform::platforms({})));

--- a/tests/opae-c/test_reset_c.cpp
+++ b/tests/opae-c/test_reset_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -99,5 +99,6 @@ TEST_P(reset_c_p, success) {
     EXPECT_EQ(fpgaReset(accel_), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reset_c_p);
 INSTANTIATE_TEST_CASE_P(reset_c, reset_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({})));

--- a/tests/opae-c/test_sdl_c.cpp
+++ b/tests/opae-c/test_sdl_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2021, Intel Corporation
+// Copyright(c) 2021-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -452,5 +452,6 @@ TEST_P(sdl_c_p, test_fpgaClose_for_null_object) {
   EXPECT_EQ(fpgaClose(nullptr), FPGA_INVALID_PARAM);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sdl_c_p);
 INSTANTIATE_TEST_CASE_P(sdl_c, sdl_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({"dfl-n3000","dfl-d5005","dfl-n6000"})));

--- a/tests/opae-c/test_umsg_c.cpp
+++ b/tests/opae-c/test_umsg_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -194,6 +194,7 @@ TEST_P(DISABLED_umsg_c_p, set_attr) {
   EXPECT_EQ(fpgaSetUmsgAttributes(dev_, disable), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(DISABLED_umsg_c_p);
 INSTANTIATE_TEST_CASE_P(DISABLED_umsg_c, DISABLED_umsg_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p"})));
 
@@ -233,6 +234,7 @@ TEST_P(DISABLED_umsg_c_mock_p, get_ptr) {
   EXPECT_EQ(fpgaSetUmsgAttributes(dev_, disable), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(DISABLED_umsg_c_mock_p);
 INSTANTIATE_TEST_CASE_P(umsg_c, DISABLED_umsg_c_mock_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p"})));
 

--- a/tests/opae-c/test_usrclk_c.cpp
+++ b/tests/opae-c/test_usrclk_c.cpp
@@ -110,6 +110,7 @@ TEST_P(usrclk_c_p, get) {
 }
 
 // TODO: Fix user clock test for DCP
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(usrclk_c_p);
 INSTANTIATE_TEST_CASE_P(usrclk_c, usrclk_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-d5005" })));
 

--- a/tests/opae-c/test_usrclk_c.cpp
+++ b/tests/opae-c/test_usrclk_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -129,6 +129,7 @@ TEST_P(usrclk_c_hw_p, set) {
   EXPECT_EQ(fpgaSetUserClock(accel_, high, low, 0), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(usrclk_c_hw_p);
 INSTANTIATE_TEST_CASE_P(usrclk_c, usrclk_c_hw_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-d5005"})));
 

--- a/tests/opae-cxx/test_buffer_cxx_core.cpp
+++ b/tests/opae-cxx/test_buffer_cxx_core.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -217,5 +217,6 @@ TEST_P(buffer_cxx_core, read_write) {
   EXPECT_EQ(0xdecafbad, buf->read<uint32_t>(0));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(buffer_cxx_core);
 INSTANTIATE_TEST_CASE_P(buffer, buffer_cxx_core,
                         ::testing::ValuesIn(test_platform::keys(true)));

--- a/tests/opae-cxx/test_events_cxx_core.cpp
+++ b/tests/opae-cxx/test_events_cxx_core.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -143,4 +143,5 @@ TEST_P(events_cxx_core, get_os_object) {
   ASSERT_NE(res, -1);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(events_cxx_core);
 INSTANTIATE_TEST_CASE_P(events, events_cxx_core, ::testing::ValuesIn(test_platform::keys(true)));

--- a/tests/opae-cxx/test_handle_cxx_core.cpp
+++ b/tests/opae-cxx/test_handle_cxx_core.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -232,5 +232,6 @@ TEST_P(handle_cxx_core, get_token) {
 }
 
 // TODO: re-enable these for n6000
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(handle_cxx_core);
 INSTANTIATE_TEST_CASE_P(handle, handle_cxx_core,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000", "dfl-d5005" })));

--- a/tests/opae-cxx/test_object_cxx_core.cpp
+++ b/tests/opae-cxx/test_object_cxx_core.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -244,6 +244,7 @@ TEST_P(sysobject_cxx_p, read_bytes) {
   }
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysobject_cxx_p);
 INSTANTIATE_TEST_CASE_P(sysobject_cxx, sysobject_cxx_p,
          ::testing::ValuesIn(test_platform::platforms({ "skx-p","dcp-rc","dcp-vc" })));
 

--- a/tests/opae-cxx/test_properties_cxx_core.cpp
+++ b/tests/opae-cxx/test_properties_cxx_core.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -298,5 +298,6 @@ TEST_P(properties_cxx_core, get_interface) {
   EXPECT_EQ(static_cast<fpga_interface>(p->interface), FPGA_IFC_DFL);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(properties_cxx_core);
 INSTANTIATE_TEST_CASE_P(properties, properties_cxx_core,
                         ::testing::ValuesIn(test_platform::keys(true)));

--- a/tests/userclk/test_userclk_c.cpp
+++ b/tests/userclk/test_userclk_c.cpp
@@ -365,6 +365,7 @@ TEST_P(userclk_c_p, main2) {
   EXPECT_NE(userclk_main(3, argv), 0);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(userclk_c_p);
 INSTANTIATE_TEST_CASE_P(userclk_c, userclk_c_p,
                         ::testing::ValuesIn(test_platform::platforms({})));
 
@@ -717,7 +718,7 @@ TEST_P(userclk_c_mock_p, main6) {
   EXPECT_EQ(userclk_main(9, argv), FPGA_INVALID_PARAM);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(userclk_c_mock_p);
 INSTANTIATE_TEST_CASE_P(userclk_c, userclk_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"skx-p", "dcp-rc"})));
-
 

--- a/tests/userclk/test_userclk_c.cpp
+++ b/tests/userclk/test_userclk_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -532,6 +532,7 @@ TEST_P(userclk_c_hw_p, main6) {
   EXPECT_EQ(userclk_main(9, argv), FPGA_INVALID_PARAM);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(userclk_c_hw_p);
 INSTANTIATE_TEST_CASE_P(userclk_c, userclk_c_hw_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({"skx-p","dcp-rc"})));
 

--- a/tests/xfpga/test_afu_metrics_c.cpp
+++ b/tests/xfpga/test_afu_metrics_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -334,5 +334,6 @@ TEST_P(afu_metrics_c_p, test_afu_metrics_04) {
   EXPECT_EQ(FPGA_OK, fpga_vector_free(&vector));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(afu_metrics_c_p);
 INSTANTIATE_TEST_CASE_P(afu_metrics_c, afu_metrics_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p", "dcp-rc","dcp-vc" })));

--- a/tests/xfpga/test_bmc_c.cpp
+++ b/tests/xfpga/test_bmc_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -558,5 +558,6 @@ TEST_P(bmc_c_p, test_bmc_7) {
   }
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(bmc_c_p);
 INSTANTIATE_TEST_CASE_P(bmc_c, bmc_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));

--- a/tests/xfpga/test_buffer_c.cpp
+++ b/tests/xfpga/test_buffer_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -292,6 +292,7 @@ std::vector<buffer_params> params{
     buffer_params{FPGA_INVALID_PARAM, 11247, FPGA_BUF_PREALLOCATED}};
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(buffer_prepare);
 INSTANTIATE_TEST_CASE_P(buffer_c, buffer_prepare,
                         ::testing::Combine(::testing::ValuesIn(test_platform::keys()),
                                            ::testing::ValuesIn(params)));
@@ -368,5 +369,6 @@ TEST_P(buffer_c_mock_p, port_dma_map) {
   EXPECT_EQ(res, FPGA_INVALID_PARAM) << "result is " << fpgaErrStr(res);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(buffer_c_mock_p);
 INSTANTIATE_TEST_CASE_P(buffer_c, buffer_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_common_c.cpp
+++ b/tests/xfpga/test_common_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -182,5 +182,5 @@ TEST_P(common_c_p, event_handle_check_and_lock) {
   EXPECT_EQ(FPGA_OK,res);
 }
 
-
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(common_c_p);
 INSTANTIATE_TEST_CASE_P(common_c, common_c_p, ::testing::ValuesIn(test_platform::keys(true)));

--- a/tests/xfpga/test_enum_c.cpp
+++ b/tests/xfpga/test_enum_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -1096,9 +1096,7 @@ TEST_P(enum_c_p, get_guid) {
   EXPECT_EQ(fpgaDestroyProperties(&prop), FPGA_OK);
 }
 
-
-
-
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_c_p);
 INSTANTIATE_TEST_CASE_P(enum_c, enum_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
@@ -1145,6 +1143,7 @@ TEST_P(enum_err_c_p, num_errors_port) {
   EXPECT_EQ(num_matches_, GetNumFpgas());
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_err_c_p);
 INSTANTIATE_TEST_CASE_P(enum_c, enum_err_c_p,
                        ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
@@ -1166,6 +1165,7 @@ TEST_P(enum_socket_c_p, socket_id) {
   EXPECT_EQ(num_matches_, GetNumMatchedFpga() * 2);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_socket_c_p);
 INSTANTIATE_TEST_CASE_P(enum_c, enum_socket_c_p,
                           ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
@@ -1200,5 +1200,6 @@ TEST_P(enum_mock_only, remove_port) {
   EXPECT_EQ(fpgaDestroyProperties(&filterp), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_mock_only);
 INSTANTIATE_TEST_CASE_P(enum_c, enum_mock_only,
                           ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_error_c.cpp
+++ b/tests/xfpga/test_error_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -631,6 +631,7 @@ TEST_P(error_c_mock_p, error_12) {
   xfpga_fpgaDestroyToken((fpga_token *)&port);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(error_c_mock_p);
 INSTANTIATE_TEST_CASE_P(error_c, error_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
@@ -724,6 +725,7 @@ TEST_P(error_c_p, error_13) {
   xfpga_fpgaDestroyToken((fpga_token *)&port);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(error_c_p);
 INSTANTIATE_TEST_CASE_P(error_c, error_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 

--- a/tests/xfpga/test_events_c.cpp
+++ b/tests/xfpga/test_events_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -692,6 +692,7 @@ TEST_P(events_dcp_p, invalid_fme_event_request){
   EXPECT_EQ(FPGA_OK, res);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(events_dcp_p);
 INSTANTIATE_TEST_CASE_P(events, events_dcp_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-n3000","dfl-d5005" })));
 

--- a/tests/xfpga/test_events_c.cpp
+++ b/tests/xfpga/test_events_c.cpp
@@ -654,6 +654,7 @@ TEST_P(events_p, irq_event_06) {
                                        eh_));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(events_p);
 INSTANTIATE_TEST_CASE_P(events, events_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000", "dfl-d5005", "dfl-n6000" })));
 
@@ -733,6 +734,7 @@ TEST_P(events_mcp_p, invalid_fme_event_request){
   EXPECT_EQ(FPGA_NOT_SUPPORTED,res);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(events_mcp_p);
 INSTANTIATE_TEST_CASE_P(events, events_mcp_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-d5005" })));
 
@@ -1285,5 +1287,6 @@ TEST_P(events_mock_p, irq_event_03) {
                                          eh_));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(events_mock_p);
 INSTANTIATE_TEST_CASE_P(events, events_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_metadata_c.cpp
+++ b/tests/xfpga/test_metadata_c.cpp
@@ -399,7 +399,9 @@ TEST_P(metadata_c, get_interface_id_03) {
   EXPECT_EQ(res, FPGA_EXCEPTION);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metadata_c);
 INSTANTIATE_TEST_CASE_P(metadata, metadata_c, ::testing::ValuesIn(test_platform::platforms({ "dfl-d5005" })));
+
 class metadata_mock_c : public metadata_c {};
 
 /**
@@ -417,6 +419,7 @@ TEST_P(metadata_mock_c, validate_bitstream_metadata) {
   EXPECT_EQ(result, FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metadata_mock_c);
 INSTANTIATE_TEST_CASE_P(metadata, metadata_mock_c,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-d5005" })));
 
@@ -445,6 +448,7 @@ TEST_P(metadata_mock_d5005_c, validate_bitstream_metadata_1) {
 	EXPECT_EQ(result, FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metadata_mock_d5005_c);
 INSTANTIATE_TEST_CASE_P(metadata, metadata_mock_d5005_c,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-d5005" })));
 

--- a/tests/xfpga/test_metadata_c.cpp
+++ b/tests/xfpga/test_metadata_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -466,5 +466,6 @@ TEST_P(metadata_hw_c, validate_bitstream_metadata) {
   EXPECT_EQ(result, FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metadata_hw_c);
 INSTANTIATE_TEST_CASE_P(metadata, metadata_hw_c,
                         ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-d5005" })));

--- a/tests/xfpga/test_metrics_c.cpp
+++ b/tests/xfpga/test_metrics_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -300,6 +300,7 @@ TEST_P(metrics_c_p, test_metric_04) {
   free(metric_array_search);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_c_p);
 INSTANTIATE_TEST_CASE_P(metrics_c, metrics_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));
 
@@ -584,5 +585,7 @@ TEST_P(metrics_afu_c_p, test_afc_metric_04) {
 
   free(metric_array_search);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_afu_c_p);
 INSTANTIATE_TEST_CASE_P(metrics_c, metrics_afu_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));

--- a/tests/xfpga/test_metrics_max10_c.cpp
+++ b/tests/xfpga/test_metrics_max10_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2021, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -185,6 +185,8 @@ TEST_P(metrics_max10_c_p, test_metric_max10_2) {
 
   EXPECT_EQ(FPGA_OK, fpga_vector_free(&vector));
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_max10_c_p);
 INSTANTIATE_TEST_CASE_P(metrics_max10_c, metrics_max10_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"dfl-n3000"})));
 
@@ -209,6 +211,8 @@ TEST_P(metrics_invalid_max10_c_p, test_metric_max10_3) {
 
   EXPECT_EQ(FPGA_OK, fpga_vector_free(&vector));
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_invalid_max10_c_p);
 INSTANTIATE_TEST_CASE_P(metrics_max10_c, metrics_invalid_max10_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));
 
@@ -241,5 +245,7 @@ TEST_P(metrics_max10_vc_c_p, test_metric_max10_4) {
 	double dvalue = 0;
 	EXPECT_EQ(FPGA_INVALID_PARAM, read_max10_value(NULL, &dvalue));
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_max10_vc_c_p);
 INSTANTIATE_TEST_CASE_P(metrics_max10_c, metrics_max10_vc_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-d5005" })));

--- a/tests/xfpga/test_metrics_utils_c.cpp
+++ b/tests/xfpga/test_metrics_utils_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -349,6 +349,7 @@ TEST_P(metrics_utils_c_p, test_metric_utils_15) {
   EXPECT_NE(FPGA_OK, get_fpga_object_type(handle_, NULL));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_utils_c_p);
 INSTANTIATE_TEST_CASE_P(metrics_utils_c, metrics_utils_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));
 
@@ -444,5 +445,6 @@ TEST_P(metrics_utils_dcp_c_p, test_metric_utils_14) {
   EXPECT_EQ(FPGA_OK, get_bmc_metrics_values(handle_, &_fpga_enum_metric, &fpga_metric));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_utils_dcp_c_p);
 INSTANTIATE_TEST_CASE_P(metrics_utils_c, metrics_utils_dcp_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));

--- a/tests/xfpga/test_mmio_c.cpp
+++ b/tests/xfpga/test_mmio_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -490,5 +490,5 @@ TEST_P (mmio_c_p, test_neg_read_write_512) {
 #endif
 }
 
-
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mmio_c_p);
 INSTANTIATE_TEST_CASE_P(mmio_c, mmio_c_p, ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_mock_errinj_c.cpp
+++ b/tests/xfpga/test_mock_errinj_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -164,6 +164,7 @@ TEST_P(err_inj_c_usd_p, dfl_tests_neg) {
   EXPECT_EQ(FPGA_NOT_SUPPORTED, xfpga_fpgaAssignPortToInterface(handle_, 0, 0, 0));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(err_inj_c_usd_p);
 INSTANTIATE_TEST_CASE_P(err_inj_c, err_inj_c_usd_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
@@ -239,6 +240,7 @@ TEST_P(err_inj_c_mock_p, port_to_interface_err) {
   EXPECT_EQ(FPGA_INVALID_PARAM, res);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(err_inj_c_mock_p);
 INSTANTIATE_TEST_CASE_P(err_inj_c, err_inj_c_mock_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 

--- a/tests/xfpga/test_object_c.cpp
+++ b/tests/xfpga/test_object_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -165,6 +165,7 @@ TEST_P(sysobject_p, xfpga_fpgaDestroyObject) {
   EXPECT_EQ(xfpga_fpgaDestroyObject(NULL), FPGA_INVALID_PARAM);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysobject_p);
 INSTANTIATE_TEST_CASE_P(sysobject_c, sysobject_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
@@ -275,5 +276,6 @@ TEST_P(sysobject_mock_p, xfpga_fpgaGetSize) {
   EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysobject_mock_p);
 INSTANTIATE_TEST_CASE_P(sysobject_c, sysobject_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_open_close_c.cpp
+++ b/tests/xfpga/test_open_close_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -354,6 +354,7 @@ TEST_P(openclose_c_dfl_p, open_share) {
   EXPECT_EQ(FPGA_OK, xfpga_fpgaClose(h1));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(openclose_c_dfl_p);
 INSTANTIATE_TEST_CASE_P(openclose_c_dfl, openclose_c_dfl_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({}, fpga_driver::linux_dfl0)));
 

--- a/tests/xfpga/test_open_close_c.cpp
+++ b/tests/xfpga/test_open_close_c.cpp
@@ -309,6 +309,7 @@ TEST_P(openclose_c_p, close_03) {
   EXPECT_EQ(res, FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(openclose_c_p);
 INSTANTIATE_TEST_CASE_P(openclose_c, openclose_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
@@ -332,6 +333,7 @@ TEST_P(openclose_c_skx_dcp_p, open_share) {
   EXPECT_EQ(FPGA_OK, xfpga_fpgaClose(h2));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(openclose_c_skx_dcp_p);
 INSTANTIATE_TEST_CASE_P(openclose_c_skx_dcp, openclose_c_skx_dcp_p,
                         ::testing::ValuesIn(test_platform::platforms({}, fpga_driver::linux_intel)));
 
@@ -398,5 +400,6 @@ TEST_P(openclose_c_mock_p, invalid_open_close) {
 #endif
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(openclose_c_mock_p);
 INSTANTIATE_TEST_CASE_P(openclose_c, openclose_c_mock_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_plugin_c.cpp
+++ b/tests/xfpga/test_plugin_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -155,6 +155,8 @@ TEST_P(xfpga_plugin_c_p, test_plugin_2) {
 		opae_plugin_mgr_free_adapter_test(adapter_table);
 
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(xfpga_plugin_c_p);
 INSTANTIATE_TEST_CASE_P(xfpga_plugin_c, xfpga_plugin_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({"skx-p","dcp-rc"})));
 
@@ -174,6 +176,7 @@ TEST_P(xfpga_plugin_mock_c_p, test_plugin_neg) {
 	EXPECT_EQ(xfpga_plugin_finalize(), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(xfpga_plugin_mock_c_p);
 INSTANTIATE_TEST_CASE_P(xfpga_plugin_mock_c, xfpga_plugin_mock_c_p,
      ::testing::ValuesIn(test_platform::mock_platforms()));
 

--- a/tests/xfpga/test_properties_c.cpp
+++ b/tests/xfpga/test_properties_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -225,6 +225,7 @@ TEST_P(properties_c_p, valid_gets) {
   EXPECT_EQ(objtype, FPGA_DEVICE);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(properties_c_p);
 INSTANTIATE_TEST_CASE_P(properties_c, properties_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 

--- a/tests/xfpga/test_reconf_c.cpp
+++ b/tests/xfpga/test_reconf_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -460,6 +460,7 @@ TEST_P(reconf_c_hw_skx_p, set_afu_userclock) {
   EXPECT_EQ(set_afu_userclock(handle_, 312, 156), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c_hw_skx_p);
 INSTANTIATE_TEST_CASE_P(reconf, reconf_c_hw_skx_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-d5005" })));
 
@@ -479,6 +480,7 @@ TEST_P(reconf_c_hw_dcp_p, set_afu_userclock) {
   EXPECT_EQ(set_afu_userclock(handle_, 312, 156), FPGA_NOT_SUPPORTED);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c_hw_dcp_p);
 INSTANTIATE_TEST_CASE_P(reconf, reconf_c_hw_dcp_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-d5005" })));
 
@@ -586,5 +588,6 @@ TEST_P(reconf_c_hw_p, fpga_reconf_slot_inv_len) {
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c_hw_p);
 INSTANTIATE_TEST_CASE_P(reconf, reconf_c_hw_p,
 	::testing::ValuesIn(test_platform::hw_platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_reconf_c.cpp
+++ b/tests/xfpga/test_reconf_c.cpp
@@ -303,6 +303,7 @@ TEST_P(reconf_c, validate_bitstream) {
   EXPECT_EQ(FPGA_EXCEPTION, result);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c);
 INSTANTIATE_TEST_CASE_P(reconf, reconf_c,
                         ::testing::ValuesIn(test_platform::platforms({})));
 
@@ -441,6 +442,7 @@ TEST_P(reconf_c_mock_p, fpga_reconf_slot_enotsup) {
   EXPECT_EQ(result, FPGA_EXCEPTION);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c_mock_p);
 INSTANTIATE_TEST_CASE_P(reconf, reconf_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 

--- a/tests/xfpga/test_reset_c.cpp
+++ b/tests/xfpga/test_reset_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2020, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -151,6 +151,7 @@ TEST_P(reset_c_p, valid_port_reset) {
   EXPECT_EQ(FPGA_OK, xfpga_fpgaReset(handle_));
 } 
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reset_c_p);
 INSTANTIATE_TEST_CASE_P(reset_c, reset_c_p, ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005","dfl-n6000" })));
 
 class reset_c_mock_p : public reset_c_p {
@@ -170,5 +171,6 @@ TEST_P(reset_c_mock_p, test_port_drv_reset_01) {
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaReset(handle_));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reset_c_mock_p);
 INSTANTIATE_TEST_CASE_P(reset_c, reset_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_sysfs_c.cpp
+++ b/tests/xfpga/test_sysfs_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2020, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -655,6 +655,7 @@ TEST_P(sysfs_c_hw_p, make_object_glob) {
   EXPECT_EQ(xfpga_fpgaDestroyObject(&object), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_c_hw_p);
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_hw_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-n3000","dfl-d5005" })));
 

--- a/tests/xfpga/test_sysfs_c.cpp
+++ b/tests/xfpga/test_sysfs_c.cpp
@@ -286,6 +286,7 @@ TEST(sysfsinit_c_p, sysfs_parse_pcie) {
 }
 
 // TODO re-enable these for n6000.
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfsinit_c_p);
 INSTANTIATE_TEST_CASE_P(sysfsinit_c, sysfsinit_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000", "dfl-d5005" })));
 
@@ -605,6 +606,7 @@ TEST_P(sysfs_c_p, get_fme_path_neg) {
   ASSERT_NE(sysfs_get_fme_path("/a/b/c", found_fme), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_c_p);
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_p,
                         ::testing::ValuesIn(test_platform::platforms({})));
 
@@ -926,6 +928,8 @@ TEST_P(sysfs_c_mock_p, fpga_sysfs_30) {
 	EXPECT_EQ(find_glob_path(NULL, path), FPGA_INVALID_PARAM);
 	EXPECT_EQ(find_glob_path(glob_path, NULL), FPGA_INVALID_PARAM);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_c_mock_p);
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
@@ -952,6 +956,8 @@ TEST_P(sysfs_dfl_c_mock_p, fpga_sysfs_08) {
 	result = sysfs_get_fme_perf_path(tokens_[0], NULL);
 	EXPECT_EQ(result, FPGA_INVALID_PARAM);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_dfl_c_mock_p);
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_dfl_c_mock_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
@@ -977,6 +983,8 @@ TEST_P(sysfs_power_mock_p, fpga_sysfs_09) {
 	result = sysfs_get_fme_pwr_path(tokens_[0], NULL);
 	EXPECT_EQ(result, FPGA_INVALID_PARAM);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_power_mock_p);
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_power_mock_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
@@ -1001,6 +1009,7 @@ TEST_P(sysfs_bmc_mock_p, fpga_sysfs_10) {
 	EXPECT_EQ(result, FPGA_INVALID_PARAM);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_bmc_mock_p);
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_bmc_mock_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dcp-rc" })));
 
@@ -1024,6 +1033,8 @@ TEST_P(sysfs_max10_mock_p, fpga_sysfs_11) {
 	result = sysfs_get_max10_path(tokens_[0], NULL);
 	EXPECT_EQ(result, FPGA_INVALID_PARAM);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_max10_mock_p);
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_max10_mock_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
@@ -1099,6 +1110,7 @@ TEST_P(sysfs_c_mock_no_drv_p, sysfs_get_bitstream_id) {
   EXPECT_NE(res, FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_c_mock_no_drv_p);
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_mock_no_drv_p,
                         ::testing::ValuesIn(test_platform::mock_platforms()));
 
@@ -1115,6 +1127,7 @@ TEST_P(sysfs_sockid_c_mock_p, fpga_sysfs_02) {
   EXPECT_EQ(result, FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_sockid_c_mock_p);
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_sockid_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
@@ -1312,6 +1325,7 @@ TEST_P(sysfs_sockid_c_p, get_port_sysfs) {
   EXPECT_EQ(get_port_sysfs(handle_, tok->sysfspath), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_sockid_c_p);
 INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_sockid_c_p,
                        ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 

--- a/tests/xfpga/test_threshold_c.cpp
+++ b/tests/xfpga/test_threshold_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2021, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -157,6 +157,8 @@ TEST_P(metrics_threshold_c_p, metrics_threshold_2) {
 
   EXPECT_NE(get_bmc_threshold_info(handle_, NULL, &num_thresholds), FPGA_OK);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_threshold_c_p);
 INSTANTIATE_TEST_CASE_P(metrics_threshold_c_c, metrics_threshold_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"dcp-vc"})));
 
@@ -213,6 +215,8 @@ TEST_P(metrics_bmc_threshold_c_p, metrics_threshold_4) {
 
   EXPECT_NE(get_max10_threshold_info(handle_, NULL, &num_thresholds), FPGA_OK);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_bmc_threshold_c_p);
 INSTANTIATE_TEST_CASE_P(metrics_threshold_c_c, metrics_bmc_threshold_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));
 
@@ -241,6 +245,7 @@ TEST_P(metrics_mcp_threshold_c_p, metrics_threshold_5) {
   EXPECT_NE(get_bmc_threshold_info(handle_, NULL, &num_thresholds), FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_mcp_threshold_c_p);
 INSTANTIATE_TEST_CASE_P(metrics_threshold_c_c, metrics_mcp_threshold_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"skx-p"})));
 
@@ -304,5 +309,7 @@ TEST_P(metrics_afu_threshold_c_p, metrics_threshold_6) {
             FPGA_OK);
   EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(handle_, NULL, NULL), FPGA_OK);
 }
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_afu_threshold_c_p);
 INSTANTIATE_TEST_CASE_P(metrics_threshold_c_c, metrics_afu_threshold_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"dcp-vc"})));

--- a/tests/xfpga/test_umsg_c.cpp
+++ b/tests/xfpga/test_umsg_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -357,6 +357,7 @@ TEST_P(umsg_c_p, test_umsg_drv_08_DISABLED) {
   _handle->fddev = fddev;
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umsg_c_p);
 INSTANTIATE_TEST_CASE_P(umsg_c, umsg_c_p, ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));
 
 class umsg_c_mcp_p : public umsg_c_p {
@@ -396,6 +397,7 @@ TEST_P(umsg_c_mcp_p, test_umsg_drv_04_DISABLED) {
   EXPECT_EQ(FPGA_OK, xfpga_fpgaSetUmsgAttributes(handle_, Umsghit_Disble));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umsg_c_mcp_p);
 INSTANTIATE_TEST_CASE_P(umsg_c, umsg_c_mcp_p,
                         ::testing::ValuesIn(test_platform::platforms({"skx-p"})));
 
@@ -615,6 +617,7 @@ TEST_P(umsg_c_mock_p, test_umsg_09_DISABLED) {
   EXPECT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaTriggerUmsg(handle_, 0));
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umsg_c_mock_p);
 INSTANTIATE_TEST_CASE_P(umsg_c, umsg_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p"})));
 

--- a/tests/xfpga/test_usrclk_c.cpp
+++ b/tests/xfpga/test_usrclk_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -348,5 +348,6 @@ uint64_t high = 312;
             FPGA_OK);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(usrclk_hw_c);
 INSTANTIATE_TEST_CASE_P(usrclk, usrclk_hw_c,
                         ::testing::ValuesIn(test_platform::hw_platforms({ "skx-p","dcp-rc" })));

--- a/tests/xfpga/test_usrclk_c.cpp
+++ b/tests/xfpga/test_usrclk_c.cpp
@@ -306,6 +306,7 @@ TEST_P(usrclk_c, get_user_clock) {
   EXPECT_NE(low, 999);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(usrclk_c);
 INSTANTIATE_TEST_CASE_P(usrclk, usrclk_c,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-d5005" })));
 
@@ -327,6 +328,7 @@ TEST_P(usrclk_mock_c, set_user_clock) {
             FPGA_NOT_SUPPORTED);
 }
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(usrclk_mock_c);
 INSTANTIATE_TEST_CASE_P(usrclk, usrclk_mock_c,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 


### PR DESCRIPTION
Fixes compile issue in Fedora >= 34

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>