### PR TITLE
Opae-tests: add stat and lstat function to opae mock

### DIFF
--- a/tests/framework/mock/c_test_system.h
+++ b/tests/framework/mock/c_test_system.h
@@ -51,7 +51,7 @@ extern "C" {
   DIR *opae_test_opendir(const char *name);
   ssize_t opae_test_readlink(const char *path, char *buf, size_t bufsize);
   int opae_test_xstat(int ver, const char *path, struct stat *buf);
-  int opae_test_lstat(int ver, const char *path, struct stat *buf);
+  int opae_test_lxstat(int ver, const char *path, struct stat *buf);
   int opae_test_access(const char *pathname, int mode);
   int opae_test_scandir(const char *dirp, struct dirent ***namelist, filter_func filter, compare_func cmp);
 
@@ -61,6 +61,9 @@ extern "C" {
                 int (*errfunc) (const char *epath, int eerrno),
                 glob_t *pglob);
   char *opae_test_realpath(const char *inp, char *dst);
+
+  int opae_test_stat(const char* str, struct stat* buf);
+  int opae_test_lstat(const char* str, struct stat* buf);
 
 #ifdef __cplusplus
 }

--- a/tests/framework/mock/mock.c
+++ b/tests/framework/mock/mock.c
@@ -90,11 +90,19 @@ int __xstat(int ver, const char *pathname, struct stat *buf) {
 }
 
 int __lxstat(int ver, const char *pathname, struct stat *buf) {
-  return opae_test_xstat(ver, pathname, buf);
+  return opae_test_lxstat(ver, pathname, buf);
 }
 
 int access(const char *pathname, int mode) {
   return opae_test_access(pathname, mode);
+}
+
+int lstat(const char* str, struct stat* buf) {
+    return opae_test_lstat(str, buf);
+}
+
+int stat(const char* str, struct stat* buf) {
+    return opae_test_stat(str, buf);
 }
 
 int scandir(const char *__restrict __dir,

--- a/tests/framework/mock/test_system.h
+++ b/tests/framework/mock/test_system.h
@@ -141,7 +141,7 @@ class test_system {
   DIR *opendir(const char *name);
   ssize_t readlink(const char *path, char *buf, size_t bufsize);
   int xstat(int ver, const char *path, stat_t *buf);
-  int lstat(int ver, const char *path, stat_t *buf);
+  int lxstat(int ver, const char *path, stat_t *buf);
   int access(const char *pathname, int mode);
   int scandir(const char *dirp, struct dirent ***namelist, filter_func filter,
               compare_func cmp);
@@ -166,6 +166,8 @@ class test_system {
   FILE *register_file(const std::string &path);
 
   void normalize_guid(std::string &guid_str, bool with_hyphens = true);
+  int stat(const char* str, struct stat* buf);
+  int lstat(const char* str, struct stat* buf);
 
  private:
   test_system();
@@ -190,6 +192,7 @@ class test_system {
   typedef ssize_t (*readlink_func)(const char *pathname, char *buf,
                                    size_t bufsiz);
   typedef int (*__xstat_func)(int ver, const char *pathname, struct stat *buf);
+  typedef int (*__lxstat_func)(int ver, const char* pathname, struct stat* buf);
   typedef int (*access_func)(const char *pathname, int mode);
   typedef int (*scandir_func)(const char *, struct dirent ***, filter_func,
                               compare_func);
@@ -200,6 +203,9 @@ class test_system {
   typedef int (*glob_func)(const char *pattern, int flags,
                            int (*errfunc)(const char *epath, int eerrno),
                            glob_t *pglob);
+
+  typedef int (*stat_func)(const char* str, struct stat* buf);
+  typedef int (*lstat_func)(const char* str, struct stat* buf);
 
   open_func open_;
   open_func open_create_;
@@ -212,12 +218,14 @@ class test_system {
   opendir_func opendir_;
   readlink_func readlink_;
   __xstat_func xstat_;
-  __xstat_func lstat_;
+  __lxstat_func lxstat_;
   access_func access_;
   scandir_func scandir_;
   sched_setaffinity_func sched_setaffinity_;
   glob_func glob_;
   realpath_func realpath_;
+  stat_func stat_;
+  lstat_func lstat_;
 
   bool hijack_sched_setaffinity_;
   int hijack_sched_setaffinity_return_val_;


### PR DESCRIPTION
gcc 11 fails to invoke mock stat() and lstat() functions.
add stat() and lstat() function to opae mock

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>