### PR TITLE
vfio-plugin: use volatile pointers for mmio

### DIFF
--- a/libraries/plugins/vfio/dfl.c
+++ b/libraries/plugins/vfio/dfl.c
@@ -106,8 +106,7 @@ int walk_fme(pci_device_t *p, struct opae_vfio *v, volatile uint8_t *mmio,
 	fab_capability_ptr cap = (fab_capability_ptr)(mmio + FAB_CAPABILITY);
 
 	fme->num_ports = cap->num_ports;
-	for_each_dfh(h, mmio)
-	{
+	for_each_dfh(h, mmio) {
 		if (h->id == PR_FEATURE_ID) {
 			uint8_t *pr_id = PR_INTFC_ID_LO + (uint8_t *)h;
 

--- a/libraries/plugins/vfio/dfl.c
+++ b/libraries/plugins/vfio/dfl.c
@@ -42,7 +42,8 @@ static fpga_result legacy_port_reset(const pci_device_t *p,
 				     volatile uint8_t *port_base)
 {
 	(void)p;
-	port_control *cntrl = (port_control *)(port_base + PORT_CONTROL);
+	port_control_ptr cntrl =
+		(port_control_ptr)(port_base + PORT_CONTROL);
 
 	cntrl->port_reset = 1;
 	(void)*cntrl;
@@ -63,10 +64,10 @@ static fpga_result legacy_port_reset(const pci_device_t *p,
 }
 
 
-static inline dfh *next_dfh(dfh *h)
+static inline dfh_ptr next_dfh(dfh_ptr h)
 {
 	if (h && h->next && !h->eol)
-		return (dfh *)(((uint8_t *)h)+h->next);
+		return (dfh_ptr)(((volatile uint8_t *)h)+h->next);
 	return NULL;
 }
 
@@ -76,8 +77,8 @@ int walk_port(vfio_token *parent, uint32_t region, volatile uint8_t *mmio)
 {
 	//walk_port
 	vfio_token *port = get_token(parent->device, region, FPGA_ACCELERATOR);
-	port_next_afu *next_afu = (port_next_afu *)(mmio+PORT_NEXT_AFU);
-	port_capability *cap = (port_capability *)(mmio+PORT_CAPABILITY);
+	port_next_afu_ptr next_afu = (port_next_afu_ptr)(mmio+PORT_NEXT_AFU);
+	port_capability_ptr cap = (port_capability_ptr)(mmio+PORT_CAPABILITY);
 
 	port->parent = parent;
 	port->mmio_size = cap->mmio_size;
@@ -107,7 +108,7 @@ int walk_fme(pci_device_t *p, struct opae_vfio *v, volatile uint8_t *mmio, int r
 	get_guid(1+(uint64_t *)mmio, fme->hdr.guid);
 	fme->bitstream_id = *(uint64_t *)(mmio+BITSTREAM_ID);
 	fme->bitstream_mdata = *(uint64_t *)(mmio+BITSTREAM_MD);
-	fab_capability *cap = (fab_capability *)(mmio+FAB_CAPABILITY);
+	fab_capability_ptr cap = (fab_capability_ptr)(mmio+FAB_CAPABILITY);
 
 	fme->num_ports = cap->num_ports;
 	for_each_dfh(h, mmio) {
@@ -118,7 +119,8 @@ int walk_fme(pci_device_t *p, struct opae_vfio *v, volatile uint8_t *mmio, int r
 		}
 	}
 	for (size_t i = 0; i < FME_PORTS; ++i) {
-		port_offset *offset_r = (port_offset *)(mmio+fme_ports[i]);
+		port_offset_ptr offset_r =
+			(port_offset_ptr)(mmio+fme_ports[i]);
 
 		if (!offset_r->implemented)
 			continue;

--- a/libraries/plugins/vfio/dfl.c
+++ b/libraries/plugins/vfio/dfl.c
@@ -25,29 +25,23 @@
 // POSSIBILITY OF SUCH DAMAGE.
 #ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif //HAVE_CONFIG_H
+#endif // HAVE_CONFIG_H
 
 #include "opae_vfio.h"
 #include "dfl.h"
 
 #define FME_PORTS 4
-uint32_t fme_ports[FME_PORTS] = {
-	0x38,
-	0x40,
-	0x48,
-	0x50
-};
+uint32_t fme_ports[FME_PORTS] = {0x38, 0x40, 0x48, 0x50};
 
 static fpga_result legacy_port_reset(const pci_device_t *p,
 				     volatile uint8_t *port_base)
 {
 	(void)p;
-	port_control_ptr cntrl =
-		(port_control_ptr)(port_base + PORT_CONTROL);
+	port_control_ptr cntrl = (port_control_ptr)(port_base + PORT_CONTROL);
 
 	cntrl->port_reset = 1;
 	(void)*cntrl;
-	struct timespec ts = { .tv_sec = 0, .tv_nsec = 500 };
+	struct timespec ts = {.tv_sec = 0, .tv_nsec = 500};
 	uint64_t cycles = 0;
 	const uint64_t port_timeout = 1000;
 
@@ -67,18 +61,17 @@ static fpga_result legacy_port_reset(const pci_device_t *p,
 static inline dfh_ptr next_dfh(dfh_ptr h)
 {
 	if (h && h->next && !h->eol)
-		return (dfh_ptr)(((volatile uint8_t *)h)+h->next);
+		return (dfh_ptr)(((volatile uint8_t *)h) + h->next);
 	return NULL;
 }
 
 
-
 int walk_port(vfio_token *parent, uint32_t region, volatile uint8_t *mmio)
 {
-	//walk_port
+	// walk_port
 	vfio_token *port = get_token(parent->device, region, FPGA_ACCELERATOR);
-	port_next_afu_ptr next_afu = (port_next_afu_ptr)(mmio+PORT_NEXT_AFU);
-	port_capability_ptr cap = (port_capability_ptr)(mmio+PORT_CAPABILITY);
+	port_next_afu_ptr next_afu = (port_next_afu_ptr)(mmio + PORT_NEXT_AFU);
+	port_capability_ptr cap = (port_capability_ptr)(mmio + PORT_CAPABILITY);
 
 	port->parent = parent;
 	port->mmio_size = cap->mmio_size;
@@ -89,7 +82,8 @@ int walk_port(vfio_token *parent, uint32_t region, volatile uint8_t *mmio)
 	if (port->ops.reset(port->device, mmio)) {
 		OPAE_ERR("error resetting port");
 	}
-	get_guid(1+(uint64_t *)(mmio+next_afu->port_afu_dfh_offset), port->hdr.guid);
+	get_guid(1 + (uint64_t *)(mmio + next_afu->port_afu_dfh_offset),
+		 port->hdr.guid);
 	// look for stp and if found, add it to user_mmio offsets
 	for_each_dfh(h, mmio) {
 		if (h->id == PORT_STP_ID) {
@@ -101,26 +95,28 @@ int walk_port(vfio_token *parent, uint32_t region, volatile uint8_t *mmio)
 	return 0;
 }
 
-int walk_fme(pci_device_t *p, struct opae_vfio *v, volatile uint8_t *mmio, int region)
+int walk_fme(pci_device_t *p, struct opae_vfio *v, volatile uint8_t *mmio,
+	     int region)
 {
 	vfio_token *fme = get_token(p, region, FPGA_DEVICE);
 
-	get_guid(1+(uint64_t *)mmio, fme->hdr.guid);
-	fme->bitstream_id = *(uint64_t *)(mmio+BITSTREAM_ID);
-	fme->bitstream_mdata = *(uint64_t *)(mmio+BITSTREAM_MD);
-	fab_capability_ptr cap = (fab_capability_ptr)(mmio+FAB_CAPABILITY);
+	get_guid(1 + (uint64_t *)mmio, fme->hdr.guid);
+	fme->bitstream_id = *(uint64_t *)(mmio + BITSTREAM_ID);
+	fme->bitstream_mdata = *(uint64_t *)(mmio + BITSTREAM_MD);
+	fab_capability_ptr cap = (fab_capability_ptr)(mmio + FAB_CAPABILITY);
 
 	fme->num_ports = cap->num_ports;
-	for_each_dfh(h, mmio) {
+	for_each_dfh(h, mmio)
+	{
 		if (h->id == PR_FEATURE_ID) {
-			uint8_t *pr_id = PR_INTFC_ID_LO+(uint8_t *)h;
+			uint8_t *pr_id = PR_INTFC_ID_LO + (uint8_t *)h;
 
 			get_guid((uint64_t *)pr_id, fme->compat_id);
 		}
 	}
 	for (size_t i = 0; i < FME_PORTS; ++i) {
 		port_offset_ptr offset_r =
-			(port_offset_ptr)(mmio+fme_ports[i]);
+			(port_offset_ptr)(mmio + fme_ports[i]);
 
 		if (!offset_r->implemented)
 			continue;
@@ -134,8 +130,7 @@ int walk_fme(pci_device_t *p, struct opae_vfio *v, volatile uint8_t *mmio, int r
 			continue;
 		}
 
-		walk_port(fme, bar, port_mmio+offset_r->offset);
+		walk_port(fme, bar, port_mmio + offset_r->offset);
 	}
 	return 0;
 }
-

--- a/libraries/plugins/vfio/dfl.h
+++ b/libraries/plugins/vfio/dfl.h
@@ -131,7 +131,7 @@ typedef struct _dfl {
 	for (dfh_ptr H = (dfh_ptr)ADDR; H; H = next_dfh(H))
 
 int walk_fme(pci_device_t *p, struct opae_vfio *v, volatile uint8_t *mmio,
-	           int region);
+	int region);
 int walk_port(vfio_token *parent, uint32_t region, volatile uint8_t *mmio);
 
 #endif /* !VFIO_DFL_H */

--- a/libraries/plugins/vfio/dfl.h
+++ b/libraries/plugins/vfio/dfl.h
@@ -38,6 +38,7 @@ typedef struct _dfh {
 	uint64_t version : 8;
 	uint64_t type : 4;
 } dfh;
+typedef volatile dfh *dfh_ptr;
 
 typedef struct _dfh0 {
 	uint64_t cci_version : 12;
@@ -47,6 +48,7 @@ typedef struct _dfh0 {
 	uint64_t reserved41 : 20;
 	uint64_t type : 4;
 } dfh0;
+typedef volatile dfh0 *dfh0_ptr;
 
 typedef struct _port_offset {
 	uint64_t offset : 24;
@@ -59,6 +61,7 @@ typedef struct _port_offset {
 	uint64_t implemented : 1;
 	uint64_t reserved61 : 3;
 } port_offset;
+typedef volatile port_offset *port_offset_ptr;
 
 #define PR_FEATURE_ID 0x5
 #define PR_INTFC_ID_LO 0xA8
@@ -74,6 +77,7 @@ typedef struct _bitstream_id {
 	uint64_t ver_minor : 4;
 	uint64_t ver_major : 4;
 } bitstream_id;
+typedef volatile bitstream_id *bitstream_id_ptr;
 
 #define BITSTREAM_MD 0x68
 #define PORT_CONTROL 0x38
@@ -85,12 +89,14 @@ typedef struct _port_control {
 	uint64_t port_reset_ack : 1;
 	uint64_t reserved5 : 59;
 } port_control;
+typedef volatile port_control *port_control_ptr;
 
 #define PORT_NEXT_AFU 0x18
 typedef struct _port_next_afu {
 	uint64_t port_afu_dfh_offset : 24;
 	uint64_t reserved24: 40;
 } port_next_afu;
+typedef volatile port_next_afu *port_next_afu_ptr;
 
 #define FAB_CAPABILITY 0x30
 typedef struct _fab_capability {
@@ -103,6 +109,7 @@ typedef struct _fab_capability {
 	uint64_t address_width : 6;
 	uint64_t reserved30 : 34;
 } fab_capability;
+typedef volatile fab_capability *fab_capability_ptr;
 
 #define PORT_CAPABILITY 0x30
 typedef struct _port_capability {
@@ -113,13 +120,15 @@ typedef struct _port_capability {
 	uint64_t num_supported_int : 4;
 	uint64_t reserved36 : 28;
 } port_capability;
+typedef volatile port_capability *port_capability_ptr;
 
 typedef struct _dfl {
 	dfh h;
 	dfh *next;
 } dfl;
 
-#define for_each_dfh(H, ADDR) for (dfh *H = (dfh *)ADDR; H; H = next_dfh(H))
+#define for_each_dfh(H, ADDR)
+	for (dfh_ptr H = (dfh_ptr)ADDR; H; H = next_dfh(H))
 int walk_fme(pci_device_t *p, struct opae_vfio *v, volatile uint8_t *mmio, int region);
 int walk_port(vfio_token *parent, uint32_t region, volatile uint8_t *mmio);
 

--- a/libraries/plugins/vfio/dfl.h
+++ b/libraries/plugins/vfio/dfl.h
@@ -31,7 +31,7 @@
 typedef struct _dfh {
 	uint64_t id : 12;
 	uint64_t major_rev : 4;
-	uint64_t  next : 24;
+	uint64_t next : 24;
 	uint64_t eol : 1;
 	uint64_t reserved41 : 7;
 	uint64_t minor_rev : 4;
@@ -43,7 +43,7 @@ typedef volatile dfh *dfh_ptr;
 typedef struct _dfh0 {
 	uint64_t cci_version : 12;
 	uint64_t cci_minor_rev : 4;
-	uint64_t  next : 24;
+	uint64_t next : 24;
 	uint64_t eol : 1;
 	uint64_t reserved41 : 20;
 	uint64_t type : 4;
@@ -94,7 +94,7 @@ typedef volatile port_control *port_control_ptr;
 #define PORT_NEXT_AFU 0x18
 typedef struct _port_next_afu {
 	uint64_t port_afu_dfh_offset : 24;
-	uint64_t reserved24: 40;
+	uint64_t reserved24 : 40;
 } port_next_afu;
 typedef volatile port_next_afu *port_next_afu_ptr;
 
@@ -127,9 +127,11 @@ typedef struct _dfl {
 	dfh *next;
 } dfl;
 
-#define for_each_dfh(H, ADDR)
+#define for_each_dfh(H, ADDR)                                                  \
 	for (dfh_ptr H = (dfh_ptr)ADDR; H; H = next_dfh(H))
-int walk_fme(pci_device_t *p, struct opae_vfio *v, volatile uint8_t *mmio, int region);
+
+int walk_fme(pci_device_t *p, struct opae_vfio *v, volatile uint8_t *mmio,
+	           int region);
 int walk_port(vfio_token *parent, uint32_t region, volatile uint8_t *mmio);
 
 #endif /* !VFIO_DFL_H */


### PR DESCRIPTION
* Add typedefs for pointers to structures that represent mmio space in
  the dfl
* Whenever those structure pointers are used for mmio, replace the
  declaration with the typedef