### PR TITLE
cmake: Findedit.cmake -> Findlibedit.cmake

### DIFF
--- a/binaries/opae.io/CMakeLists.txt
+++ b/binaries/opae.io/CMakeLists.txt
@@ -26,7 +26,7 @@
 
 if (PLATFORM_SUPPORTS_VFIO AND OPAE_WITH_PYBIND11 AND OPAE_WITH_LIBEDIT)
 
-    find_package(edit REQUIRED)
+    find_package(libedit REQUIRED)
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
     set(PYBIND11_CPP_STANDARD -std=c++11)

--- a/cmake/modules/Findlibedit.cmake
+++ b/cmake/modules/Findlibedit.cmake
@@ -1,5 +1,5 @@
 #!/usr/bin/cmake -P
-## Copyright(c) 2020, Intel Corporation
+## Copyright(c) 2020-2022, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:

--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -116,7 +116,7 @@ for s in \
     FindTbb.cmake \
     FindUUID.cmake \
     FindUdev.cmake \
-    Findedit.cmake \
+    Findlibedit.cmake \
     Findjson-c.cmake \
     Findspdlog.cmake \
     OFS.cmake \

--- a/opae.spec.rhel
+++ b/opae.spec.rhel
@@ -94,7 +94,7 @@ for s in \
     FindTbb.cmake \
     FindUUID.cmake \
     FindUdev.cmake \
-    Findedit.cmake \
+    Findlibedit.cmake \
     Findjson-c.cmake \
     Findspdlog.cmake \
     OFS.cmake \


### PR DESCRIPTION
Resolves the following warning:

The package name passed to `find_package_handle_standard_args` (libedit)
does not match the name of the calling package (edit).  This can lead to
problems in calling code that expects `find_package` result variables
(e.g., `_FOUND`) to follow a certain pattern.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>