### PR TITLE
opae.admin: (cherry-pcik)add error checking to supports_ecap (#2499)

### DIFF
--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -590,8 +590,12 @@ class fpga_base(sysfs_device):
     def safe_rsu_boot(self, available_image, **kwargs):
         root_port = self.pci_node.root
         force = kwargs.pop('force', False)
-        if root_port.supports_ecap('dpc') or force:
-            self.log.debug('ECAP_DPC supported')
+        supports_dpc = root_port.supports_ecap('dpc')
+        if supports_dpc or force:
+            if supports_dpc:
+                self.log.debug('ECAP_DPC supported')
+            elif force:
+                self.log.warn('forcing rsu routine')
             self.rsu_routine(available_image, **kwargs)
         else:
             if root_port.supports_ecap('aer'):
@@ -599,7 +603,9 @@ class fpga_base(sysfs_device):
                 with self.disable_aer(root_port):
                     self.rsu_routine(available_image, **kwargs)
             else:
-                self.log.error('ECAP_DPC and ECAP_AER not supported')
+                msg = 'ECAP_AER and ECAP_DPC not supported'
+                self.log.error(msg)
+                raise IOError(msg)
 
     def rsu_routine(self, available_image, **kwargs):
         wait_time = kwargs.pop('wait', 10)

--- a/python/opae.admin/opae/admin/sysfs.py
+++ b/python/opae.admin/opae/admin/sysfs.py
@@ -574,7 +574,11 @@ class pci_node(sysfs_node):
         if ecap in ['AER', 'DPC']:
             cmd = ['/usr/sbin/setpci',
                    '-s', self.pci_address, f'ECAP_{ecap}.L']
-            return check_call(cmd) == 0
+            try:
+                return check_call(cmd) == 0
+            except CalledProcessError as err:
+                self.log.debug(f'{cmd} resulted in error: {err}')
+                return False
         raise NameError(f'{ecap} not a known or supported extended capability')
 
 

--- a/python/opae.admin/opae/admin/tools/rsu.py
+++ b/python/opae.admin/opae/admin/tools/rsu.py
@@ -150,7 +150,7 @@ def set_fpga_default(device, args):
 
 
 def device_rsu(device, available_image, **kwargs):
-    device.safe_rsu_boot(available_image)
+    device.safe_rsu_boot(available_image, **kwargs)
 
 
 def device_rsu_bmc(device, args):
@@ -275,8 +275,8 @@ def main():
                 fcntl.flock(flock.fileno(), fcntl.LOCK_EX)
                 try:
                     args.func(device, args)
-                except IOError:
-                    logging.error('RSU operation failed')
+                except IOError as err:
+                    logging.error(f'RSU operation failed: {err}')
                 else:
                     exit_code = os.EX_OK
                     logging.info('RSU operation complete')


### PR DESCRIPTION
* opae.admin: add error checking to supports_ecap

Put the call to the subprocess in a try/except block and return False if
it fails.

`device_rsu` wasn't passing the **kwargs to `safe_rsu_boot` which meant
that --force was not being honored. This fixes it by passing in
**kwarrgs to `safe_rsu_boot`.


improve err handling in rsu

In fpga.py:
* Add log messages for
  * debug level when DPC is suported
  * warn level when force is being used
* raise an IOError when DPC and AER aren't supported

In rsu.py:
* Catch IOError as err and use it when logging

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>