### PR TITLE
gtest: INSTANTIATE_TEST_CASE_P is deprecated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ endif()
 ## Sub-projects ############################################################
 ############################################################################
 
+set(GTEST_VERSION "1.11.0" CACHE STRING "googletest version in use" FORCE)
+
 # begin opae-libs
 
 set(OPAE_VERSION_LOCAL   "" CACHE STRING "OPAE local version")

--- a/cmake/modules/OPAE.cmake
+++ b/cmake/modules/OPAE.cmake
@@ -1,5 +1,5 @@
 #!/usr/bin/cmake -P
-## Copyright(c) 2020, Intel Corporation
+## Copyright(c) 2020-2022, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -57,7 +57,7 @@ include(FindUdev)
 
 include(OPAECompiler)
 if(OPAE_BUILD_TESTS)
-    find_package(GTest 1.11.0)
+    find_package(GTest ${GTEST_VERSION})
 endif(OPAE_BUILD_TESTS)
 include(OPAETest)
 include(OPAEPackaging)

--- a/cmake/modules/OPAE.cmake
+++ b/cmake/modules/OPAE.cmake
@@ -57,7 +57,7 @@ include(FindUdev)
 
 include(OPAECompiler)
 if(OPAE_BUILD_TESTS)
-    find_package(GTest 1.8.0)
+    find_package(GTest 1.11.0)
 endif(OPAE_BUILD_TESTS)
 include(OPAETest)
 include(OPAEPackaging)

--- a/cmake/modules/OPAETest.cmake
+++ b/cmake/modules/OPAETest.cmake
@@ -36,6 +36,10 @@ function(opae_load_gtest)
                               GIT_URL https://github.com/google/googletest
                               GIT_TAG release-1.11.0
                               PRESERVE_REPOS ${OPAE_PRESERVE_REPOS})
+
+    set(GTEST_INCLUDE_DIR ${gtest_ROOT}/googletest/include CACHE PATH "gtest include directory" FORCE)
+    set(GTEST_LIBRARY ${LIBRARY_OUTPUT_PATH}/libgtest.a CACHE PATH "path to gtest library" FORCE)
+    set(GTEST_MAIN_LIBRARY ${LIBRARY_OUTPUT_PATH}/libgtest_main.a CACHE PATH "path to gtest main library" FORCE)
 endfunction()
 
 function(opae_test_add)
@@ -81,7 +85,7 @@ function(opae_test_add)
 	    ${OPAE_LIB_SOURCE}/plugins/xfpga
 	    ${OPAE_LIB_SOURCE}/libopae-c
             ${opae-test_ROOT}/framework
-            ${GTEST_INCLUDE_DIRS})
+            ${GTEST_INCLUDE_DIR})
 
     if(${OPAE_TEST_ADD_TEST_FPGAD})
         target_include_directories(${OPAE_TEST_ADD_TARGET}
@@ -94,7 +98,8 @@ function(opae_test_add)
         ${OPAE_TEST_LIBRARIES}
         ${libjson-c_LIBRARIES}
         ${libuuid_LIBRARIES}
-        gtest_main
+        ${GTEST_LIBRARY}
+        ${GTEST_MAIN_LIBRARY}
         ${OPAE_TEST_ADD_LIBS})
 
     opae_coverage_build(TARGET ${OPAE_TEST_ADD_TARGET}

--- a/cmake/modules/OPAETest.cmake
+++ b/cmake/modules/OPAETest.cmake
@@ -40,6 +40,8 @@ function(opae_load_gtest)
     set(GTEST_INCLUDE_DIR ${gtest_ROOT}/googletest/include CACHE PATH "gtest include directory" FORCE)
     set(GTEST_LIBRARY ${LIBRARY_OUTPUT_PATH}/libgtest.a CACHE PATH "path to gtest library" FORCE)
     set(GTEST_MAIN_LIBRARY ${LIBRARY_OUTPUT_PATH}/libgtest_main.a CACHE PATH "path to gtest main library" FORCE)
+    set(GTEST_LIBRARY_DEBUG ${LIBRARY_OUTPUT_PATH}/libgtestd.a CACHE PATH "path to (debug) gtest library" FORCE)
+    set(GTEST_MAIN_LIBRARY_DEBUG ${LIBRARY_OUTPUT_PATH}/libgtest_maind.a CACHE PATH "path to (debug) gtest main library" FORCE)
 endfunction()
 
 function(opae_test_add)
@@ -93,13 +95,18 @@ function(opae_test_add)
                 ${opae-test_ROOT}/framework/mock/test_fpgad)
     endif(${OPAE_TEST_ADD_TEST_FPGAD})
 
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+        set(GTEST_LIBRARIES ${GTEST_LIBRARY_DEBUG} ${GTEST_MAIN_LIBRARY_DEBUG})
+    else()
+        set(GTEST_LIBRARIES ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY})
+    endif()
+
     target_link_libraries(${OPAE_TEST_ADD_TARGET}
         ${CMAKE_THREAD_LIBS_INIT}
         ${OPAE_TEST_LIBRARIES}
         ${libjson-c_LIBRARIES}
         ${libuuid_LIBRARIES}
-        ${GTEST_LIBRARY}
-        ${GTEST_MAIN_LIBRARY}
+        ${GTEST_LIBRARIES}
         ${OPAE_TEST_ADD_LIBS})
 
     opae_coverage_build(TARGET ${OPAE_TEST_ADD_TARGET}

--- a/cmake/modules/OPAETest.cmake
+++ b/cmake/modules/OPAETest.cmake
@@ -34,7 +34,7 @@ function(opae_load_gtest)
     message(STATUS "Trying to fetch gtest through git...")
     opae_external_project_add(PROJECT_NAME gtest
                               GIT_URL https://github.com/google/googletest
-                              GIT_TAG release-1.11.0
+                              GIT_TAG release-${GTEST_VERSION}
                               PRESERVE_REPOS ${OPAE_PRESERVE_REPOS})
 
     set(GTEST_INCLUDE_DIR ${gtest_ROOT}/googletest/include CACHE PATH "gtest include directory" FORCE)

--- a/cmake/modules/OPAETest.cmake
+++ b/cmake/modules/OPAETest.cmake
@@ -95,12 +95,6 @@ function(opae_test_add)
                 ${opae-test_ROOT}/framework/mock/test_fpgad)
     endif(${OPAE_TEST_ADD_TEST_FPGAD})
 
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-        set(GTEST_LIBRARIES ${GTEST_LIBRARY_DEBUG} ${GTEST_MAIN_LIBRARY_DEBUG})
-    else()
-        set(GTEST_LIBRARIES ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY})
-    endif()
-
     target_link_libraries(${OPAE_TEST_ADD_TARGET}
         ${CMAKE_THREAD_LIBS_INIT}
         ${OPAE_TEST_LIBRARIES}

--- a/samples/object_api/object_api.c
+++ b/samples/object_api/object_api.c
@@ -61,7 +61,7 @@ struct {
 	void *param;
 } cleanup[MAX_CLEANUP];
 
-STATIC int cleanup_size = 0;
+STATIC int cleanup_size;
 
 #define ADD_TO_CLEANUP(func, p)                                         \
 do {									\

--- a/samples/object_api/object_api.c
+++ b/samples/object_api/object_api.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -61,7 +61,7 @@ struct {
 	void *param;
 } cleanup[MAX_CLEANUP];
 
-static int cleanup_size;
+STATIC int cleanup_size = 0;
 
 #define ADD_TO_CLEANUP(func, p)                                         \
 do {									\

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,7 +30,20 @@ project(testing)
 if(${GTest_FOUND})
     message(STATUS Found GTest)
 else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
     opae_load_gtest()
+endif()
+
+message(STATUS "GTEST_INCLUDE_DIR: ${GTEST_INCLUDE_DIR}")
+message(STATUS "GTEST_LIBRARY: ${GTEST_LIBRARY}")
+message(STATUS "GTEST_MAIN_LIBRARY: ${GTEST_MAIN_LIBRARY}")
+message(STATUS "GTEST_LIBRARY_DEBUG: ${GTEST_LIBRARY_DEBUG}")
+message(STATUS "GTEST_MAIN_LIBRARY_DEBUG: ${GTEST_MAIN_LIBRARY_DEBUG}")
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(GTEST_LIBRARIES ${GTEST_LIBRARY_DEBUG} ${GTEST_MAIN_LIBRARY_DEBUG} CACHE STRING "gtest link libraries" FORCE)
+else()
+    set(GTEST_LIBRARIES ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY} CACHE STRING "gtest link libraries" FORCE)
 endif()
 
 # Disable some warnings that fire during gtest compilation

--- a/tests/argsfilter/test_argsfilter_c.cpp
+++ b/tests/argsfilter/test_argsfilter_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2021, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -487,5 +487,5 @@ TEST_P(argsfilter_c_p, addr_bdf) {
     EXPECT_EQ(result, 0);
 }
 
-INSTANTIATE_TEST_CASE_P(argsfilter_c, argsfilter_c_p,
+INSTANTIATE_TEST_SUITE_P(argsfilter_c, argsfilter_c_p,
         ::testing::ValuesIn(test_platform::platforms()));

--- a/tests/bitstream/test_bits_utils_c.cpp
+++ b/tests/bitstream/test_bits_utils_c.cpp
@@ -619,7 +619,7 @@ TEST_P(bits_utils_c_p, is_valid6) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(bits_utils_c_p);
-INSTANTIATE_TEST_CASE_P(bits_utils_c, bits_utils_c_p,
+INSTANTIATE_TEST_SUITE_P(bits_utils_c, bits_utils_c_p,
     ::testing::ValuesIn(test_platform::platforms({})));
 
 
@@ -651,5 +651,5 @@ TEST_P(mock_bits_utils_c_p, string_err2) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_bits_utils_c_p);
-INSTANTIATE_TEST_CASE_P(bits_utils_c, mock_bits_utils_c_p,
+INSTANTIATE_TEST_SUITE_P(bits_utils_c, mock_bits_utils_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({})));

--- a/tests/bitstream/test_bitstream_c.cpp
+++ b/tests/bitstream/test_bitstream_c.cpp
@@ -360,7 +360,7 @@ TEST_P(bitstream_c_p, unload_err1) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(bitstream_c_p);
-INSTANTIATE_TEST_CASE_P(bitstream_c, bitstream_c_p,
+INSTANTIATE_TEST_SUITE_P(bitstream_c, bitstream_c_p,
     ::testing::ValuesIn(test_platform::platforms({})));
 
 
@@ -400,5 +400,5 @@ TEST_P(mock_bitstream_c_p, resolve_err2) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_bitstream_c_p);
-INSTANTIATE_TEST_CASE_P(bitstream_c, mock_bitstream_c_p,
+INSTANTIATE_TEST_SUITE_P(bitstream_c, mock_bitstream_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({})));

--- a/tests/bitstream/test_metadatav1_c.cpp
+++ b/tests/bitstream/test_metadatav1_c.cpp
@@ -802,7 +802,7 @@ TEST_P(metadatav1_c_p, parse_v1_ok) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metadatav1_c_p);
-INSTANTIATE_TEST_CASE_P(metadatav1_c, metadatav1_c_p,
+INSTANTIATE_TEST_SUITE_P(metadatav1_c, metadatav1_c_p,
     ::testing::ValuesIn(test_platform::platforms({})));
 
 
@@ -893,5 +893,5 @@ TEST_P(mock_metadatav1_c_p, parse_v1_err0) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_metadatav1_c_p);
-INSTANTIATE_TEST_CASE_P(metadatav1_c, mock_metadatav1_c_p,
+INSTANTIATE_TEST_SUITE_P(metadatav1_c, mock_metadatav1_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({})));

--- a/tests/board/test_board_a10gx.cpp
+++ b/tests/board/test_board_a10gx.cpp
@@ -365,7 +365,7 @@ TEST_P(board_a10gx_c_p, board_a10gx_7) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_a10gx_c_p);
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     baord_a10gx_c, board_a10gx_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"dcp-a10gx"})));
 
