### PR TITLE
opae-sdk: add range check to host exerciser cmd line input  interleave

### DIFF
--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -359,6 +359,7 @@ public:
     host_exerciser()
   : test_afu("host_exerciser", nullptr, "warning")
   , count_(1)
+  , he_interleave_(0)
   , he_interrupt_(99)
   {
     // Mode
@@ -384,7 +385,7 @@ public:
     app_.add_option("-d,--delay", he_delay_, "Enables random delay insertion between requests")->default_val("false");
 
     // Configure interleave requests in Throughput mode
-    app_.add_option("--interleave", he_interleave_, interleave_help)->default_val("0");
+    app_.add_option("--interleave", he_interleave_, interleave_help)->transform(CLI::Range(0, 2));
 
     // The Interrupt Vector Number for the device
     app_.add_option("--interrupt", he_interrupt_,


### PR DESCRIPTION
specifies how many requests to interleave when TestMode = 3'b011
Ex. 3'b000 - Rd,Wr,Rd,Wr
Ex. 3'b001 - Rd, Rd, Wr, Wr
Ex. 3'b010 - Rd, Rd, Rd, Rd, Wr, Wr, Wr, Wr
Not used when TestMode != 3'b011

host exerciser interleave range from 0 to 2

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>