### PR TITLE
fpgad: fix error in sysfs path to match N5010

### DIFF
--- a/binaries/fpgad/plugins/fpgad-vc/fpgad-vc.c
+++ b/binaries/fpgad/plugins/fpgad-vc/fpgad-vc.c
@@ -428,6 +428,8 @@ STATIC const char *glob_patterns[] = {
 	"*-hwmon.*.auto/hwmon/hwmon*/*_label",
 	"/sys/bus/pci/devices/%s/fpga_region/region*/dfl-fme.*/"
 	"dfl_dev.*/*-hwmon.*.auto/hwmon/hwmon*/*_label",
+	"/sys/bus/pci/devices/%s/fpga_region/region*/dfl-fme.*/"
+	"dfl_dev.*/spi*/spi*/spi*/*-hwmon.*.auto/hwmon/hwmon*/*_label",
 	NULL
 };
 


### PR DESCRIPTION
Signed-off-by: Roger Christensen <rc@silicom.dk>