### PR TITLE
build: add OPAEPlugin.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,5 +577,6 @@ install(FILES
 
 install(FILES
     ${OPAE_SDK_SOURCE}/cmake/modules/OPAEGit.cmake
+    ${OPAE_SDK_SOURCE}/cmake/modules/OPAEPlugin.cmake
     DESTINATION lib/opae-${OPAE_VERSION}/modules
 )

--- a/cmake/modules/OPAEPlugin.cmake
+++ b/cmake/modules/OPAEPlugin.cmake
@@ -1,0 +1,51 @@
+#!/usr/bin/cmake -P
+## Copyright(c) 2022, Intel Corporation
+##
+## Redistribution  and  use  in source  and  binary  forms,  with  or  without
+## modification, are permitted provided that the following conditions are met:
+##
+## * Redistributions of  source code  must retain the  above copyright notice,
+##   this list of conditions and the following disclaimer.
+## * Redistributions in binary form must reproduce the above copyright notice,
+##   this list of conditions and the following disclaimer in the documentation
+##   and/or other materials provided with the distribution.
+## * Neither the name  of Intel Corporation  nor the names of its contributors
+##   may be used to  endorse or promote  products derived  from this  software
+##   without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+## IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+## ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+## LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+## CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+## SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+## INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+## CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+## POSSIBILITY OF SUCH DAMAGE.
+function(opae_add_shared_plugin)
+    set(options )
+    set(oneValueArgs TARGET PLUGIN)
+    set(multiValueArgs SOURCE)
+    cmake_parse_arguments(OPAE_ADD_SHARED_PLUGIN  "${options}"
+        "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    set(register_c ${OPAE_ADD_SHARED_PLUGIN_PLUGIN}_register)
+    set(plugin_so lib${OPAE_ADD_SHARED_PLUGIN_PLUGIN}.so)
+    set(source_code
+"#include <opae/plugin.h>
+__attribute__ ((constructor)) static void ${register_c}(void)
+{
+    opae_plugin_mgr_register_plugin(\"${plugin_so}\", NULL)\;
+}"
+    )
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${register_c}.c ${source_code})
+    add_library(${OPAE_ADD_SHARED_PLUGIN_TARGET} SHARED
+        ${register_c}.c
+        ${OPAE_ADD_SHARED_PLUGIN_SOURCE}
+    )
+    target_link_libraries(${OPAE_ADD_SHARED_PLUGIN_TARGET}
+        PUBLIC opae-c-archive
+    )
+endfunction()

--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -124,6 +124,7 @@ for s in \
     OPAECompiler.cmake \
     OPAEExternal.cmake \
     OPAEGit.cmake \
+    OPAEPlugin.cmake \
     OPAEPackaging.cmake \
     OPAETest.cmake
 do

--- a/opae.spec.rhel
+++ b/opae.spec.rhel
@@ -100,6 +100,7 @@ for s in \
     OPAECompiler.cmake \
     OPAEExternal.cmake \
     OPAEGit.cmake \
+    OPAEPlugin.cmake \
     OPAEPackaging.cmake \
     OPAETest.cmake
 do


### PR DESCRIPTION
* define cmake function called opae_add_shared_plugin that creates a
  shared library that registers a plugin as defined by its PLUGIN
  argument. To make the shared library it:
  * writes a file with C code implementing a library constructor that
    registers a plugin
  * adds any source files as listed after the SOURCE keyword
  * links this to opae-c-archive

The end result is a shared library that implements the OPAE API but has
the named plugin registered when the library loads.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>