### PR TITLE
opae.io: add 32-bit support for actions

### DIFF
--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -59,6 +59,7 @@ VENDOR_DEVICE_PATTERN = r'(?P<vendor>[\da-f]{0,4}):(?P<device>[\da-f]{0,4})'
 VENDOR_DEVICE_RE = re.compile(VENDOR_DEVICE_PATTERN, re.IGNORECASE)
 
 PICKLE_FILE = '/var/lib/opae/opae.io.pickle'
+ACCESS_MODE = 64
 
 
 class pcicfg(Enum):
@@ -227,6 +228,7 @@ def vfio_release(pci_addr):
 
 
 class opae_register(Union):
+    _upper_mask = 0xFFFFFFFF00000000
     def __init__(self, region, offset, value=None):
         self.region = region
         self.offset = offset
@@ -259,12 +261,21 @@ class opae_register(Union):
     def commit(self, value=None):
         if value is not None:
             self.value = value
-        self.wr(self.offset, self.value)
+        if ACCESS_MODE == 32 and self.width == 64:
+            self.region.write32(self.offset, self._upper_mask & value)
+            self.region.write32(self.offset + 4, value >> 32)
+        else:
+            self.wr(self.offset, self.value)
 
     def update(self):
         if self.region is None:
             raise OSError(os.EX_OSERR, 'no region open')
-        self.value = self.rd(self.offset)
+        if ACCESS_MODE == 32 and self.width == 64:
+            lo = self.region.read32(self.offset)
+            self.value = self.reaion.read32(self.offset+4) << 32
+            self.value |= lo
+        else:
+            self.value = self.rd(self.offset)
 
     def __enter__(self):
         pass
