### PR TITLE
cmake: fix warning in Findspdlog.cmake

### DIFF
--- a/cmake/modules/Findspdlog.cmake
+++ b/cmake/modules/Findspdlog.cmake
@@ -72,7 +72,7 @@ if(pkgcfg_lib_PC_SPDLOG_fmt)
     set(spdlog_LIBRARIES ${spdlog_LIBRARIES} ${pkgcfg_lib_PC_SPDLOG_fmt})
 endif(pkgcfg_lib_PC_SPDLOG_fmt)
 
-set(spdlog_LIBRARIES ${spdlog_LIBRARIES} CACHE PATHS "Paths to spdlog libraries and dependencies")
+set(spdlog_LIBRARIES ${spdlog_LIBRARIES} CACHE STRING "Paths to spdlog libraries and dependencies")
 if(spdlog_LIBRARIES AND spdlog_INCLUDE_DIRS)
     set(spdlog_FOUND TRUE)
     set(spdlog_DEFINITIONS


### PR DESCRIPTION
CMake Warning (dev) at cmake/modules/Findspdlog.cmake:75 (set):
implicitly converting 'PATHS' to 'STRING' type.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>