### PR TITLE
opae.io: add 32 bit support

### DIFF
--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -164,7 +164,16 @@ def vfio_init(pci_addr, new_owner=''):
         if exc.errno != errno.EEXIST:
             return
 
-    time.sleep(0.25)
+    time.sleep(0.50)
+
+    try:
+        bind_driver('vfio-pci', pci_addr)
+    except OSError as exc:
+        if exc.errno != errno.EBUSY:
+            print(exc)
+            return
+
+    time.sleep(0.50)
 
     iommu_group = os.path.join('/sys/bus/pci/devices',
                                pci_addr,


### PR DESCRIPTION
* Add 32-bit register support by modifying opae_register class
  * Change the `define` class member to take a width parameter
  * Create a width attribute in the dynamicaly created type
  * Use the `width` attribute in the constructor of the register class
    to determine which read/write method to use for reading/writing from
    the region.
* Made several spacing fixes to fix Python code style
* Changed the __str__ method to use format string (f'')