### PR TITLE
packaging: export cmake config files

### DIFF
--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -285,6 +285,7 @@ done
 %{_libdir}/libopaemem.so
 %{_libdir}/libopaeuio.so
 %{_libdir}/libopaevfio.so
+%{_prefix}/lib/opae-%{version}
 
 %{_bindir}/bitstreaminfo
 %{_bindir}/fpgaflash

--- a/opae.spec.rhel
+++ b/opae.spec.rhel
@@ -277,6 +277,7 @@ done
 %{_libdir}/libopaemem.so
 %{_libdir}/libopaeuio.so
 %{_libdir}/libopaevfio.so
+%{_prefix}/lib/opae-%{version}
 
 %{_bindir}/bitstreaminfo
 %{_bindir}/fpgaflash

--- a/packaging/opae/deb/create
+++ b/packaging/opae/deb/create
@@ -83,6 +83,7 @@ mkdir -p "${TARBALL_DIR}/debian/source"
 
 for f in 'changelog' \
          'opae.install' \
+         'opae-devel.dirs' \
          'opae-devel.install' \
          'opae-extra-tools.install'
 do

--- a/packaging/opae/deb/opae-devel.dirs
+++ b/packaging/opae/deb/opae-devel.dirs
@@ -2,3 +2,4 @@ usr/include/opae
 usr/include/opae/cxx/core
 usr/src/opae
 usr/share/opae
+usr/lib/opae-@VERSION@


### PR DESCRIPTION
* Modify RPM spec files to include cmake configuration directory installed
  in <prefix>/lib/opae-<version>
* Modify debian build scripts/input files to account for cmake
  configuration directory inside the "dev" package

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>