### PR TITLE
packaging: deb: enable Ubuntu 22.04 LTS

### DIFF
--- a/packaging/opae/deb/control
+++ b/packaging/opae/deb/control
@@ -20,7 +20,7 @@ Package: opae
 Section: libs
 Priority: optional
 Architecture: any
-Depends: uuid, libjson-c3,
+Depends: libuuid1, libjson-c5,
          ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}
 Description: OPAE runtime
 
@@ -39,6 +39,6 @@ Priority: optional
 Architecture: any
 Multi-Arch: same
 Depends: opae (= ${binary:Version}), opae-devel (= ${binary:Version}),
-         libhwloc, libtbb, libedit,
+         libhwloc15, libtbb12, libedit2,
          ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends},
 Description: OPAE extra tool binaries

--- a/packaging/opae/deb/opae-devel.install
+++ b/packaging/opae/deb/opae-devel.install
@@ -57,10 +57,10 @@ usr/bin/nlb3
 usr/bin/nlb7
 usr/bin/vabtool
 usr/share/opae/*
-usr/lib/python*/site-packages/ethernet*
-usr/lib/python*/site-packages/hssi_ethernet*
-usr/lib/python*/site-packages/pacsign*
-usr/lib/python*/site-packages/packager*
-usr/lib/python*/dist-packages/libvfio*
-usr/lib/python*/dist-packages/opae.fpga*
-usr/lib/python*/dist-packages/opae/fpga*
+usr/lib/python3/dist-packages/ethernet*
+usr/lib/python3/dist-packages/hssi_ethernet*
+usr/lib/python3/dist-packages/pacsign*
+usr/lib/python3/dist-packages/packager*
+usr/lib/python3/dist-packages/libvfio*
+usr/lib/python3/dist-packages/opae.fpga*
+usr/lib/python3/dist-packages/opae/fpga*

--- a/packaging/opae/deb/opae-extra-tools.install
+++ b/packaging/opae/deb/opae-extra-tools.install
@@ -22,8 +22,8 @@ usr/bin/hps
 usr/bin/hssi
 usr/bin/opae.io
 usr/bin/mem_tg
-usr/lib/python*/dist-packages/opae.diag*
-usr/lib/python*/dist-packages/opae/diag*
-usr/lib/python*/dist-packages/opae.io*
-usr/lib/python*/dist-packages/opae/io*
-usr/lib/python*/dist-packages/pyopaeuio*
+usr/lib/python3/dist-packages/opae.diag*
+usr/lib/python3/dist-packages/opae/diag*
+usr/lib/python3/dist-packages/opae.io*
+usr/lib/python3/dist-packages/opae/io*
+usr/lib/python3/dist-packages/pyopaeuio*

--- a/packaging/opae/deb/opae.dirs
+++ b/packaging/opae/deb/opae.dirs
@@ -1,4 +1,3 @@
 usr/share/opae
 usr/lib/opae
-usr/lib/python*/site-packages/opae/admin
 etc/opae

--- a/packaging/opae/deb/opae.install
+++ b/packaging/opae/deb/opae.install
@@ -30,11 +30,10 @@ usr/bin/fpgainfo
 usr/bin/fpgasupdate
 usr/bin/rsu
 usr/bin/pci_device
-usr/lib/python*/site-packages/opae.admin*
-usr/lib/python*/site-packages/opae/admin*
-usr/lib/python*/dist-packages/opae/admin*
-usr/lib/python*/dist-packages/opae/__init__.py
-usr/lib/python*/dist-packages/opae/__pycache__*
+usr/lib/python3/dist-packages/opae.admin*
+usr/lib/python3/dist-packages/opae/admin*
+usr/lib/python3/dist-packages/opae/__init__.py
+usr/lib/python3/dist-packages/opae/__pycache__*
 etc/opae/fpgad.cfg
 etc/sysconfig/fpgad.conf
 usr/lib/systemd/system/fpgad.service


### PR DESCRIPTION
Updates runtime package requirements.
Change site-packages to dist-packages.
Replace python* with python3.