### PR TITLE
tests: refactor xfpga tests to new fixtures.

### DIFF
--- a/tests/xfpga/test_enum_c.cpp
+++ b/tests/xfpga/test_enum_c.cpp
@@ -31,6 +31,8 @@
 
 #define NO_OPAE_C
 #include "mock/opae_fixtures.h"
+KEEP_XFPGA_SYMBOLS
+
 #include "opae_drv.h"
 #include "types_int.h"
 #include "sysfs_int.h"

--- a/tests/xfpga/test_metrics_max10_c.cpp
+++ b/tests/xfpga/test_metrics_max10_c.cpp
@@ -23,80 +23,40 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
+#define NO_OPAE_C
+#include "mock/opae_fixtures.h"
+KEEP_XFPGA_SYMBOLS
+
 extern "C" {
-#include <json-c/json.h>
-#include <uuid/uuid.h>
 #include "metrics/metrics_int.h"
 #include "metrics/metrics_max10.h"
 #include "metrics/vector.h"
 #include "opae_int.h"
 #include "types_int.h"
-}
-
-#include <config.h>
-#include <opae/fpga.h>
-
-#include <vector>
-#include "gtest/gtest.h"
 #include "sysfs_int.h"
-#include "mock/test_system.h"
-#include "mock/test_utils.h"
 #include "xfpga.h"
 
-extern "C" {
 int xfpga_plugin_initialize(void);
 int xfpga_plugin_finalize(void);
 }
 
 using namespace opae::testing;
 
-class metrics_max10_c_p : public ::testing::TestWithParam<std::string> {
+class metrics_max10_c_p : public opae_device_p<xfpga_> {
  protected:
-  metrics_max10_c_p() : tokens_{{nullptr, nullptr}}, handle_(nullptr) {}
 
-  virtual void SetUp() override {
-    ASSERT_TRUE(test_platform::exists(GetParam()));
-    platform_ = test_platform::get(GetParam());
-    system_ = test_system::instance();
-    system_->initialize();
-    system_->prepare_syfs(platform_);
-    ASSERT_EQ(xfpga_plugin_initialize(), FPGA_OK);
-    ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
-    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
-    ASSERT_EQ(xfpga_fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
-                                  &num_matches_),
-              FPGA_OK);
-    ASSERT_GT(num_matches_, 0);
-    ASSERT_EQ(xfpga_fpgaOpen(tokens_[0], &handle_, 0), FPGA_OK);
+  virtual void OPAEInitialize() override {
+    ASSERT_EQ(xfpga_plugin_initialize(), 0);
   }
 
-  virtual void TearDown() override {
-    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-    for (auto &t : tokens_) {
-      if (t) {
-        EXPECT_EQ(xfpga_fpgaDestroyToken(&t), FPGA_OK);
-        t = nullptr;
-      }
-    }
-    if (handle_ != nullptr) {
-      EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
-      handle_ = nullptr;
-    }
-    xfpga_plugin_finalize();
-    system_->finalize();
+  virtual void OPAEFinalize() override {
+    ASSERT_EQ(xfpga_plugin_finalize(), 0);
   }
 
-  std::array<fpga_token, 2> tokens_;
-  fpga_handle handle_;
-  fpga_properties filter_;
-  uint32_t num_matches_;
-  test_platform platform_;
-  test_system *system_;
 };
 
 /**
@@ -159,7 +119,7 @@ TEST_P(metrics_max10_c_p, test_metric_max10_1) {
 *
 */
 TEST_P(metrics_max10_c_p, test_metric_max10_2) {
-  struct _fpga_handle *_handle = (struct _fpga_handle *)handle_;
+  struct _fpga_handle *_handle = (struct _fpga_handle *)device_;
   fpga_metric_vector vector;
   uint64_t metric_num = 0;
 
@@ -188,7 +148,7 @@ TEST_P(metrics_max10_c_p, test_metric_max10_2) {
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_max10_c_p);
 INSTANTIATE_TEST_SUITE_P(metrics_max10_c, metrics_max10_c_p,
-    ::testing::ValuesIn(test_platform::mock_platforms({"dfl-n3000"})));
+                         ::testing::ValuesIn(test_platform::mock_platforms({"dfl-n3000"})));
 
 class metrics_invalid_max10_c_p : public metrics_max10_c_p {};
 
@@ -200,7 +160,7 @@ class metrics_invalid_max10_c_p : public metrics_max10_c_p {};
 *
 */
 TEST_P(metrics_invalid_max10_c_p, test_metric_max10_3) {
-  struct _fpga_handle *_handle = (struct _fpga_handle *)handle_;
+  struct _fpga_handle *_handle = (struct _fpga_handle *)device_;
   fpga_metric_vector vector;
   uint64_t metric_num = 0;
 
@@ -214,13 +174,9 @@ TEST_P(metrics_invalid_max10_c_p, test_metric_max10_3) {
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_invalid_max10_c_p);
 INSTANTIATE_TEST_SUITE_P(metrics_max10_c, metrics_invalid_max10_c_p,
-    ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));
+                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));
 
-
-class metrics_max10_vc_c_p : public metrics_max10_c_p {
-protected:
-	metrics_max10_vc_c_p() {}
-};
+class metrics_max10_vc_c_p : public metrics_max10_c_p {};
 
 /**
 * @test       test_metric_max10_4
@@ -232,13 +188,13 @@ protected:
 TEST_P(metrics_max10_vc_c_p, test_metric_max10_4) {
 
 	/*
-	struct _fpga_handle *_handle = (struct _fpga_handle *)handle_;
-	EXPECT_EQ(FPGA_OK, enum_fpga_metrics(handle_));
+	struct _fpga_handle *_handle = (struct _fpga_handle *)device_;
+	EXPECT_EQ(FPGA_OK, enum_fpga_metrics(device_));
 
 	struct fpga_metric fpga_metric;
 
 	EXPECT_EQ(FPGA_OK,
-		get_fme_metric_value(handle_, &(_handle->fpga_enum_metric_vector),
+		get_fme_metric_value(device_, &(_handle->fpga_enum_metric_vector),
 			1, &fpga_metric));
 	*/
 
@@ -248,4 +204,4 @@ TEST_P(metrics_max10_vc_c_p, test_metric_max10_4) {
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_max10_vc_c_p);
 INSTANTIATE_TEST_SUITE_P(metrics_max10_c, metrics_max10_vc_c_p,
-	::testing::ValuesIn(test_platform::mock_platforms({ "dfl-d5005" })));
+                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-d5005" })));

--- a/tests/xfpga/test_metrics_vector_c.cpp
+++ b/tests/xfpga/test_metrics_vector_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -23,33 +23,17 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
 extern "C" {
-
-#include <json-c/json.h>
-#include <uuid/uuid.h>
 #include "metrics/vector.h"
 #include "opae_int.h"
 #include "types_int.h"
 }
 
-#include <config.h>
-#include <opae/fpga.h>
-
-#include <array>
-#include <cstdlib>
-#include <map>
-#include <memory>
-#include <string>
-#include <vector>
 #include "gtest/gtest.h"
