### PR TITLE
Typos, grammar, Markdown, Sphinx directives

### DIFF
--- a/doc/src/fpga_api/quick_start/readme.md
+++ b/doc/src/fpga_api/quick_start/readme.md
@@ -77,22 +77,24 @@ Download the OPAE SDK source package:
 1. Go to the section corresponding to the desired release on
 [GitHub](https://github.com/OPAE/opae-sdk/releases):
 2. Click the `Source code (tar.gz)` link under the section's `Assets`.
+3. On the command line, go through the following steps to install it:
 
-After downloading the source, unpack, configure, and compile it:
-
-```bash
-tar xfvz opae-sdk-<release>.tar.gz
-cd opae-sdk-<release>
-mkdir build
-cd build
-# The default installation prefix is `/usr/local`
-# You have the option to pick a different location:
-cmake [-DCMAKE_INSTALL_PREFIX=<prefix>] ..
-make
-# You need system administration privileges (`sudo`)
-# if you have elected to install in the default location:
-[sudo] make install
-```
+   ```bash
+   # Unpack
+   tar xfvz opae-sdk-<release>.tar.gz
+   # Configure
+   cd opae-sdk-<release>
+   mkdir build
+   cd build
+   # The default installation prefix is `/usr/local`;
+   # You have the option to configure for a different location
+   cmake [-DCMAKE_INSTALL_PREFIX=<prefix>] ..
+   # Compile
+   make
+   # Install: you need system administration privileges (`sudo`)
+   # if you have elected to install in the default location
+   [sudo] make install
+   ```
 
 The remainder of this guide assumes you installed into `/usr/local`.
 

--- a/doc/src/fpga_api/quick_start/readme.md
+++ b/doc/src/fpga_api/quick_start/readme.md
@@ -1,23 +1,23 @@
-# Quick Start Guide #
+# Quick Start Guide
 
-```eval_rst
-.. toctree::
+```{toctree}
 ```
 
-## Overview ##
+## Overview
+
 The OPAE C library is a lightweight user-space library that provides
-abstraction for FPGA resources in a compute environment. Built on top of the
+an abstraction for FPGA resources in a compute environment. Built on top of the
 OPAE Intel&reg; FPGA driver stack that supports Intel&reg; FPGA platforms, the library
-abstracts away hardware specific and OS specific details and exposes the
+abstracts away hardware-specific and OS-specific details and exposes the
 underlying FPGA resources as a set of features accessible from within
 software programs running on the host.
 
 These features include the acceleration logic preconfigured on the
 device, as well as functions to manage and reconfigure the
-device. Hence, the library is able to enable user applications to
+device. Hence, the library can enable user applications to
 transparently and seamlessly leverage FPGA-based acceleration.
 
-In this document, we will explore the initial steps on how to setup
+In this document, we will explore the initial steps on how to set up
 the required libraries and utilities to use the FPGA devices.
 
 If you do not have access to an Intel&reg; Xeon&reg; processor with integrated
@@ -26,95 +26,97 @@ processors, you will not be able to run the examples below. However, you can
 still make use of the AFU simulation environment (ASE) to develop and test
 accelerator RTL with OPAE applications.
 
-
 The source for the OPAE SDK Linux device drivers is available at the
 [OPAE Linux DFL drivers repository](https://github.com/OPAE/linux-dfl).
 
-``
-## Build the OPAE Linux device drivers from source ##
-For building the OPAE kernel and kernel driver, the kernel development environment is required. So before you build the kernel, you must install the required packages. Run the following commands:
+## Build the OPAE Linux device drivers from the source
 
-We using Federa 32 as an example.
-```console
-$ sudo yum install gcc gcc-c++ make kernel-headers kernel-devel elfutils-libelf-devel ncurses-devel openssl-devel bison flex
+For building the OPAE kernel and kernel driver, the kernel development environment is required. So before you build the kernel, you must install the required packages. Run the following commands (we are using Fedora 32 as an example):
+
+```bash
+sudo yum install gcc gcc-c++ make kernel-headers kernel-devel elfutils-libelf-devel ncurses-devel openssl-devel bison flex
 ```
 
-Download the OPAE upstream kernel tree from github.
-```console
-$ git clone https://github.com/OPAE/linux-dfl.git -b fpga-upstream-dev-5.8.0
+Download the OPAE upstream kernel tree from GitHub:
+
+```bash
+git clone https://github.com/OPAE/linux-dfl.git -b fpga-upstream-dev-5.8.0
 ```
 
-Configure the kernel.
-```console
-$ cd linux-dfl
-$ cp /boot/config-`uname -r` .config
-$ cat configs/n3000_d5005_defconfig >> .config 
-$ echo 'CONFIG_LOCALVERSION="-dfl"' >> .config
-$ echo 'CONFIG_LOCALVERSION_AUTO=y' >> .config
-$ make olddefconfig
+Configure the kernel:
+
+```bash
+cd linux-dfl
+cp /boot/config-`uname -r` .config
+cat configs/n3000_d5005_defconfig >> .config 
+echo 'CONFIG_LOCALVERSION="-dfl"' >> .config
+echo 'CONFIG_LOCALVERSION_AUTO=y' >> .config
+make olddefconfig
 ```
 
-Compile and install the new kernel.
-```console
-$ make -j
-$ sudo make modules_install
-$ sudo make install
+Compile and install the new kernel:
+
+```bash
+make -j
+sudo make modules_install
+sudo make install
 ```
-When installed finished, reboot your system.
-When the system login again, check the kernel version is correctly or not.
-```console
-[figo@localhost linux-dfl]$ uname -a
+
+After the installation finishes, reboot your system.
+Log back into the system, and confirm the correct version for the kernel:
+
+```bash
+$ uname -a
 Linux localhost.localdomain 5.8.0-rc1-dfl-g73e16386cda0 #6 SMP Wed Aug 19 08:38:32 EDT 2020 x86_64 x86_64 x86_64 GNU/Linux
 ```
 
-## Building and installing the OPAE SDK from source ##
-Download the OPAE SDK source package from the respective [release page on
-GitHub](https://github.com/OPAE/opae-sdk/releases) - click the `Source code
-(tar.gz)` link under "Downloads".
+## Building and installing the OPAE SDK from the source
+
+Download the OPAE SDK source package:
+
+1. Go to the section corresponding to the desired release on
+[GitHub](https://github.com/OPAE/opae-sdk/releases):
+2. Click the `Source code (tar.gz)` link under the section's `Assets`.
 
 After downloading the source, unpack, configure, and compile it:
 
-```console
-    tar xfvz opae-sdk-<release>.tar.gz
-    cd opae-sdk-<release>
-    mkdir build
-    cd build
-    cmake ..
-    make
+```bash
+tar xfvz opae-sdk-<release>.tar.gz
+cd opae-sdk-<release>
+mkdir build
+cd build
+# The default installation prefix is `/usr/local`
+# You have the option to pick a different location:
+cmake [-DCMAKE_INSTALL_PREFIX=<prefix>] ..
+make
+# You need system administration privileges (`sudo`)
+# if you have elected to install in the default location:
+[sudo] make install
 ```
 
-By default, the OPAE SDK will install into `/usr/local` if you also issue the following:
-
-```console
-    sudo make install
-```
-
-You can change this installation prefix from `/usr/local` into something else
-by adding `-DCMAKE_INSTALL_PREFIX=<new prefix>` to the `cmake` command above.
 The remainder of this guide assumes you installed into `/usr/local`.
 
-## Configuring the FPGA (loading an FPGA AFU)##
+## Configuring the FPGA (loading an FPGA AFU)
 
-
-The *fpgaconf* tool exercises the AFU reconfiguration
+The `fpgaconf` tool exercises the AFU reconfiguration
 functionality. It shows how to read a bitstream from a disk file,
-check its validity and compatability, and then injects it into FPGA to
+check its validity and compatibility, and then injects it into FPGA to
 be configured as a new AFU, which can then be discovered and used by
 user applications.
 
-For this step you require a valid green bitstream (GBS) file. To
-reconfigure the FPGA slot, you can issue following command as system
-administrator (*root*):
+For this step, you require a valid green bitstream (GBS) file. To
+reconfigure the FPGA slot, you can issue the following command as system
+administrator:
 
-```console
-$ sudo fpgaconf -b 0x5e <filename>.gbs
+```bash
+sudo fpgaconf -b 0x5e <filename>.gbs
 ```
 
-The `-b` parameter to *fpgaconf* indicates the *target bus number* of the
+The `-b` option to `fpgaconf` indicates the *target bus number* of the
 FPGA slot to be reconfigured. Alternatively, you can also specify the
-*target socket number* of the FPGA using the `-s` parameter.
+*target socket number* of the FPGA using the `-s` option.
 
-```console
+```bash
 $ sudo fpgaconf --help
 Usage:
         fpgaconf [-hvn] [-b <bus>] [-d <device>] [-f <function>] [-s <socket>] <gbs>
@@ -128,44 +130,44 @@ Usage:
                 -s,--socket         Set target socket number
 ```
 
+````{note}
+The sample application on the Building a Sample Application
+section requires loading of an AFU called "Native Loopback
+Adapter" (NLB) on the FPGA. Please refer to the NLB documentation
+for the location of the NLB's green bitstream. You also can verify
+if the NLB green bitstream has already been loaded into the FPGA
+slot by typing the following command and checking the output
+matches the following:
 
-```eval_rst
-.. note::
-    The sample application on the Building a Sample Application
-    section requires loading of an AFU called "Native Loopback
-    Adapter" (NLB) on the FPGA. Please refer to the NLB documentation
-    for the location of the NLB's green bitstream. You also can verify
-    if the NLB green bitstream has already been loaded into the FPGA
-    slot by typing the following command and checking the output
-    matches the following:
-
-    $ cat /sys/class/fpga_region/region0/dfl-port.0/afu_id
-
-    d8424dc4a4a3c413f89e433683f9040b
+```bash
+$ cat /sys/class/fpga_region/region0/dfl-port.0/afu_id
+d8424dc4a4a3c413f89e433683f9040b
 ```
-```eval_rst
-.. note::
-    The fpgaconf tool is not available for the Intel PAC N3000. The NLB is
-    alrealy include in AFU.
+````
+
+```{note}
+The fpgaconf tool is not available for the Intel PAC N3000. The NLB is
+already included in the AFU.
 ```
 
-## Building a sample application ##
+## Building a sample application
+
 The library source includes code samples. Use these samples to learn
 how to call functions in the library. Build and run these samples as
 quick sanity checks to determine if your installation and environment
 are set up properly.
 
-In this guide, we will build *hello\_fpga.c*. This is the "Hello
+In this guide, we will build `hello_fpga.c`. This is the "Hello
 World!" example of using the library.  This code searches for a
 predefined and known AFU called "Native Loopback Adapter" on the
 FPGA. If found, it acquires ownership and then interacts with the AFU
-by sending it a 2MB message and waiting for the message being echoed
+by sending it a 2MB message and waiting for the message to be echoed
 back. This code exercises all major components of the API except for
 AFU reconfiguration: AFU search, enumeration, access, MMIO, and memory
 management.
 
-You can also find the source for `hello\_fpga` in the `samples` directory of the
-OPAE SDK repository on github.
+You can also find the source for `hello_fpga` in the `samples` directory of the
+OPAE SDK repository on GitHub.
 
 ```c
     int main(int argc, char *argv[])
@@ -344,72 +346,73 @@ should include the header file `fpga.h`. Taking the GCC compiler on
 Linux as an example, the minimalist compile and link line should look
 like:
 
-```console
-$ gcc -std=c99 hello_fpga.c -I/usr/local/include -L/usr/local/lib -lopae-c -luuid -ljson-c -lpthread -o hello_fpga
+```bash
+gcc -std=c99 hello_fpga.c -I/usr/local/include -L/usr/local/lib -lopae-c -luuid -ljson-c -lpthread -o hello_fpga
 ```
 
-
-```eval_rst
-.. note:
-    The API uses some features from the C99 language standard. The
-    `-std=c99` switch is required if the compiler does not support C99 by
-    default.
+```{note}
+The API uses some features from the C99 language standard. The
+`-std=c99` switch is required if the compiler does not support C99 by
+default.
 ```
 
-
-```eval_rst
-.. note::
-    Third-party library dependency: The library internally uses
-    `libuuid` and `libjson-c`. But they are not distributed as part of the
-    library. Make sure you have these libraries properly installed.
+```{note}
+Third-party library dependency: The library internally uses
+`libuuid` and `libjson-c`. But they are not distributed as part of the
+library. Make sure you have these libraries properly installed.
 ```
 
-```eval_rst
-.. note:
-    The layout of AFU is difference between the N3000 card and Rush Creek/Darby Creek.
-    In N3000 card, the NLB and DMA are contained in the AFU, so we need to do enumeration again in AFU to discover the NLB
-    To run the hello_fpga application on N3000 card, it should use the `c` argument to support N3000 card.
+````{note}
+The layout of AFU is different between the N3000 card and Rush Creek/Darby Creek.
+In the N3000 card, the NLB and DMA are contained in the AFU, so we need to do
+enumeration again in AFU to discover the NLB.
+To run the hello_fpga application on the N3000 card, it should use the `-c`
+option to support the N3000 card:
+
+```bash
 $ sudo ./hello_fpga -c
-    Running Test
-    Running on bus 0x08.
-    AFU NLB0 found @ 28000
-    Done Running Test
-
+Running Test
+Running on bus 0x08.
+AFU NLB0 found @ 28000
+Done Running Test
 ```
-To run the *hello_fpga* application; just issue:
+````
 
-```console
+To run the `hello_fpga` application; just issue:
+
+```bash
 $ sudo ./hello_fpga
-
 Running Test
 Done
-
 ```
 
-## Setup IOFS Release1 Bitstream on FPGA PCIe card  ##
+## Setup IOFS Release1 Bitstream on FPGA PCIe card
 
-Program IOFS Release1 bitstream on FPGA D5005 or N6000 cards and reboot system.
+Program IOFS Release1 bitstream on the FPGA D5005 or N6000 cards and reboot the system.
 
-Run command: lspci | grep acc
+Run this command:
 
-```3b:00.0 Processing accelerators: Intel Corporation Device af00 (rev 01)```
-
-Number of virtual functions supported by bitstream
-
-``` 
-   cat /sys/bus/pci/devices/0000:3b:00.0/sriov_totalvfs 
-   output: 3
+```bash
+$ lspci | grep acc
+3b:00.0 Processing accelerators: Intel Corporation Device af00 (rev 01)
 ```
 
-Enable FPGA virtual functions
+Number of virtual functions supported by bitstream:
 
-``` 
-   sudo sh -c "echo 3 > /sys/bus/pci/devices/0000:3b:00.0/sriov_numvfs"
+```bash
+$ cat /sys/bus/pci/devices/0000:3b:00.0/sriov_totalvfs 
+output: 3
 ```
 
-List of FPGA PF and VF's
+Enable FPGA virtual functions:
 
-``` 
+```bash
+sudo sh -c "echo 3 > /sys/bus/pci/devices/0000:3b:00.0/sriov_numvfs"
+```
+
+List of FPGA PF and VF's:
+
+```txt
 Physical Functions (PFs):
   3b:00.0 Processing accelerators: Intel Corporation Device af00 (rev 01)
 
@@ -417,20 +420,20 @@ Virtual Functions (VFs).
   3b:00.1 Processing accelerators: Intel Corporation Device af01 (rev 01)
   3b:00.2 Processing accelerators: Intel Corporation Device af01 (rev 01)
   3b:00.3 Processing accelerators: Intel Corporation Device af01 (rev 01)
-``` 
-
-Bind vfio-pcie driver to FPGA virtual functions
-
-``` 
-   sudo opaevfio  -i 0000:3b:00.1 -u userid -g groupid
-   sudo opaevfio  -i 0000:3b:00.2 -u userid -g groupid
-   sudo opaevfio  -i 0000:3b:00.3 -u userid -g groupid
 ```
 
-list of fpga accelerators 
+Bind vfio-pcie driver to FPGA virtual functions:
 
-``` 
-command: fpgainfo port
+```bash
+sudo opaevfio  -i 0000:3b:00.1 -u userid -g groupid
+sudo opaevfio  -i 0000:3b:00.2 -u userid -g groupid
+sudo opaevfio  -i 0000:3b:00.3 -u userid -g groupid
+```
+
+List of fpga accelerators:
+
+```bash
+$ fpgainfo port
 
   //****** PORT ******//
   Object Id                        : 0x600D000000000000
@@ -453,25 +456,22 @@ command: fpgainfo port
   Socket Id                        : 0xFF
   Accelerator Id                   : 56e203e9-864f-49a7-b94b-12284c31e02b
   Accelerator GUID                 : 56e203e9-864f-49a7-b94b-12284c31e02b
-```
 
 FPGA VF1/3b:00.1/Host Exerciser Loopback Accelerator GUID: 56E203E9-864F-49A7-B94B-12284C31E02B
-
 FPGA VF2/3b:00.2/Host Exerciser Memory Accelerator GUID: 8568AB4E-6bA5-4616-BB65-2A578330A8EB
-
 FPGA VF3/3b:00.3/Host Exerciser HSSI Accelerator GUID: 43425ee6-92b2-4742-b03a-bd8d4a533812
-
-
-Unbind pcie-vfio dirver to FPGA virtual functions
-
-``` 
-   sudo opaevfio  -r 0000:3b:00.1
 ```
 
-Host Exerciser Loopback (HE-LBK) AFU can move data between host memory and FPGA.
+Unbind pcie-vfio dirver to FPGA virtual functions:
 
-``` 
-  host_exerciser lpbk
+```bash
+sudo opaevfio  -r 0000:3b:00.1
+```
+
+Host Exerciser Loopback (HE-LBK) AFU can move data between host memory and FPGA:
+
+```bash
+$ host_exerciser lpbk
   
   [lpbk] [info] starting test run, count of 1
   Input Config:0
@@ -486,42 +486,49 @@ Host Exerciser Loopback (HE-LBK) AFU can move data between host memory and FPGA.
   Host Exerciser numPendReads:0
   Host Exerciser numPendWrites:0
   [lpbk] [info] Test lpbk(1): PASS
-
 ```
 
-
-```eval_rst
-.. note::
+````{note}
   In order to successfully run hello\_fpga, the user needs to configure
   system hugepage to reserve 2M-hugepages.
   For example, the command below reserves 20 2M-hugepages:
 
-  $ echo 20 | sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+  ```bash
+  echo 20 | sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+  ```
 
-  For x86_64 architecture CPU, user can use following command to find out avaiable huge page sizes:
+  For x86_64 architecture CPU, user can use the following command to find out available huge page sizes:
 
+  ```bash
   $ grep pse /proc/cpuinfo | uniq
   flags : ... pse ...
+  ```
 
-  If this commands returns a non-empty string, 2MB pages are supported:
+  If this command returns a non-empty string, 2MB pages are supported:
 
+  ```bash
   $ grep pse /proc/cpuinfo | uniq
   flags : ... pdpe1gb ...
+  ```
 
-  If this commands returns a non-empty string, 1GB pages are supported:
+  If this commands returns a non-empty string, 1GB pages are supported.
+  ````
 
+````{note}
+The default configuration for many Linux distributions currently sets a
+relatively low limit for pinned memory allocations per process 
+(RLIMIT_MEMLOCK, often set to a default of 64kiB).
+
+To run an OPAE application that attempts to share more memory than specified
+by this limit between software and an accelerator, you can either:
+
+* Run the application as root, or
+* Increase the limit for locked memory via `ulimit`:
+
+```bash
+ulimit -l unlimited
 ```
 
-```eval_rst
-.. note::
-  The default configuration for many Linux distribution currently sets a relatively low limit for pinned memory allocations per process (RLIMIT_MEMLOCK, often set to a default of 64kiB).
-  To run an OPAE application which attempts to share more memory than specified by this limit between software and an accelerator, you can either:
-
-     * Run the application as root, or
-     * Increase the limit for locked memory via ulimit:
-
-     $ ulimit -l unlimited
-
-  See the Installation Guide for how to permanently adjust the memlock limit.
-
-```
+See the Installation Guide for how to permanently adjust the memlock limit.
+````
+  


### PR DESCRIPTION
- Fix typos.
- Fix grammar (missing articles, missing verbs, and general construction of sentences).
- Filter personal account information from examples.
- Fix BKM for Markdown (no closing headers, careful use of blank lines and indentation,...).
- Fix directives for Sphinx (using native fences, with appropriate nesting where needed).