### PR TITLE
build: export adapter.h into include/opae/plugin

### DIFF
--- a/libraries/libopae-c/CMakeLists.txt
+++ b/libraries/libopae-c/CMakeLists.txt
@@ -43,3 +43,8 @@ opae_add_shared_library(TARGET opae-c
     SOVERSION ${OPAE_VERSION_MAJOR}
     COMPONENT opaeclib
 )
+
+install(FILES adapter.h
+    DESTINATION include/opae/plugin
+)
+


### PR DESCRIPTION
Install adapter.h so to facilitate the development of a project
implemeting a plugin.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>