### PR TITLE
opae.io: return pci_address in lower case

### DIFF
--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -82,7 +82,7 @@ def pci_address(inp):
         raise ValueError('wrong pci address format: {}'.format(inp))
 
     d = m.groupdict()
-    return '{}:{}'.format(d.get('segment') or '0000', d['bdf'])
+    return '{}:{}'.format(d.get('segment') or '0000', d['bdf']).lower()
 
 
 def vid_did_for_address(pci_addr):


### PR DESCRIPTION
Change pci_address parser function to always return pci address in lower
case becasue sysfs operates in lower case hex.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>