### PR TITLE
opae.io: fix pci_id for older Python versions

### DIFF
--- a/binaries/opae.io/opae/io/pci.py
+++ b/binaries/opae.io/opae/io/pci.py
@@ -40,9 +40,13 @@ VENDOR_DEVICE_RE = re.compile(VENDOR_DEVICE_PATTERN, re.IGNORECASE)
 
 pci_id = namedtuple(
     'pci_id', [
-        'vendor', 'device', 'subsystem_vendor', 'subsystem_device'], defaults=[
-            0, 0])
-pci_id.short = lambda i: pci_id(i.vendor, i.device)
+        'vendor', 'device', 'subsystem_vendor', 'subsystem_device'])
+
+pci_id.short = lambda i: pci_id(i.vendor, i.device, 0, 0)
+
+
+def make_id(vendor, device, s_vendor=0, s_device=0):
+    return pci_id(vendor, device, s_vendor, s_device)
 
 
 SYSFS_PCI_DEVICES = '/sys/bus/pci/devices'
@@ -155,7 +159,10 @@ class device:
             except FileNotFoundError:
                 values[a] = 0
         if values:
-            return pci_id(**values)
+            return pci_id(values['vendor'],
+                          values['device'],
+                          values['subsystem_vendor'],
+                          values['subsystem_device'])
         return None
 
 

--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -382,22 +382,22 @@ class feature(object):
 
 
 fpga_devices = {
-    pci.pci_id(0x8086, 0x09c4): "Intel PAC A10 GX",
-    pci.pci_id(0x8086, 0x09c5): "Intel PAC A10 GX VF",
-    pci.pci_id(0x8086, 0x0b2b): "Intel PAC D5005",
-    pci.pci_id(0x8086, 0x0b2c): "Intel PAC D5005 VF",
-    pci.pci_id(0x8086, 0x0b30): "Intel PAC N3000",
-    pci.pci_id(0x8086, 0x0b31): "Intel PAC N3000 VF",
-    pci.pci_id(0x8086, 0xbcce, 0x8086, 0x1770): "Intel N6000 ADP",
-    pci.pci_id(0x8086, 0xbccf, 0x8086, 0x1770): "Intel N6000 ADP VF",
-    pci.pci_id(0x8086, 0xbcce, 0x8086, 0x1771): "Intel N6001 ADP",
-    pci.pci_id(0x8086, 0xbccf, 0x8086, 0x1771): "Intel N6001 ADP VF",
-    pci.pci_id(0x8086, 0xbcce, 0x8086, 0x17d4): "Intel C6100 ADP",
-    pci.pci_id(0x8086, 0xbccf, 0x8086, 0x17d4): "Intel C6100 ADP VF",
-    pci.pci_id(0x8086, 0xbcce, 0x8086, 0x138d): "Intel D5005 ADP",
-    pci.pci_id(0x8086, 0xbccf, 0x8086, 0x138e): "Intel D5005 ADP VF",
-    pci.pci_id(0x1c2c, 0x1000): "Silicom SmartNIC N5010",
-    pci.pci_id(0x1c2c, 0x1001): "Silicom SmartNIC N5011",
+    pci.make_id(0x8086, 0x09c4): "Intel PAC A10 GX",
+    pci.make_id(0x8086, 0x09c5): "Intel PAC A10 GX VF",
+    pci.make_id(0x8086, 0x0b2b): "Intel PAC D5005",
+    pci.make_id(0x8086, 0x0b2c): "Intel PAC D5005 VF",
+    pci.make_id(0x8086, 0x0b30): "Intel PAC N3000",
+    pci.make_id(0x8086, 0x0b31): "Intel PAC N3000 VF",
+    pci.make_id(0x8086, 0xbcce, 0x8086, 0x1770): "Intel N6000 ADP",
+    pci.make_id(0x8086, 0xbccf, 0x8086, 0x1770): "Intel N6000 ADP VF",
+    pci.make_id(0x8086, 0xbcce, 0x8086, 0x1771): "Intel N6001 ADP",
+    pci.make_id(0x8086, 0xbccf, 0x8086, 0x1771): "Intel N6001 ADP VF",
+    pci.make_id(0x8086, 0xbcce, 0x8086, 0x17d4): "Intel C6100 ADP",
+    pci.make_id(0x8086, 0xbccf, 0x8086, 0x17d4): "Intel C6100 ADP VF",
+    pci.make_id(0x8086, 0xbcce, 0x8086, 0x138d): "Intel D5005 ADP",
+    pci.make_id(0x8086, 0xbccf, 0x8086, 0x138e): "Intel D5005 ADP VF",
+    pci.make_id(0x1c2c, 0x1000): "Silicom SmartNIC N5010",
+    pci.make_id(0x1c2c, 0x1001): "Silicom SmartNIC N5011",
 }
 
 def read_attr(dirname, attr):
@@ -431,7 +431,7 @@ def get_conf_devices(data):
         except:
             print(f'error with vendor/device: {k}')
         else:
-            conf_ids[pci.pci_id(*[int(i, 16) for i in ids])] = v
+            conf_ids[pci.make_id(*[int(i, 16) for i in ids])] = v
     return conf_ids
 
 


### PR DESCRIPTION
Older versions of Python 3 don't comprehend `default` named parameter.
This wraps creating a pci_id object with a make_id function that
defaults subsystem_vendor/subsystem_device to 0.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>