### PR TITLE
opae-sdk: fix static code analysis issue  check buffer boundaries and…

### DIFF
--- a/libraries/plugins/xfpga/usrclk/fpga_user_clk.c
+++ b/libraries/plugins/xfpga/usrclk/fpga_user_clk.c
@@ -536,7 +536,7 @@ fpga_result get_usrclk_uio(const char *sysfs_path,
 				res = FPGA_NOT_FOUND;
 				goto free;
 			}
-			strncpy(dfl_dev_str, p, end - p);
+			memcpy(dfl_dev_str, p, end - p);
 			*(dfl_dev_str + (end - p)) = '\0';
 
 			ret = opae_uio_open(uio, dfl_dev_str);


### PR DESCRIPTION
… may overflow buffer

issue: function 'strncpy' may incorrectly check buffer boundaries and may overflow buffer 'dfl_dev_str' of fixed size (256)
fix: replace 'strncpy'  with memcpy

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>