### PR TITLE
xfpga: sysobject: use minimum sysfs file size

### DIFF
--- a/libraries/plugins/xfpga/sysfs.c
+++ b/libraries/plugins/xfpga/sysfs.c
@@ -2454,7 +2454,9 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 	}
 	obj->handle = handle;
 	obj->type = FPGA_SYSFS_FILE;
-	obj->max_size = MIN_SYSOBJECT_FILESIZE;
+	obj->max_size = objstat.st_size;
+	if (obj->max_size < MIN_SYSOBJECT_FILESIZE)
+		obj->max_size = MIN_SYSOBJECT_FILESIZE;
 	obj->buffer = calloc(obj->max_size, sizeof(uint8_t));
 	if (handle && (objstat.st_mode & (S_IWUSR | S_IWGRP | S_IWOTH))) {
 		if ((objstat.st_mode & (S_IRUSR | S_IRGRP | S_IROTH))) {


### PR DESCRIPTION
An issue was identified with a sysfs file that contained a single 0.
In that case, the obj->max_size value was being set to 2, which caused
a subsequent fpgaObjectWrite64() call (with size > 2) to fail. Setting
the default size large enough to accomodate most sysfs entries prevents
this issue from occurring.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>