### PR TITLE
opae-sdk: add  dfhv0.5 support to hssi tools

### DIFF
--- a/binaries/hssi/ethernet/hssicommon.py
+++ b/binaries/hssi/ethernet/hssicommon.py
@@ -1064,7 +1064,7 @@ class HSSICOMMON(object):
             print("{0: <24}:{1}".format("guidh", hex(guidh)))
 
             if guidl != self.hssi_csr.HSSI_DFHV05_GUILDL:
-                print("bad guidh {0}!={1}".format(hex(guidl),
+                print("bad guidl {0}!={1}".format(hex(guidl),
                                                   hex(self.hssi_csr.HSSI_DFHV05_GUILDL)))
                 return False
 

--- a/binaries/hssi/ethernet/hssicommon.py
+++ b/binaries/hssi/ethernet/hssicommon.py
@@ -1073,8 +1073,8 @@ class HSSICOMMON(object):
                                                   hex(self.hssi_csr.HSSI_DFHV05_GUILDH)))
                 return False
 
-            csr_addr = csr_addr(self.read64(0, self.hssi_csr.FEATUR_ADDR_CSR))
-            self.hssi_csr.set_csr_dfhv05_offset(csr_addr.addr)
+            hssi_csr_addr = csr_addr(self.read64(0, self.hssi_csr.FEATUR_ADDR_CSR))
+            self.hssi_csr.set_csr_dfhv05_offset(hssi_csr_addr.addr)
         else:
             print("dfh version not supported:", hex(hssi_dfh.feature_rev))
             return False

--- a/binaries/hssi/ethernet/hssiloopback.py
+++ b/binaries/hssi/ethernet/hssiloopback.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-# Copyright(c) 2021, Intel Corporation
+# Copyright(c) 2021-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -56,8 +56,8 @@ class FPGAHSSILPBK(HSSICOMMON):
         """
         self.open(self._hssi_grps[0][0])
 
-        hssi_feature_list = hssi_feature(self.read32(0, 0xC))
-        if (self._port >= HSSI_PORT_COUNT):
+        hssi_feature_list = hssi_feature(self.read32(0, self.hssi_csr.HSSI_FEATURE_LIST))
+        if (self._port >= self.hssi_csr.HSSI_PORT_COUNT):
             print("Invalid Input port number")
             self.close()
             return False
@@ -71,9 +71,9 @@ class FPGAHSSILPBK(HSSICOMMON):
 
         ctl_addr = hssi_ctl_addr(0)
         if self._loopback == 'enable':
-            ctl_addr.sal_cmd = HSSI_SALCMD.ENABLE_LOOPBACK.value
+            ctl_addr.sal_cmd = HSSI_SAL_CMD.ENABLE_LOOPBACK.value
         else:
-            ctl_addr.sal_cmd = HSSI_SALCMD.DISABLE_LOOPBACK.value
+            ctl_addr.sal_cmd = HSSI_SAL_CMD.DISABLE_LOOPBACK.value
 
         # set port number
         ctl_addr.port_address = self._port
@@ -87,11 +87,11 @@ class FPGAHSSILPBK(HSSICOMMON):
             self.close()
             return False
 
-        self.write32(0, HSSI_CSR.HSSI_CTL_ADDRESS.value, ctl_addr.value)
-        self.write32(0, HSSI_CSR.HSSI_CTL_STS.value, cmd_sts.value)
+        self.write32(0, self.hssi_csr.HSSI_CTL_ADDRESS, ctl_addr.value)
+        self.write32(0, self.hssi_csr.HSSI_CTL_STS, cmd_sts.value)
 
         if not self.read_poll_timeout(0,
-                                      HSSI_CSR.HSSI_CTL_STS.value,
+                                      self.hssi_csr.HSSI_CTL_STS,
                                       0x2):
             print("HSSI ctl sts csr fails to update ACK")
             self.close()

--- a/binaries/hssi/ethernet/hssimac.py
+++ b/binaries/hssi/ethernet/hssimac.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-# Copyright(c) 2021, Intel Corporation
+# Copyright(c) 2021-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -52,8 +52,8 @@ class FPGAHSSIMAC(HSSICOMMON):
         """
         self.open(self._hssi_grps[0][0])
 
-        hssi_feature_list = hssi_feature(self.read32(0, 0xC))
-        if self._port >= HSSI_PORT_COUNT:
+        hssi_feature_list = hssi_feature(self.read32(0, self.hssi_csr.HSSI_FEATURE_LIST))
+        if self._port >= self.hssi_csr.HSSI_PORT_COUNT:
             print("Invalid input port number")
             self.close()
             return False
@@ -67,10 +67,10 @@ class FPGAHSSIMAC(HSSICOMMON):
             return False
 
         ctl_addr = hssi_ctl_addr(0)
-        ctl_addr.sal_cmd = HSSI_SALCMD.GET_MTU.value
+        ctl_addr.sal_cmd = HSSI_SAL_CMD.GET_MTU.value
+
         # set port number
         ctl_addr.port_address = self._port
-
         res, value = self.read_reg(0, ctl_addr.value)
         if not res:
             self.close()
@@ -81,10 +81,10 @@ class FPGAHSSIMAC(HSSICOMMON):
         width = 16
         for x in range(width):
             mask |= (1 << x)
-        #HSSI Read Data CSR [15:0] Maximum Rx frame size
+        """HSSI Read Data CSR [15:0] Maximum Rx frame size"""
         print("Port{0} Maximum RX frame size:{1}".format(self._port,
                                                          value & mask))
-        #HSSI Read Data CSR [31:16] Maximum Tx frame size
+        """HSSI Read Data CSR [31:16] Maximum Tx frame size"""
         print("Port{0} Maximum TX frame size:{1}".format(self._port,
                                                          value >> width))
 


### PR DESCRIPTION
- HSSI tools support both dffv0 and dfhv0.5 versions
- HSSI CSR offset changed in dfhv0.5, HSSI tools verifies DFH version and sets offset
- Added new HSSI debug and TSE control registers.

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>