### PR TITLE
opae.io: fix reference to access_mode

### DIFF
--- a/binaries/opae.io/pymain.h
+++ b/binaries/opae.io/pymain.h
@@ -123,7 +123,7 @@ class peek_action(base_action):
             raise SystemExit('Need device for peek.')
         if not self.region:
             raise SystemExit('Need region for peek.')
-        rd = self.region.read64 if args.access_mode == 64 else self.region.read32
+        rd = self.region.read64 if utils.ACCESS_MODE == 64 else self.region.read32
         print('0x{:0x}'.format(rd(args.offset)))
         raise SystemExit(0)
 
@@ -139,7 +139,7 @@ class poke_action(base_action):
             raise SystemExit('Need device for poke.')
         if not self.region:
             raise SystemExit('Need region for poke.')
-        wr = self.region.write64 if args.access_mode == 64 else self.region.write32
+        wr = self.region.write64 if utils.ACCESS_MODE == 64 else self.region.write32
         wr(args.offset, args.value)
         raise SystemExit(0)
 


### PR DESCRIPTION
access_mode is not an attribute of the namespace object passed into
actions (like peek/poke). This PR changes the peek/poke action to
reference utils.ACCESS_MODE instead of args.access_mode.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>