### PR TITLE
cpeng: fix return code of hps command

### DIFF
--- a/ofs/apps/cpeng/hps.cpp
+++ b/ofs/apps/cpeng/hps.cpp
@@ -325,7 +325,6 @@ int main(int argc, char *argv[])
   opae::afu_test::afu hps(cpeng_guid);
   hps.register_command<cpeng>();
   hps.register_command<heartbeat>();
-  hps.main(argc, argv);
-  return 0;
+  return hps.main(argc, argv);
 }
 


### PR DESCRIPTION
In main for hps executable, return exit code returned by calling the
app's main function. If/when CLI11's validators determine an argument to
be invalid, the exit code returned from CLI11 will be returned.
In the case of a validation error, the error code returned is the
enumeration ValidationError which equals 105.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>