### PR TITLE
(cherry-pick) packaging: add ASE to packaging/opae/rpm/create (#2501)

### DIFF
--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -64,6 +64,7 @@ the OPAE software stack.
 
 %package devel
 Summary:    OPAE headers, sample source, and documentation
+Requires:   opae
 Requires:   libuuid-devel, %{name}%{?_isa} = %{version}-%{release}
 Requires:   openssl-devel
 
@@ -73,9 +74,18 @@ OPAE headers, tools, sample source, and documentation
 
 %package extra-tools
 Summary:    Additional OPAE tools
+Requires:   opae-devel
 
 %description extra-tools
 Additional OPAE tools
+
+
+%package ase
+Summary:    OPAE AFU Simulation Environment
+Requires:   opae-devel
+
+%description ase
+OPAE AFU Simulation Environment
 
 
 %{?python_disable_dependency_generator}
@@ -90,7 +100,10 @@ Additional OPAE tools
 %cmake -DCMAKE_INSTALL_PREFIX=/usr \
        -DOPAE_PRESERVE_REPOS=ON \
        -DOPAE_BUILD_PYTHON_DIST=ON \
-       -DOPAE_BUILD_FPGABIST=ON .
+       -DOPAE_BUILD_FPGABIST=ON \
+       -DOPAE_BUILD_SIM=ON \
+       -DOPAE_SIM_TAG=@OPAE_SIM_TAG@ \
+       .
 %if 0%{?rhel}
   %make_build
 %else
@@ -134,11 +147,14 @@ mkdir -p %{buildroot}%{_usr}/src/opae/samples/hello_events/
 mkdir -p %{buildroot}%{_usr}/src/opae/samples/object_api/
 mkdir -p %{buildroot}%{_usr}/src/opae/samples/n5010-test/
 
-
 cp samples/hello_fpga/hello_fpga.c %{buildroot}%{_usr}/src/opae/samples/hello_fpga/
 cp samples/hello_events/hello_events.c %{buildroot}%{_usr}/src/opae/samples/hello_events/
 cp samples/object_api/object_api.c %{buildroot}%{_usr}/src/opae/samples/object_api/
 cp samples/n5010-test/n5010-test.c %{buildroot}%{_usr}/src/opae/samples/n5010-test/
+
+mkdir -p %{buildroot}%{_usr}/share/opae/ase
+cp external/opae-sim/LICENSE %{buildroot}%{_usr}/share/opae/ase
+
 
 %if 0%{?rhel}
   %make_install
@@ -354,6 +370,28 @@ done
 %{python3_sitearch}/opae.io*
 %{python3_sitearch}/opae/io*
 %{python3_sitearch}/pyopaeuio*
+
+
+%files ase
+%dir %{_usr}/share/opae/ase
+%license %{_usr}/share/opae/ase/LICENSE
+%{_usr}/share/opae/ase/rtl/*
+%{_usr}/share/opae/ase/sw/*
+%{_usr}/share/opae/ase/scripts/*
+%{_usr}/share/opae/ase/Makefile
+%{_usr}/share/opae/ase/ase.cfg
+%{_usr}/share/opae/ase/ase_regress.sh
+%{_usr}/share/opae/ase/opae_ase.cfg
+
+%{_bindir}/afu_sim_setup
+%{_bindir}/with_ase
+
+%{_libdir}/libopae-c-ase.so.*
+%{_libdir}/libase.so.*
+
+%{_libdir}/libopae-c-ase.so
+%{_libdir}/libase.so
+
 
 %changelog
 * Mon Dec 14 2020 The OPAE Dev Team <opae@lists.01.org> - 2.0.0-2

--- a/opae.spec.rhel
+++ b/opae.spec.rhel
@@ -52,11 +52,20 @@ the OPAE software stack.
 
 %package devel
 Summary:    OPAE headers, sample source, and documentation
+Requires:   opae
 Requires:   libuuid-devel, %{name}%{?_isa} = %{version}-%{release}
 Requires:   openssl-devel
 
 %description devel
 OPAE headers, tools, sample source, and documentation
+
+
+%package ase
+Summary:    OPAE AFU Simulation Environment
+Requires:   opae-devel
+
+%description ase
+OPAE AFU Simulation Environment
 
 
 %{?python_disable_dependency_generator}
@@ -68,7 +77,10 @@ OPAE headers, tools, sample source, and documentation
 %setup -q -n %{name}-%{version}-%{opae_release}
 
 %build
-%cmake -DOPAE_MINIMAL_BUILD=ON .
+%cmake -DOPAE_MINIMAL_BUILD=ON \
+       -DOPAE_BUILD_SIM=ON \
+       -DOPAE_SIM_TAG=@OPAE_SIM_TAG@ \
+       .
 %if 0%{?rhel}
   %make_build
 %else
@@ -130,6 +142,10 @@ cp binaries/opae.io/*.{cpp,h,py} %{buildroot}%{_usr}/src/opae/samples/opae.io/
 cp binaries/opae.io/opae/*.py %{buildroot}%{_usr}/src/opae/samples/opae.io/opae
 cp binaries/opae.io/opae/io/*.py %{buildroot}%{_usr}/src/opae/samples/opae.io/opae/io
 cp binaries/opae.io/scripts/*.py %{buildroot}%{_usr}/src/opae/samples/opae.io/scripts
+
+mkdir -p %{buildroot}%{_usr}/share/opae/ase
+cp external/opae-sim/LICENSE %{buildroot}%{_usr}/share/opae/ase
+
 
 %if 0%{?rhel}
   %make_install
@@ -315,6 +331,28 @@ done
 %{python3_sitelib}/hssi_ethernet*
 %{python3_sitelib}/pacsign*
 %{python3_sitelib}/packager*
+
+
+%files ase
+%dir %{_usr}/share/opae/ase
+%license %{_usr}/share/opae/ase/LICENSE
+%{_usr}/share/opae/ase/rtl/*
+%{_usr}/share/opae/ase/sw/*
+%{_usr}/share/opae/ase/scripts/*
+%{_usr}/share/opae/ase/Makefile
+%{_usr}/share/opae/ase/ase.cfg
+%{_usr}/share/opae/ase/ase_regress.sh
+%{_usr}/share/opae/ase/opae_ase.cfg
+
+%{_bindir}/afu_sim_setup
+%{_bindir}/with_ase
+
+%{_libdir}/libopae-c-ase.so.*
+%{_libdir}/libase.so.*
+
+%{_libdir}/libopae-c-ase.so
+%{_libdir}/libase.so
+
 
 %changelog
 * Mon Dec 14 2020 The OPAE Dev Team <opae@lists.01.org> - 2.0.0-2

--- a/packaging/opae/rpm/create
+++ b/packaging/opae/rpm/create
@@ -32,6 +32,8 @@ source "${SCRIPT_DIR}/../version"
 RPMBUILD_DIR="${SCRIPT_DIR}/rpmbuild"
 SDK_DIR="$(cd "${SCRIPT_DIR}/../../../" && pwd)"
 
+let ${OPAE_SIM_TAG:=master}
+
 declare WHICH_RPM=''
 
 if [ $# -lt 1 -o \( "$1" != 'rhel' -a "$1" != 'fedora' \) ]; then
@@ -96,12 +98,16 @@ mkdir ${CMAKE_BUILD_DIR}
 
 if [ "${WHICH_RPM}" = 'rhel' ]; then
 cmake -S ${SDK_DIR} -B ${CMAKE_BUILD_DIR} \
-  -DOPAE_MINIMAL_BUILD=ON
+  -DOPAE_MINIMAL_BUILD=ON \
+  -DOPAE_BUILD_SIM=ON \
+  -DOPAE_SIM_TAG=${OPAE_SIM_TAG}
 else
 cmake -S ${SDK_DIR} -B ${CMAKE_BUILD_DIR} \
   -DOPAE_PRESERVE_REPOS=ON \
   -DOPAE_BUILD_PYTHON_DIST=ON \
-  -DOPAE_BUILD_FPGABIST=ON
+  -DOPAE_BUILD_FPGABIST=ON \
+  -DOPAE_BUILD_SIM=ON \
+  -DOPAE_SIM_TAG=${OPAE_SIM_TAG}
 fi
 
 # Create source tarball.
@@ -127,7 +133,9 @@ mv ${SDK_DIR}/../opae-${PROJECT_VERSION}-${PROJECT_RELEASE}.tar.gz .
 cp opae-${PROJECT_VERSION}-${PROJECT_RELEASE}.tar.gz "${RPMBUILD_DIR}/SOURCES"
 
 cat "${SDK_DIR}/${RPM_SPEC}" | \
-  sed -e "s/@VERSION@/${PROJECT_VERSION}/" -e "s/@RELEASE@/${PROJECT_RELEASE}/" \
+  sed -e "s/@VERSION@/${PROJECT_VERSION}/" \
+      -e "s/@RELEASE@/${PROJECT_RELEASE}/" \
+      -e "s/@OPAE_SIM_TAG@/${OPAE_SIM_TAG}/" \
   > "${RPMBUILD_DIR}/SPECS/opae.spec"
 
 # Create RPMS.


### PR DESCRIPTION
Create new opae-ase.rpm, following the packaging method from
the cmake-based RPM creation.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>