### PR TITLE
(cherry-pick) opaevfio.py: catch write to new_id exception (#2475)

### DIFF
--- a/python/opae.admin/opae/admin/tools/opaevfio.py
+++ b/python/opae.admin/opae/admin/tools/opaevfio.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright(c) 2020, Intel Corporation
+# Copyright(c) 2020-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -28,6 +28,7 @@
 """ Bind/Unbind a PCIe device to/from vfio-pci. """
 
 import argparse
+import errno
 import grp
 import os
 import pwd
@@ -36,7 +37,7 @@ import subprocess
 import sys
 import time
 
-OPAEVFIO_VERSION = '1.0.0'
+OPAEVFIO_VERSION = '1.0.1'
 
 ABBREV_PCI_ADDR_PATTERN = r'([\da-fA-F]{2}):' \
                           r'([\da-fA-F]{2})\.' \
@@ -137,8 +138,12 @@ def bind_driver(driver, addr):
     """
     bind = '/sys/bus/pci/drivers/{}/bind'.format(driver)
     if os.path.exists(bind):
-        with open(bind, 'w') as outf:
-            outf.write(addr)
+        try:
+            with open(bind, 'w') as outf:
+                outf.write(addr)
+        except OSError:
+            return False
+    return True
 
 
 def load_driver(driver, *args):
@@ -183,8 +188,13 @@ def initialize_vfio(addr, new_owner, enable_sriov):
 
     print('Binding {} to vfio-pci'.format(msg))
     new_id = '/sys/bus/pci/drivers/vfio-pci/new_id'
-    with open(new_id, 'w') as outf:
-        outf.write('{} {}'.format(vid_did[0], vid_did[1]))
+    try:
+        with open(new_id, 'w') as outf:
+            outf.write('{} {}'.format(vid_did[0], vid_did[1]))
+    except OSError as exc:
+        if exc.errno != errno.EEXIST:
+            print(exc)
+            return
 
     time.sleep(0.25)
 
@@ -233,8 +243,8 @@ def release_vfio(addr, new_driver):
     print('Releasing {} from vfio-pci'.format(msg))
     unbind_driver(driver, addr)
 
-    print('Rebinding {} to {}'.format(msg, new_driver))
-    bind_driver(new_driver, addr)
+    if new_driver and bind_driver(new_driver, addr):
+        print('Rebinding {} to {}'.format(msg, new_driver))
 
 
 def main():


### PR DESCRIPTION
Catch any OSError exception that occurs when attempting to write
the new_id sysfs node. Print the exception and exit if it is not EEXIST,
else continue.

Catch exception generated when writing to drivers/dfl-pci/bind. If
the driver enumeration does not claim the device, this will result in
an OSError exception.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>