@@ -348,13 +359,19 @@ def walk(region,
 def dump(region, start=0, output=sys.stdout, fmt='hex', count=None):
     stop_at = start + count*8 if count else len(region)
     offset = start
+    if ACCESS_MODE == 64:
+        rd = region.read64
+        byte_length = 8
+    else:
+        rd = region.read32
+        byte_length = 4
     while offset < stop_at:
-        value = region.read64(offset)
+        value = rd(offset)
         if fmt == 'hex':
             output.write(f'0x{offset:04x}: 0x{value:016x}\n')
         else:
-            output.write(value.to_bytes(8, 'little'))
-        offset += 8
+            output.write(value.to_bytes(byte_length, 'little'))
+        offset += byte_length
 
 
 class feature(object):

--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -228,7 +228,7 @@ def vfio_release(pci_addr):
 
 
 class opae_register(Union):
-    _upper_mask = 0xFFFFFFFF00000000
+    _upper_mask = 0x00000000FFFFFFFF
     def __init__(self, region, offset, value=None):
         self.region = region
         self.offset = offset

--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -272,7 +272,7 @@ class opae_register(Union):
             raise OSError(os.EX_OSERR, 'no region open')
         if ACCESS_MODE == 32 and self.width == 64:
             lo = self.region.read32(self.offset)
-            self.value = self.reaion.read32(self.offset+4) << 32
+            self.value = self.region.read32(self.offset+4) << 32
             self.value |= lo
         else:
             self.value = self.rd(self.offset)

--- a/binaries/opae.io/pymain.h
+++ b/binaries/opae.io/pymain.h
@@ -43,6 +43,7 @@ def default_parser():
     parser.add_argument('command', nargs='?')
     parser.add_argument('-d', '--device', type=utils.pci_address)
     parser.add_argument('-r', '--region', type=int, default=0)
+    parser.add_argument('-a', '--access-mode', type=int, default=64, choices=[64, 32])
     parser.add_argument('--version', action='store_true', default=False)
     parser.add_argument('-h', '--help', action='store_true', default=False)
     parser.add_argument('--pdb', action='store_true', default=False)
@@ -122,7 +123,8 @@ class peek_action(base_action):
             raise SystemExit('Need device for peek.')
         if not self.region:
             raise SystemExit('Need region for peek.')
-        print('0x{:0x}'.format(self.region.read64(args.offset)))
+        rd = self.region.read64 if args.access_mode == 64 else self.region.read32
+        print('0x{:0x}'.format(rd(args.offset)))
         raise SystemExit(0)
 
 class poke_action(base_action):
@@ -137,7 +139,8 @@ class poke_action(base_action):
             raise SystemExit('Need device for poke.')
         if not self.region:
             raise SystemExit('Need region for poke.')
-        self.region.write64(args.offset, args.value)
+        wr = self.region.write64 if args.access_mode == 64 else self.region.write32
+        wr(args.offset, args.value)
         raise SystemExit(0)
 
 class script_action(base_action):
@@ -230,16 +233,16 @@ def show_help():
       "opae.io -v | --version"
       "opae.io -h | --help"
       "opae.io ls [-v | --viddid <VID:DID>]"
-      "opae.io [-d | --device <PCI_ADDRESS>] [-r | --region <REGION_NUMBER>] [init | release | peek | poke | <script> [arg1...argN]]
+      "opae.io [-d | --device <PCI_ADDRESS>] [-r | --region <REGION_NUMBER>] [-a <ACCESS_MODE>] [init | release | peek | poke | <script> [arg1...argN]]
       "opae.io init [-d <PCI_ADDRESS>] <USER>[:<GROUP>]"
       "opae.io release [-d <PCI_ADDRESS>]"
       "opae.io [-d <PCI_ADDRESS>]"
-      "opae.io [-d <PCI_ADDRESS>] [-r <REGION_NUMBER>]"
-      "opae.io [-d <PCI_ADDRESS>] [-r <REGION_NUMBER>] walk [<OFFSET>] [-u | --show-uuid]"
-      "opae.io [-d <PCI_ADDRESS>] [-r <REGION_NUMBER>] dump [<OFFSET>] [-o | --output <FILE>] [-f | --format (hex, bin)] [ -c | --count <WORD COUNT>]
-      "opae.io [-d <PCI_ADDRESS>] [-r <REGION_NUMBER>] peek <OFFSET>"
-      "opae.io [-d <PCI_ADDRESS>] [-r <REGION_NUMBER>] poke <OFFSET> <VALUE>"
-      "opae.io [-d <PCI_ADDRESS>] [-r <REGION_NUMBER>] <SCRIPT> <ARG1> <ARG2> ... <ARGN>"
+      "opae.io [-d <PCI_ADDRESS>] [-r <REGION_NUMBER>] [-a <ACCESS_MODE>]"
+      "opae.io [-d <PCI_ADDRESS>] [-r <REGION_NUMBER>] [-a <ACCESS_MODE>] walk [<OFFSET>] [-u | --show-uuid]"
+      "opae.io [-d <PCI_ADDRESS>] [-r <REGION_NUMBER>] [-a <ACCESS_MODE>] dump [<OFFSET>] [-o | --output <FILE>] [-f | --format (hex, bin)] [ -c | --count <WORD COUNT>]
+      "opae.io [-d <PCI_ADDRESS>] [-r <REGION_NUMBER>] [-a <ACCESS_MODE>] peek <OFFSET>"
+      "opae.io [-d <PCI_ADDRESS>] [-r <REGION_NUMBER>] [-a <ACCESS_MODE>] poke <OFFSET> <VALUE>"
+      "opae.io [-d <PCI_ADDRESS>] [-r <REGION_NUMBER>] [-a <ACCESS_MODE>] <SCRIPT> <ARG1> <ARG2> ... <ARGN>"
 
   NOTE
   If -d or --device is omitted, opae.io will attempt to open the first device found.
@@ -332,6 +335,7 @@ def main(argv=None):
     if action is None:
         show_help()
     else:
+        utils.ACCESS_MODE = args.access_mode
         action(rest)
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Add --access-mode CLI argument
  * Setting access mode sets utils.ACCESS_MODE accordingly
* Modify opae.io actions to read/write registers in 32 bit mode

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>