### PR TITLE
build: add 'EXPORT' got opae_add_static_library

### DIFF
--- a/cmake/modules/OPAECompiler.cmake
+++ b/cmake/modules/OPAECompiler.cmake
@@ -328,7 +328,7 @@ endfunction()
 #   opae_add_static_library(TARGET sometarget SOURCE ${SRC})
 function(opae_add_static_library)
     set(options )
-    set(oneValueArgs TARGET COMPONENT DESTINATION)
+    set(oneValueArgs TARGET COMPONENT DESTINATION EXPORT)
     set(multiValueArgs SOURCE LIBS)
     cmake_parse_arguments(OPAE_ADD_STATIC_LIBRARY "${options}"
         "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -366,9 +366,16 @@ function(opae_add_static_library)
             set(dest ${OPAE_LIB_INSTALL_DIR})
         endif(OPAE_ADD_STATIC_LIBRARY_DESTINATION)
 
-        install(TARGETS ${OPAE_ADD_STATIC_LIBRARY_TARGET}
-                ARCHIVE DESTINATION ${dest}
-                COMPONENT ${OPAE_ADD_STATIC_LIBRARY_COMPONENT})
+        if(OPAE_ADD_STATIC_LIBRARY_EXPORT)
+            install(TARGETS ${OPAE_ADD_STATIC_LIBRARY_TARGET}
+                    EXPORT ${OPAE_ADD_STATIC_LIBRARY_EXPORT}
+                    LIBRARY DESTINATION ${dest}
+                    COMPONENT ${OPAE_ADD_STATIC_LIBRARY_COMPONENT})
+        else(OPAE_ADD_STATIC_LIBRARY_EXPORT)
+            install(TARGETS ${OPAE_ADD_STATIC_LIBRARY_TARGET}
+                    LIBRARY DESTINATION ${dest}
+                    COMPONENT ${OPAE_ADD_STATIC_LIBRARY_COMPONENT})
+        endif(OPAE_ADD_STATIC_LIBRARY_EXPORT)
     endif(OPAE_ADD_STATIC_LIBRARY_COMPONENT)
 endfunction()
 

--- a/libraries/libopae-c/CMakeLists.txt
+++ b/libraries/libopae-c/CMakeLists.txt
@@ -44,6 +44,17 @@ opae_add_shared_library(TARGET opae-c
     COMPONENT opaeclib
 )
 
+opae_add_static_library(TARGET opae-c-static
+    EXPORT opae-targets
+    SOURCE ${SRC}
+    LIBS
+        dl
+        ${CMAKE_THREAD_LIBS_INIT}
+        ${libjson-c_LIBRARIES}
+        ${libuuid_LIBRARIES}
+    COMPONENT opaeclib
+)
+
 install(FILES adapter.h props.h opae_int.h
     DESTINATION include/opae/plugin
 )

--- a/libraries/libopae-c/CMakeLists.txt
+++ b/libraries/libopae-c/CMakeLists.txt
@@ -44,7 +44,7 @@ opae_add_shared_library(TARGET opae-c
     COMPONENT opaeclib
 )
 
-opae_add_static_library(TARGET opae-c-static
+opae_add_static_library(TARGET opae-c-archive
     EXPORT opae-targets
     SOURCE ${SRC}
     LIBS


### PR DESCRIPTION
* Modify opae_add_static_library to accept EXPORT argument and export
  use cmake install with EXPORT when present.
* Modify CMakeLists.txt in libopae-c to also generate a static library
  of libopae-c.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>