### PR TITLE
c++ bindings: add subsystem_vendor/device IDs.

### DIFF
--- a/include/opae/cxx/core/properties.h
+++ b/include/opae/cxx/core/properties.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -124,6 +124,8 @@ class properties {
   pvalue<fpga_version> bbs_version;
   pvalue<uint16_t> vendor_id;
   pvalue<uint16_t> device_id;
+  pvalue<uint16_t> subsystem_vendor_id;
+  pvalue<uint16_t> subsystem_device_id;
   pvalue<char *> model;
   pvalue<uint64_t> local_memory_size;
   pvalue<uint64_t> capabilities;

--- a/libraries/libopaecxx/src/properties.cpp
+++ b/libraries/libopaecxx/src/properties.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -51,6 +51,10 @@ properties::properties(bool alloc_props)
                   fpgaPropertiesSetBBSVersion),
       vendor_id(&props_, fpgaPropertiesGetVendorID, fpgaPropertiesSetVendorID),
       device_id(&props_, fpgaPropertiesGetDeviceID, fpgaPropertiesSetDeviceID),
+      subsystem_vendor_id(&props_, fpgaPropertiesGetSubsystemVendorID,
+                          fpgaPropertiesSetSubsystemVendorID),
+      subsystem_device_id(&props_, fpgaPropertiesGetSubsystemDeviceID,
+                          fpgaPropertiesSetSubsystemDeviceID),
       model(&props_, fpgaPropertiesGetModel, fpgaPropertiesSetModel),
       local_memory_size(&props_, fpgaPropertiesGetLocalMemorySize,
                         fpgaPropertiesSetLocalMemorySize),

--- a/tests/opae-cxx/test_properties_cxx_core.cpp
+++ b/tests/opae-cxx/test_properties_cxx_core.cpp
@@ -298,6 +298,34 @@ TEST_P(properties_cxx_core, get_interface) {
   EXPECT_EQ(static_cast<fpga_interface>(p->interface), FPGA_IFC_DFL);
 }
 
+/**
+ * @test get_subsystem_vendor_id
+ * Given a properties properties object with the subsystem_vendor_id
+ * property set to a known value
+ * When I get the subsystem_vendor_id property
+ * Then the number is the expected value.
+ */
+TEST_P(properties_cxx_core, get_subsystem_vendor_id) {
+  auto p = properties::get();
+  uint16_t v = 0x8087;
+  p->subsystem_vendor_id = v;
+  EXPECT_EQ(static_cast<uint16_t>(p->subsystem_vendor_id), v);
+}
+
+/**
+ * @test get_subsystem_device_id
+ * Given a properties properties object with the subsystem_device_id
+ * property set to a known value
+ * When I get the subsystem_device_id property
+ * Then the number is the expected value.
+ */
+TEST_P(properties_cxx_core, get_subsystem_device_id) {
+  auto p = properties::get();
+  uint16_t d = 0xa55a;
+  p->subsystem_device_id = d;
+  EXPECT_EQ(static_cast<uint16_t>(p->subsystem_device_id), d);
+}
+
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(properties_cxx_core);
 INSTANTIATE_TEST_CASE_P(properties, properties_cxx_core,
                         ::testing::ValuesIn(test_platform::keys(true)));


### PR DESCRIPTION
Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>