### PR TITLE
opae-sdk: add SR/PR SDM key hash and cancel  to  fpgainfo security

### DIFF
--- a/libraries/libboard/board_n6000/board_n6000.c
+++ b/libraries/libboard/board_n6000/board_n6000.c
@@ -64,7 +64,11 @@
 #define DFL_SEC_PR_ROOT           DFL_SEC_PMCI_GLOB "pr_root_entry_hash"
 #define DFL_SEC_SR_CANCEL         DFL_SEC_PMCI_GLOB "sr_canceled_csks"
 #define DFL_SEC_SR_ROOT           DFL_SEC_PMCI_GLOB "sr_root_entry_hash"
-#define DFL_SEC_SDM_STATUS        DFL_SEC_PMCI_GLOB "sdm_sr_provision_status"
+#define DFL_SEC_PR_SDM_CANCEL     DFL_SEC_PMCI_GLOB "pr_sdm_canceled_csks"
+#define DFL_SEC_PR_SDM_ROOT       DFL_SEC_PMCI_GLOB "pr_sdm_root_entry_hash"
+#define DFL_SEC_SR_SDM_CANCEL     DFL_SEC_PMCI_GLOB "sr_sdm_canceled_csks"
+#define DFL_SEC_SR_SDM_ROOT       DFL_SEC_PMCI_GLOB "sr_sdm_root_entry_hash"
+
 
 #define HSSI_FEATURE_ID                  0x15
 #define HSSI_100G_PROFILE                       27
@@ -762,13 +766,45 @@ fpga_result print_sec_info(fpga_token token)
 		resval = res;
 	}
 
-	res = read_sysfs(token, DFL_SEC_SDM_STATUS, name,
+	// PR SDM Keys
+	res = read_sysfs(token, DFL_SEC_PR_SDM_CANCEL, name,
 		SYSFS_PATH_MAX - 1);
 	if (res == FPGA_OK) {
-		printf("%-32s : %s\n", "SDM provisioning status", name);
+		printf("%-32s : %s\n", "PR SDM CSK IDs canceled", name);
 	} else {
-		OPAE_MSG("Failed to SDM provisioning status");
-		printf("%-32s : %s\n", "SDM provisioning status", "None");
+		OPAE_MSG("Failed to PR SDM CSK IDs canceled");
+		printf("%-32s : %s\n", "PR SDM CSK IDs canceled", "None");
+		resval = res;
+	}
+
+	res = read_sysfs(token, DFL_SEC_PR_SDM_ROOT, name,
+		SYSFS_PATH_MAX - 1);
+	if (res == FPGA_OK) {
+		printf("%-32s : %s\n", "PR SDM root entry hash", name);
+	} else {
+		OPAE_MSG("Failed to PR SDM root entry hash");
+		printf("%-32s : %s\n", "PR SDM root entry hash", "None");
+		resval = res;
+	}
+
+	// SR SDM Keys
+	res = read_sysfs(token, DFL_SEC_SR_SDM_CANCEL, name,
+		SYSFS_PATH_MAX - 1);
+	if (res == FPGA_OK) {
+		printf("%-32s : %s\n", "SR SDM CSK IDs canceled", name);
+	} else {
+		OPAE_MSG("Failed to SR SDM CSK IDs canceled");
+		printf("%-32s : %s\n", "SR SDM CSK IDs canceled", "None");
+		resval = res;
+	}
+
+	res = read_sysfs(token, DFL_SEC_SR_SDM_ROOT, name,
+		SYSFS_PATH_MAX - 1);
+	if (res == FPGA_OK) {
+		printf("%-32s : %s\n", "SR SDM root entry hash", name);
+	} else {
+		OPAE_MSG("Failed to SR SDM root entry hash");
+		printf("%-32s : %s\n", "SR SDM root entry hash", "None");
 		resval = res;
 	}
 


### PR DESCRIPTION
add  “SR SDM CSK IDs canceled”,  “SR SDM root entry hash”,  “PR SDM CSK IDs canceled”,  “PR SDM root entry hash”,
Remove “ SR SDM provision status”

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>