### PR TITLE
opae.io: fix init action to use default user/group

### DIFF
--- a/binaries/opae.io/pymain.h
+++ b/binaries/opae.io/pymain.h
@@ -99,7 +99,7 @@ class ls_action(base_action):
 
 class init_action(base_action):
     def add_args(self):
-        self.parser.add_argument('user_group', default='root:root')
+        self.parser.add_argument('user_group', default='root:root', nargs='?')
 
     def execute(self, args):
         if not self.device:


### PR DESCRIPTION
Setting nargs to ? indicates it's optional allowing it to use the
default 'root:root' when omitted in the command line.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>