### PR TITLE
opae.admin: handle DPC and AER capabilities

### DIFF
--- a/doc/src/fpga_tools/rsu/rsu.md
+++ b/doc/src/fpga_tools/rsu/rsu.md
@@ -49,6 +49,9 @@ show this help message and exit
 `-d, --debug`
 log debug statements
 
+`--force`
+force rsu operation
+
 ## EXAMPLE ##
 
 ```console
@@ -71,6 +74,18 @@ log debug statements
 
  Triggers a reconfiguration of the FPGA (user2 page) for the
  device with PCIe address 25:00.0.
+
+```console
+# rsu --force fpga --page=user2 25:00.0
+```
+
+ Forces a reconfiguration of the FPGA (user2 page) for the
+ device with PCIe address 25:00.0. Default behavior is to not perform
+ the rsu operation if DPC (downstream port containment) is not supported
+ and AER (advanced error reporting) is also not supported. Using --force
+ changes this behavior to perform rsu operation regardless but may result
+ in a surprise removal of pci devices which may cause the Linux kernel
+ to panic.
 
 ```console
 # rsu fpga --page=factory 25:00.0

--- a/python/opae.admin/opae/admin/sysfs.py
+++ b/python/opae.admin/opae/admin/sysfs.py
@@ -30,7 +30,7 @@ import os
 import re
 from contextlib import contextmanager
 from pathlib import Path
-from subprocess import CalledProcessError
+from subprocess import CalledProcessError, check_call
 from opae.admin.path import sysfs_path
 from opae.admin.utils.process import call_process, DRY_RUN
 from opae.admin.utils.log import loggable, LOG
@@ -568,6 +568,14 @@ class pci_node(sysfs_node):
             True if this pci_node supports SR-IOV functions.
         """
         return bool(self.sriov_totalvfs)
+
+    def supports_ecap(self, cap):
+        ecap = cap.upper()
+        if ecap in ['AER', 'DPC']:
+            cmd = ['/usr/sbin/setpci',
+                   '-s', self.pci_address, f'ECAP_{ecap}.L']
+            return check_call(cmd) == 0
+        raise NameError(f'{ecap} not a known or supported extended capability')
 
 
 class sysfs_driver(sysfs_node):

--- a/python/opae.admin/opae/admin/tools/rsu.py
+++ b/python/opae.admin/opae/admin/tools/rsu.py
@@ -149,24 +149,24 @@ def set_fpga_default(device, args):
         raise IOError
 
 
-def device_rsu(device, available_image):
+def device_rsu(device, available_image, **kwargs):
     device.safe_rsu_boot(available_image)
 
 
 def device_rsu_bmc(device, args):
-    device_rsu(device, 'bmc_' + args.page)
+    device_rsu(device, 'bmc_' + args.page, force=args.force)
 
 
 def device_rsu_retimer(device, args):
-    device_rsu(device, 'retimer_fw')
+    device_rsu(device, 'retimer_fw', force=args.force)
 
 
 def device_rsu_fpga(device, args):
-    device_rsu(device, 'fpga_' + args.page)
+    device_rsu(device, 'fpga_' + args.page, force=args.force)
 
 
 def device_rsu_sdm(device, args):
-    device_rsu(device, 'sdm')
+    device_rsu(device, 'sdm', force=args.force)
 
 
 def parse_args():
@@ -175,6 +175,8 @@ def parse_args():
                                      formatter_class=fc_)
     parser.add_argument('-d', '--debug', action='store_true',
                         help='log debug statements')
+    parser.add_argument('--force', action='store_true', default=False,
+                        help='perform operation without disabling AER')
 
     subparser = parser.add_subparsers(dest='which')
 


### PR DESCRIPTION
* add `supports_ecap` method to pci_node class
  * currently hard coded to support DPC and AER
  * uses setpci to read the base register given by extended capability
    (ECAP). If non-zero is returned then the pci device does not support
    the given capability.
* refactor `safe_rsu_boot` to check for support of DPC and AER prior to
  performing the actual rsu routine.
  * Move the rsu routine (with removing, rescanning, etc.) to
    `rsu_routine` method.
  * If DPC is supported (or if `force` is True in the **kwargs) then
    perform the rsu routine
  * If AER is supported then disable AER using the context manager
    `disable_aer`
* modiufy rsu.py to add a '--force' CLI argument and use this in the
  subparser functions when calling `device_rsu`
* Update rsu.md doc to call out --force CLI argument and explain how it
  changes behavior of tool.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>