### PR TITLE
packaging: include 'include/opae/plugin' in specs

### DIFF
--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -262,6 +262,7 @@ done
 %{_includedir}/opae/*.h
 %{_includedir}/opae/cxx/core.h
 %{_includedir}/opae/cxx/core/*.h
+%{_includedir}/opae/plugin/*.h
 %dir %{_usr}/src/opae
 %{_usr}/src/opae/samples/hello_fpga/hello_fpga.c
 %{_usr}/src/opae/samples/hello_events/hello_events.c

--- a/opae.spec.rhel
+++ b/opae.spec.rhel
@@ -222,6 +222,7 @@ done
 %{_includedir}/opae/*.h
 %{_includedir}/opae/cxx/core.h
 %{_includedir}/opae/cxx/core/*.h
+%{_includedir}/opae/plugin/*.h
 %dir %{_usr}/src/opae
 %{_usr}/src/opae/samples/hello_fpga/hello_fpga.c
 %{_usr}/src/opae/samples/hello_events/hello_events.c

--- a/packaging/opae/deb/opae-devel.install
+++ b/packaging/opae/deb/opae-devel.install
@@ -1,5 +1,6 @@
 usr/include/opae/*.h
 usr/include/opae/cxx/core/*.h
+usr/include/opae/plugin/*.h
 usr/src/opae/samples/hello_fpga/hello_fpga.c
 usr/src/opae/samples/hello_events/hello_events.c
 usr/src/opae/samples/object_api/object_api.c


### PR DESCRIPTION
include opae/plugin/*.h in spec files for fedora and rhel

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>