-#include "mock/test_system.h"
-
-using namespace opae::testing;
 
 /**
  * @test       opaec

--- a/tests/xfpga/test_open_close_c.cpp
+++ b/tests/xfpga/test_open_close_c.cpp
@@ -23,24 +23,22 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
-#include "gtest/gtest.h"
-#include "mock/test_system.h"
-#include "xfpga.h"
-#include "types_int.h"
-#include "opae/mmio.h"
-#include "fpga-dfl.h"
-#include "opae/access.h"
-#include "linux/ioctl.h"
-#include "cstdarg"
+#define NO_OPAE_C
+#include "mock/opae_fixtures.h"
+KEEP_XFPGA_SYMBOLS
 
-#include "error_int.h"
+#include <linux/ioctl.h>
 
 extern "C" {
+#include "xfpga.h"
+#include "types_int.h"
+#include "fpga-dfl.h"
+#include "error_int.h"
+
 int xfpga_plugin_initialize(void);
 int xfpga_plugin_finalize(void);
 }
@@ -73,82 +71,60 @@ static bool mmio_map_is_empty(struct wsid_map *root) {
 #endif
 
 int mmio_ioctl(mock_object * m, int request, va_list argp) {
-	int retval = -1;
-	errno = EINVAL;
-	UNUSED_PARAM(m);
-	UNUSED_PARAM(request);
-	struct dfl_fpga_port_region_info *rinfo = va_arg(argp, struct dfl_fpga_port_region_info *);
-	if (!rinfo) {
-		OPAE_MSG("rinfo is NULL");
-		goto out_EINVAL;
-	}
-	if (rinfo->argsz != sizeof(*rinfo)) {
-		OPAE_MSG("wrong structure size");
-		goto out_EINVAL;
-	}
-	if (rinfo->index > 1) {
-		OPAE_MSG("unsupported MMIO index");
-		goto out_EINVAL;
-	}
-	if (rinfo->padding != 0) {
-		OPAE_MSG("unsupported padding");
-		goto out_EINVAL;
-	}
-	rinfo->flags = DFL_PORT_REGION_READ | DFL_PORT_REGION_WRITE | DFL_PORT_REGION_MMAP;
-	rinfo->size = 0x40000;
-	rinfo->offset = 0;
-	retval = 0;
-	errno = 0;
+  int retval = -1;
+  errno = EINVAL;
+  UNUSED_PARAM(m);
+  UNUSED_PARAM(request);
+  struct dfl_fpga_port_region_info *rinfo = va_arg(argp, struct dfl_fpga_port_region_info *);
+  if (!rinfo) {
+    OPAE_MSG("rinfo is NULL");
+    goto out_EINVAL;
+  }
+  if (rinfo->argsz != sizeof(*rinfo)) {
+    OPAE_MSG("wrong structure size");
+    goto out_EINVAL;
+  }
+  if (rinfo->index > 1) {
+    OPAE_MSG("unsupported MMIO index");
+    goto out_EINVAL;
+  }
+  if (rinfo->padding != 0) {
+    OPAE_MSG("unsupported padding");
+    goto out_EINVAL;
+  }
+  rinfo->flags = DFL_PORT_REGION_READ | DFL_PORT_REGION_WRITE | DFL_PORT_REGION_MMAP;
+  rinfo->size = 0x40000;
+  rinfo->offset = 0;
+  retval = 0;
+  errno = 0;
 out:
-	return retval;
+  return retval;
 
 out_EINVAL:
-	retval = -1;
-	errno = EINVAL;
-	goto out;
+  retval = -1;
+  errno = EINVAL;
+  goto out;
 }
 
 
-class openclose_c_p
-    : public ::testing::TestWithParam<std::string> {
+class openclose_c_p : public opae_p<xfpga_> {
  protected:
-  openclose_c_p()
-  : handle_(nullptr),
-    tokens_{{nullptr, nullptr}} {}
+
+  virtual void OPAEInitialize() override {
+    ASSERT_EQ(xfpga_plugin_initialize(), 0);
+  }
+
+  virtual void OPAEFinalize() override {
+    ASSERT_EQ(xfpga_plugin_finalize(), 0);
+  }
 
   virtual void SetUp() override {
-    ASSERT_TRUE(test_platform::exists(GetParam()));
-    platform_ = test_platform::get(GetParam());
-    system_ = test_system::instance();
-    system_->initialize();
-    system_->prepare_syfs(platform_);
-    ASSERT_EQ(xfpga_plugin_initialize(), FPGA_OK);
-    ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
-    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
-    ASSERT_EQ(xfpga_fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
-                            &num_matches_),
-              FPGA_OK);
+    opae_p<xfpga_>::SetUp();
+
+    EXPECT_EQ(xfpga_fpgaClose(accel_), FPGA_OK);
+    accel_ = nullptr;
   }
 
-  virtual void TearDown() override {
-    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-
-    for (auto &t : tokens_){
-      if (t) {
-        EXPECT_EQ(FPGA_OK, xfpga_fpgaDestroyToken(&t));
-        t = nullptr;
-      }
-    }
-    xfpga_plugin_finalize();
-    system_->finalize();
-  }
-
-  fpga_handle handle_;
-  std::array<fpga_token, 2> tokens_;
-  fpga_properties filter_;
-  uint32_t num_matches_;
-  test_platform platform_;
-  test_system *system_;
 };
 
 /**
@@ -171,8 +147,8 @@ TEST_P(openclose_c_p, open_01) {
  */
 
 TEST_P(openclose_c_p, open_02) {
-  fpga_handle handle_;
-  ASSERT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaOpen(NULL, &handle_, 0));
+  ASSERT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaOpen(NULL, &accel_, 0));
+  EXPECT_EQ(accel_, nullptr);
 }
 
 /**
@@ -183,8 +159,9 @@ TEST_P(openclose_c_p, open_02) {
  *
  */
 TEST_P(openclose_c_p, open_03) {
-  ASSERT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaOpen(tokens_[0], NULL, 42));
-  ASSERT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaOpen(tokens_[0], &handle_, 42));
+  ASSERT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaOpen(accel_token_, NULL, 42));
+  ASSERT_EQ(FPGA_INVALID_PARAM, xfpga_fpgaOpen(accel_token_, &accel_, 42));
+  EXPECT_EQ(accel_, nullptr);
 }
 
 /**
@@ -195,14 +172,16 @@ TEST_P(openclose_c_p, open_03) {
  *
  */
 TEST_P(openclose_c_p, open_04) {
-  auto _token = (struct _fpga_token*)tokens_[0];
-  auto res = xfpga_fpgaOpen(tokens_[0], &handle_, 42);
+  auto _token = (struct _fpga_token*)accel_token_;
+  auto res = xfpga_fpgaOpen(accel_token_, &accel_, 42);
   ASSERT_EQ(FPGA_INVALID_PARAM, res);
+  EXPECT_EQ(accel_, nullptr);
 
   // Invalid token magic
   _token->hdr.magic = 0x123;
-  res = xfpga_fpgaOpen(tokens_[0], &handle_, FPGA_OPEN_SHARED);
+  res = xfpga_fpgaOpen(accel_token_, &accel_, FPGA_OPEN_SHARED);
   ASSERT_EQ(FPGA_INVALID_PARAM, res);
+  EXPECT_EQ(accel_, nullptr);
 
   // Reset token magic
   _token->hdr.magic = FPGA_TOKEN_MAGIC;
@@ -217,22 +196,24 @@ TEST_P(openclose_c_p, open_04) {
  */
 TEST_P(openclose_c_p, open_05) {
   fpga_result res;
-  struct _fpga_token* _token = (struct _fpga_token*)tokens_[0];
+  struct _fpga_token* _token = (struct _fpga_token*)accel_token_;
 
   // Invalid flag
-  res = xfpga_fpgaOpen(tokens_[0], &handle_, 42);
+  res = xfpga_fpgaOpen(accel_token_, &accel_, 42);
   ASSERT_EQ(FPGA_INVALID_PARAM, res);
- 
-  handle_ = nullptr; 
+  EXPECT_EQ(accel_, nullptr);
+
   // Valid flag
-  res = xfpga_fpgaOpen(tokens_[0], &handle_, FPGA_OPEN_SHARED);
+  res = xfpga_fpgaOpen(accel_token_, &accel_, FPGA_OPEN_SHARED);
   ASSERT_EQ(FPGA_OK, res);
-  ASSERT_EQ(FPGA_OK, xfpga_fpgaClose(handle_));
+  ASSERT_EQ(FPGA_OK, xfpga_fpgaClose(accel_));
 
   // Invalid token path
+  accel_ = nullptr;
   strcpy(_token->devpath,"/dev/intel-fpga-fme.01");
-  res = xfpga_fpgaOpen(tokens_[0], &handle_, FPGA_OPEN_SHARED);
+  res = xfpga_fpgaOpen(accel_token_, &accel_, FPGA_OPEN_SHARED);
   ASSERT_EQ(FPGA_NO_DRIVER, res);
+  EXPECT_EQ(accel_, nullptr);
 }
 
 /**
@@ -244,8 +225,9 @@ TEST_P(openclose_c_p, open_05) {
  */
 TEST_P(openclose_c_p, open_06) {
   system_->invalidate_malloc();
-  auto res = xfpga_fpgaOpen(tokens_[0], &handle_, 0);
+  auto res = xfpga_fpgaOpen(accel_token_, &accel_, 0);
   ASSERT_EQ(FPGA_NO_MEMORY, res);
+  EXPECT_EQ(accel_, nullptr);
 }
 
 /**
@@ -258,20 +240,21 @@ TEST_P(openclose_c_p, open_06) {
  */
 TEST_P(openclose_c_p, close_01) {
   int fddev = -1;
-  auto res = xfpga_fpgaOpen(tokens_[0], &handle_, 0);
+  auto res = xfpga_fpgaOpen(accel_token_, &accel_, 0);
   ASSERT_EQ(FPGA_OK, res);
 
-  struct _fpga_handle* _handle = (struct _fpga_handle*)handle_;
+  struct _fpga_handle* _handle = (struct _fpga_handle*)accel_;
 
   // Invalid handle fd
   fddev = _handle->fddev;
   _handle->fddev = -1;
-  res = xfpga_fpgaClose(handle_);
+  res = xfpga_fpgaClose(accel_);
   EXPECT_EQ(res, FPGA_INVALID_PARAM);
 
   // Valid handle fd
   _handle->fddev = fddev;
-   res = xfpga_fpgaClose(handle_);
+  res = xfpga_fpgaClose(accel_);
+  accel_ = nullptr;
   EXPECT_EQ(res, FPGA_OK);
 }
 
@@ -295,26 +278,30 @@ TEST_P(openclose_c_p, invalid_close) {
  */
 TEST_P(openclose_c_p, close_03) {
   uint64_t * mmio_ptr = nullptr;
-  auto res = xfpga_fpgaOpen(tokens_[0], &handle_, 0);
+  auto res = xfpga_fpgaOpen(accel_token_, &accel_, 0);
   ASSERT_EQ(FPGA_OK, res);
 
   // Register valid ioctl
   system_->register_ioctl_handler(DFL_FPGA_PORT_GET_REGION_INFO, mmio_ioctl);
-  EXPECT_TRUE(mmio_map_is_empty(((struct _fpga_handle*)handle_)->mmio_root));
+  EXPECT_TRUE(mmio_map_is_empty(((struct _fpga_handle*)accel_)->mmio_root));
 
-  ASSERT_EQ(FPGA_OK, xfpga_fpgaMapMMIO(handle_, 0, &mmio_ptr));
+  ASSERT_EQ(FPGA_OK, xfpga_fpgaMapMMIO(accel_, 0, &mmio_ptr));
   EXPECT_NE(mmio_ptr,nullptr);
 
-  res = xfpga_fpgaClose(handle_);
+  res = xfpga_fpgaClose(accel_);
   EXPECT_EQ(res, FPGA_OK);
+  accel_ = nullptr;
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(openclose_c_p);
 INSTANTIATE_TEST_SUITE_P(openclose_c, openclose_c_p, 
-                        ::testing::ValuesIn(test_platform::platforms({ "dfl-n3000","dfl-d5005" })));
+                         ::testing::ValuesIn(test_platform::platforms({
+                                                                        "dfl-d5005",
+                                                                        "dfl-n3000",
+                                                                        "dfl-n6000"
+                                                                      })));
 
-class openclose_c_skx_dcp_p
-    : public openclose_c_p {};
+class openclose_c_skx_dcp_p : public openclose_c_p {};
 
 /**
  * @test       open_share
@@ -327,18 +314,17 @@ TEST_P(openclose_c_skx_dcp_p, open_share) {
   fpga_handle h1 = nullptr;
   fpga_handle h2 = nullptr;
 
-  EXPECT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_[0], &h1, FPGA_OPEN_SHARED));
-  EXPECT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_[0], &h2, FPGA_OPEN_SHARED));
+  EXPECT_EQ(FPGA_OK, xfpga_fpgaOpen(accel_token_, &h1, FPGA_OPEN_SHARED));
+  EXPECT_EQ(FPGA_OK, xfpga_fpgaOpen(accel_token_, &h2, FPGA_OPEN_SHARED));
   EXPECT_EQ(FPGA_OK, xfpga_fpgaClose(h1));
   EXPECT_EQ(FPGA_OK, xfpga_fpgaClose(h2));
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(openclose_c_skx_dcp_p);
 INSTANTIATE_TEST_SUITE_P(openclose_c_skx_dcp, openclose_c_skx_dcp_p,
-                        ::testing::ValuesIn(test_platform::platforms({}, fpga_driver::linux_intel)));
+                         ::testing::ValuesIn(test_platform::platforms({}, fpga_driver::linux_intel)));
 
-class openclose_c_dfl_p
-    : public openclose_c_p {};
+class openclose_c_dfl_p : public openclose_c_p {};
 
 /**
  * @test       open_share
@@ -351,14 +337,16 @@ TEST_P(openclose_c_dfl_p, open_share) {
   fpga_handle h1 = nullptr;
   fpga_handle h2 = nullptr;
 
-  EXPECT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_[0], &h1, FPGA_OPEN_SHARED));
-  EXPECT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_[0], &h2, FPGA_OPEN_SHARED));
+  EXPECT_EQ(FPGA_OK, xfpga_fpgaOpen(accel_token_, &h1, FPGA_OPEN_SHARED));
+  EXPECT_EQ(FPGA_OK, xfpga_fpgaOpen(accel_token_, &h2, FPGA_OPEN_SHARED));
   EXPECT_EQ(FPGA_OK, xfpga_fpgaClose(h1));
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(openclose_c_dfl_p);
 INSTANTIATE_TEST_SUITE_P(openclose_c_dfl, openclose_c_dfl_p,
-                        ::testing::ValuesIn(test_platform::hw_platforms({}, fpga_driver::linux_dfl0)));
+                         ::testing::ValuesIn(test_platform::hw_platforms({}, fpga_driver::linux_dfl0)));
+
+class openclose_c_mock_p : public openclose_c_p {};
 
 /**
  * @test       invalid_open_close
@@ -367,13 +355,6 @@ INSTANTIATE_TEST_SUITE_P(openclose_c_dfl, openclose_c_dfl_p,
  *             but driver is not loaded. the function returns FPGA_NO_DRIVER.
  *
  */
-class openclose_c_mock_p
-    : public ::testing::TestWithParam<std::string> {
- protected:
-  openclose_c_mock_p() {}
-
-};
-
 TEST_P(openclose_c_mock_p, invalid_open_close) {
   struct _fpga_token _tok;
   fpga_token tok = &_tok;
@@ -402,4 +383,8 @@ TEST_P(openclose_c_mock_p, invalid_open_close) {
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(openclose_c_mock_p);
 INSTANTIATE_TEST_SUITE_P(openclose_c, openclose_c_mock_p, 
-                        ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
+                         ::testing::ValuesIn(test_platform::mock_platforms({
+                                                                             "dfl-d5005",
+                                                                             "dfl-n3000",
+                                                                             "dfl-n6000"
+                                                                           })));

--- a/tests/xfpga/test_plugin_c.cpp
+++ b/tests/xfpga/test_plugin_c.cpp
@@ -23,121 +23,84 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
+#define NO_OPAE_C
+#include "mock/opae_fixtures.h"
+KEEP_XFPGA_SYMBOLS
+
 extern "C" {
-#include <opae/utils.h>
 #include "sysfs_int.h"
 #include "types_int.h"
 #include "adapter.h"
+#include "xfpga.h"
 
 int xfpga_plugin_initialize(void);
 int xfpga_plugin_finalize(void);
 int opae_plugin_configure(opae_api_adapter_table *adapter,
-	const char *jsonConfig);
+                          const char *jsonConfig);
 }
-
-#include <opae/enum.h>
-#include <opae/fpga.h>
-#include <dlfcn.h>
-#include "xfpga.h"
-#include <fcntl.h>
-#include "gtest/gtest.h"
-#include "mock/test_system.h"
-#include "adapter.h"
 
 using namespace opae::testing;
 
-class xfpga_plugin_c_p : public ::testing::TestWithParam<std::string> {
-protected:
-	xfpga_plugin_c_p()
-		: tokens_{ {nullptr, nullptr} },
-		handle_(nullptr) {}
+class xfpga_plugin_c_p : public opae_base_p<xfpga_> {
+ protected:
 
-	virtual void SetUp() override {
-		ASSERT_TRUE(test_platform::exists(GetParam()));
-		platform_ = test_platform::get(GetParam());
-		system_ = test_system::instance();
-		system_->initialize();
-		system_->prepare_syfs(platform_);
-		ASSERT_EQ(xfpga_plugin_initialize(), FPGA_OK);
+  virtual void OPAEInitialize() override {
+    ASSERT_EQ(xfpga_plugin_initialize(), 0);
+  }
 
-		ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
-		ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
-		ASSERT_EQ(xfpga_fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
-			&num_matches_), FPGA_OK);
-		ASSERT_GT(num_matches_, 0);
-		ASSERT_EQ(xfpga_fpgaOpen(tokens_[0], &handle_, 0), FPGA_OK);
-	}
+  virtual void OPAEFinalize() override {
+    ASSERT_EQ(xfpga_plugin_finalize(), 0);
+  }
 
-	virtual void TearDown() override {
-		EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-		for (auto &t : tokens_) {
-			if (t) {
-				EXPECT_EQ(xfpga_fpgaDestroyToken(&t), FPGA_OK);
-				t = nullptr;
-			}
-		}
-		if (handle_ != nullptr) {
-			EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
-			handle_ = nullptr;
-		}
-		xfpga_plugin_finalize();
-		system_->finalize();
-	}
-
-	std::array<fpga_token, 2> tokens_;
-	fpga_handle handle_;
-	fpga_properties filter_;
-	uint32_t num_matches_;
-	test_platform platform_;
-	test_system *system_;
-
-	opae_api_adapter_table *opae_plugin_mgr_alloc_adapter_test(const char *lib_path)
-	{
-		void *dl_handle;
-		opae_api_adapter_table *adapter;
-		dl_handle = dlopen(lib_path, RTLD_LAZY | RTLD_LOCAL);
-		if (!dl_handle) {
-			char *err = dlerror();
-			OPAE_ERR("failed to load \"%s\" %s", lib_path, err ? err : "");
-			return NULL;
-		}
-
-		adapter = (opae_api_adapter_table *)calloc(
-			1, sizeof(opae_api_adapter_table));
-
-		if (!adapter) {
-			dlclose(dl_handle);
-			OPAE_ERR("out of memory");
-			return NULL;
-		}
-		adapter->plugin.path = (char *)lib_path;
-		adapter->plugin.dl_handle = dl_handle;
-
-		return adapter;
-	}
-
-	int opae_plugin_mgr_free_adapter_test(opae_api_adapter_table *adapter)
-	{
-		int res;
-		char *err;
-
-		res = dlclose(adapter->plugin.dl_handle);
-
-		if (res) {
-			err = dlerror();
-			OPAE_ERR("dlclose failed with %d %s", res, err ? err : "");
-		}
-
-		free(adapter);
-
-		return res;
-	}
+  opae_api_adapter_table *opae_plugin_mgr_alloc_adapter_test(const char *lib_path);
+  int opae_plugin_mgr_free_adapter_test(opae_api_adapter_table *adapter);
 };
+
+opae_api_adapter_table * xfpga_plugin_c_p::opae_plugin_mgr_alloc_adapter_test(const char *lib_path)
+{
+  void *dl_handle;
+  opae_api_adapter_table *adapter;
+  dl_handle = dlopen(lib_path, RTLD_LAZY | RTLD_LOCAL);
+  if (!dl_handle) {
+    char *err = dlerror();
+    OPAE_ERR("failed to load \"%s\" %s", lib_path, err ? err : "");
+    return NULL;
+  }
+
+  adapter = (opae_api_adapter_table *)calloc(
+             1, sizeof(opae_api_adapter_table));
+
+  if (!adapter) {
+    dlclose(dl_handle);
+    OPAE_ERR("out of memory");
+    return NULL;
+  }
+  adapter->plugin.path = (char *)lib_path;
+  adapter->plugin.dl_handle = dl_handle;
+
+  return adapter;
+}
+
+int xfpga_plugin_c_p::opae_plugin_mgr_free_adapter_test(opae_api_adapter_table *adapter)
+{
+  int res;
+  char *err;
+
+  res = dlclose(adapter->plugin.dl_handle);
+
+  if (res) {
+    err = dlerror();
+    OPAE_ERR("dlclose failed with %d %s", res, err ? err : "");
+  }
+
+  free(adapter);
+
+  return res;
+}
 
 /*
 * @test       plugin
@@ -147,36 +110,18 @@ protected:
 */
 TEST_P(xfpga_plugin_c_p, test_plugin_2) {
 
-	opae_api_adapter_table *adapter_table = opae_plugin_mgr_alloc_adapter_test("libxfpga.so");
+  opae_api_adapter_table *adapter_table = opae_plugin_mgr_alloc_adapter_test("libxfpga.so");
 
-	EXPECT_EQ(opae_plugin_configure(adapter_table, NULL), 0);
+  EXPECT_EQ(opae_plugin_configure(adapter_table, NULL), 0);
 
-	if (adapter_table)
-		opae_plugin_mgr_free_adapter_test(adapter_table);
-
+  if (adapter_table)
+    opae_plugin_mgr_free_adapter_test(adapter_table);
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(xfpga_plugin_c_p);
 INSTANTIATE_TEST_SUITE_P(xfpga_plugin_c, xfpga_plugin_c_p,
-	::testing::ValuesIn(test_platform::mock_platforms({"skx-p","dcp-rc"})));
-
-class xfpga_plugin_mock_c_p : public ::testing::TestWithParam<std::string> {
-protected:
-    xfpga_plugin_mock_c_p() {};
-};
-
-/*
-* @test       test_plugin_neg
-* @brief      Tests:xfpga_plugin_initialize
-*                   xfpga_plugin_finalize
-* @details    When no driver is present, returns FPGA_NO_DRIVER.
-*/
-TEST_P(xfpga_plugin_mock_c_p, test_plugin_neg) {
-	EXPECT_EQ(xfpga_plugin_initialize(), FPGA_NO_DRIVER);
-	EXPECT_EQ(xfpga_plugin_finalize(), FPGA_OK);
-}
-
-GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(xfpga_plugin_mock_c_p);
-INSTANTIATE_TEST_SUITE_P(xfpga_plugin_mock_c, xfpga_plugin_mock_c_p,
-     ::testing::ValuesIn(test_platform::mock_platforms()));
-
+                         ::testing::ValuesIn(test_platform::mock_platforms({
+                                                                             "dfl-d5005",
+                                                                             "dfl-n3000",
+                                                                             "dfl-n6000"
+                                                                           })));

--- a/tests/xfpga/test_reconf_c.cpp
+++ b/tests/xfpga/test_reconf_c.cpp
@@ -23,22 +23,22 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-#include "gtest/gtest.h"
-#include "mock/test_system.h"
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#define NO_OPAE_C
+#include "mock/opae_fixtures.h"
+KEEP_XFPGA_SYMBOLS
 #include "mock/test_utils.h"
 
 extern "C" {
-#include <bitstream_int.h>
-#include <opae/access.h>
-#include <opae/enum.h>
-#include <opae/properties.h>
+#include "bitstream_int.h"
 #include "fpga-dfl.h"
 #include "reconf_int.h"
 #include "xfpga.h"
 #include "sysfs_int.h"
-}
 
-extern "C" {
 fpga_result open_accel(fpga_handle handle, fpga_handle *accel);
 fpga_result clear_port_errors(fpga_handle handle);
 fpga_result validate_bitstream(fpga_handle, const uint8_t *bitstream, 
@@ -49,32 +49,27 @@ int xfpga_plugin_finalize(void);
 
 using namespace opae::testing;
 
-class reconf_c : public ::testing::TestWithParam<std::string> {
+class reconf_c : public opae_device_p<xfpga_> {
  protected:
-  reconf_c()
-  : tokens_{{nullptr, nullptr}},
-    handle_(nullptr) {}
+
+  virtual void OPAEInitialize() override {
+    ASSERT_EQ(xfpga_plugin_initialize(), 0);
+  }
+
+  virtual void OPAEFinalize() override {
+    ASSERT_EQ(xfpga_plugin_finalize(), 0);
+  }
 
   virtual void SetUp() override {
-    ASSERT_TRUE(test_platform::exists(GetParam()));
-    platform_ = test_platform::get(GetParam());
-    system_ = test_system::instance();
-    system_->initialize();
-    system_->prepare_syfs(platform_);
+    opae_device_p<xfpga_>::SetUp();
 
-    ASSERT_EQ(xfpga_plugin_initialize(), FPGA_OK);
-    ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
-    ASSERT_EQ(fpgaPropertiesSetDeviceID(filter_, platform_.devices[0].device_id), FPGA_OK);
-    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
-    ASSERT_EQ(xfpga_fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
-                                  &num_matches_), FPGA_OK);
+    test_device device = platform_.devices[0];
 
-    bitstream_valid_ = system_->assemble_gbs_header(platform_.devices[0]);
-    // Valid bitstream - no clk
+    bitstream_valid_ = system_->assemble_gbs_header(device);
     std::string version = "630";
 
-    auto fme_guid = platform_.devices[0].fme_guid;
-    auto afu_guid = platform_.devices[0].afu_guid;
+    auto fme_guid = device.fme_guid;
+    auto afu_guid = device.afu_guid;
 
     // clang-format off
     auto bitstream_j = jobject
@@ -92,34 +87,11 @@ class reconf_c : public ::testing::TestWithParam<std::string> {
     )
     ("platform-name", "");
     // clang-format on
-    bitstream_valid_no_clk_ =
-        system_->assemble_gbs_header(platform_.devices[0], bitstream_j.c_str());
+
+    bitstream_valid_no_clk_ = system_->assemble_gbs_header(device, bitstream_j.c_str());
     bitstream_j.put();
   }
 
-  virtual void TearDown() override {
-    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-    if (handle_) { 
-        EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK); 
-        handle_ = nullptr;
-    }
-
-    for (auto &t : tokens_) {
-      if (t) {
-        EXPECT_EQ(xfpga_fpgaDestroyToken(&t), FPGA_OK);
-        t = nullptr;
-      }
-    }
-    xfpga_plugin_finalize();
-    system_->finalize();
-  }
-
-  std::array<fpga_token, 2> tokens_;
-  fpga_handle handle_;
-  fpga_properties filter_;
-  uint32_t num_matches_;
-  test_platform platform_;
-  test_system *system_;
   std::vector<uint8_t> bitstream_valid_;
   std::vector<uint8_t> bitstream_valid_no_clk_;
 };
@@ -134,15 +106,12 @@ class reconf_c : public ::testing::TestWithParam<std::string> {
 TEST_P(reconf_c, set_afu_userclock) {
   fpga_result result;
 
-  // Open port device
-  ASSERT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_[0], &handle_, 0));
-
   // Null handle
   result = set_afu_userclock(NULL, 0, 0);
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 
   // Invalid params
-  result = set_afu_userclock(handle_, 0, 0);
+  result = set_afu_userclock(device_, 0, 0);
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 }
 
@@ -170,24 +139,21 @@ TEST_P(reconf_c, fpga_reconf_slot) {
   uint32_t slot = 0;
   int flags = 0;
 
-  // Open port device
-  ASSERT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_[0], &handle_, 0));
-
   // Invalid bitstream - null
-  result = xfpga_fpgaReconfigureSlot(handle_, slot, NULL, 0, flags);
+  result = xfpga_fpgaReconfigureSlot(device_, slot, NULL, 0, flags);
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 
   // Invalid bitstream - empty
-  result = xfpga_fpgaReconfigureSlot(handle_, slot, bitstream_empty, 0, flags);
+  result = xfpga_fpgaReconfigureSlot(device_, slot, bitstream_empty, 0, flags);
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 
   // Invalid bitstream - invalid guid
-  result = xfpga_fpgaReconfigureSlot(handle_, slot, bitstream_invalid_guid,
+  result = xfpga_fpgaReconfigureSlot(device_, slot, bitstream_invalid_guid,
                                      bitstream_valid_len, flags);
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 
   // Invalid bitstream - invalid json
-  result = xfpga_fpgaReconfigureSlot(handle_, slot, bitstream_invalid_json,
+  result = xfpga_fpgaReconfigureSlot(device_, slot, bitstream_invalid_json,
                                      bitstream_valid_len, flags);
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 
@@ -198,13 +164,13 @@ TEST_P(reconf_c, fpga_reconf_slot) {
 
   // Invalid handle file descriptor
   auto &no_clk_arr = bitstream_valid_no_clk_;
-  struct _fpga_handle *handle = (struct _fpga_handle *)handle_;
+  struct _fpga_handle *handle = (struct _fpga_handle *)device_;
   uint32_t fddev = handle->fddev;
 
   handle->fddev = -1;
 
   result =
-      xfpga_fpgaReconfigureSlot(handle_, slot, no_clk_arr.data(), no_clk_arr.size(), flags);
+      xfpga_fpgaReconfigureSlot(device_, slot, no_clk_arr.data(), no_clk_arr.size(), flags);
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 
   handle->fddev = fddev;
@@ -220,25 +186,23 @@ TEST_P(reconf_c, open_accel_01) {
   fpga_result result;
   fpga_handle accel = nullptr;
 
-  ASSERT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_[0], &handle_, 0));
-
   // Null handle
   result = open_accel(NULL, &accel);
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 
   // Valid handle
-  result = open_accel(handle_, &accel);
+  result = open_accel(device_, &accel);
   EXPECT_EQ(result, FPGA_OK);
 
   EXPECT_EQ(xfpga_fpgaClose(accel), FPGA_OK);
 
   // Invalid object type
-  struct _fpga_handle *handle = (struct _fpga_handle *)handle_;
+  struct _fpga_handle *handle = (struct _fpga_handle *)device_;
   struct _fpga_token *token = (struct _fpga_token *)&handle->token;
 
   handle->token = NULL;
 
-  result = open_accel(handle_, &accel);
+  result = open_accel(device_, &accel);
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 
   handle->token = token;
@@ -257,8 +221,6 @@ TEST_P(reconf_c, open_accel_02) {
   fpga_handle accel = nullptr;
   uint32_t num_matches_accel;
 
-  ASSERT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_[0], &handle_, 0));
-
   ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_accel), FPGA_OK);
   ASSERT_EQ(fpgaPropertiesSetObjectType(filter_accel, FPGA_ACCELERATOR),
             FPGA_OK);
@@ -267,7 +229,7 @@ TEST_P(reconf_c, open_accel_02) {
             FPGA_OK);
   ASSERT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_accel[0], &handle_accel, 0));
 
