### PR TITLE
pybind11: honor OPAE_PRESERVE_REPOS

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -37,6 +37,7 @@ if(OPAE_WITH_PYBIND11)
     opae_external_project_add(PROJECT_NAME pybind11
                               GIT_URL https://github.com/pybind/pybind11.git
                               GIT_TAG "${PYBIND11_TAG}"
+                              PRESERVE_REPOS ${OPAE_PRESERVE_REPOS}
     )
 
 endif(OPAE_WITH_PYBIND11)


### PR DESCRIPTION
The PRESERVE_REPOS option for opae_external_project_add was not
specifying that OPAE_PRESERVE_REPOS be honored. This was resulting
in a weird error caused by double-cloning of pybind11 when trying
to create RPMs.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>