### PR TITLE
(cherry pick) opaevfio, opae.io: explicitly bind to vfio-pci (#2485)

### DIFF
--- a/tools/extra/opae.io/opae/io/utils.py
+++ b/tools/extra/opae.io/opae/io/utils.py
@@ -153,7 +153,16 @@ def vfio_init(pci_addr, new_owner=''):
         if exc.errno != errno.EEXIST:
             return
 
-    time.sleep(0.25)
+    time.sleep(0.50)
+
+    try:
+        bind_driver('vfio-pci', pci_addr)
+    except OSError as exc:
+        if exc.errno != errno.EBUSY:
+            print(exc)
+            return
+
+    time.sleep(0.50)
 
     iommu_group = os.path.join('/sys/bus/pci/devices',
                                pci_addr,


### PR DESCRIPTION
On recent kernels, eg >= 5.15, writing to new_id on the first attempt
after creating the VFs successfully binds the VF to vfio-pci. However,
after the VF is released, trying to bind it again without an explicit
write to vfio-pci's bind sysfs node fails. Handle EBUSY in the case
that the driver bind is attempted after the first write to new_id.
On subsequent writes to new_id, explicit binding is required.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>