### PR TITLE
packaging: create opae-extra-tools RPM for Fedora

### DIFF
--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -71,6 +71,13 @@ Requires:   openssl-devel
 OPAE headers, tools, sample source, and documentation
 
 
+%package extra-tools
+Summary:    Additional OPAE tools
+
+%description extra-tools
+Additional OPAE tools
+
+
 %{?python_disable_dependency_generator}
 # Workaround a problem with pybind11 *.so not having build-id's
 %undefine _missing_build_ids_terminate_build
@@ -251,17 +258,16 @@ done
 %{_usr}/src/opae/samples/object_api/object_api.c
 %{_usr}/src/opae/samples/n5010-test/n5010-test.c
 %{_usr}/src/opae/samples/n5010-ctl/n5010-ctl.c
-%{_usr}/src/opae/cmake/*
 %{_usr}/src/opae/cmake/modules/*
 %{_usr}/src/opae/argsfilter/argsfilter.c
 %{_usr}/src/opae/argsfilter/argsfilter.h
 
+%{_libdir}/libfpgad-api.so
 %{_libdir}/libopae-c++-nlb.so
 %{_libdir}/libopae-cxx-core.so
 %{_libdir}/libopae-c++-utils.so
 %{_libdir}/libopae-c.so
 %{_libdir}/libbitstream.so
-%{_libdir}/libfpgad-api.so
 %{_libdir}/libmml-stream.so
 %{_libdir}/libmml-srv.so
 %{_libdir}/libofs.so
@@ -269,25 +275,7 @@ done
 %{_libdir}/libopaemem.so
 %{_libdir}/libopaeuio.so
 %{_libdir}/libopaevfio.so
-%{_bindir}/bist_app
-%{_bindir}/dummy_afu
-%{_bindir}/bist_app.py
-%{_bindir}/bist_common.py
-%{_bindir}/bist_dma.py
-%{_bindir}/bist_def.py
-%{_bindir}/bist_nlb3.py
-%{_bindir}/bist_nlb0.py
-%{_bindir}/fpgabist
-%{_bindir}/nlb0
-%{_bindir}/nlb3
-%{_bindir}/nlb7
-%{_bindir}/fecmode
-%{_bindir}/fpgamac
-%{_bindir}/fvlbypass
-%{_bindir}/mactest
-%{_bindir}/fpgadiag
-%{_bindir}/fpgalpbk
-%{_bindir}/fpgastats
+
 %{_bindir}/bitstreaminfo
 %{_bindir}/fpgaflash
 %{_bindir}/fpgaotsu
@@ -302,12 +290,9 @@ done
 %{_bindir}/afu_json_mgr
 %{_bindir}/packager
 %{_bindir}/fpgametrics
-%{_bindir}/fpga_dma_N3000_test
-%{_bindir}/fpga_dma_test
 %{_bindir}/n5010-test
 %{_bindir}/n5010-ctl
 %{_bindir}/PACSign
-%{_bindir}/host_exerciser
 %{_bindir}/opaevfio
 %{_bindir}/opaevfiotest
 %{_bindir}/regmap-debugfs
@@ -315,17 +300,17 @@ done
 %{_bindir}/afu_platform_config
 %{_bindir}/afu_platform_info
 %{_bindir}/afu_synth_setup
-%{_bindir}/bist
-%{_bindir}/hps
-%{_bindir}/hssi
 %{_bindir}/hssiloopback
 %{_bindir}/hssimac
 %{_bindir}/hssistats
-%{_bindir}/opae.io
 %{_bindir}/opaeuiotest
 %{_bindir}/pac_hssi_config.py
 %{_bindir}/rtl_src_config
+%{_bindir}/nlb0
+%{_bindir}/nlb3
+%{_bindir}/nlb7
 %{_bindir}/vabtool
+
 
 %{_usr}/share/opae/*
 %{python3_sitelib}/ethernet*
@@ -333,14 +318,41 @@ done
 %{python3_sitelib}/pacsign*
 %{python3_sitelib}/packager*
 %{python3_sitearch}/libvfio*
+
+%{python3_sitearch}/opae.fpga*
+%{python3_sitearch}/opae/fpga*
+%{python3_sitearch}/opae*
+
+%files extra-tools
+%{_bindir}/bist_app
+%{_bindir}/dummy_afu
+%{_bindir}/bist_app.py
+%{_bindir}/bist_common.py
+%{_bindir}/bist_dma.py
+%{_bindir}/bist_def.py
+%{_bindir}/bist_nlb3.py
+%{_bindir}/bist_nlb0.py
+%{_bindir}/fpgabist
+%{_bindir}/fecmode
+%{_bindir}/fpgamac
+%{_bindir}/fvlbypass
+%{_bindir}/mactest
+%{_bindir}/fpgadiag
+%{_bindir}/fpgalpbk
+%{_bindir}/fpgastats
+%{_bindir}/fpga_dma_N3000_test
+%{_bindir}/fpga_dma_test
+%{_bindir}/host_exerciser
+%{_bindir}/bist
+%{_bindir}/hps
+%{_bindir}/hssi
+%{_bindir}/opae.io
+
 %{python3_sitearch}/opae.diag*
 %{python3_sitearch}/opae/diag*
 %{python3_sitearch}/opae.io*
 %{python3_sitearch}/opae/io*
 %{python3_sitearch}/pyopaeuio*
-%{python3_sitearch}/opae.fpga*
-%{python3_sitearch}/opae/fpga*
-%{python3_sitearch}/opae*
 
 %changelog
 * Mon Dec 14 2020 The OPAE Dev Team <opae@lists.01.org> - 2.0.0-2

--- a/opae.spec.rhel
+++ b/opae.spec.rhel
@@ -208,6 +208,7 @@ done
 
 %post
 %systemd_post fpgad.service
+/sbin/ldconfig
 
 %preun
 %systemd_preun fpgad.service
@@ -219,13 +220,16 @@ done
 %{_includedir}/opae/cxx/core.h
 %{_includedir}/opae/cxx/core/*.h
 %dir %{_usr}/src/opae
-%{_usr}/src/opae/samples/afu-test/afu_test.cpp
-%{_usr}/src/opae/samples/afu-test/afu_test.h
 %{_usr}/src/opae/samples/hello_fpga/hello_fpga.c
 %{_usr}/src/opae/samples/hello_events/hello_events.c
 %{_usr}/src/opae/samples/object_api/object_api.c
 %{_usr}/src/opae/samples/n5010-test/n5010-test.c
 %{_usr}/src/opae/samples/n5010-ctl/n5010-ctl.c
+%{_usr}/src/opae/cmake/modules/*
+%{_usr}/src/opae/argsfilter/argsfilter.c
+%{_usr}/src/opae/argsfilter/argsfilter.h
+%{_usr}/src/opae/samples/afu-test/afu_test.cpp
+%{_usr}/src/opae/samples/afu-test/afu_test.h
 %{_usr}/src/opae/samples/dummy_afu/ddr.h
 %{_usr}/src/opae/samples/dummy_afu/dummy_afu.cpp
 %{_usr}/src/opae/samples/dummy_afu/dummy_afu.h
@@ -256,10 +260,6 @@ done
 %{_usr}/src/opae/samples/opae.io/scripts/nlb_walk.py
 %{_usr}/src/opae/samples/opae.io/scripts/port.py
 %{_usr}/src/opae/samples/opae.io/scripts/walk.py
-%{_usr}/src/opae/cmake/*
-%{_usr}/src/opae/cmake/modules/*
-%{_usr}/src/opae/argsfilter/argsfilter.c
-%{_usr}/src/opae/argsfilter/argsfilter.h
 
 %{_libdir}/libfpgad-api.so
 %{_libdir}/libopae-c++-nlb.so
@@ -274,6 +274,7 @@ done
 %{_libdir}/libopaemem.so
 %{_libdir}/libopaeuio.so
 %{_libdir}/libopaevfio.so
+
 %{_bindir}/bitstreaminfo
 %{_bindir}/fpgaflash
 %{_bindir}/fpgaotsu


### PR DESCRIPTION
Keep the opae.rpm and opae-devel.rpm contents the same between
RHEL and Fedora. Place additional collateral that is not
available in RHEL into a new 3rd Fedora RPM opae-extra-tools.rpm.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>