@@ -405,6 +405,6 @@ TEST_P(board_a10gx_invalid_c_p, board_a10gx_10) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_a10gx_invalid_c_p);
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     board_a10gx_invalid_c, board_a10gx_invalid_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"skx-p"})));

--- a/tests/board/test_board_d5005.cpp
+++ b/tests/board/test_board_d5005.cpp
@@ -341,7 +341,7 @@ TEST_P(board_dfl_d5005_c_p, board_d5005_9) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_dfl_d5005_c_p);
-INSTANTIATE_TEST_CASE_P(baord_d5005_c, board_dfl_d5005_c_p,
+INSTANTIATE_TEST_SUITE_P(baord_d5005_c, board_dfl_d5005_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-d5005" })));
 
 // test invalid sysfs attributes
@@ -370,5 +370,5 @@ TEST_P(board_d5005_invalid_c_p, invalid_board_d5005_1) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_d5005_invalid_c_p);
-INSTANTIATE_TEST_CASE_P(board_d5005_invalid_c, board_d5005_invalid_c_p,
+INSTANTIATE_TEST_SUITE_P(board_d5005_invalid_c, board_d5005_invalid_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/tests/board/test_board_n3000.cpp
+++ b/tests/board/test_board_n3000.cpp
@@ -445,7 +445,7 @@ TEST_P(board_dfl_n3000_c_p, board_n3000_20) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_dfl_n3000_c_p);
-INSTANTIATE_TEST_CASE_P(board_dfl_n3000_c, board_dfl_n3000_c_p,
+INSTANTIATE_TEST_SUITE_P(board_dfl_n3000_c, board_dfl_n3000_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000" })));
 
 // test invalid sysfs attributes
@@ -491,5 +491,5 @@ TEST_P(board_n3000_invalid_c_p, board_n3000_9) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_n3000_invalid_c_p);
-INSTANTIATE_TEST_CASE_P(board_n3000_invalid_c, board_n3000_invalid_c_p,
+INSTANTIATE_TEST_SUITE_P(board_n3000_invalid_c, board_n3000_invalid_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/tests/board/test_board_n5010.cpp
+++ b/tests/board/test_board_n5010.cpp
@@ -180,7 +180,7 @@ TEST_P(board_dfl_n5010_c_p, DISABLED_board_n5010_6) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_dfl_n5010_c_p);
-INSTANTIATE_TEST_CASE_P(board_n5010_c, board_dfl_n5010_c_p,
+INSTANTIATE_TEST_SUITE_P(board_n5010_c, board_dfl_n5010_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n6000" })));
 
 // test invalid sysfs attributes
@@ -211,5 +211,5 @@ TEST_P(board_n5010_invalid_c_p, board_n5010_9) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_n5010_invalid_c_p);
-INSTANTIATE_TEST_CASE_P(board_n5010_invalid_c, board_n5010_invalid_c_p,
+INSTANTIATE_TEST_SUITE_P(board_n5010_invalid_c, board_n5010_invalid_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/tests/board/test_board_n6000.cpp
+++ b/tests/board/test_board_n6000.cpp
@@ -506,7 +506,7 @@ TEST_P(board_dfl_n6000_c_p, board_n6000_12) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_dfl_n6000_c_p);
-INSTANTIATE_TEST_CASE_P(board_dfl_n6000_c, board_dfl_n6000_c_p,
+INSTANTIATE_TEST_SUITE_P(board_dfl_n6000_c, board_dfl_n6000_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n6000" })));
 
 // test invalid sysfs attributes
@@ -539,5 +539,5 @@ TEST_P(board_n6000_invalid_c_p, board_n6000_11) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(board_n6000_invalid_c_p);
-INSTANTIATE_TEST_CASE_P(board_n6000_invalid_c, board_n6000_invalid_c_p,
+INSTANTIATE_TEST_SUITE_P(board_n6000_invalid_c, board_n6000_invalid_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/tests/dummy_afu/test_dummy_afu.cpp
+++ b/tests/dummy_afu/test_dummy_afu.cpp
@@ -264,7 +264,7 @@ TEST_P(dummy_afu_p, main_invalid_guid) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(dummy_afu_p);
-INSTANTIATE_TEST_CASE_P(dummy_afu, dummy_afu_p,
+INSTANTIATE_TEST_SUITE_P(dummy_afu, dummy_afu_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"dfl-d5005"})));
 
 TEST(dummy_afu, parse_pcie_address)

--- a/tests/fpgaconf/test_fpgaconf_c.cpp
+++ b/tests/fpgaconf/test_fpgaconf_c.cpp
@@ -819,7 +819,7 @@ TEST_P(fpgaconf_c_p, circular_symlink) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgaconf_c_p);
-INSTANTIATE_TEST_CASE_P(fpgaconf_c, fpgaconf_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgaconf_c, fpgaconf_c_p,
                         ::testing::ValuesIn(test_platform::platforms({"skx-p"})));
 
 
@@ -1001,6 +1001,6 @@ TEST_P(fpgaconf_c_mock_p, prog_bs2) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgaconf_c_mock_p);
-INSTANTIATE_TEST_CASE_P(fpgaconf_c, fpgaconf_c_mock_p,
+INSTANTIATE_TEST_SUITE_P(fpgaconf_c, fpgaconf_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"skx-p"})));
 

--- a/tests/fpgad/test_api_device_monitoring_c.cpp
+++ b/tests/fpgad/test_api_device_monitoring_c.cpp
@@ -135,5 +135,5 @@ TEST_P(fpgad_device_monitoring_c_p, mon02) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_device_monitoring_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_c, fpgad_device_monitoring_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_c, fpgad_device_monitoring_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_api_logging_c.cpp
+++ b/tests/fpgad/test_api_logging_c.cpp
@@ -102,5 +102,5 @@ TEST_P(fpgad_log_c_p, log02) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_log_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_log_c, fpgad_log_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_log_c, fpgad_log_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_api_opae_events_api_c.cpp
+++ b/tests/fpgad/test_api_opae_events_api_c.cpp
@@ -179,5 +179,5 @@ TEST_P(fpgad_opae_events_api_c_p, events03) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_opae_events_api_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_c, fpgad_opae_events_api_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_c, fpgad_opae_events_api_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_api_sysfs_c.cpp
+++ b/tests/fpgad/test_api_sysfs_c.cpp
@@ -127,5 +127,5 @@ TEST_P(fpgad_sysfs_c_p, dup02) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_sysfs_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_c, fpgad_sysfs_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_c, fpgad_sysfs_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_command_line_c.cpp
+++ b/tests/fpgad/test_command_line_c.cpp
@@ -424,5 +424,5 @@ TEST_P(fpgad_command_line_c_p, symlink4) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_command_line_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_command_line_c, fpgad_command_line_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_command_line_c, fpgad_command_line_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_config_file_c.cpp
+++ b/tests/fpgad/test_config_file_c.cpp
@@ -456,7 +456,7 @@ TEST_P(fpgad_config_file_c_p, process_plugin8) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_config_file_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_config_file_c, fpgad_config_file_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_config_file_c, fpgad_config_file_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));
 
 
@@ -683,7 +683,7 @@ TEST_P(fpgad_config_file_devices_p, process_plugin_devices9) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_config_file_devices_p);
-INSTANTIATE_TEST_CASE_P(fpgad_config_file_c, fpgad_config_file_devices_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_config_file_c, fpgad_config_file_devices_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));
 
 
@@ -823,7 +823,7 @@ TEST_P(mock_fpgad_config_file_c_p, process_plugin10) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_fpgad_config_file_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_config_file_c, mock_fpgad_config_file_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_config_file_c, mock_fpgad_config_file_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));
 
 
@@ -875,5 +875,5 @@ TEST_P(mock_fpgad_config_file_devices_p, process_plugin_devices8) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_fpgad_config_file_devices_p);
-INSTANTIATE_TEST_CASE_P(fpgad_config_file_c, mock_fpgad_config_file_devices_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_config_file_c, mock_fpgad_config_file_devices_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/tests/fpgad/test_daemonize_c.cpp
+++ b/tests/fpgad/test_daemonize_c.cpp
@@ -139,5 +139,5 @@ TEST_P(fpgad_daemonize_c_p, test) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_daemonize_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_daemonize_c, fpgad_daemonize_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_daemonize_c, fpgad_daemonize_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_event_dispatcher_thread_c.cpp
+++ b/tests/fpgad/test_event_dispatcher_thread_c.cpp
@@ -164,5 +164,5 @@ TEST_P(fpgad_evt_c_p, normal_dispatch) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_evt_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_evt_c, fpgad_evt_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_evt_c, fpgad_evt_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_events_api_thread_c.cpp
+++ b/tests/fpgad/test_events_api_thread_c.cpp
@@ -124,5 +124,5 @@ TEST_P(fpgad_events_api_c_p, remove0) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_events_api_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_events_api_c, fpgad_events_api_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_events_api_c, fpgad_events_api_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_fpgad_c.cpp
+++ b/tests/fpgad/test_fpgad_c.cpp
@@ -318,5 +318,5 @@ TEST_P(fpgad_fpgad_c_p, main_valid) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_fpgad_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_fpgad_c, fpgad_fpgad_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_fpgad_c, fpgad_fpgad_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_monitor_thread_c.cpp
+++ b/tests/fpgad/test_monitor_thread_c.cpp
@@ -205,5 +205,5 @@ TEST_P(fpgad_monitor_c_p, null_response0) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_monitor_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_monitor_c, fpgad_monitor_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_monitor_c, fpgad_monitor_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));

