### PR TITLE
build: reduce targets that are exported

### DIFF
--- a/binaries/fpgaconf/CMakeLists.txt
+++ b/binaries/fpgaconf/CMakeLists.txt
@@ -25,6 +25,7 @@
 ## POSSIBILITY OF SUCH DAMAGE.
 
 opae_add_executable(TARGET fpgaconf
+    EXPORT opae-targets
     SOURCE fpgaconf.c
     LIBS
         ${CMAKE_THREAD_LIBS_INIT}

--- a/cmake/modules/OPAECompiler.cmake
+++ b/cmake/modules/OPAECompiler.cmake
@@ -169,7 +169,7 @@ endfunction()
 #   opae_add_executable(TARGET fpgaconf SOURCE a.c b.c LIBS opae-c)
 function(opae_add_executable)
     set(options )
-    set(oneValueArgs TARGET COMPONENT DESTINATION)
+    set(oneValueArgs TARGET COMPONENT DESTINATION EXPORT)
     set(multiValueArgs SOURCE LIBS)
     cmake_parse_arguments(OPAE_ADD_EXECUTABLE "${options}"
         "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -205,11 +205,16 @@ function(opae_add_executable)
         else(OPAE_ADD_EXECUTABLE_DESTINATION)
             set(dest bin)
         endif(OPAE_ADD_EXECUTABLE_DESTINATION)
-
-        install(TARGETS ${OPAE_ADD_EXECUTABLE_TARGET}
-                EXPORT opae-targets
-                RUNTIME DESTINATION ${dest}
-                COMPONENT ${OPAE_ADD_EXECUTABLE_COMPONENT})
+        if(OPAE_ADD_EXECUTABLE_EXPORT)
+            install(TARGETS ${OPAE_ADD_EXECUTABLE_TARGET}
+                    EXPORT ${OPAE_ADD_EXECUTABLE_EXPORT}
+                    RUNTIME DESTINATION ${dest}
+                    COMPONENT ${OPAE_ADD_EXECUTABLE_COMPONENT})
+        else(OPAE_ADD_EXECUTABLE_EXPORT)
+            install(TARGETS ${OPAE_ADD_EXECUTABLE_TARGET}
+                    RUNTIME DESTINATION ${dest}
+                    COMPONENT ${OPAE_ADD_EXECUTABLE_COMPONENT})
+        endif(OPAE_ADD_EXECUTABLE_EXPORT)
     endif(OPAE_ADD_EXECUTABLE_COMPONENT)
 endfunction()
 
@@ -217,7 +222,7 @@ endfunction()
 #   opae_add_shared_library(TARGET opae-c SOURCE a.c b.c LIBS dl)
 function(opae_add_shared_library)
     set(options )
-    set(oneValueArgs TARGET VERSION SOVERSION COMPONENT DESTINATION)
+    set(oneValueArgs TARGET VERSION SOVERSION COMPONENT DESTINATION EXPORT)
     set(multiValueArgs SOURCE LIBS)
     cmake_parse_arguments(OPAE_ADD_SHARED_LIBRARY "${options}"
         "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -226,7 +231,7 @@ function(opae_add_shared_library)
 
     target_include_directories(${OPAE_ADD_SHARED_LIBRARY_TARGET} PUBLIC
         $<BUILD_INTERFACE:${OPAE_INCLUDE_PATH}>
-	$<BUILD_INTERFACE:${OPAE_LIB_SOURCE}>
+        $<BUILD_INTERFACE:${OPAE_LIB_SOURCE}>
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
         PUBLIC ${libjson-c_INCLUDE_DIRS}
@@ -260,10 +265,16 @@ function(opae_add_shared_library)
             set(dest ${OPAE_LIB_INSTALL_DIR})
         endif(OPAE_ADD_SHARED_LIBRARY_DESTINATION)
 
-        install(TARGETS ${OPAE_ADD_SHARED_LIBRARY_TARGET}
-                EXPORT opae-targets
-                LIBRARY DESTINATION ${dest}
-                COMPONENT ${OPAE_ADD_SHARED_LIBRARY_COMPONENT})
+        if(OPAE_ADD_SHARED_LIBRARY_EXPORT)
+            install(TARGETS ${OPAE_ADD_SHARED_LIBRARY_TARGET}
+                    EXPORT ${OPAE_ADD_SHARED_LIBRARY_EXPORT}
+                    LIBRARY DESTINATION ${dest}
+                    COMPONENT ${OPAE_ADD_SHARED_LIBRARY_COMPONENT})
+        else(OPAE_ADD_SHARED_LIBRARY_EXPORT)
+            install(TARGETS ${OPAE_ADD_SHARED_LIBRARY_TARGET}
+                    LIBRARY DESTINATION ${dest}
+                    COMPONENT ${OPAE_ADD_SHARED_LIBRARY_COMPONENT})
+        endif(OPAE_ADD_SHARED_LIBRARY_EXPORT)
     endif(OPAE_ADD_SHARED_LIBRARY_COMPONENT)
 endfunction()
 

--- a/libraries/libbitstream/CMakeLists.txt
+++ b/libraries/libbitstream/CMakeLists.txt
@@ -25,6 +25,7 @@
 ## POSSIBILITY OF SUCH DAMAGE.
 
 opae_add_shared_library(TARGET bitstream
+    EXPORT opae-targets
     SOURCE
         bitstream.c
         bits_utils.c

--- a/libraries/libofs/CMakeLists.txt
+++ b/libraries/libofs/CMakeLists.txt
@@ -31,6 +31,7 @@ set(src
 
 opae_add_shared_library(
     TARGET ofs
+    EXPORT opae-targets
     SOURCE ${src}
     LIBS
         rt

--- a/libraries/libopae-c/CMakeLists.txt
+++ b/libraries/libopae-c/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SRC
 )
 
 opae_add_shared_library(TARGET opae-c
+    EXPORT opae-targets
     SOURCE ${SRC}
     LIBS
         dl

--- a/libraries/libopaecxx/CMakeLists.txt
+++ b/libraries/libopaecxx/CMakeLists.txt
@@ -39,6 +39,7 @@ set(OPAECXXCORE_SRC
 )
 
 opae_add_shared_library(TARGET opae-cxx-core
+    EXPORT opae-targets
     SOURCE ${OPAECXXCORE_SRC}
     VERSION ${OPAE_VERSION}
     SOVERSION ${OPAE_VERSION_MAJOR}

--- a/libraries/libopaemem/CMakeLists.txt
+++ b/libraries/libopaemem/CMakeLists.txt
@@ -25,6 +25,7 @@
 ## POSSIBILITY OF SUCH DAMAGE.
 
 opae_add_shared_library(TARGET opaemem
+    EXPORT opae-targets
     SOURCE mem_alloc.c
     VERSION ${OPAE_VERSION}
     SOVERSION ${OPAE_VERSION_MAJOR}

--- a/libraries/libopaeuio/CMakeLists.txt
+++ b/libraries/libopaeuio/CMakeLists.txt
@@ -25,6 +25,7 @@
 ## POSSIBILITY OF SUCH DAMAGE.
 
 opae_add_shared_library(TARGET opaeuio
+    EXPORT opae-targets
     SOURCE opaeuio.c
     VERSION ${OPAE_VERSION}
     SOVERSION ${OPAE_VERSION_MAJOR}

--- a/libraries/libopaevfio/CMakeLists.txt
+++ b/libraries/libopaevfio/CMakeLists.txt
@@ -25,6 +25,7 @@
 ## POSSIBILITY OF SUCH DAMAGE.
 
 opae_add_shared_library(TARGET opaevfio
+    EXPORT opae-targets
     SOURCE opaevfio.c
     LIBS
         ${CMAKE_THREAD_LIBS_INIT}


### PR DESCRIPTION
Realizing that not all targets should be imported by external CMake
projects, I've narrowed down the list of targets to the following:
* opae-c
* opae-cxx-core
* opaemem
* ofs
* opaeuio
* opaevfio
* bitstream
* fpgaconf

For this, I've modified the opae_add_executable and
opae_add_shared_library functions to take in an optional one-value
argument to indicate the export name. I've modified the CMakeLists.txt
that are used for building the targets listing above to add the EXPORT
argument in the add target directive.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>