### PR TITLE
packaging: add missing packages to Fedora RPM

### DIFF
--- a/libraries/pyopae/CMakeLists.txt
+++ b/libraries/pyopae/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2018-2020, Intel Corporation
+## Copyright(c) 2018-2022, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -87,7 +87,7 @@ add_custom_command(TARGET _opae
     COMMENT "Copying Python test files")
 
 if (OPAE_BUILD_PYTHON_DIST)
-    set(SETUP_INCLUDE_DIRS "${OPAE_INCLUDE_DIR}:${PYBIND_INCLUDE_DIR}")
+    set(SETUP_INCLUDE_DIRS "${OPAE_INCLUDE_PATH}:${PYBIND_INCLUDE_DIR}")
 
     set(PYFILES
         setup.py
@@ -110,7 +110,7 @@ if (OPAE_BUILD_PYTHON_DIST)
     add_custom_target(pyopae-dist
         COMMAND ${PYTHON_EXECUTABLE} setup.py sdist
         COMMAND ${PYTHON_EXECUTABLE} setup.py build_ext
-        --include-dirs=${OPAE_INCLUDE_DIR}
+	--include-dirs=${OPAE_INCLUDE_PATH}
         --library-dirs=${LIBRARY_OUTPUT_PATH}
         COMMAND ${PYTHON_EXECUTABLE} setup.py bdist_wheel
         DEPENDS ${PYFILES} ${PYOPAE_SRC}

--- a/libraries/pyopae/setup.py
+++ b/libraries/pyopae/setup.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2018, Intel Corporation
+# Copyright(c) 2018-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -70,12 +70,12 @@ extensions = [
               extra_link_args=["-std=c++11"],
               include_dirs=[
                   "@CMAKE_INSTALL_PREFIX@/include",
-                  os.environ.get("OPAE_INCLUDE_DIR", ""),
+                  "@OPAE_INCLUDE_PATH@",
                   pybind_include_dirs(),
                   pybind_include_dirs(True)
               ],
               libraries=["opae-c", "opae-cxx-core", "uuid"],
-              library_dirs=[os.environ.get("OPAE_LIBRARY_DIR", ""),
+              library_dirs=["@LIBRARY_OUTPUT_PATH@",
                             "@CMAKE_INSTALL_PREFIX@/lib",
                             "@CMAKE_INSTALL_PREFIX@/lib64"])
 ]

--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -34,6 +34,7 @@ BuildRequires:  python3-jsonschema
 BuildRequires:  python3-pip
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-pyyaml
+BuildRequires:  python3-pybind11
 BuildRequires:  rpm-build
 BuildRequires:  systemd-devel
 BuildRequires:  tbb-devel
@@ -139,15 +140,11 @@ cp samples/n5010-test/n5010-test.c %{buildroot}%{_usr}/src/opae/samples/n5010-te
 %endif
 
 prev=$PWD
-pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/python/opae.admin/
-%{__python3} setup.py install --single-version-externally-managed  --root=%{buildroot} 
+pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/binaries/opae.io
+%{__python3} setup.py install --single-version-externally-managed --root=%{buildroot}
 popd
 
-pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/python/pacsign
-%{__python3} setup.py install --single-version-externally-managed --root=%{buildroot} 
-popd
-
-pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/python/packager
+pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/binaries/hssi
 %{__python3} setup.py install --single-version-externally-managed --root=%{buildroot}
 popd
 
@@ -155,7 +152,23 @@ pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/binaries/fpgadiag
 %{__python3} setup.py install --single-version-externally-managed --root=%{buildroot}
 popd
 
-pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/binaries/opae.io
+pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/%__cmake_builddir/libraries/pyopae/stage
+%{__python3} setup.py install --single-version-externally-managed --root=%{buildroot}
+popd
+
+pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/libraries/pyopaeuio
+%{__python3} setup.py install --single-version-externally-managed --root=%{buildroot}
+popd
+
+pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/python/opae.admin
+%{__python3} setup.py install --single-version-externally-managed --root=%{buildroot}
+popd
+
+pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/python/pacsign
+%{__python3} setup.py install --single-version-externally-managed --root=%{buildroot}
+popd
+
+pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/python/packager
 %{__python3} setup.py install --single-version-externally-managed --root=%{buildroot}
 popd
 
@@ -325,6 +338,9 @@ done
 %{python3_sitearch}/opae.io*
 %{python3_sitearch}/opae/io*
 %{python3_sitearch}/pyopaeuio*
+%{python3_sitearch}/opae.fpga*
+%{python3_sitearch}/opae/fpga*
+%{python3_sitearch}/opae*
 
 %changelog
 * Mon Dec 14 2020 The OPAE Dev Team <opae@lists.01.org> - 2.0.0-2

--- a/packaging/opae/rpm/create
+++ b/packaging/opae/rpm/create
@@ -70,6 +70,7 @@ if [ "${WHICH_RPM}" = 'fedora' ]; then
   PKG_DEPS=(${PKG_DEPS[@]} \
 'python3-setuptools' \
 'python3-pyyaml' \
+'python3-pybind11' \
 'tbb-devel' \
 'hwloc-devel' \
 'pybind11-devel' \


### PR DESCRIPTION
Some of the Python projects in the tree were not being invoked
(the "setup.py install" was not being done), notably the OPAE
Python bindings. This change ensures that each of the projects'
setup.py's are being called and packaged.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>