-  EXPECT_NE(handle_, nullptr);
+  EXPECT_NE(device_, nullptr);
   EXPECT_NE(handle_accel, nullptr);
   auto result = open_accel(handle_accel, &accel);
   EXPECT_EQ(result, FPGA_BUSY);
@@ -296,41 +258,34 @@ TEST_P(reconf_c, validate_bitstream) {
   int header_len;
   fpga_result result;
 
-  ASSERT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_[0], &handle_, 0));
-
-  result = validate_bitstream(handle_, bitstream_invalid_len,
+  result = validate_bitstream(device_, bitstream_invalid_len,
                               bitstream_len, &header_len);
   EXPECT_EQ(FPGA_EXCEPTION, result);
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c);
 INSTANTIATE_TEST_SUITE_P(reconf, reconf_c,
-                        ::testing::ValuesIn(test_platform::platforms({})));
+                         ::testing::ValuesIn(test_platform::platforms({})));
 
-class reconf_c_mock_p : public ::testing::TestWithParam<std::string> {
+class reconf_c_mock_p : public opae_device_p<xfpga_> {
  protected:
-  reconf_c_mock_p()
-  : tokens_{{nullptr, nullptr}},
-    handle_(nullptr) {}
+
+  virtual void OPAEInitialize() override {
+    ASSERT_EQ(xfpga_plugin_initialize(), 0);
+  }
+
+  virtual void OPAEFinalize() override {
+    ASSERT_EQ(xfpga_plugin_finalize(), 0);
+  }
 
   virtual void SetUp() override {
-    ASSERT_TRUE(test_platform::exists(GetParam()));
-    platform_ = test_platform::get(GetParam());
-    system_ = test_system::instance();
-    system_->initialize();
-    system_->prepare_syfs(platform_);
-    ASSERT_EQ(xfpga_plugin_initialize(), FPGA_OK);
-    ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
-    ASSERT_EQ(fpgaPropertiesSetDeviceID(filter_, platform_.devices[0].device_id), FPGA_OK);
-    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
-    ASSERT_EQ(xfpga_fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
-                                  &num_matches_), FPGA_OK);
-    EXPECT_GT(num_matches_, 0);
-    ASSERT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_[0], &handle_, 0));
+    opae_device_p<xfpga_>::SetUp();
+
+    test_device device = platform_.devices[0];
 
     // assemble valid bitstream header
