### PR TITLE
pluginmgr: add API to register a plugin

### DIFF
--- a/binaries/fpgametrics/fpgametrics.c
+++ b/binaries/fpgametrics/fpgametrics.c
@@ -92,8 +92,9 @@ void FpgaMetricsAppShowHelp(void)
 	       "OPAE Metrics API sample\n"
 	       "\n");
 	printf("Usage:\n");
-	printf("        fpgametrics [-S <segment>] [-B <bus>] [-D <device>] [-F <function>] [PCI_ADDR]\n");
+	printf("        fpgametrics [-h]  [-S <segment>] [-B <bus>] [-D <device>] [-F <function>] [PCI_ADDR]\n");
 	printf("\n");
+	printf("                -h,--help               Print this help\n");
 	printf("                -s,--shared             Open in shared mode\n");
 	printf("                -f,--fme-metrics        Display FME metrics\n");
 	printf("                -a,--afu-metrics        Display AFU metrics\n");
@@ -101,10 +102,11 @@ void FpgaMetricsAppShowHelp(void)
 	printf("\n");
 }
 
-#define GETOPT_STRING "fasv"
+#define GETOPT_STRING "hfasv"
 fpga_result parse_args(int argc, char *argv[])
 {
 	struct option longopts[] = {
+		{ "help",        no_argument,       NULL, 'h'},
 		{ "fme-metrics", no_argument,       NULL, 'f' },
 		{ "afu-metrics", no_argument,       NULL, 'a' },
 		{ "shared",      no_argument,       NULL, 's' },
@@ -124,6 +126,9 @@ fpga_result parse_args(int argc, char *argv[])
 		}
 
 		switch (getopt_ret) {
+		case 'h': /* help */
+			FpgaMetricsAppShowHelp();
+			return -1;
 		case 's':
 			config.target.open_flags |= FPGA_OPEN_SHARED;
 			break;

--- a/libraries/libopae-c/adapter.h
+++ b/libraries/libopae-c/adapter.h
@@ -219,4 +219,5 @@ typedef struct _opae_api_adapter_table {
 
 } opae_api_adapter_table;
 
+int opae_plugin_mgr_register_plugin(const char *name, const char *cfg);
 #endif /* __OPAE_ADAPTER_H__ */

--- a/libraries/libopae-c/pluginmgr.c
+++ b/libraries/libopae-c/pluginmgr.c
@@ -818,3 +818,32 @@ out_unlock:
 
 	return cb_res;
 }
+
+int opae_plugin_mgr_register_plugin(const char *name, const char *cfg)
+{
+	opae_api_adapter_table *adapter = opae_plugin_mgr_alloc_adapter(name);
+	if (!adapter) {
+		OPAE_ERR("malloc failed");
+		return 1;
+	}
+
+
+	int res = opae_plugin_mgr_configure_plugin(adapter, cfg);
+	if (res) {
+		opae_plugin_mgr_free_adapter(adapter);
+		OPAE_ERR("failed to configure plugin \"%s\"", name);
+		return res;
+	}
+
+	res = opae_plugin_mgr_register_adapter(adapter);
+	if (res) {
+		opae_plugin_mgr_free_adapter(adapter);
+		OPAE_ERR("Failed to register \"%s\"", name);
+		return res;
+	}
+
+
+
+	return 0;
+}
+

--- a/libraries/libopae-c/pluginmgr.c
+++ b/libraries/libopae-c/pluginmgr.c
@@ -836,7 +836,7 @@ int opae_plugin_mgr_register_plugin(const char *name, const char *cfg)
 	}
 
 	if (opae_mutex_lock(lock_res, &adapter_list_lock))
-		return res;
+		return lock_res;
 	res = opae_plugin_mgr_register_adapter(adapter);
 	opae_mutex_unlock(lock_res, &adapter_list_lock);
 


### PR DESCRIPTION
This adds a prototype in adapter.h and implements it in pluginmgr.c
This function is meant to register a plugin given only the plugin module
name. This allows client code to register a plugin and not have to rely
on built-in plugin loading and configuration.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>