### PR TITLE
plugin: add priority to c'tors

### DIFF
--- a/cmake/modules/OPAEPlugin.cmake
+++ b/cmake/modules/OPAEPlugin.cmake
@@ -26,15 +26,21 @@
 ## POSSIBILITY OF SUCH DAMAGE.
 function(opae_add_shared_plugin)
     set(options )
-    set(oneValueArgs TARGET PLUGIN)
+    set(oneValueArgs TARGET PLUGIN PRIORITY)
     set(multiValueArgs SOURCE)
     cmake_parse_arguments(OPAE_ADD_SHARED_PLUGIN  "${options}"
         "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     set(register_c ${OPAE_ADD_SHARED_PLUGIN_PLUGIN}_register)
     set(plugin_so lib${OPAE_ADD_SHARED_PLUGIN_PLUGIN}.so)
+    if (OPAE_ADD_SHARED_PLUGIN_PRIORITY)
+        set(priority ${OPAE_ADD_SHARED_PLUGIN_PRIORITY})
+    else()
+        set(priority 1100)
+    endif()
+
     set(source_code
 "#include <opae/plugin.h>
-__attribute__ ((constructor)) static void ${register_c}(void)
+__attribute__ ((constructor(${priority}))) static void ${register_c}(void)
 {
     opae_plugin_mgr_register_plugin(\"${plugin_so}\", NULL)\;
 }"

--- a/libraries/libopae-c/init.c
+++ b/libraries/libopae-c/init.c
@@ -161,7 +161,7 @@ STATIC char *find_ase_cfg(void)
 	return NULL;
 }
 
-__attribute__((constructor)) STATIC void opae_init(void)
+__attribute__((constructor(1000))) STATIC void opae_init(void)
 {
 	fpga_result res;
 	g_logfile = NULL;


### PR DESCRIPTION
* Set the priority for libopae-c constructor to 1000.
* Extend cmake function opae_add_shared_plugin to take in PRIORITY
  argument but default to 1100. This allows setting the priority in
  cmake so that the constructor generated includes the priority in the
  constructor attribute.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>