--- a/tests/fpgad/test_monitored_device_c.cpp
+++ b/tests/fpgad/test_monitored_device_c.cpp
@@ -109,7 +109,7 @@ TEST_P(fpgad_monitored_device_c_p, enum_err) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgad_monitored_device_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_monitored_device_c, fpgad_monitored_device_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_monitored_device_c, fpgad_monitored_device_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));
 
 class mock_fpgad_monitored_device_c_p : public ::testing::TestWithParam<std::string> {
@@ -150,5 +150,5 @@ TEST_P(mock_fpgad_monitored_device_c_p, enum_err0) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_fpgad_monitored_device_c_p);
-INSTANTIATE_TEST_CASE_P(mock_fpgad_monitored_device_c, mock_fpgad_monitored_device_c_p,
+INSTANTIATE_TEST_SUITE_P(mock_fpgad_monitored_device_c, mock_fpgad_monitored_device_c_p,
   ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/tests/fpgad/test_plugin_fpgad_xfpga_c.cpp
+++ b/tests/fpgad/test_plugin_fpgad_xfpga_c.cpp
@@ -480,7 +480,7 @@ TEST_P(mock_port_fpgad_xfpga_c_p, configure) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_port_fpgad_xfpga_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_c, mock_port_fpgad_xfpga_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_c, mock_port_fpgad_xfpga_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));
 
 
@@ -692,5 +692,5 @@ TEST_P(mock_fme_fpgad_xfpga_c_p, configure) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_fme_fpgad_xfpga_c_p);
-INSTANTIATE_TEST_CASE_P(fpgad_c, mock_fme_fpgad_xfpga_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgad_c, mock_fme_fpgad_xfpga_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));