-    auto fme_guid = platform_.devices[0].fme_guid;
-    auto afu_guid = platform_.devices[0].afu_guid;
+    auto fme_guid = device.fme_guid;
+    auto afu_guid = device.afu_guid;
 
     auto bitstream_j = jobject
     ("version", "640")
@@ -347,34 +302,10 @@ class reconf_c_mock_p : public ::testing::TestWithParam<std::string> {
     )
     ("platform-name", "");
 
-    bitstream_valid_ =
-          system_->assemble_gbs_header(platform_.devices[0], bitstream_j.c_str());
+    bitstream_valid_ = system_->assemble_gbs_header(device, bitstream_j.c_str());
     bitstream_j.put();
   }
 
-  virtual void TearDown() override {
-    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-    if (handle_) { 
-        EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK); 
-        handle_ = nullptr;
-    }
-
-    for (auto &t : tokens_) {
-      if (t) {
-        EXPECT_EQ(xfpga_fpgaDestroyToken(&t), FPGA_OK);
-        t = nullptr;
-      }
-    }
-    xfpga_plugin_finalize();
-    system_->finalize();
-  }
-
-  std::array<fpga_token, 2> tokens_;
-  fpga_handle handle_;
-  fpga_properties filter_;
-  uint32_t num_matches_;
-  test_platform platform_;
-  test_system *system_;
   std::vector<uint8_t> bitstream_valid_;
 };
 
