### PR TITLE
errors API: add "inject_errors" as clearable

### DIFF
--- a/libraries/plugins/xfpga/error.c
+++ b/libraries/plugins/xfpga/error.c
@@ -199,12 +199,13 @@ const char *errors_exclude[NUM_ERRORS_EXCLUDE] = {
 };
 
 /* files that can be cleared by writing their value to them */
-#define NUM_ERRORS_CLEARABLE 6
+#define NUM_ERRORS_CLEARABLE 7
 const char *errors_clearable[] = {
 	"pcie0_errors",
 	"pcie1_errors",
 	"warning_errors",
 	"inject_error",
+	"inject_errors",
 	"fme_errors",
 	"errors"
 };

--- a/tests/opae-c/test_error_c.cpp
+++ b/tests/opae-c/test_error_c.cpp
@@ -60,7 +60,7 @@ TEST_P(error_c_p, read) {
  *             it retrieves the info of the requested error,<br>
  *             and the fn returns FPGA_OK.<br>
  */
-TEST_P(error_c_p, DISABLED_get_info) {
+TEST_P(error_c_p, get_info) {
   fpga_properties props = nullptr;
   uint32_t num_errors = 0;
 


### PR DESCRIPTION
Older versions of the driver exported inject_error. The most recent
driver creates inject_errors. Support both versions.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>