### PR TITLE
packaging: rhel: add missing file opae/io/pci.py

### DIFF
--- a/opae.spec.rhel
+++ b/opae.spec.rhel
@@ -256,6 +256,7 @@ done
 %{_usr}/src/opae/samples/opae.io/opae/__init__.py
 %{_usr}/src/opae/samples/opae.io/opae/io/__init__.py
 %{_usr}/src/opae/samples/opae.io/opae/io/utils.py
+%{_usr}/src/opae/samples/opae.io/opae/io/pci.py
 %{_usr}/src/opae/samples/opae.io/scripts/args.py
 %{_usr}/src/opae/samples/opae.io/scripts/nlb0.py
 %{_usr}/src/opae/samples/opae.io/scripts/nlb_walk.py


### PR DESCRIPTION
Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>