@@ -385,7 +316,7 @@ class reconf_c_mock_p : public ::testing::TestWithParam<std::string> {
  *          returns FPGA_NOT_SUPPORTED on mock platforms.
  */
 TEST_P(reconf_c_mock_p, set_afu_userclock) {
-  EXPECT_EQ(set_afu_userclock(handle_, 312, 156), FPGA_INVALID_PARAM);
+  EXPECT_EQ(set_afu_userclock(device_, 312, 156), FPGA_INVALID_PARAM);
 }
 
 /**
@@ -399,7 +330,7 @@ TEST_P(reconf_c_mock_p, fpga_reconf_slot) {
   uint32_t slot = 0;
   int flags = 0;
 
-  result = xfpga_fpgaReconfigureSlot(handle_, slot, bitstream_valid_.data(),
+  result = xfpga_fpgaReconfigureSlot(device_, slot, bitstream_valid_.data(),
                                      bitstream_valid_.size(), flags);
   EXPECT_EQ(result, FPGA_OK);
 }
@@ -418,7 +349,7 @@ TEST_P(reconf_c_mock_p, fpga_reconf_slot_einval) {
 
   // register an ioctl handler that will return -1 and set errno to EINVAL
   system_->register_ioctl_handler(DFL_FPGA_FME_PORT_PR, dummy_ioctl<-1, EINVAL>);
-  result = xfpga_fpgaReconfigureSlot(handle_, slot, bitstream_valid_.data(),
+  result = xfpga_fpgaReconfigureSlot(device_, slot, bitstream_valid_.data(),
                                      bitstream_valid_.size(), flags);
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 }
@@ -437,19 +368,16 @@ TEST_P(reconf_c_mock_p, fpga_reconf_slot_enotsup) {
 
   // register an ioctl handler that will return -1 and set errno to ENOTSUP
   system_->register_ioctl_handler(DFL_FPGA_FME_PORT_PR, dummy_ioctl<-1, ENOTSUP>);
-  result = xfpga_fpgaReconfigureSlot(handle_, slot, bitstream_valid_.data(),
+  result = xfpga_fpgaReconfigureSlot(device_, slot, bitstream_valid_.data(),
                                      bitstream_valid_.size(), flags);
   EXPECT_EQ(result, FPGA_EXCEPTION);
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c_mock_p);
 INSTANTIATE_TEST_SUITE_P(reconf, reconf_c_mock_p,
-                        ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
+                         ::testing::ValuesIn(test_platform::mock_platforms({ "dfl-n3000","dfl-d5005" })));
 
-class reconf_c_hw_skx_p : public reconf_c {
-  protected:
-    reconf_c_hw_skx_p() {};
-};
+class reconf_c_hw_skx_p : public reconf_c {};
 
 /**
  * @test    set_afu_userclock
@@ -458,18 +386,14 @@ class reconf_c_hw_skx_p : public reconf_c {
  *          FPGA_OK on mcp hw platforms.
  */
 TEST_P(reconf_c_hw_skx_p, set_afu_userclock) {
-  ASSERT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_[0], &handle_, 0));
-  EXPECT_EQ(set_afu_userclock(handle_, 312, 156), FPGA_OK);
+  EXPECT_EQ(set_afu_userclock(device_, 312, 156), FPGA_OK);
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c_hw_skx_p);
 INSTANTIATE_TEST_SUITE_P(reconf, reconf_c_hw_skx_p,
-                        ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-d5005" })));
+                         ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-d5005" })));
 
-class reconf_c_hw_dcp_p : public reconf_c {
-  protected:
-    reconf_c_hw_dcp_p() {};
-};
+class reconf_c_hw_dcp_p : public reconf_c {};
 
 /**
  * @test    set_afu_userclock
@@ -478,13 +402,12 @@ class reconf_c_hw_dcp_p : public reconf_c {
  *          FPGA_NOT_SUPPORTED on dcp hw platforms.
  */
 TEST_P(reconf_c_hw_dcp_p, set_afu_userclock) {
-  ASSERT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_[0], &handle_, 0));
-  EXPECT_EQ(set_afu_userclock(handle_, 312, 156), FPGA_NOT_SUPPORTED);
+  EXPECT_EQ(set_afu_userclock(device_, 312, 156), FPGA_NOT_SUPPORTED);
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c_hw_dcp_p);
 INSTANTIATE_TEST_SUITE_P(reconf, reconf_c_hw_dcp_p,
-                        ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-d5005" })));
+                         ::testing::ValuesIn(test_platform::hw_platforms({ "dfl-d5005" })));
 
 /**
 * @test    clear_port_errors
@@ -500,30 +423,25 @@ TEST(reconf, clear_port_errors) {
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 }
 
-class reconf_c_hw_p : public reconf_c {
-  protected:
-    reconf_c_hw_p()
-  : tokens_{{nullptr, nullptr}},
-    handle_(nullptr) {}
+class reconf_c_hw_p : public opae_device_p<xfpga_> {
+ protected:
+
+  virtual void OPAEInitialize() override {
+    ASSERT_EQ(xfpga_plugin_initialize(), 0);
+  }
+
+  virtual void OPAEFinalize() override {
+    ASSERT_EQ(xfpga_plugin_finalize(), 0);
+  }
 
   virtual void SetUp() override {
-    ASSERT_TRUE(test_platform::exists(GetParam()));
-    platform_ = test_platform::get(GetParam());
-    system_ = test_system::instance();
-    system_->initialize();
-    system_->prepare_syfs(platform_);
+    opae_device_p<xfpga_>::SetUp();
 
-    ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
-    ASSERT_EQ(fpgaPropertiesSetDeviceID(filter_, platform_.devices[0].device_id), FPGA_OK);
-    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
-    ASSERT_EQ(xfpga_fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
-                                  &num_matches_), FPGA_OK);
-    EXPECT_GT(num_matches_, 0);
-    ASSERT_EQ(FPGA_OK, xfpga_fpgaOpen(tokens_[0], &handle_, 0));
+    test_device device = platform_.devices[0];
 
     // assemble valid bitstream header
-    auto fme_guid = platform_.devices[0].fme_guid;
-    auto afu_guid = platform_.devices[0].afu_guid;
+    auto fme_guid = device.fme_guid;
+    auto afu_guid = device.afu_guid;
 
     auto bitstream_j = jobject
     ("version", "640")
@@ -540,33 +458,10 @@ class reconf_c_hw_p : public reconf_c {
     )
     ("platform-name", "");
 
-    bitstream_valid_ =
-          system_->assemble_gbs_header(platform_.devices[0], bitstream_j.c_str());
+    bitstream_valid_ = system_->assemble_gbs_header(device, bitstream_j.c_str());
     bitstream_j.put();
   }
 
-  virtual void TearDown() override {
-    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-    if (handle_) {
-        EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
-        handle_ = nullptr;
-    }
-
-    for (auto &t : tokens_) {
-      if (t) {
-        EXPECT_EQ(xfpga_fpgaDestroyToken(&t), FPGA_OK);
-        t = nullptr;
-      }
-    }
-    system_->finalize();
-  }
-
-  std::array<fpga_token, 2> tokens_;
-  fpga_handle handle_;
-  fpga_properties filter_;
-  uint32_t num_matches_;
-  test_platform platform_;
-  test_system *system_;
   std::vector<uint8_t> bitstream_valid_;
 };
 
@@ -581,15 +476,19 @@ TEST_P(reconf_c_hw_p, fpga_reconf_slot_inv_len) {
   uint32_t slot = 0;
   int flags = 0;
 
-  result = xfpga_fpgaReconfigureSlot(handle_, slot, bitstream_valid_.data(),
+  result = xfpga_fpgaReconfigureSlot(device_, slot, bitstream_valid_.data(),
                                      -123456789, flags);
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 
-  result = xfpga_fpgaReconfigureSlot(handle_, slot, bitstream_valid_.data(),
+  result = xfpga_fpgaReconfigureSlot(device_, slot, bitstream_valid_.data(),
                                      123456789, flags);
   EXPECT_EQ(result, FPGA_INVALID_PARAM);
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(reconf_c_hw_p);
 INSTANTIATE_TEST_SUITE_P(reconf, reconf_c_hw_p,
-	::testing::ValuesIn(test_platform::hw_platforms({ "dfl-n3000","dfl-d5005" })));
+                         ::testing::ValuesIn(test_platform::hw_platforms({
+                                                                           "dfl-d5005",
+                                                                           "dfl-n3000",
+                                                                           "dfl-n6000"
+                                                                         })));

--- a/tests/xfpga/test_threshold_c.cpp
+++ b/tests/xfpga/test_threshold_c.cpp
@@ -23,15 +23,15 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
-extern "C" {
+#define NO_OPAE_C
+#include "mock/opae_fixtures.h"
+KEEP_XFPGA_SYMBOLS
 
-#include <json-c/json.h>
-#include <uuid/uuid.h>
+extern "C" {
 #include "metrics/metrics_int.h"
 #include "metrics/metrics_max10.h"
 #include "metrics/threshold.h"
@@ -39,73 +39,25 @@ extern "C" {
 #include "opae_int.h"
 #include "types_int.h"
 #include "xfpga.h"
-}
-
-#include <config.h>
-#include <dlfcn.h>
-#include <opae/fpga.h>
-#include <array>
-#include <cstdlib>
-#include <map>
-#include <memory>
-#include <string>
-#include <vector>
-
-#include "gtest/gtest.h"
-#include "mock/test_system.h"
-#include "mock/test_utils.h"
-
 #include "sysfs_int.h"
 
-extern "C" {
 int xfpga_plugin_initialize(void);
 int xfpga_plugin_finalize(void);
 }
 
 using namespace opae::testing;
 
-class metrics_threshold_c_p : public ::testing::TestWithParam<std::string> {
+class metrics_threshold_c_p : public opae_device_p<xfpga_> {
  protected:
-  metrics_threshold_c_p() : tokens_{{nullptr, nullptr}}, handle_(nullptr) {}
 
-  virtual void SetUp() override {
-    ASSERT_TRUE(test_platform::exists(GetParam()));
-    platform_ = test_platform::get(GetParam());
-    system_ = test_system::instance();
-    system_->initialize();
-    system_->prepare_syfs(platform_);
-    ASSERT_EQ(xfpga_plugin_initialize(), FPGA_OK);
-    ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
-    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_DEVICE), FPGA_OK);
-    ASSERT_EQ(xfpga_fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
-                                  &num_matches_),
-              FPGA_OK);
-    ASSERT_GT(num_matches_, 0);
-    ASSERT_EQ(xfpga_fpgaOpen(tokens_[0], &handle_, 0), FPGA_OK);
+  virtual void OPAEInitialize() override {
+    ASSERT_EQ(xfpga_plugin_initialize(), 0);
   }
 
-  virtual void TearDown() override {
-    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-    for (auto &t : tokens_) {
-      if (t) {
-        EXPECT_EQ(xfpga_fpgaDestroyToken(&t), FPGA_OK);
-        t = nullptr;
-      }
-    }
-    if (handle_ != nullptr) {
-      EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
-      handle_ = nullptr;
-    }
-    xfpga_plugin_finalize();
-    system_->finalize();
+  virtual void OPAEFinalize() override {
+    ASSERT_EQ(xfpga_plugin_finalize(), 0);
   }
 
-  std::array<fpga_token, 2> tokens_;
-  fpga_handle handle_;
-  fpga_properties filter_;
-  uint32_t num_matches_;
-  test_platform platform_;
-  test_system *system_;
 };
 
 /**
@@ -120,11 +72,11 @@ class metrics_threshold_c_p : public ::testing::TestWithParam<std::string> {
 TEST_P(metrics_threshold_c_p, metrics_threshold_1) {
   uint32_t num_thresholds;
 
-  EXPECT_EQ(xfpga_fpgaGetMetricsThresholdInfo(handle_, NULL, &num_thresholds),
+  EXPECT_EQ(xfpga_fpgaGetMetricsThresholdInfo(device_, NULL, &num_thresholds),
             FPGA_OK);
   EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(NULL, NULL, &num_thresholds),
             FPGA_OK);
-  EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(handle_, NULL, NULL), FPGA_OK);
+  EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(device_, NULL, NULL), FPGA_OK);
 }
 
 /**
@@ -140,27 +92,27 @@ TEST_P(metrics_threshold_c_p, metrics_threshold_2) {
   uint32_t num_thresholds;
   metric_threshold *pmetric_thresholds;
 
-  EXPECT_NE(get_max10_threshold_info(handle_, NULL, NULL), FPGA_OK);
+  EXPECT_NE(get_max10_threshold_info(device_, NULL, NULL), FPGA_OK);
   EXPECT_NE(get_max10_threshold_info(NULL, NULL, &num_thresholds), FPGA_OK);
 
-  EXPECT_EQ(get_max10_threshold_info(handle_, NULL, &num_thresholds), FPGA_OK);
+  EXPECT_EQ(get_max10_threshold_info(device_, NULL, &num_thresholds), FPGA_OK);
 
   pmetric_thresholds = (struct metric_threshold *)calloc(
       sizeof(struct metric_threshold), num_thresholds);
   ASSERT_NE(pmetric_thresholds, (void *)nullptr);
 
   EXPECT_EQ(
-      get_max10_threshold_info(handle_, pmetric_thresholds, &num_thresholds),
+      get_max10_threshold_info(device_, pmetric_thresholds, &num_thresholds),
       FPGA_OK);
 
   if (pmetric_thresholds) free(pmetric_thresholds);
 
-  EXPECT_NE(get_bmc_threshold_info(handle_, NULL, &num_thresholds), FPGA_OK);
+  EXPECT_NE(get_bmc_threshold_info(device_, NULL, &num_thresholds), FPGA_OK);
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_threshold_c_p);
 INSTANTIATE_TEST_SUITE_P(metrics_threshold_c_c, metrics_threshold_c_p,
-    ::testing::ValuesIn(test_platform::mock_platforms({"dcp-vc"})));
+                         ::testing::ValuesIn(test_platform::mock_platforms({ "dcp-vc" })));
 
 class metrics_bmc_threshold_c_p : public metrics_threshold_c_p {};
 
@@ -174,11 +126,11 @@ class metrics_bmc_threshold_c_p : public metrics_threshold_c_p {};
 TEST_P(metrics_bmc_threshold_c_p, metrics_threshold_3) {
   uint32_t num_thresholds;
 
-  EXPECT_EQ(xfpga_fpgaGetMetricsThresholdInfo(handle_, NULL, &num_thresholds),
+  EXPECT_EQ(xfpga_fpgaGetMetricsThresholdInfo(device_, NULL, &num_thresholds),
             FPGA_OK);
   EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(NULL, NULL, &num_thresholds),
             FPGA_OK);
-  EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(handle_, NULL, NULL), FPGA_OK);
+  EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(device_, NULL, NULL), FPGA_OK);
 }
 
 /**
@@ -193,32 +145,32 @@ TEST_P(metrics_bmc_threshold_c_p, metrics_threshold_3) {
 TEST_P(metrics_bmc_threshold_c_p, metrics_threshold_4) {
   uint32_t num_thresholds;
   metric_threshold *pmetric_thresholds;
-  struct _fpga_handle *_handle = (struct _fpga_handle *)handle_;
+  struct _fpga_handle *_handle = (struct _fpga_handle *)device_;
 
-  EXPECT_NE(get_bmc_threshold_info(handle_, NULL, NULL), FPGA_OK);
+  EXPECT_NE(get_bmc_threshold_info(device_, NULL, NULL), FPGA_OK);
   EXPECT_NE(get_bmc_threshold_info(NULL, NULL, &num_thresholds), FPGA_OK);
 
   _handle->bmc_handle = metrics_load_bmc_lib();
   ASSERT_NE(_handle->bmc_handle, (void *)nullptr);
 
-  EXPECT_EQ(get_bmc_threshold_info(handle_, NULL, &num_thresholds), FPGA_OK);
+  EXPECT_EQ(get_bmc_threshold_info(device_, NULL, &num_thresholds), FPGA_OK);
 
   pmetric_thresholds = (struct metric_threshold *)calloc(
       sizeof(struct metric_threshold), num_thresholds);
   ASSERT_NE(pmetric_thresholds, (void *)nullptr);
 
   EXPECT_EQ(
-      get_bmc_threshold_info(handle_, pmetric_thresholds, &num_thresholds),
+      get_bmc_threshold_info(device_, pmetric_thresholds, &num_thresholds),
       FPGA_OK);
 
   if (pmetric_thresholds) free(pmetric_thresholds);
 
-  EXPECT_NE(get_max10_threshold_info(handle_, NULL, &num_thresholds), FPGA_OK);
+  EXPECT_NE(get_max10_threshold_info(device_, NULL, &num_thresholds), FPGA_OK);
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_bmc_threshold_c_p);
 INSTANTIATE_TEST_SUITE_P(metrics_threshold_c_c, metrics_bmc_threshold_c_p,
-    ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));
+                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-rc"})));
 
 class metrics_mcp_threshold_c_p : public metrics_threshold_c_p {};
 
@@ -233,64 +185,33 @@ class metrics_mcp_threshold_c_p : public metrics_threshold_c_p {};
 TEST_P(metrics_mcp_threshold_c_p, metrics_threshold_5) {
   uint32_t num_thresholds;
 
-  EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(handle_, NULL, &num_thresholds),
+  EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(device_, NULL, &num_thresholds),
             FPGA_OK);
 
   EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(NULL, NULL, &num_thresholds),
             FPGA_OK);
-  EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(handle_, NULL, NULL), FPGA_OK);
+  EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(device_, NULL, NULL), FPGA_OK);
 
-  EXPECT_NE(get_max10_threshold_info(handle_, NULL, &num_thresholds), FPGA_OK);
+  EXPECT_NE(get_max10_threshold_info(device_, NULL, &num_thresholds), FPGA_OK);
 
-  EXPECT_NE(get_bmc_threshold_info(handle_, NULL, &num_thresholds), FPGA_OK);
+  EXPECT_NE(get_bmc_threshold_info(device_, NULL, &num_thresholds), FPGA_OK);
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_mcp_threshold_c_p);
 INSTANTIATE_TEST_SUITE_P(metrics_threshold_c_c, metrics_mcp_threshold_c_p,
-    ::testing::ValuesIn(test_platform::mock_platforms({"skx-p"})));
+                         ::testing::ValuesIn(test_platform::mock_platforms({"skx-p"})));
 
-class metrics_afu_threshold_c_p : public ::testing::TestWithParam<std::string> {
+class metrics_afu_threshold_c_p : public opae_p<xfpga_> {
  protected:
-  metrics_afu_threshold_c_p() : tokens_{{nullptr, nullptr}}, handle_(nullptr) {}
 
-  virtual void SetUp() override {
-    ASSERT_TRUE(test_platform::exists(GetParam()));
-    platform_ = test_platform::get(GetParam());
-    system_ = test_system::instance();
-    system_->initialize();
-    system_->prepare_syfs(platform_);
-    ASSERT_EQ(xfpga_plugin_initialize(), FPGA_OK);
-    ASSERT_EQ(xfpga_fpgaGetProperties(nullptr, &filter_), FPGA_OK);
-    ASSERT_EQ(fpgaPropertiesSetObjectType(filter_, FPGA_ACCELERATOR), FPGA_OK);
-    ASSERT_EQ(xfpga_fpgaEnumerate(&filter_, 1, tokens_.data(), tokens_.size(),
-                                  &num_matches_),
-              FPGA_OK);
-    ASSERT_GT(num_matches_, 0);
-    ASSERT_EQ(xfpga_fpgaOpen(tokens_[0], &handle_, 0), FPGA_OK);
+  virtual void OPAEInitialize() override {
+    ASSERT_EQ(xfpga_plugin_initialize(), 0);
   }
 
-  virtual void TearDown() override {
-    EXPECT_EQ(fpgaDestroyProperties(&filter_), FPGA_OK);
-    for (auto &t : tokens_) {
-      if (t) {
-        EXPECT_EQ(xfpga_fpgaDestroyToken(&t), FPGA_OK);
-        t = nullptr;
-      }
-    }
-    if (handle_ != nullptr) {
-      EXPECT_EQ(xfpga_fpgaClose(handle_), FPGA_OK);
-      handle_ = nullptr;
-    }
-    xfpga_plugin_finalize();
-    system_->finalize();
+  virtual void OPAEFinalize() override {
+    ASSERT_EQ(xfpga_plugin_finalize(), 0);
   }
 
-  std::array<fpga_token, 2> tokens_;
-  fpga_handle handle_;
-  fpga_properties filter_;
-  uint32_t num_matches_;
-  test_platform platform_;
-  test_system *system_;
 };
 
 /**
@@ -303,13 +224,13 @@ class metrics_afu_threshold_c_p : public ::testing::TestWithParam<std::string> {
 TEST_P(metrics_afu_threshold_c_p, metrics_threshold_6) {
   uint32_t num_thresholds;
 
-  EXPECT_EQ(xfpga_fpgaGetMetricsThresholdInfo(handle_, NULL, &num_thresholds),
+  EXPECT_EQ(xfpga_fpgaGetMetricsThresholdInfo(accel_, NULL, &num_thresholds),
             FPGA_OK);
   EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(NULL, NULL, &num_thresholds),
             FPGA_OK);
-  EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(handle_, NULL, NULL), FPGA_OK);
+  EXPECT_NE(xfpga_fpgaGetMetricsThresholdInfo(accel_, NULL, NULL), FPGA_OK);
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(metrics_afu_threshold_c_p);
 INSTANTIATE_TEST_SUITE_P(metrics_threshold_c_c, metrics_afu_threshold_c_p,
-    ::testing::ValuesIn(test_platform::mock_platforms({"dcp-vc"})));
+                         ::testing::ValuesIn(test_platform::mock_platforms({"dcp-vc"})));

--- a/tests/xfpga/test_version_c.cpp
+++ b/tests/xfpga/test_version_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2020, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -23,22 +23,17 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
 
-#include <opae/fpga.h>
-#include "gtest/gtest.h"
+#define NO_OPAE_C
+#include "mock/opae_fixtures.h"
+
 #include "xfpga.h"
-#include "mock/test_system.h"
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "config.h"
-
-#ifdef __cplusplus
-}
-#endif
 
 using namespace opae::testing;
+
 /**
  * @test       version_01
  *
@@ -151,4 +146,3 @@ TEST(version_c, version_08) {
   EXPECT_EQ(FPGA_OK, xfpga_fpgaGetOPAECBuildString(have, 80));
   EXPECT_STREQ(want, have);
 }
-

--- a/tests/xfpga/test_wsid_list_c.cpp
+++ b/tests/xfpga/test_wsid_list_c.cpp
@@ -23,24 +23,17 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
-
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif // HAVE_CONFIG_H
 
-#ifdef __cplusplus
-
 extern "C" {
-#endif
 #include <opae/utils.h>
 #include "wsid_list_int.h"
-
-#ifdef __cplusplus
 }
-#endif
+
 #include <random>
-#include <chrono>
-#include <thread>
+
 #include "gtest/gtest.h"
 
 #ifndef BUILD_ASE


### PR DESCRIPTION
Also, add specific device identification in
opae_base_p<>::device_filter() so that the tests will run on multi-card
systems.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>