### PR TITLE
build: add plugin.h, export OPAEGit.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,3 +575,7 @@ install(FILES
     ${CMAKE_BINARY_DIR}/cmake/pkg/opae-config-version.cmake
     DESTINATION lib/opae-${OPAE_VERSION})
 
+install(FILES
+    ${OPAE_SDK_SOURCE}/cmake/modules/OPAEGit.cmake
+    DESTINATION lib/opae-${OPAE_VERSION}/modules
+)

--- a/cmake/pkg/opae-config.cmake.in
+++ b/cmake/pkg/opae-config.cmake.in
@@ -3,5 +3,9 @@ get_filename_component(_prefix "${_dir}/../.." ABSOLUTE)
 
 # import targets
 include("${_prefix}/lib/opae-@OPAE_VERSION@/opae-targets.cmake")
+set(CMAKE_MODULE_PATH
+	${CMAKE_MODULE_PATH}
+	"${_prefix}/lib/opae-@OPAE_VERSION@/modules"
+)
 
 set(opae_INCLUDE_DIRS "${_prefix}/include/opae")

--- a/libraries/libopae-c/CMakeLists.txt
+++ b/libraries/libopae-c/CMakeLists.txt
@@ -44,7 +44,10 @@ opae_add_shared_library(TARGET opae-c
     COMPONENT opaeclib
 )
 
-install(FILES adapter.h
+install(FILES adapter.h props.h opae_int.h
     DESTINATION include/opae/plugin
+)
+install(FILES plugin.h
+    DESTINATION include/opae
 )
 

--- a/libraries/libopae-c/plugin.h
+++ b/libraries/libopae-c/plugin.h
@@ -1,0 +1,35 @@
+// Copyright(c) 2021, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef OPAE_PLUGIN_H
+#define OPAE_PLUGIN_H
+#include <opae/plugin/adapter.h>
+#include <opae/plugin/opae_int.h>
+#include <opae/plugin/props.h>
+
+
+
+#endif /* !OPAE_PLUGIN_H */


### PR DESCRIPTION
* add plugin.h for plugin development
  * Add plugin.h that includes headers that can be used in plugins
  * Install new plugin.h as well as adapter.h, opae_int.h, and props.h
* export OPAEGit.cmake
  * Install OPAEGit.cmake into <prefix>/lib/opae-<version>/modules 
  * Add the modules path to CMAKE_MODULE_PATH so that developers can
    include OPAE cmake modules

  Currently only OPAEGit.cmake is being installed into this module path
  (as opposed to the modules being installed in RPM packages).
  Eventually, we need to only install modules that make sense for
  developers. Also, we need to structure modules so that they can be
  consumed by other software that is importing opae cmake configuration.
  For now OPAEGit.cmake is potentially installed in two places.