--- a/tests/fpgainfo/test_board_c.cpp
+++ b/tests/fpgainfo/test_board_c.cpp
@@ -306,6 +306,6 @@ TEST_P(fpgainfo_board_c_p, phy_group_info) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgainfo_board_c_p);
-INSTANTIATE_TEST_CASE_P(fpgainfo_c, fpgainfo_board_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgainfo_c, fpgainfo_board_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p","dcp-rc","dcp-vc" })));
 

--- a/tests/fpgainfo/test_fpgainfo_c.cpp
+++ b/tests/fpgainfo/test_fpgainfo_c.cpp
@@ -1507,5 +1507,5 @@ TEST_P(fpgainfo_c_p, main_7) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpgainfo_c_p);
-INSTANTIATE_TEST_CASE_P(fpgainfo_c, fpgainfo_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgainfo_c, fpgainfo_c_p,
         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000" })));

--- a/tests/fpgametrics/test_fpgametrics_c.cpp
+++ b/tests/fpgametrics/test_fpgametrics_c.cpp
@@ -257,5 +257,5 @@ TEST_P(fpga_metrics_c_p, main2) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(fpga_metrics_c_p);
-INSTANTIATE_TEST_CASE_P(fpgametrics_c, fpga_metrics_c_p,
+INSTANTIATE_TEST_SUITE_P(fpgametrics_c, fpga_metrics_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000" })));

--- a/tests/framework/CMakeLists.txt
+++ b/tests/framework/CMakeLists.txt
@@ -36,6 +36,12 @@ include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-Wno-error=frame-address"
   CXX_SUPPORTS_NO_ERROR_FRAME_ADDRESS)
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(GTEST_LIB ${GTEST_LIBRARY_DEBUG})
+else()
+    set(GTEST_LIB ${GTEST_LIBRARY})
+endif()
+
 opae_add_shared_library(TARGET test_system
     SOURCE
         mock/test_system.cpp
@@ -45,6 +51,7 @@ opae_add_shared_library(TARGET test_system
         opae-c
         fpga_db
         dl
+	${GTEST_LIB}
 )
 
 if (CXX_SUPPORTS_NO_ERROR_FRAME_ADDRESS)

--- a/tests/framework/CMakeLists.txt
+++ b/tests/framework/CMakeLists.txt
@@ -24,7 +24,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 # projectname is the same as the main-executable
 project(framework)
@@ -37,19 +37,29 @@ check_cxx_compiler_flag("-Wno-error=frame-address"
   CXX_SUPPORTS_NO_ERROR_FRAME_ADDRESS)
 
 opae_add_shared_library(TARGET test_system
-    SOURCE mock/test_system.cpp mock/ioctl_handlers.cpp
-    LIBS fpga_db dl
+    SOURCE
+        mock/test_system.cpp
+	mock/ioctl_handlers.cpp
+        mock/opae_fixtures.cpp
+    LIBS
+        opae-c
+        fpga_db
+        dl
 )
 
 if (CXX_SUPPORTS_NO_ERROR_FRAME_ADDRESS)
   set_target_properties(test_system PROPERTIES COMPILE_FLAGS "-Wno-error=frame-address")
 endif()
 
-target_include_directories(test_system PUBLIC
-  $<BUILD_INTERFACE:${OPAE_INCLUDE_PATH}>
-  PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-          $<BUILD_INTERFACE:${OPAE_LIB_SOURCE}/libopae-c>
-	  $<BUILD_INTERFACE:${OPAE_LIB_SOURCE}/plugins/xfpga>)
+target_include_directories(test_system
+    PUBLIC
+        $<BUILD_INTERFACE:${OPAE_INCLUDE_PATH}>
+        $<BUILD_INTERFACE:${GTEST_INCLUDE_DIR}>
+    PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${OPAE_LIB_SOURCE}/libopae-c>
+        $<BUILD_INTERFACE:${OPAE_LIB_SOURCE}/plugins/xfpga>
+)
 
 opae_add_shared_library(TARGET fpga_db
     SOURCE platform/fpga_hw.cpp

--- a/tests/framework/mock/opae_fixtures.cpp
+++ b/tests/framework/mock/opae_fixtures.cpp
@@ -1,0 +1,46 @@
+// Copyright(c) 2022, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#include "opae_fixtures.h"
+
+namespace opae {
+namespace testing {
+
+uint32_t opae_p::num_tokens_for(fpga_properties filter)
+{
+  uint32_t num_tokens = 0;
+
+  fpgaEnumerate(&filter, 1, NULL, 0, &num_tokens);
+
+  return num_tokens;
+}
+
+void opae_p::enumerate_device_tokens()
+{
+
+}
+
+} // end of namespace testing
+} // end of namespace opae

--- a/tests/framework/mock/opae_fixtures.h
+++ b/tests/framework/mock/opae_fixtures.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2019, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -24,19 +24,32 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 /*
- * mock_opae.h
+ * opae_fixtures.h
  */
 #pragma once
-
-
 
 #include <opae/fpga.h>
 #include <dlfcn.h>
 #include "gtest/gtest.h"
 #include "test_system.h"
 
+#include <string>
+#include <vector>
+
 namespace opae {
 namespace testing {
+
+class opae_p : public ::testing::TestWithParam<std::string> {
+ protected:
+
+
+
+  std::vector<fpga_token> device_tokens_;
+
+ private:
+  uint32_t num_tokens_for(fpga_properties filter);
+  void enumerate_device_tokens();
+};
 
 extern const char xfpga_[] = "xfpga_";
 extern const char none_[] = "";

--- a/tests/hello_events/test_hello_events_c.cpp
+++ b/tests/hello_events/test_hello_events_c.cpp
@@ -241,7 +241,7 @@ TEST_P(hello_events_c_p, main1) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(hello_events_c_p);
-INSTANTIATE_TEST_CASE_P(hello_events_c, hello_events_c_p,
+INSTANTIATE_TEST_SUITE_P(hello_events_c, hello_events_c_p,
                         ::testing::ValuesIn(test_platform::keys(true)));
 
 
@@ -298,7 +298,7 @@ TEST_P(mock_hello_events_c_fpgad_p, main2) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_hello_events_c_fpgad_p);
-INSTANTIATE_TEST_CASE_P(mock_hello_events_c_fpgad, mock_hello_events_c_fpgad_p,
+INSTANTIATE_TEST_SUITE_P(mock_hello_events_c_fpgad, mock_hello_events_c_fpgad_p,
   ::testing::ValuesIn(test_platform::mock_platforms()));
 
 
@@ -328,5 +328,5 @@ TEST_P(hw_hello_events_c_fpgad_p, main2) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(hw_hello_events_c_fpgad_p);
-INSTANTIATE_TEST_CASE_P(hw_hello_events_c_fpgad, hw_hello_events_c_fpgad_p,
+INSTANTIATE_TEST_SUITE_P(hw_hello_events_c_fpgad, hw_hello_events_c_fpgad_p,
   ::testing::ValuesIn(test_platform::hw_platforms({}, fpga_driver::linux_intel)));

--- a/tests/hello_fpga/test_hello_fpga_c.cpp
+++ b/tests/hello_fpga/test_hello_fpga_c.cpp
@@ -252,7 +252,7 @@ TEST_P(hello_fpga_c_p, main0) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(hello_fpga_c_p);
-INSTANTIATE_TEST_CASE_P(hello_fpga_c, hello_fpga_c_p,
+INSTANTIATE_TEST_SUITE_P(hello_fpga_c, hello_fpga_c_p,
                         ::testing::ValuesIn(test_platform::keys(true)));
 
 class mock_hello_fpga_c_p : public hello_fpga_c_p {
@@ -285,7 +285,7 @@ TEST_P(mock_hello_fpga_c_p, main1) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mock_hello_fpga_c_p);
-INSTANTIATE_TEST_CASE_P(mock_hello_fpga_c, mock_hello_fpga_c_p,
+INSTANTIATE_TEST_SUITE_P(mock_hello_fpga_c, mock_hello_fpga_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"skx-p", "dcp-rc"})));
 
 class hw_hello_fpga_c_p : public mock_hello_fpga_c_p {
@@ -314,5 +314,5 @@ TEST_P(hw_hello_fpga_c_p, main1) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(hw_hello_fpga_c_p);
-INSTANTIATE_TEST_CASE_P(hw_hello_fpga_c, hw_hello_fpga_c_p,
+INSTANTIATE_TEST_SUITE_P(hw_hello_fpga_c, hw_hello_fpga_c_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({"skx-p","dcp-rc"})));

--- a/tests/object_api/test_object_api_c.cpp
+++ b/tests/object_api/test_object_api_c.cpp
@@ -35,6 +35,8 @@ extern struct config options;
 void print_err(const char*, fpga_result);
 fpga_result parse_args(int argc, char* argv[]);
 int object_api_main(int argc, char* argv[]);
+
+extern int cleanup_size;
 }
 
 #include <config.h>
@@ -61,6 +63,8 @@ class object_api_c_p : public ::testing::TestWithParam<std::string> {
 
     optind = 0;
     options_ = options;
+
+    cleanup_size = 0;
   }
 
   virtual void TearDown() override {

--- a/tests/object_api/test_object_api_c.cpp
+++ b/tests/object_api/test_object_api_c.cpp
@@ -138,7 +138,7 @@ TEST_P(object_api_c_p, main0) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(object_api_c_p);
-INSTANTIATE_TEST_CASE_P(object_api_c, object_api_c_p,
+INSTANTIATE_TEST_SUITE_P(object_api_c, object_api_c_p,
                         ::testing::ValuesIn(test_platform::platforms({})));
 
 
@@ -169,7 +169,7 @@ TEST_P(object_api_c_mock_p, main1) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(object_api_c_mock_p);
-INSTANTIATE_TEST_CASE_P(object_api_c, object_api_c_mock_p,
+INSTANTIATE_TEST_SUITE_P(object_api_c, object_api_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p" })));
 
 class object_api_c_mcp_hw_p : public object_api_c_p {
@@ -197,7 +197,7 @@ TEST_P(object_api_c_mcp_hw_p, main1) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(object_api_c_mcp_hw_p);
-INSTANTIATE_TEST_CASE_P(object_api_c, object_api_c_mcp_hw_p,
+INSTANTIATE_TEST_SUITE_P(object_api_c, object_api_c_mcp_hw_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({"skx-p"})));
 
 
@@ -226,5 +226,5 @@ TEST_P(object_api_c_dcp_hw_p, main1) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(object_api_c_dcp_hw_p);
-INSTANTIATE_TEST_CASE_P(object_api_c, object_api_c_dcp_hw_p,
+INSTANTIATE_TEST_SUITE_P(object_api_c, object_api_c_dcp_hw_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({"dcp-rc"})));

--- a/tests/opae-c/test_buffer_c.cpp
+++ b/tests/opae-c/test_buffer_c.cpp
@@ -42,7 +42,7 @@ extern "C" {
 #include <string>
 #include <vector>
 #include <unistd.h>
-#include "mock/mock_opae.h"
+#include "mock/opae_fixtures.h"
 
 using namespace opae::testing;
 
@@ -163,5 +163,5 @@ TEST_P(buffer_c_p, neg_test2) {
 
 // TODO: re-enable these for n6000
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(buffer_c_p);
-INSTANTIATE_TEST_CASE_P(buffer_c, buffer_c_p,
+INSTANTIATE_TEST_SUITE_P(buffer_c, buffer_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000", "dfl-d5005" })));

--- a/tests/opae-c/test_enum_c.cpp
+++ b/tests/opae-c/test_enum_c.cpp
@@ -49,7 +49,7 @@ extern "C" {
 #include <memory>
 #include <string>
 #include <vector>
-#include "mock/mock_opae.h"
+#include "mock/opae_fixtures.h"
 #include <algorithm>
 #include <cstdarg>
 
@@ -729,7 +729,7 @@ TEST(wrapper, validate) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_c_p);
-INSTANTIATE_TEST_CASE_P(enum_c, enum_c_p,
+INSTANTIATE_TEST_SUITE_P(enum_c, enum_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000", "dfl-d5005" })));
 
 class enum_c_mock_p : public enum_c_p {};
@@ -747,7 +747,7 @@ TEST_P(enum_c_mock_p, clone_token02) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_c_mock_p);
-INSTANTIATE_TEST_CASE_P(enum_c, enum_c_mock_p,
+INSTANTIATE_TEST_SUITE_P(enum_c, enum_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000", "dfl-d5005" })));
 
 class enum_c_err_p : public enum_c_p {};
@@ -785,7 +785,7 @@ TEST_P(enum_c_err_p, num_errors) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_c_err_p);
-INSTANTIATE_TEST_CASE_P(enum_c, enum_c_err_p,
+INSTANTIATE_TEST_SUITE_P(enum_c, enum_c_err_p,
                         ::testing::ValuesIn(test_platform::platforms({"dfl-n3000", "dfl-d5005" })));
 
 class enum_c_socket_p : public enum_c_p {};
@@ -809,5 +809,5 @@ TEST_P(enum_c_socket_p, socket_id) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_c_socket_p);
-INSTANTIATE_TEST_CASE_P(enum_c, enum_c_socket_p,
+INSTANTIATE_TEST_SUITE_P(enum_c, enum_c_socket_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/opae-c/test_error_c.cpp
+++ b/tests/opae-c/test_error_c.cpp
@@ -163,5 +163,5 @@ TEST_P(error_c_p, clear_all) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(error_c_p);
-INSTANTIATE_TEST_CASE_P(error_c, error_c_p,
+INSTANTIATE_TEST_SUITE_P(error_c, error_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/opae-c/test_event_c.cpp
+++ b/tests/opae-c/test_event_c.cpp
@@ -252,7 +252,7 @@ TEST_P(event_c_p, destroy_err) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(event_c_p);
-INSTANTIATE_TEST_CASE_P(event_c, event_c_p, 
+INSTANTIATE_TEST_SUITE_P(event_c, event_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({})));
 
 
@@ -379,5 +379,5 @@ TEST_P(events_handle_p, manual_ap6) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(events_handle_p);
-INSTANTIATE_TEST_CASE_P(events, events_handle_p,
+INSTANTIATE_TEST_SUITE_P(events, events_handle_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"skx-p"})));

--- a/tests/opae-c/test_hostif_c.cpp
+++ b/tests/opae-c/test_hostif_c.cpp
@@ -120,7 +120,7 @@ TEST_P(hostif_c_p, release_from_ifc) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(hostif_c_p);
-INSTANTIATE_TEST_CASE_P(hostif_c, hostif_c_p, 
+INSTANTIATE_TEST_SUITE_P(hostif_c, hostif_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({})));
 
 class hostif_c_mock_p : public hostif_c_p{
@@ -140,6 +140,6 @@ TEST_P(hostif_c_mock_p, assign_port) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(hostif_c_mock_p);
-INSTANTIATE_TEST_CASE_P(hostif_c, hostif_c_mock_p, 
+INSTANTIATE_TEST_SUITE_P(hostif_c, hostif_c_mock_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({})));
 

--- a/tests/opae-c/test_init_c.cpp
+++ b/tests/opae-c/test_init_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -526,5 +526,5 @@ TEST_P(init_ase_cfg_p, find_ase_cfg_4) {
       unlink(tmpfile3_);
 }
 
-INSTANTIATE_TEST_CASE_P(init_ase_cfg, init_ase_cfg_p,
+INSTANTIATE_TEST_SUITE_P(init_ase_cfg, init_ase_cfg_p,
                         ::testing::ValuesIn(_ase_home_configs));

--- a/tests/opae-c/test_metrics_c.cpp
+++ b/tests/opae-c/test_metrics_c.cpp
@@ -160,5 +160,5 @@ TEST_P(metrics_c_p, threshold0) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_c_p);
-INSTANTIATE_TEST_CASE_P(metrics_c, metrics_c_p,
+INSTANTIATE_TEST_SUITE_P(metrics_c, metrics_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));

--- a/tests/opae-c/test_mmio_c.cpp
+++ b/tests/opae-c/test_mmio_c.cpp
@@ -255,5 +255,5 @@ TEST_P(mmio_c_p, mmio512_neg_test) {
 #endif // TEST_SUPPORTS_AVX512
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mmio_c_p);
-INSTANTIATE_TEST_CASE_P(mmio_c, mmio_c_p,
+INSTANTIATE_TEST_SUITE_P(mmio_c, mmio_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/opae-c/test_object_c.cpp
+++ b/tests/opae-c/test_object_c.cpp
@@ -395,7 +395,7 @@ TEST_P(object_c_p, obj_close) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(object_c_p);
-INSTANTIATE_TEST_CASE_P(object_c, object_c_p,
+INSTANTIATE_TEST_SUITE_P(object_c, object_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
 class object_c_mock_p : public object_c_p {
@@ -453,6 +453,6 @@ TEST_P(object_c_mock_p, obj_get_obj_err) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(object_c_mock_p);
-INSTANTIATE_TEST_CASE_P(object_c, object_c_mock_p,
+INSTANTIATE_TEST_SUITE_P(object_c, object_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 

--- a/tests/opae-c/test_open_c.cpp
+++ b/tests/opae-c/test_open_c.cpp
@@ -96,5 +96,5 @@ TEST_P(open_c_p, mallocfails) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(open_c_p);
-INSTANTIATE_TEST_CASE_P(open_c, open_c_p, 
+INSTANTIATE_TEST_SUITE_P(open_c, open_c_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({})));

--- a/tests/opae-c/test_pluginmgr_c.cpp
+++ b/tests/opae-c/test_pluginmgr_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -234,7 +234,7 @@ TEST_P(pluginmgr_c_p, bad_final_all) {
   EXPECT_EQ(2, test_plugin_finalize_called);
 }
 
-INSTANTIATE_TEST_CASE_P(pluginmgr_c, pluginmgr_c_p, ::testing::ValuesIn(test_platform::keys(true)));
+INSTANTIATE_TEST_SUITE_P(pluginmgr_c, pluginmgr_c_p, ::testing::ValuesIn(test_platform::keys(true)));
 
 const char *plugin_cfg_1 = R"plug(
 {
@@ -598,5 +598,5 @@ TEST_P(pluginmgr_cfg_p, find_and_parse_cfg) {
   opae_plugin_mgr_reset_cfg(); 
 }
 
-INSTANTIATE_TEST_CASE_P(pluginmgr_cfg, pluginmgr_cfg_p,
+INSTANTIATE_TEST_SUITE_P(pluginmgr_cfg, pluginmgr_cfg_p,
                         ::testing::ValuesIn(_opae_home_configs));

--- a/tests/opae-c/test_props_c.cpp
+++ b/tests/opae-c/test_props_c.cpp
@@ -3664,7 +3664,7 @@ TEST_P(properties_c_p, get_sub_device_id03) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(properties_c_p);
-INSTANTIATE_TEST_CASE_P(properties_c, properties_c_p,
+INSTANTIATE_TEST_SUITE_P(properties_c, properties_c_p,
                         ::testing::ValuesIn(test_platform::platforms({})));
 
 class properties_c_mock_p : public properties_c_p{
@@ -3714,6 +3714,6 @@ TEST_P(properties_c_mock_p, fpga_clone_properties02) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(properties_c_mock_p);
-INSTANTIATE_TEST_CASE_P(properties_c, properties_c_mock_p,
+INSTANTIATE_TEST_SUITE_P(properties_c, properties_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({})));
 

--- a/tests/opae-c/test_reconf_c.cpp
+++ b/tests/opae-c/test_reconf_c.cpp
@@ -110,5 +110,5 @@ TEST_P(reconf_c_p, pr) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c_p);
-INSTANTIATE_TEST_CASE_P(reconf_c, reconf_c_p,
+INSTANTIATE_TEST_SUITE_P(reconf_c, reconf_c_p,
                         ::testing::ValuesIn(test_platform::platforms({})));

--- a/tests/opae-c/test_reset_c.cpp
+++ b/tests/opae-c/test_reset_c.cpp
@@ -100,5 +100,5 @@ TEST_P(reset_c_p, success) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reset_c_p);
-INSTANTIATE_TEST_CASE_P(reset_c, reset_c_p, 
+INSTANTIATE_TEST_SUITE_P(reset_c, reset_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({})));

--- a/tests/opae-c/test_sdl_c.cpp
+++ b/tests/opae-c/test_sdl_c.cpp
@@ -453,5 +453,5 @@ TEST_P(sdl_c_p, test_fpgaClose_for_null_object) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sdl_c_p);
-INSTANTIATE_TEST_CASE_P(sdl_c, sdl_c_p, 
+INSTANTIATE_TEST_SUITE_P(sdl_c, sdl_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({"dfl-n3000","dfl-d5005","dfl-n6000"})));

--- a/tests/opae-c/test_umsg_c.cpp
+++ b/tests/opae-c/test_umsg_c.cpp
@@ -195,7 +195,7 @@ TEST_P(DISABLED_umsg_c_p, set_attr) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(DISABLED_umsg_c_p);
-INSTANTIATE_TEST_CASE_P(DISABLED_umsg_c, DISABLED_umsg_c_p, 
+INSTANTIATE_TEST_SUITE_P(DISABLED_umsg_c, DISABLED_umsg_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({ "skx-p"})));
 
 class DISABLED_umsg_c_mock_p: public DISABLED_umsg_c_p{
@@ -235,6 +235,6 @@ TEST_P(DISABLED_umsg_c_mock_p, get_ptr) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(DISABLED_umsg_c_mock_p);
-INSTANTIATE_TEST_CASE_P(umsg_c, DISABLED_umsg_c_mock_p, 
+INSTANTIATE_TEST_SUITE_P(umsg_c, DISABLED_umsg_c_mock_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p"})));
 

--- a/tests/opae-c/test_usrclk_c.cpp
+++ b/tests/opae-c/test_usrclk_c.cpp
@@ -109,7 +109,7 @@ TEST_P(usrclk_c_p, get) {
 
 // TODO: Fix user clock test for DCP
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(usrclk_c_p);
-INSTANTIATE_TEST_CASE_P(usrclk_c, usrclk_c_p,
+INSTANTIATE_TEST_SUITE_P(usrclk_c, usrclk_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-d5005" })));
 
 class usrclk_c_hw_p : public usrclk_c_p{
@@ -129,6 +129,6 @@ TEST_P(usrclk_c_hw_p, set) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(usrclk_c_hw_p);
-INSTANTIATE_TEST_CASE_P(usrclk_c, usrclk_c_hw_p,
+INSTANTIATE_TEST_SUITE_P(usrclk_c, usrclk_c_hw_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-d5005"})));
 

--- a/tests/opae-cxx/test_buffer_cxx_core.cpp
+++ b/tests/opae-cxx/test_buffer_cxx_core.cpp
@@ -218,5 +218,5 @@ TEST_P(buffer_cxx_core, read_write) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(buffer_cxx_core);
-INSTANTIATE_TEST_CASE_P(buffer, buffer_cxx_core,
+INSTANTIATE_TEST_SUITE_P(buffer, buffer_cxx_core,
                         ::testing::ValuesIn(test_platform::keys(true)));

--- a/tests/opae-cxx/test_errors_cxx_core.cpp
+++ b/tests/opae-cxx/test_errors_cxx_core.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -102,4 +102,4 @@ TEST_P(errors_cxx_core, throw_error) {
 
 
 
-INSTANTIATE_TEST_CASE_P(error, errors_cxx_core, ::testing::ValuesIn(test_platform::keys(true)));
+INSTANTIATE_TEST_SUITE_P(error, errors_cxx_core, ::testing::ValuesIn(test_platform::keys(true)));

--- a/tests/opae-cxx/test_events_cxx_core.cpp
+++ b/tests/opae-cxx/test_events_cxx_core.cpp
@@ -144,4 +144,4 @@ TEST_P(events_cxx_core, get_os_object) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(events_cxx_core);
-INSTANTIATE_TEST_CASE_P(events, events_cxx_core, ::testing::ValuesIn(test_platform::keys(true)));
+INSTANTIATE_TEST_SUITE_P(events, events_cxx_core, ::testing::ValuesIn(test_platform::keys(true)));

--- a/tests/opae-cxx/test_handle_cxx_core.cpp
+++ b/tests/opae-cxx/test_handle_cxx_core.cpp
@@ -205,7 +205,7 @@ TEST_P(handle_cxx_core, mmio_ptr) {
   int flags = 0;
   uint64_t offset = 0x100;
   uint32_t csr_space = 0;
-  uint8_t *h;
+  uint8_t *h = nullptr;
 
   handle_ = handle::open(tokens_[0], flags);
   ASSERT_NE(nullptr, handle_.get());
@@ -233,5 +233,5 @@ TEST_P(handle_cxx_core, get_token) {
 
 // TODO: re-enable these for n6000
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(handle_cxx_core);
-INSTANTIATE_TEST_CASE_P(handle, handle_cxx_core,
+INSTANTIATE_TEST_SUITE_P(handle, handle_cxx_core,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000", "dfl-d5005" })));

--- a/tests/opae-cxx/test_object_cxx_core.cpp
+++ b/tests/opae-cxx/test_object_cxx_core.cpp
@@ -245,6 +245,6 @@ TEST_P(sysobject_cxx_p, read_bytes) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysobject_cxx_p);
-INSTANTIATE_TEST_CASE_P(sysobject_cxx, sysobject_cxx_p,
+INSTANTIATE_TEST_SUITE_P(sysobject_cxx, sysobject_cxx_p,
          ::testing::ValuesIn(test_platform::platforms({ "skx-p","dcp-rc","dcp-vc" })));
 

--- a/tests/opae-cxx/test_properties_cxx_core.cpp
+++ b/tests/opae-cxx/test_properties_cxx_core.cpp
@@ -327,5 +327,5 @@ TEST_P(properties_cxx_core, get_subsystem_device_id) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(properties_cxx_core);
-INSTANTIATE_TEST_CASE_P(properties, properties_cxx_core,
+INSTANTIATE_TEST_SUITE_P(properties, properties_cxx_core,
                         ::testing::ValuesIn(test_platform::keys(true)));

--- a/tests/userclk/test_userclk_c.cpp
+++ b/tests/userclk/test_userclk_c.cpp
@@ -366,7 +366,7 @@ TEST_P(userclk_c_p, main2) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(userclk_c_p);
-INSTANTIATE_TEST_CASE_P(userclk_c, userclk_c_p,
+INSTANTIATE_TEST_SUITE_P(userclk_c, userclk_c_p,
                         ::testing::ValuesIn(test_platform::platforms({})));
 
 class userclk_c_hw_p : public userclk_c_p{
@@ -534,7 +534,7 @@ TEST_P(userclk_c_hw_p, main6) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(userclk_c_hw_p);
-INSTANTIATE_TEST_CASE_P(userclk_c, userclk_c_hw_p,
+INSTANTIATE_TEST_SUITE_P(userclk_c, userclk_c_hw_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({"skx-p","dcp-rc"})));
 
 
@@ -719,6 +719,6 @@ TEST_P(userclk_c_mock_p, main6) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(userclk_c_mock_p);
-INSTANTIATE_TEST_CASE_P(userclk_c, userclk_c_mock_p,
+INSTANTIATE_TEST_SUITE_P(userclk_c, userclk_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 

--- a/tests/xfpga/test_afu_metrics_c.cpp
+++ b/tests/xfpga/test_afu_metrics_c.cpp
@@ -335,5 +335,5 @@ TEST_P(afu_metrics_c_p, test_afu_metrics_04) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(afu_metrics_c_p);
-INSTANTIATE_TEST_CASE_P(afu_metrics_c, afu_metrics_c_p,
+INSTANTIATE_TEST_SUITE_P(afu_metrics_c, afu_metrics_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p", "dcp-rc","dcp-vc" })));

--- a/tests/xfpga/test_bmc_c.cpp
+++ b/tests/xfpga/test_bmc_c.cpp
@@ -559,5 +559,5 @@ TEST_P(bmc_c_p, test_bmc_7) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(bmc_c_p);
-INSTANTIATE_TEST_CASE_P(bmc_c, bmc_c_p,
+INSTANTIATE_TEST_SUITE_P(bmc_c, bmc_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));

--- a/tests/xfpga/test_buffer_c.cpp
+++ b/tests/xfpga/test_buffer_c.cpp
@@ -293,7 +293,7 @@ std::vector<buffer_params> params{
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(buffer_prepare);
-INSTANTIATE_TEST_CASE_P(buffer_c, buffer_prepare,
+INSTANTIATE_TEST_SUITE_P(buffer_c, buffer_prepare,
                         ::testing::Combine(::testing::ValuesIn(test_platform::keys()),
                                            ::testing::ValuesIn(params)));
 
@@ -370,5 +370,5 @@ TEST_P(buffer_c_mock_p, port_dma_map) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(buffer_c_mock_p);
-INSTANTIATE_TEST_CASE_P(buffer_c, buffer_c_mock_p,
+INSTANTIATE_TEST_SUITE_P(buffer_c, buffer_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_common_c.cpp
+++ b/tests/xfpga/test_common_c.cpp
@@ -183,4 +183,4 @@ TEST_P(common_c_p, event_handle_check_and_lock) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(common_c_p);
-INSTANTIATE_TEST_CASE_P(common_c, common_c_p, ::testing::ValuesIn(test_platform::keys(true)));
+INSTANTIATE_TEST_SUITE_P(common_c, common_c_p, ::testing::ValuesIn(test_platform::keys(true)));

--- a/tests/xfpga/test_enum_c.cpp
+++ b/tests/xfpga/test_enum_c.cpp
@@ -44,7 +44,7 @@
 #include "opae_drv.h"
 #include "types_int.h"
 #include "sysfs_int.h"
-#include "mock/mock_opae.h"
+#include "mock/opae_fixtures.h"
 extern "C" {
 #include "fpga-dfl.h"
 }
@@ -1097,7 +1097,7 @@ TEST_P(enum_c_p, get_guid) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_c_p);
-INSTANTIATE_TEST_CASE_P(enum_c, enum_c_p, 
+INSTANTIATE_TEST_SUITE_P(enum_c, enum_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
 class enum_err_c_p : public enum_c_p {};
@@ -1144,7 +1144,7 @@ TEST_P(enum_err_c_p, num_errors_port) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_err_c_p);
-INSTANTIATE_TEST_CASE_P(enum_c, enum_err_c_p,
+INSTANTIATE_TEST_SUITE_P(enum_c, enum_err_c_p,
                        ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
 class enum_socket_c_p : public enum_c_p {};
@@ -1166,7 +1166,7 @@ TEST_P(enum_socket_c_p, socket_id) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_socket_c_p);
-INSTANTIATE_TEST_CASE_P(enum_c, enum_socket_c_p,
+INSTANTIATE_TEST_SUITE_P(enum_c, enum_socket_c_p,
                           ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
 class enum_mock_only : public enum_c_p {};
@@ -1201,5 +1201,5 @@ TEST_P(enum_mock_only, remove_port) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(enum_mock_only);
-INSTANTIATE_TEST_CASE_P(enum_c, enum_mock_only,
+INSTANTIATE_TEST_SUITE_P(enum_c, enum_mock_only,
                           ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_error_c.cpp
+++ b/tests/xfpga/test_error_c.cpp
@@ -632,7 +632,7 @@ TEST_P(error_c_mock_p, error_12) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(error_c_mock_p);
-INSTANTIATE_TEST_CASE_P(error_c, error_c_mock_p,
+INSTANTIATE_TEST_SUITE_P(error_c, error_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
 class error_c_p : public error_c_mock_p {};
@@ -726,7 +726,7 @@ TEST_P(error_c_p, error_13) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(error_c_p);
-INSTANTIATE_TEST_CASE_P(error_c, error_c_p,
+INSTANTIATE_TEST_SUITE_P(error_c, error_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
 /**

--- a/tests/xfpga/test_events_c.cpp
+++ b/tests/xfpga/test_events_c.cpp
@@ -655,7 +655,7 @@ TEST_P(events_p, irq_event_06) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(events_p);
-INSTANTIATE_TEST_CASE_P(events, events_p,
+INSTANTIATE_TEST_SUITE_P(events, events_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000", "dfl-d5005", "dfl-n6000" })));
 
 
@@ -694,7 +694,7 @@ TEST_P(events_dcp_p, invalid_fme_event_request){
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(events_dcp_p);
-INSTANTIATE_TEST_CASE_P(events, events_dcp_p,
+INSTANTIATE_TEST_SUITE_P(events, events_dcp_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-n3000","dfl-d5005" })));
 
 
@@ -735,7 +735,7 @@ TEST_P(events_mcp_p, invalid_fme_event_request){
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(events_mcp_p);
-INSTANTIATE_TEST_CASE_P(events, events_mcp_p,
+INSTANTIATE_TEST_SUITE_P(events, events_mcp_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-d5005" })));
 
 
@@ -1288,5 +1288,5 @@ TEST_P(events_mock_p, irq_event_03) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(events_mock_p);
-INSTANTIATE_TEST_CASE_P(events, events_mock_p,
+INSTANTIATE_TEST_SUITE_P(events, events_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_metadata_c.cpp
+++ b/tests/xfpga/test_metadata_c.cpp
@@ -400,7 +400,7 @@ TEST_P(metadata_c, get_interface_id_03) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metadata_c);
-INSTANTIATE_TEST_CASE_P(metadata, metadata_c, ::testing::ValuesIn(test_platform::platforms({ "dfl-d5005" })));
+INSTANTIATE_TEST_SUITE_P(metadata, metadata_c, ::testing::ValuesIn(test_platform::platforms({ "dfl-d5005" })));
 
 class metadata_mock_c : public metadata_c {};
 
@@ -420,7 +420,7 @@ TEST_P(metadata_mock_c, validate_bitstream_metadata) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metadata_mock_c);
-INSTANTIATE_TEST_CASE_P(metadata, metadata_mock_c,
+INSTANTIATE_TEST_SUITE_P(metadata, metadata_mock_c,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-d5005" })));
 
 class metadata_mock_d5005_c : public metadata_c {};
@@ -449,7 +449,7 @@ TEST_P(metadata_mock_d5005_c, validate_bitstream_metadata_1) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metadata_mock_d5005_c);
-INSTANTIATE_TEST_CASE_P(metadata, metadata_mock_d5005_c,
+INSTANTIATE_TEST_SUITE_P(metadata, metadata_mock_d5005_c,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-d5005" })));
 
 
@@ -471,5 +471,5 @@ TEST_P(metadata_hw_c, validate_bitstream_metadata) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metadata_hw_c);
-INSTANTIATE_TEST_CASE_P(metadata, metadata_hw_c,
+INSTANTIATE_TEST_SUITE_P(metadata, metadata_hw_c,
                         ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-d5005" })));

--- a/tests/xfpga/test_metrics_c.cpp
+++ b/tests/xfpga/test_metrics_c.cpp
@@ -301,7 +301,7 @@ TEST_P(metrics_c_p, test_metric_04) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_c_p);
-INSTANTIATE_TEST_CASE_P(metrics_c, metrics_c_p,
+INSTANTIATE_TEST_SUITE_P(metrics_c, metrics_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));
 
 /**
@@ -587,5 +587,5 @@ TEST_P(metrics_afu_c_p, test_afc_metric_04) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_afu_c_p);
-INSTANTIATE_TEST_CASE_P(metrics_c, metrics_afu_c_p,
+INSTANTIATE_TEST_SUITE_P(metrics_c, metrics_afu_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));

--- a/tests/xfpga/test_metrics_max10_c.cpp
+++ b/tests/xfpga/test_metrics_max10_c.cpp
@@ -187,7 +187,7 @@ TEST_P(metrics_max10_c_p, test_metric_max10_2) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_max10_c_p);
-INSTANTIATE_TEST_CASE_P(metrics_max10_c, metrics_max10_c_p,
+INSTANTIATE_TEST_SUITE_P(metrics_max10_c, metrics_max10_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"dfl-n3000"})));
 
 class metrics_invalid_max10_c_p : public metrics_max10_c_p {};
@@ -213,7 +213,7 @@ TEST_P(metrics_invalid_max10_c_p, test_metric_max10_3) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_invalid_max10_c_p);
-INSTANTIATE_TEST_CASE_P(metrics_max10_c, metrics_invalid_max10_c_p,
+INSTANTIATE_TEST_SUITE_P(metrics_max10_c, metrics_invalid_max10_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));
 
 
@@ -247,5 +247,5 @@ TEST_P(metrics_max10_vc_c_p, test_metric_max10_4) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_max10_vc_c_p);
-INSTANTIATE_TEST_CASE_P(metrics_max10_c, metrics_max10_vc_c_p,
+INSTANTIATE_TEST_SUITE_P(metrics_max10_c, metrics_max10_vc_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-d5005" })));

--- a/tests/xfpga/test_metrics_utils_c.cpp
+++ b/tests/xfpga/test_metrics_utils_c.cpp
@@ -350,7 +350,7 @@ TEST_P(metrics_utils_c_p, test_metric_utils_15) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_utils_c_p);
-INSTANTIATE_TEST_CASE_P(metrics_utils_c, metrics_utils_c_p,
+INSTANTIATE_TEST_SUITE_P(metrics_utils_c, metrics_utils_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));
 
 class metrics_utils_dcp_c_p : public ::testing::TestWithParam<std::string> {
@@ -446,5 +446,5 @@ TEST_P(metrics_utils_dcp_c_p, test_metric_utils_14) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_utils_dcp_c_p);
-INSTANTIATE_TEST_CASE_P(metrics_utils_c, metrics_utils_dcp_c_p,
+INSTANTIATE_TEST_SUITE_P(metrics_utils_c, metrics_utils_dcp_c_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));

--- a/tests/xfpga/test_mmio_c.cpp
+++ b/tests/xfpga/test_mmio_c.cpp
@@ -491,4 +491,4 @@ TEST_P (mmio_c_p, test_neg_read_write_512) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(mmio_c_p);
-INSTANTIATE_TEST_CASE_P(mmio_c, mmio_c_p, ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
+INSTANTIATE_TEST_SUITE_P(mmio_c, mmio_c_p, ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_mock_errinj_c.cpp
+++ b/tests/xfpga/test_mock_errinj_c.cpp
@@ -165,7 +165,7 @@ TEST_P(err_inj_c_usd_p, dfl_tests_neg) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(err_inj_c_usd_p);
-INSTANTIATE_TEST_CASE_P(err_inj_c, err_inj_c_usd_p, 
+INSTANTIATE_TEST_SUITE_P(err_inj_c, err_inj_c_usd_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
 class err_inj_c_mock_p : public err_inj_c_p {
@@ -241,7 +241,7 @@ TEST_P(err_inj_c_mock_p, port_to_interface_err) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(err_inj_c_mock_p);
-INSTANTIATE_TEST_CASE_P(err_inj_c, err_inj_c_mock_p, 
+INSTANTIATE_TEST_SUITE_P(err_inj_c, err_inj_c_mock_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
 /**

--- a/tests/xfpga/test_object_c.cpp
+++ b/tests/xfpga/test_object_c.cpp
@@ -166,7 +166,7 @@ TEST_P(sysobject_p, xfpga_fpgaDestroyObject) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysobject_p);
-INSTANTIATE_TEST_CASE_P(sysobject_c, sysobject_p,
+INSTANTIATE_TEST_SUITE_P(sysobject_c, sysobject_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
 
@@ -277,5 +277,5 @@ TEST_P(sysobject_mock_p, xfpga_fpgaGetSize) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysobject_mock_p);
-INSTANTIATE_TEST_CASE_P(sysobject_c, sysobject_mock_p,
+INSTANTIATE_TEST_SUITE_P(sysobject_c, sysobject_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_open_close_c.cpp
+++ b/tests/xfpga/test_open_close_c.cpp
@@ -310,7 +310,7 @@ TEST_P(openclose_c_p, close_03) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(openclose_c_p);
-INSTANTIATE_TEST_CASE_P(openclose_c, openclose_c_p, 
+INSTANTIATE_TEST_SUITE_P(openclose_c, openclose_c_p, 
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
 class openclose_c_skx_dcp_p
@@ -334,7 +334,7 @@ TEST_P(openclose_c_skx_dcp_p, open_share) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(openclose_c_skx_dcp_p);
-INSTANTIATE_TEST_CASE_P(openclose_c_skx_dcp, openclose_c_skx_dcp_p,
+INSTANTIATE_TEST_SUITE_P(openclose_c_skx_dcp, openclose_c_skx_dcp_p,
                         ::testing::ValuesIn(test_platform::platforms({}, fpga_driver::linux_intel)));
 
 class openclose_c_dfl_p
@@ -357,7 +357,7 @@ TEST_P(openclose_c_dfl_p, open_share) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(openclose_c_dfl_p);
-INSTANTIATE_TEST_CASE_P(openclose_c_dfl, openclose_c_dfl_p,
+INSTANTIATE_TEST_SUITE_P(openclose_c_dfl, openclose_c_dfl_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({}, fpga_driver::linux_dfl0)));
 
 /**
@@ -401,5 +401,5 @@ TEST_P(openclose_c_mock_p, invalid_open_close) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(openclose_c_mock_p);
-INSTANTIATE_TEST_CASE_P(openclose_c, openclose_c_mock_p, 
+INSTANTIATE_TEST_SUITE_P(openclose_c, openclose_c_mock_p, 
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_plugin_c.cpp
+++ b/tests/xfpga/test_plugin_c.cpp
@@ -157,7 +157,7 @@ TEST_P(xfpga_plugin_c_p, test_plugin_2) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(xfpga_plugin_c_p);
-INSTANTIATE_TEST_CASE_P(xfpga_plugin_c, xfpga_plugin_c_p,
+INSTANTIATE_TEST_SUITE_P(xfpga_plugin_c, xfpga_plugin_c_p,
 	::testing::ValuesIn(test_platform::mock_platforms({"skx-p","dcp-rc"})));
 
 class xfpga_plugin_mock_c_p : public ::testing::TestWithParam<std::string> {
@@ -177,6 +177,6 @@ TEST_P(xfpga_plugin_mock_c_p, test_plugin_neg) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(xfpga_plugin_mock_c_p);
-INSTANTIATE_TEST_CASE_P(xfpga_plugin_mock_c, xfpga_plugin_mock_c_p,
+INSTANTIATE_TEST_SUITE_P(xfpga_plugin_mock_c, xfpga_plugin_mock_c_p,
      ::testing::ValuesIn(test_platform::mock_platforms()));
 

--- a/tests/xfpga/test_properties_c.cpp
+++ b/tests/xfpga/test_properties_c.cpp
@@ -226,7 +226,7 @@ TEST_P(properties_c_p, valid_gets) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(properties_c_p);
-INSTANTIATE_TEST_CASE_P(properties_c, properties_c_p,
+INSTANTIATE_TEST_SUITE_P(properties_c, properties_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
 /**

--- a/tests/xfpga/test_reconf_c.cpp
+++ b/tests/xfpga/test_reconf_c.cpp
@@ -304,7 +304,7 @@ TEST_P(reconf_c, validate_bitstream) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c);
-INSTANTIATE_TEST_CASE_P(reconf, reconf_c,
+INSTANTIATE_TEST_SUITE_P(reconf, reconf_c,
                         ::testing::ValuesIn(test_platform::platforms({})));
 
 class reconf_c_mock_p : public ::testing::TestWithParam<std::string> {
@@ -443,7 +443,7 @@ TEST_P(reconf_c_mock_p, fpga_reconf_slot_enotsup) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c_mock_p);
-INSTANTIATE_TEST_CASE_P(reconf, reconf_c_mock_p,
+INSTANTIATE_TEST_SUITE_P(reconf, reconf_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
 class reconf_c_hw_skx_p : public reconf_c {
@@ -463,7 +463,7 @@ TEST_P(reconf_c_hw_skx_p, set_afu_userclock) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c_hw_skx_p);
-INSTANTIATE_TEST_CASE_P(reconf, reconf_c_hw_skx_p,
+INSTANTIATE_TEST_SUITE_P(reconf, reconf_c_hw_skx_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-d5005" })));
 
 class reconf_c_hw_dcp_p : public reconf_c {
@@ -483,7 +483,7 @@ TEST_P(reconf_c_hw_dcp_p, set_afu_userclock) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c_hw_dcp_p);
-INSTANTIATE_TEST_CASE_P(reconf, reconf_c_hw_dcp_p,
+INSTANTIATE_TEST_SUITE_P(reconf, reconf_c_hw_dcp_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-d5005" })));
 
 /**
@@ -591,5 +591,5 @@ TEST_P(reconf_c_hw_p, fpga_reconf_slot_inv_len) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c_hw_p);
-INSTANTIATE_TEST_CASE_P(reconf, reconf_c_hw_p,
+INSTANTIATE_TEST_SUITE_P(reconf, reconf_c_hw_p,
 	::testing::ValuesIn(test_platform::hw_platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_reset_c.cpp
+++ b/tests/xfpga/test_reset_c.cpp
@@ -152,7 +152,8 @@ TEST_P(reset_c_p, valid_port_reset) {
 } 
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reset_c_p);
-INSTANTIATE_TEST_CASE_P(reset_c, reset_c_p, ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005","dfl-n6000" })));
+INSTANTIATE_TEST_SUITE_P(reset_c, reset_c_p,
+                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005","dfl-n6000" })));
 
 class reset_c_mock_p : public reset_c_p {
  protected:
@@ -172,5 +173,5 @@ TEST_P(reset_c_mock_p, test_port_drv_reset_01) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reset_c_mock_p);
-INSTANTIATE_TEST_CASE_P(reset_c, reset_c_mock_p,
+INSTANTIATE_TEST_SUITE_P(reset_c, reset_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));

--- a/tests/xfpga/test_sysfs_c.cpp
+++ b/tests/xfpga/test_sysfs_c.cpp
@@ -287,7 +287,7 @@ TEST(sysfsinit_c_p, sysfs_parse_pcie) {
 
 // TODO re-enable these for n6000.
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfsinit_c_p);
-INSTANTIATE_TEST_CASE_P(sysfsinit_c, sysfsinit_c_p,
+INSTANTIATE_TEST_SUITE_P(sysfsinit_c, sysfsinit_c_p,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000", "dfl-d5005" })));
 
 class sysfs_c_p : public ::testing::TestWithParam<std::string> {
@@ -607,7 +607,7 @@ TEST_P(sysfs_c_p, get_fme_path_neg) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_c_p);
-INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_p,
+INSTANTIATE_TEST_SUITE_P(sysfs_c, sysfs_c_p,
                         ::testing::ValuesIn(test_platform::platforms({})));
 
 class sysfs_c_hw_p : public sysfs_c_p {
@@ -658,7 +658,7 @@ TEST_P(sysfs_c_hw_p, make_object_glob) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_c_hw_p);
-INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_hw_p,
+INSTANTIATE_TEST_SUITE_P(sysfs_c, sysfs_c_hw_p,
                         ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-n3000","dfl-d5005" })));
 
 class sysfs_c_mock_p : public sysfs_c_p {
@@ -930,7 +930,7 @@ TEST_P(sysfs_c_mock_p, fpga_sysfs_30) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_c_mock_p);
-INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_mock_p,
+INSTANTIATE_TEST_SUITE_P(sysfs_c, sysfs_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
 
@@ -958,7 +958,7 @@ TEST_P(sysfs_dfl_c_mock_p, fpga_sysfs_08) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_dfl_c_mock_p);
-INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_dfl_c_mock_p,
+INSTANTIATE_TEST_SUITE_P(sysfs_c, sysfs_dfl_c_mock_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
 class sysfs_power_mock_p : public sysfs_c_mock_p { };
@@ -985,7 +985,7 @@ TEST_P(sysfs_power_mock_p, fpga_sysfs_09) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_power_mock_p);
-INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_power_mock_p,
+INSTANTIATE_TEST_SUITE_P(sysfs_c, sysfs_power_mock_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
 
@@ -1010,7 +1010,7 @@ TEST_P(sysfs_bmc_mock_p, fpga_sysfs_10) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_bmc_mock_p);
-INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_bmc_mock_p,
+INSTANTIATE_TEST_SUITE_P(sysfs_c, sysfs_bmc_mock_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dcp-rc" })));
 
 
@@ -1035,7 +1035,7 @@ TEST_P(sysfs_max10_mock_p, fpga_sysfs_11) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_max10_mock_p);
-INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_max10_mock_p,
+INSTANTIATE_TEST_SUITE_P(sysfs_c, sysfs_max10_mock_p,
 	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
 
@@ -1111,7 +1111,7 @@ TEST_P(sysfs_c_mock_no_drv_p, sysfs_get_bitstream_id) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_c_mock_no_drv_p);
-INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_c_mock_no_drv_p,
+INSTANTIATE_TEST_SUITE_P(sysfs_c, sysfs_c_mock_no_drv_p,
                         ::testing::ValuesIn(test_platform::mock_platforms()));
 
 class sysfs_sockid_c_mock_p : public sysfs_c_mock_p { };
@@ -1128,7 +1128,7 @@ TEST_P(sysfs_sockid_c_mock_p, fpga_sysfs_02) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_sockid_c_mock_p);
-INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_sockid_c_mock_p,
+INSTANTIATE_TEST_SUITE_P(sysfs_c, sysfs_sockid_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
 
@@ -1326,7 +1326,7 @@ TEST_P(sysfs_sockid_c_p, get_port_sysfs) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(sysfs_sockid_c_p);
-INSTANTIATE_TEST_CASE_P(sysfs_c, sysfs_sockid_c_p,
+INSTANTIATE_TEST_SUITE_P(sysfs_c, sysfs_sockid_c_p,
                        ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
 
 /**

--- a/tests/xfpga/test_threshold_c.cpp
+++ b/tests/xfpga/test_threshold_c.cpp
@@ -159,7 +159,7 @@ TEST_P(metrics_threshold_c_p, metrics_threshold_2) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_threshold_c_p);
-INSTANTIATE_TEST_CASE_P(metrics_threshold_c_c, metrics_threshold_c_p,
+INSTANTIATE_TEST_SUITE_P(metrics_threshold_c_c, metrics_threshold_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"dcp-vc"})));
 
 class metrics_bmc_threshold_c_p : public metrics_threshold_c_p {};
@@ -217,7 +217,7 @@ TEST_P(metrics_bmc_threshold_c_p, metrics_threshold_4) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_bmc_threshold_c_p);
-INSTANTIATE_TEST_CASE_P(metrics_threshold_c_c, metrics_bmc_threshold_c_p,
+INSTANTIATE_TEST_SUITE_P(metrics_threshold_c_c, metrics_bmc_threshold_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));
 
 class metrics_mcp_threshold_c_p : public metrics_threshold_c_p {};
@@ -246,7 +246,7 @@ TEST_P(metrics_mcp_threshold_c_p, metrics_threshold_5) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_mcp_threshold_c_p);
-INSTANTIATE_TEST_CASE_P(metrics_threshold_c_c, metrics_mcp_threshold_c_p,
+INSTANTIATE_TEST_SUITE_P(metrics_threshold_c_c, metrics_mcp_threshold_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"skx-p"})));
 
 class metrics_afu_threshold_c_p : public ::testing::TestWithParam<std::string> {
@@ -311,5 +311,5 @@ TEST_P(metrics_afu_threshold_c_p, metrics_threshold_6) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_afu_threshold_c_p);
-INSTANTIATE_TEST_CASE_P(metrics_threshold_c_c, metrics_afu_threshold_c_p,
+INSTANTIATE_TEST_SUITE_P(metrics_threshold_c_c, metrics_afu_threshold_c_p,
     ::testing::ValuesIn(test_platform::mock_platforms({"dcp-vc"})));

--- a/tests/xfpga/test_umsg_c.cpp
+++ b/tests/xfpga/test_umsg_c.cpp
@@ -358,7 +358,7 @@ TEST_P(umsg_c_p, test_umsg_drv_08_DISABLED) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umsg_c_p);
-INSTANTIATE_TEST_CASE_P(umsg_c, umsg_c_p, ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));
+INSTANTIATE_TEST_SUITE_P(umsg_c, umsg_c_p, ::testing::ValuesIn(test_platform::platforms({ "skx-p" })));
 
 class umsg_c_mcp_p : public umsg_c_p {
 };
@@ -398,7 +398,7 @@ TEST_P(umsg_c_mcp_p, test_umsg_drv_04_DISABLED) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umsg_c_mcp_p);
-INSTANTIATE_TEST_CASE_P(umsg_c, umsg_c_mcp_p,
+INSTANTIATE_TEST_SUITE_P(umsg_c, umsg_c_mcp_p,
                         ::testing::ValuesIn(test_platform::platforms({"skx-p"})));
 
 class umsg_c_mock_p : public umsg_c_p {
@@ -618,6 +618,6 @@ TEST_P(umsg_c_mock_p, test_umsg_09_DISABLED) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umsg_c_mock_p);
-INSTANTIATE_TEST_CASE_P(umsg_c, umsg_c_mock_p,
+INSTANTIATE_TEST_SUITE_P(umsg_c, umsg_c_mock_p,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "skx-p"})));
 

--- a/tests/xfpga/test_usrclk_c.cpp
+++ b/tests/xfpga/test_usrclk_c.cpp
@@ -261,7 +261,7 @@ TEST_P(usrclk_c, get_user_clock) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(usrclk_c);
-INSTANTIATE_TEST_CASE_P(usrclk, usrclk_c,
+INSTANTIATE_TEST_SUITE_P(usrclk, usrclk_c,
                         ::testing::ValuesIn(test_platform::platforms({ "dfl-d5005" })));
 
 class usrclk_mock_c : public usrclk_c {};
@@ -283,7 +283,7 @@ TEST_P(usrclk_mock_c, set_user_clock) {
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(usrclk_mock_c);
-INSTANTIATE_TEST_CASE_P(usrclk, usrclk_mock_c,
+INSTANTIATE_TEST_SUITE_P(usrclk, usrclk_mock_c,
                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
 class usrclk_hw_c : public usrclk_c {};
@@ -305,5 +305,5 @@ uint64_t high = 312;
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(usrclk_hw_c);
-INSTANTIATE_TEST_CASE_P(usrclk, usrclk_hw_c,
+INSTANTIATE_TEST_SUITE_P(usrclk, usrclk_hw_c,
                         ::testing::ValuesIn(test_platform::hw_platforms({ "skx-p","dcp-rc" })));


### PR DESCRIPTION
Replace with INSTANTIATE_TEST_SUITE_P, per the gtest docs.
Set the gtest variables correctly when manually fetching gtest.

Link with debug gtest libraries when CMAKE_BUILD_TYPE is Debug or
RelWithDebInfo.

Fix bug in object_api tests.  Reset cleanup_size to 0 at the beginning
of each test, because main() is called multiple times.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>