### PR TITLE
test framework: replace std C calls with opae_X 

### DIFF
--- a/cmake/modules/OPAETest.cmake
+++ b/cmake/modules/OPAETest.cmake
@@ -52,7 +52,7 @@ function(opae_test_add)
         "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if(OPAE_ENABLE_MOCK)
-        set(MOCK_C ${opae-test_ROOT}/framework/mock/mock.c)
+        set(MOCK_C ${opae-test_ROOT}/framework/mock/mock.c ${opae-test_ROOT}/framework/mock/opae_std.c)
     endif()
 
     add_executable(${OPAE_TEST_ADD_TARGET}
@@ -136,7 +136,9 @@ function(opae_test_add_static_lib)
         PRIVATE
             ${OPAE_LIB_SOURCE}
 	    ${OPAE_LIB_SOURCE}/plugins/xfpga
-	    ${OPAE_LIB_SOURCE}/libopae-c)
+	    ${OPAE_LIB_SOURCE}/libopae-c
+            ${opae-test_ROOT}/framework
+    )
 
     set_property(TARGET ${OPAE_TEST_ADD_STATIC_LIB_TARGET}
         PROPERTY

--- a/libraries/plugins/xfpga/CMakeLists.txt
+++ b/libraries/plugins/xfpga/CMakeLists.txt
@@ -54,7 +54,8 @@ set(SRC
   metrics/afu_metrics.c
   metrics/vector.c
   metrics/metrics_max10.c
-  metrics/threshold.c)
+  metrics/threshold.c
+  ${opae-test_ROOT}/framework/mock/opae_std.c)
 
 opae_add_module_library(TARGET xfpga
     SOURCE ${SRC}
@@ -69,4 +70,8 @@ opae_add_module_library(TARGET xfpga
     COMPONENT opaeclib
 )
 
-target_include_directories(xfpga PRIVATE ${OPAE_LIB_SOURCE}/libopae-c)
+target_include_directories(xfpga
+    PRIVATE
+        ${OPAE_LIB_SOURCE}/libopae-c
+        ${opae-test_ROOT}/framework
+)

--- a/libraries/plugins/xfpga/bitstream.c
+++ b/libraries/plugins/xfpga/bitstream.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -38,6 +38,7 @@
 
 #include "common_int.h"
 #include "bitstream_int.h"
+#include "mock/opae_std.h"
 
 #define METADATA_GUID "58656F6E-4650-4741-B747-425376303031"
 #define METADATA_GUID_LEN 16

--- a/libraries/plugins/xfpga/bitstream.c
+++ b/libraries/plugins/xfpga/bitstream.c
@@ -264,7 +264,7 @@ fpga_result validate_bitstream_metadata(fpga_handle handle,
 
 	json_metadata_ptr = bitstream + METADATA_GUID_LEN + sizeof(uint32_t);
 
-	json_metadata = (char *) malloc(json_len + 1);
+	json_metadata = (char *) opae_malloc(json_len + 1);
 	if (json_metadata == NULL) {
 		OPAE_ERR("Could not allocate memory for metadata");
 		return FPGA_NO_MEMORY;
@@ -323,7 +323,7 @@ out_free:
 	if (root)
 		json_object_put(root);
 	if (json_metadata)
-		free(json_metadata);
+		opae_free(json_metadata);
 
 	return result;
 }
@@ -372,7 +372,7 @@ fpga_result read_gbs_metadata(const uint8_t *bitstream,
 
 	json_metadata_ptr = bitstream + METADATA_GUID_LEN + sizeof(uint32_t);
 
-	json_metadata = (char *) malloc(json_len + 1);
+	json_metadata = (char *) opae_malloc(json_len + 1);
 	if (!json_metadata) {
 		OPAE_ERR("Could not allocate memory for metadata");
 		return FPGA_NO_MEMORY;
@@ -480,7 +480,7 @@ out_free:
 	if (root)
 		json_object_put(root);
 	if (json_metadata)
-		free(json_metadata);
+		opae_free(json_metadata);
 
 	return result;
 }

--- a/libraries/plugins/xfpga/close.c
+++ b/libraries/plugins/xfpga/close.c
@@ -71,9 +71,9 @@ fpga_result __XFPGA_API__ xfpga_fpgaClose(fpga_handle handle)
 	// free metric enum vector
 	free_fpga_enum_metrics_vector(_handle);
 
-	close(_handle->fddev);
+	opae_close(_handle->fddev);
 	if (_handle->fdfpgad >= 0)
-		close(_handle->fdfpgad);
+		opae_close(_handle->fdfpgad);
 
 	// invalidate magic (just in case)
 	_handle->magic = FPGA_INVALID_MAGIC;
@@ -87,7 +87,7 @@ fpga_result __XFPGA_API__ xfpga_fpgaClose(fpga_handle handle)
 		OPAE_ERR("pthread_mutex_unlock() failed: %S", strerror(err));
 	}
 
-	free(_handle);
+	opae_free(_handle);
 
 	return FPGA_OK;
 }

--- a/libraries/plugins/xfpga/enum.c
+++ b/libraries/plugins/xfpga/enum.c
@@ -447,7 +447,7 @@ STATIC fpga_result sync_afu(struct dev_list *afu)
 	afu->accelerator_num_mmios = 0;
 	afu->accelerator_num_irqs = 0;
 
-	res = open(afu->devpath, O_RDWR);
+	res = opae_open(afu->devpath, O_RDWR);
 	if (-1 == res) {
 		afu->accelerator_state = FPGA_ACCELERATOR_ASSIGNED;
 	} else {
@@ -459,7 +459,7 @@ STATIC fpga_result sync_afu(struct dev_list *afu)
 				afu->accelerator_num_irqs = info.num_uafu_irqs;
 		}
 
-		close(res);
+		opae_close(res);
 
 		afu->accelerator_state = FPGA_ACCELERATOR_UNASSIGNED;
 	}
@@ -676,7 +676,7 @@ struct _fpga_token *token_add(struct dev_list *dev)
 	if (snprintf(errpath, sizeof(errpath),
 		     "%s/errors", dev->sysfspath) < 0) {
 		OPAE_ERR("snprintf buffer overflow");
-		free(_tok);
+		opae_free(_tok);
 		return NULL;
 	}
 
@@ -772,7 +772,7 @@ fpga_result __XFPGA_API__ xfpga_fpgaEnumerate(const fpga_properties *filters,
 					result = FPGA_NO_MEMORY;
 
 					for (i = 0 ; i < *num_matches ; ++i)
-						free(tokens[i]);
+						opae_free(tokens[i]);
 					*num_matches = 0;
 
 					goto out_free_trash;
@@ -787,7 +787,7 @@ out_free_trash:
 	for (lptr = head.next; NULL != lptr;) {
 		struct dev_list *trash = lptr;
 		lptr = lptr->next;
-		free(trash);
+		opae_free(trash);
 	}
 
 	return result;
@@ -809,7 +809,7 @@ fpga_result __XFPGA_API__ xfpga_fpgaCloneToken(fpga_token src, fpga_token *dst)
 		return FPGA_INVALID_PARAM;
 	}
 
-	_dst = calloc(1, sizeof(struct _fpga_token));
+	_dst = opae_calloc(1, sizeof(struct _fpga_token));
 	if (NULL == _dst) {
 		OPAE_MSG("Failed to allocate memory for token");
 		return FPGA_NO_MEMORY;
@@ -854,13 +854,13 @@ fpga_result __XFPGA_API__ xfpga_fpgaDestroyToken(fpga_token *token)
 	while (err) {
 		struct error_list *trash = err;
 		err = err->next;
-		free(trash);
+		opae_free(trash);
 	}
 
 	// invalidate token header (just in case)
 	memset(&_token->hdr, 0, sizeof(_token->hdr));
 
-	free(*token);
+	opae_free(*token);
 	*token = NULL;
 
 	return FPGA_OK;

--- a/libraries/plugins/xfpga/enum.c
+++ b/libraries/plugins/xfpga/enum.c
@@ -42,6 +42,7 @@
 #include "error_int.h"
 #include "props.h"
 #include "opae_drv.h"
+#include "mock/opae_std.h"
 
 
 struct dev_list {

--- a/libraries/plugins/xfpga/error.c
+++ b/libraries/plugins/xfpga/error.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -37,6 +37,7 @@
 #include "opae/error.h"
 
 #include "error_int.h"
+#include "mock/opae_std.h"
 
 #define INJECT_ERROR "inject_error"
 

--- a/libraries/plugins/xfpga/error.c
+++ b/libraries/plugins/xfpga/error.c
@@ -248,7 +248,7 @@ build_error_list(const char *path, struct error_list **list)
 
 	// now we've added one to length
 
-	dir = opendir(path);
+	dir = opae_opendir(path);
 	if (!dir) {
 		OPAE_MSG("unable to open %s", path);
 		return 0;
@@ -306,7 +306,7 @@ build_error_list(const char *path, struct error_list **list)
 			continue;
 
 		// append error info to list
-		struct error_list *new_entry = malloc(sizeof(struct error_list));
+		struct error_list *new_entry = opae_malloc(sizeof(struct error_list));
 		if (!new_entry) {
 			OPAE_MSG("can't allocate memory");
 			n--;
@@ -363,7 +363,7 @@ build_error_list(const char *path, struct error_list **list)
 			*el = new_entry;
 		el = &new_entry->next;
 	}
-	closedir(dir);
+	opae_closedir(dir);
 
 	return n;
 }
@@ -379,7 +379,7 @@ struct error_list *clone_error_list(struct error_list *src)
 	struct error_list **plist = &clone;
 
 	while (src) {
-		struct error_list *p = malloc(sizeof(struct error_list));
+		struct error_list *p = opae_malloc(sizeof(struct error_list));
 		if (!p) {
 			OPAE_ERR("malloc failed");
 			goto free_list;
@@ -400,7 +400,7 @@ free_list:
 	while (clone) {
 		struct error_list *trash = clone;
 		clone = clone->next;
-		free(trash);
+		opae_free(trash);
 	}
 	return NULL;
 }

--- a/libraries/plugins/xfpga/event.c
+++ b/libraries/plugins/xfpga/event.c
@@ -524,7 +524,7 @@ STATIC fpga_result daemon_register_event(fpga_handle handle,
 	return result;
 
 out_close_conn:
-	close(_handle->fdfpgad);
+	opae_close(_handle->fdfpgad);
 	_handle->fdfpgad = -1;
 	return result;
 }
@@ -578,7 +578,7 @@ STATIC fpga_result daemon_unregister_event(fpga_handle handle,
 	return result;
 
 out_close_conn:
-	close(_handle->fdfpgad);
+	opae_close(_handle->fdfpgad);
 	_handle->fdfpgad = -1;
 	return result;
 }
@@ -593,7 +593,7 @@ xfpga_fpgaCreateEventHandle(fpga_event_handle *event_handle)
 
 	ASSERT_NOT_NULL(event_handle);
 
-	_eh = malloc(sizeof(struct _fpga_event_handle));
+	_eh = opae_malloc(sizeof(struct _fpga_event_handle));
 	if (NULL == _eh) {
 		OPAE_ERR("Could not allocate memory for event handle");
 		return FPGA_NO_MEMORY;
@@ -639,7 +639,7 @@ out_attr_destroy:
 			 strerror(err));
 
 out_free:
-	free(_eh);
+	opae_free(_eh);
 	return result;
 }
 
@@ -684,7 +684,7 @@ xfpga_fpgaDestroyEventHandle(fpga_event_handle *event_handle)
 	if (err)
 		OPAE_ERR("pthread_mutex_destroy() failed: %S", strerror(err));
 
-	free(*event_handle);
+	opae_free(*event_handle);
 	*event_handle = NULL;
 	return FPGA_OK;
 }

--- a/libraries/plugins/xfpga/event.c
+++ b/libraries/plugins/xfpga/event.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -44,6 +44,7 @@
 #include "opae_drv.h"
 #include "types_int.h"
 #include "intel-fpga.h"
+#include "mock/opae_std.h"
 
 #define EVENT_SOCKET_NAME "/tmp/fpga_event_socket"
 #define EVENT_SOCKET_NAME_LEN 23

--- a/libraries/plugins/xfpga/metrics/bmc/CMakeLists.txt
+++ b/libraries/plugins/xfpga/metrics/bmc/CMakeLists.txt
@@ -1,4 +1,4 @@
-## Copyright(c) 2018-2020, Intel Corporation
+## Copyright(c) 2018-2022, Intel Corporation
 ##
 ## Redistribution  and  use  in source  and  binary  forms,  with  or  without
 ## modification, are permitted provided that the following conditions are met:
@@ -28,7 +28,9 @@ set(SRC
     bmc.c
     bmcdata.c
     bmc_ioctl.c
-    bmcinfo.c)
+    bmcinfo.c
+    ${opae-test_ROOT}/framework/mock/opae_std.c)
+
 
 #opae_add_shared_library(TARGET bmc
 #    SOURCE ${SRC}
@@ -52,4 +54,9 @@ opae_add_module_library(TARGET modbmc
         dl
         ${CMAKE_THREAD_LIBS_INIT}
     COMPONENT opaetoolslibs
+)
+
+target_include_directories(modbmc
+    PRIVATE
+        ${opae-test_ROOT}/framework
 )

--- a/libraries/plugins/xfpga/metrics/bmc/bmc.c
+++ b/libraries/plugins/xfpga/metrics/bmc/bmc.c
@@ -80,20 +80,20 @@ fpga_result read_sysfs_file(fpga_token token, const char *file,
 	}
 
 	glob_t pglob;
-	int gres = glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
+	int gres = opae_glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
 	if ((gres) || (1 != pglob.gl_pathc)) {
-		globfree(&pglob);
+		opae_globfree(&pglob);
 		return FPGA_NOT_FOUND;
 	}
 
-	fd = open(pglob.gl_pathv[0], O_RDONLY);
-	globfree(&pglob);
+	fd = opae_open(pglob.gl_pathv[0], O_RDONLY);
+	opae_globfree(&pglob);
 	if (fd < 0) {
 		return FPGA_NOT_FOUND;
 	}
 
 	if (fstat(fd, &stats) != 0) {
-		close(fd);
+		opae_close(fd);
 		return FPGA_NOT_FOUND;
 	}
 
@@ -114,11 +114,11 @@ fpga_result read_sysfs_file(fpga_token token, const char *file,
 		tot_bytes += bytes_read;
 	} while ((tot_bytes < stats.st_size) && (bytes_read > 0));
 
-	close(fd);
+	opae_close(fd);
 
 	if ((tot_bytes > stats.st_size) || (bytes_read < 0)) {
 		res = FPGA_EXCEPTION;
-		free(*buf);
+		opae_free(*buf);
 		*buf = NULL;
 		goto out;
 	}
@@ -146,7 +146,7 @@ fpga_result bmcLoadSDRs(fpga_token token, bmc_sdr_handle *records,
 	res = read_sysfs_file(token, SYSFS_SDR_FILE, (void **)&tmp, &tot_bytes);
 	if (FPGA_OK != res) {
 		if (tmp) {
-			free(tmp);
+			opae_free(tmp);
 		}
 		goto out;
 	}
@@ -156,13 +156,13 @@ fpga_result bmcLoadSDRs(fpga_token token, bmc_sdr_handle *records,
 
 	*num_sensors = num_of_sensors;
 	if (NULL == records) {
-		free(tmp);
+		opae_free(tmp);
 		return FPGA_OK;
 	}
 
 	*records = (bmc_sdr_handle)calloc(1, sizeof(struct _sdr_rec));
 	if (NULL == *records) {
-		free(tmp);
+		opae_free(tmp);
 		return FPGA_NO_MEMORY;
 	}
 	recs = (struct _sdr_rec *)*records;
@@ -210,7 +210,7 @@ fpga_result bmcReadSensorValues(bmc_sdr_handle records, bmc_values_handle *value
 	if ((NULL == tmp) || (FPGA_OK != res)) {
 		fprintf(stderr, "Cannot read sensor file.\n");
 		if (tmp) {
-			free(tmp);
+			opae_free(tmp);
 		}
 		return FPGA_EXCEPTION;
 	}
@@ -221,7 +221,7 @@ fpga_result bmcReadSensorValues(bmc_sdr_handle records, bmc_values_handle *value
 			" struct size %d.\n",
 			(int)tot_bytes,
 			(int)(sdr->num_records * sizeof(sensor_reading)));
-		free(tmp);
+		opae_free(tmp);
 		return FPGA_EXCEPTION;
 	}
 
@@ -229,7 +229,7 @@ fpga_result bmcReadSensorValues(bmc_sdr_handle records, bmc_values_handle *value
 
 	*values = (bmc_values_handle)calloc(1, sizeof(struct _bmc_values));
 	if (NULL == *values) {
-		free(tmp);
+		opae_free(tmp);
 		return FPGA_NO_MEMORY;
 	}
 	vals = (struct _bmc_values *)*values;
@@ -357,10 +357,10 @@ fpga_result bmcDestroySDRs(bmc_sdr_handle *records)
 		goto out;
 	}
 
-	free(sdr->contents);
+	opae_free(sdr->contents);
 
 	sdr->magic = 0;
-	free(sdr);
+	opae_free(sdr);
 
 	*records = NULL;
 
@@ -383,15 +383,15 @@ fpga_result bmcDestroySensorValues(bmc_values_handle *values)
 	}
 
 	for (i = 0; i < vals->num_records; i++) {
-		free(vals->values[i]->name);
-		free(vals->values[i]);
+		opae_free(vals->values[i]->name);
+		opae_free(vals->values[i]);
 	}
 
-	free(vals->contents);
-	free(vals->values);
+	opae_free(vals->contents);
+	opae_free(vals->values);
 
 	vals->magic = 0;
-	free(vals);
+	opae_free(vals);
 
 	*values = NULL;
 
@@ -499,7 +499,7 @@ fpga_result bmcDestroyTripped(tripped_thresholds *tripped)
 
 	NULL_CHECK(tripped);
 
-	free(tripped);
+	opae_free(tripped);
 
 	return res;
 }
@@ -537,7 +537,7 @@ fpga_result bmcGetFirmwareVersion(fpga_token token, uint32_t *version)
 
 out:
 	if (tmp) {
-		free(tmp);
+		opae_free(tmp);
 	}
 
 	return res;
@@ -575,7 +575,7 @@ fpga_result bmcGetLastPowerdownCause(fpga_token token, char **cause)
 
 out:
 	if (tmp) {
-		free(tmp);
+		opae_free(tmp);
 	}
 
 	return res;
@@ -663,7 +663,7 @@ fpga_result bmcGetLastResetCause(fpga_token token, char **cause)
 
 out:
 	if (tmp) {
-		free(tmp);
+		opae_free(tmp);
 	}
 
 	return res;

--- a/libraries/plugins/xfpga/metrics/bmc/bmc.c
+++ b/libraries/plugins/xfpga/metrics/bmc/bmc.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -32,6 +32,7 @@
 #define _TIMESPEC_DEFINED
 #include "../../types_int.h"
 #include "bmcdata.h"
+#include "mock/opae_std.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <string.h>

--- a/libraries/plugins/xfpga/metrics/bmc/bmc_ioctl.c
+++ b/libraries/plugins/xfpga/metrics/bmc/bmc_ioctl.c
@@ -232,15 +232,15 @@ fpga_result bmcSetHWThresholds(bmc_sdr_handle sdr_h, uint32_t sensor,
 	}
 
 	glob_t pglob;
-	int gres = glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
+	int gres = opae_glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
 	if ((gres) || (1 != pglob.gl_pathc)) {
-		globfree(&pglob);
+		opae_globfree(&pglob);
 		return FPGA_NOT_FOUND;
 	}
 
 	char *avmmi = strrchr(pglob.gl_pathv[0], '/');
 	if (NULL == avmmi) {
-		globfree(&pglob);
+		opae_globfree(&pglob);
 		return FPGA_NOT_FOUND;
 	}
 
@@ -248,8 +248,8 @@ fpga_result bmcSetHWThresholds(bmc_sdr_handle sdr_h, uint32_t sensor,
 	len = strnlen(&avmmi[1], sizeof(sysfspath) - 6);
 	strncat(sysfspath, &avmmi[1], len + 1);
 
-	fd = open(sysfspath, O_RDWR);
-	globfree(&pglob);
+	fd = opae_open(sysfspath, O_RDWR);
+	opae_globfree(&pglob);
 	if (fd < 0) {
 		return FPGA_NOT_FOUND;
 	}
@@ -262,7 +262,7 @@ fpga_result bmcSetHWThresholds(bmc_sdr_handle sdr_h, uint32_t sensor,
 				&sdr->contents[sensor].body);
 
 	if (NULL == vals) {
-		close(fd);
+		opae_close(fd);
 		return FPGA_NO_MEMORY;
 	}
 
@@ -284,14 +284,14 @@ fpga_result bmcSetHWThresholds(bmc_sdr_handle sdr_h, uint32_t sensor,
 	fill_set_request(vals, thresh, &req);
 
 	if (vals->name)
-		free(vals->name);
+		opae_free(vals->name);
 
 	if (vals)
-		free(vals);
+		opae_free(vals);
 
 	res = _bmcSetThreshold(fd, sensor, &req);
 
-	close(fd);
+	opae_close(fd);
 
 	return res;
 }

--- a/libraries/plugins/xfpga/metrics/bmc/bmc_ioctl.c
+++ b/libraries/plugins/xfpga/metrics/bmc/bmc_ioctl.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -31,6 +31,7 @@
 #include <opae/fpga.h>
 #include "bmc.h"
 #include "bmcdata.h"
+#include "mock/opae_std.h"
 #include <sys/types.h>
 #include <string.h>
 #ifndef _WIN32

--- a/libraries/plugins/xfpga/metrics/metrics_max10.c
+++ b/libraries/plugins/xfpga/metrics/metrics_max10.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -57,6 +57,7 @@
 #include "metrics/vector.h"
 #include "xfpga.h"
 #include "metrics_max10.h"
+#include "mock/opae_std.h"
 
 // Max10 Metric limits
 #define THERMAL_HIGH_LIMIT             300.00

--- a/libraries/plugins/xfpga/metrics/metrics_max10.c
+++ b/libraries/plugins/xfpga/metrics/metrics_max10.c
@@ -94,20 +94,20 @@ fpga_result read_sensor_sysfs_file(const char *sysfs, const char *file,
 	}
 
 	glob_t pglob;
-	int gres = glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
+	int gres = opae_glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
 	if ((gres) || (1 != pglob.gl_pathc)) {
-		globfree(&pglob);
+		opae_globfree(&pglob);
 		return FPGA_NOT_FOUND;
 	}
 
-	fd = open(pglob.gl_pathv[0], O_RDONLY);
-	globfree(&pglob);
+	fd = opae_open(pglob.gl_pathv[0], O_RDONLY);
+	opae_globfree(&pglob);
 	if (fd < 0) {
 		return FPGA_NOT_FOUND;
 	}
 
 	if (fstat(fd, &stats) != 0) {
-		close(fd);
+		opae_close(fd);
 		return FPGA_NOT_FOUND;
 	}
 
@@ -128,11 +128,11 @@ fpga_result read_sensor_sysfs_file(const char *sysfs, const char *file,
 		tot_bytes += bytes_read;
 	} while ((tot_bytes < stats.st_size) && (bytes_read > 0));
 
-	close(fd);
+	opae_close(fd);
 
 	if ((tot_bytes > stats.st_size) || (bytes_read < 0)) {
 		res = FPGA_EXCEPTION;
-		free(*buf);
+		opae_free(*buf);
 		*buf = NULL;
 		goto out;
 	}
@@ -195,17 +195,17 @@ fpga_result  dfl_enum_max10_metrics_info(struct _fpga_handle *_handle,
 	}
 
 
-	int gres = glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
+	int gres = opae_glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
 	if ((gres) || (1 != pglob.gl_pathc)) {
 		OPAE_ERR("Failed pattern match %s: %s", sysfspath, strerror(errno));
-		globfree(&pglob);
+		opae_globfree(&pglob);
 		return FPGA_NOT_FOUND;
 	}
 
 	len = strnlen(pglob.gl_pathv[0], sizeof(group_sysfs) - 1);
 	memcpy(group_sysfs, pglob.gl_pathv[0], len);
 	group_sysfs[len] = '\0';
-	globfree(&pglob);
+	opae_globfree(&pglob);
 
 	// Enum sensors
 	if (strlen(sysfspath) + sizeof(DFL_MAX10_SYSFS_LABEL) >= SYSFS_PATH_MAX) {
@@ -215,10 +215,10 @@ fpga_result  dfl_enum_max10_metrics_info(struct _fpga_handle *_handle,
 	}
 	strncat(sysfspath, DFL_MAX10_SYSFS_LABEL, strlen(DFL_MAX10_SYSFS_LABEL) + 1);
 
-	gres = glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
+	gres = opae_glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
 	if (gres) {
 		OPAE_ERR("Failed pattern match %s: %s", sysfspath, strerror(errno));
-		globfree(&pglob);
+		opae_globfree(&pglob);
 		return FPGA_NOT_FOUND;
 	}
 
@@ -230,7 +230,7 @@ fpga_result  dfl_enum_max10_metrics_info(struct _fpga_handle *_handle,
 		result = read_sensor_sysfs_file(pglob.gl_pathv[i], NULL, (void **)&tmp, &tot_bytes);
 		if (FPGA_OK != result || !tmp) {
 			if (tmp) {
-				free(tmp);
+				opae_free(tmp);
 				tmp = NULL;
 			}
 			continue;
@@ -244,7 +244,7 @@ fpga_result  dfl_enum_max10_metrics_info(struct _fpga_handle *_handle,
 			metric_name[len - 1] = '\0';
 
 		if (tmp) {
-			free(tmp);
+			opae_free(tmp);
 			tmp = NULL;
 		}
 
@@ -351,7 +351,7 @@ fpga_result  dfl_enum_max10_metrics_info(struct _fpga_handle *_handle,
 	} // end for loop
 
 out:
-	globfree(&pglob);
+	opae_globfree(&pglob);
 	return result;
 }
 

--- a/libraries/plugins/xfpga/metrics/metrics_utils.c
+++ b/libraries/plugins/xfpga/metrics/metrics_utils.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -51,6 +51,7 @@
 #include "metrics/bmc/bmc.h"
 #include "metrics/metrics_metadata.h"
 #include "metrics_max10.h"
+#include "mock/opae_std.h"
 
 fpga_result metric_sysfs_path_is_dir(const char *path)
 {

--- a/libraries/plugins/xfpga/metrics/metrics_utils.c
+++ b/libraries/plugins/xfpga/metrics/metrics_utils.c
@@ -690,7 +690,7 @@ fpga_result get_bmc_metrics_values(fpga_handle handle,
 	}
 
 	if (_handle->_bmc_metric_cache_value == NULL) {
-		_handle->_bmc_metric_cache_value = calloc(sizeof(struct _fpga_bmc_metric), num_sensors);
+		_handle->_bmc_metric_cache_value = opae_calloc(sizeof(struct _fpga_bmc_metric), num_sensors);
 		if (_handle->_bmc_metric_cache_value == NULL) {
 			OPAE_ERR("Failed to allocate memory");
 			result = FPGA_NO_MEMORY;
@@ -904,7 +904,7 @@ fpga_result  clear_cached_values(fpga_handle handle)
 	fpga_result result           = FPGA_OK;
 
 	if (_handle->_bmc_metric_cache_value) {
-		free(_handle->_bmc_metric_cache_value);
+		opae_free(_handle->_bmc_metric_cache_value);
 		_handle->_bmc_metric_cache_value = NULL;
 	}
 

--- a/libraries/plugins/xfpga/metrics/threshold.c
+++ b/libraries/plugins/xfpga/metrics/threshold.c
@@ -358,13 +358,13 @@ fpga_result get_max10_threshold_info(fpga_handle handle,
 		return FPGA_EXCEPTION;
 	}
 
-	int gres = glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
+	int gres = opae_glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
 	if ((gres) || (1 != pglob.gl_pathc)) {
 		OPAE_ERR("Failed pattern match %s: %s", sysfspath, strerror(errno));
-		globfree(&pglob);
+		opae_globfree(&pglob);
 		return FPGA_NOT_FOUND;
 	}
-	globfree(&pglob);
+	opae_globfree(&pglob);
 
 
 	// scan sensors
@@ -374,10 +374,10 @@ fpga_result get_max10_threshold_info(fpga_handle handle,
 		return FPGA_EXCEPTION;
 	}
 
-	gres = glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
+	gres = opae_glob(sysfspath, GLOB_NOSORT, NULL, &pglob);
 	if (gres) {
 		OPAE_ERR("Failed pattern match %s: %s", sysfspath, strerror(errno));
-		globfree(&pglob);
+		opae_globfree(&pglob);
 		return FPGA_NOT_FOUND;
 	}
 
@@ -394,7 +394,7 @@ fpga_result get_max10_threshold_info(fpga_handle handle,
 		result = read_sensor_sysfs_file(pglob.gl_pathv[i], SENSOR_SYSFS_NAME, (void **)&tmp, &tot_bytes);
 		if (FPGA_OK != result || !tmp) {
 			if (tmp) {
-				free(tmp);
+				opae_free(tmp);
 				tmp = NULL;
 			}
 			continue;
@@ -405,7 +405,7 @@ fpga_result get_max10_threshold_info(fpga_handle handle,
 		memcpy(metric_thresholds[i].metric_name, tmp, len);
 		metric_thresholds[i].metric_name[len] = '\0';
 		if (tmp) {
-			free(tmp);
+			opae_free(tmp);
 			tmp = NULL;
 		}
 
@@ -492,6 +492,6 @@ fpga_result get_max10_threshold_info(fpga_handle handle,
 	} //end for loop
 
 out:
-	globfree(&pglob);
+	opae_globfree(&pglob);
 	return result;
 }

--- a/libraries/plugins/xfpga/metrics/threshold.c
+++ b/libraries/plugins/xfpga/metrics/threshold.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -49,6 +49,7 @@
 #include "metrics_int.h"
 #include "metrics_max10.h"
 #include "threshold.h"
+#include "mock/opae_std.h"
 
 
 fpga_result xfpga_fpgaGetMetricsThresholdInfo(fpga_handle handle,

--- a/libraries/plugins/xfpga/metrics/vector.c
+++ b/libraries/plugins/xfpga/metrics/vector.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -40,6 +40,7 @@
 #include "opae/enum.h"
 #include "opae/properties.h"
 #include "common_int.h"
+#include "mock/opae_std.h"
 
 #define FPGA_VECTOR_CAPACITY     20
 

--- a/libraries/plugins/xfpga/metrics/vector.c
+++ b/libraries/plugins/xfpga/metrics/vector.c
@@ -52,7 +52,7 @@ fpga_result fpga_vector_init(fpga_metric_vector *vector)
 
 	vector->capacity = FPGA_VECTOR_CAPACITY;
 	vector->total = 0;
-	vector->fpga_metric_item = malloc(sizeof(void *) * vector->capacity);
+	vector->fpga_metric_item = opae_malloc(sizeof(void *) * vector->capacity);
 
 	if (vector->fpga_metric_item == NULL)
 		return FPGA_NO_MEMORY;
@@ -70,12 +70,12 @@ fpga_result fpga_vector_free(fpga_metric_vector *vector)
 	}
 	for (i = 0; i < vector->total; i++) {
 		if (vector->fpga_metric_item[i]) {
-			free(vector->fpga_metric_item[i]);
+			opae_free(vector->fpga_metric_item[i]);
 			vector->fpga_metric_item[i] = NULL;
 		}
 	}
 	if (vector->fpga_metric_item)
-		free(vector->fpga_metric_item);
+		opae_free(vector->fpga_metric_item);
 
 	vector->fpga_metric_item = NULL;
 
@@ -154,7 +154,7 @@ fpga_result fpga_vector_delete(fpga_metric_vector *vector, uint64_t index)
 		return FPGA_INVALID_PARAM;
 
 	if (vector->fpga_metric_item[index])
-		free(vector->fpga_metric_item[index]);
+		opae_free(vector->fpga_metric_item[index]);
 
 	vector->fpga_metric_item[index] = NULL;
 

--- a/libraries/plugins/xfpga/opae_drv.c
+++ b/libraries/plugins/xfpga/opae_drv.c
@@ -286,7 +286,7 @@ fpga_result intel_port_set_user_irq(int fd, uint32_t flags, uint32_t start,
 			"flags currently not supported in FPGA_FME_ERR_SET_IRQ");
 	}
 
-	irq = malloc(sz);
+	irq = opae_malloc(sz);
 	if (!irq) {
 		OPAE_ERR("Could not allocate memory for irq request");
 		return FPGA_NO_MEMORY;
@@ -301,7 +301,7 @@ fpga_result intel_port_set_user_irq(int fd, uint32_t flags, uint32_t start,
 
 	res = opae_ioctl(fd, FPGA_PORT_UAFU_SET_IRQ, irq);
 
-	free(irq);
+	opae_free(irq);
 	return res;
 }
 
@@ -481,7 +481,7 @@ fpga_result dfl_set_irq(int fd, uint32_t start,
 		return FPGA_INVALID_PARAM;
 	}
 
-	irq = malloc(sz);
+	irq = opae_malloc(sz);
 
 	if (!irq) {
 		OPAE_ERR("Could not allocate memory for irq request");
@@ -497,7 +497,7 @@ fpga_result dfl_set_irq(int fd, uint32_t start,
 		OPAE_ERR("Ioctl error=%d", res);
 	}
 
-	free(irq);
+	opae_free(irq);
 	return res;
 }
 

--- a/libraries/plugins/xfpga/opae_drv.c
+++ b/libraries/plugins/xfpga/opae_drv.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2020, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -41,6 +41,7 @@
 #include "opae_drv.h"
 #include "intel-fpga.h"
 #include "fpga-dfl.h"
+#include "mock/opae_std.h"
 
 typedef struct _ioctl_ops {
 	fpga_result (*get_fme_info)(int fd, opae_fme_info *info);
@@ -89,7 +90,7 @@ typedef struct _ioctl_ops {
 		uint32_t count, int32_t *eventfd);
 } ioctl_ops;
 
-fpga_result opae_ioctl(int fd, int request, ...)
+fpga_result opae_internal_ioctl(int fd, int request, ...)
 {
 	fpga_result res = FPGA_OK;
 	va_list argp;
@@ -124,14 +125,14 @@ fpga_result opae_ioctl(int fd, int request, ...)
 
 fpga_result intel_fpga_version(int fd)
 {
-	return opae_ioctl(fd, FPGA_GET_API_VERSION, NULL);
+	return opae_internal_ioctl(fd, FPGA_GET_API_VERSION, NULL);
 }
 
 fpga_result intel_get_fme_info(int fd, opae_fme_info *info)
 {
 	ASSERT_NOT_NULL(info);
 	struct fpga_fme_info fme_info = {.argsz = sizeof(fme_info), .flags = 0};
-	int res = opae_ioctl(fd, FPGA_FME_GET_INFO, &fme_info);
+	int res = opae_internal_ioctl(fd, FPGA_FME_GET_INFO, &fme_info);
 	if (!res) {
 		info->flags = fme_info.flags;
 		info->capability = fme_info.capability;
@@ -143,7 +144,7 @@ fpga_result intel_get_port_info(int fd, opae_port_info *info)
 {
 	ASSERT_NOT_NULL(info);
 	struct fpga_port_info pinfo = {.argsz = sizeof(pinfo), .flags = 0};
-	int res = opae_ioctl(fd, FPGA_PORT_GET_INFO, &pinfo);
+	int res = opae_internal_ioctl(fd, FPGA_PORT_GET_INFO, &pinfo);
 	if (!res) {
 		info->flags = pinfo.flags;
 		info->capability = pinfo.capability;
@@ -163,7 +164,7 @@ fpga_result intel_get_port_region_info(int fd, uint32_t index,
 	ASSERT_NOT_NULL(info);
 	struct fpga_port_region_info rinfo = {
 		.argsz = sizeof(rinfo), .padding = 0, .index = index};
-	int res = opae_ioctl(fd, FPGA_PORT_GET_REGION_INFO, &rinfo);
+	int res = opae_internal_ioctl(fd, FPGA_PORT_GET_REGION_INFO, &rinfo);
 	if (!res) {
 		info->flags = rinfo.flags;
 		info->size = rinfo.size;
@@ -190,7 +191,7 @@ fpga_result intel_port_map(int fd, void *addr, uint64_t len, uint32_t flags,
 	req = FPGA_PORT_DMA_MAP;
 	msg = &dma_map;
 
-	res = opae_ioctl(fd, req, msg);
+	res = opae_internal_ioctl(fd, req, msg);
 	if (!res) {
 		*io_addr = dma_map.iova;
 	}
@@ -204,7 +205,7 @@ fpga_result intel_port_unmap(int fd, uint64_t io_addr)
 		.argsz = sizeof(dma_unmap), .flags = 0, .iova = io_addr};
 
 	/* Dispatch ioctl command */
-	return opae_ioctl(fd, FPGA_PORT_DMA_UNMAP, &dma_unmap);
+	return opae_internal_ioctl(fd, FPGA_PORT_DMA_UNMAP, &dma_unmap);
 }
 
 fpga_result intel_port_umsg_cfg(int fd, uint32_t flags, uint32_t hint_bitmap)
@@ -217,7 +218,7 @@ fpga_result intel_port_umsg_cfg(int fd, uint32_t flags, uint32_t hint_bitmap)
 	struct fpga_port_umsg_cfg umsg_cfg = {.argsz = sizeof(umsg_cfg),
 					      .flags = 0,
 					      .hint_bitmap = hint_bitmap};
-	return opae_ioctl(fd, FPGA_PORT_UMSG_SET_MODE, &umsg_cfg);
+	return opae_internal_ioctl(fd, FPGA_PORT_UMSG_SET_MODE, &umsg_cfg);
 }
 
 fpga_result intel_port_umsg_set_base_addr(int fd, uint32_t flags,
@@ -230,17 +231,17 @@ fpga_result intel_port_umsg_set_base_addr(int fd, uint32_t flags,
 
 	struct fpga_port_umsg_base_addr baseaddr = {
 		.argsz = sizeof(baseaddr), .flags = 0, .iova = io_addr};
-	return opae_ioctl(fd, FPGA_PORT_UMSG_SET_BASE_ADDR, &baseaddr);
+	return opae_internal_ioctl(fd, FPGA_PORT_UMSG_SET_BASE_ADDR, &baseaddr);
 }
 
 fpga_result intel_port_umsg_enable(int fd)
 {
-	return opae_ioctl(fd, FPGA_PORT_UMSG_ENABLE, NULL);
+	return opae_internal_ioctl(fd, FPGA_PORT_UMSG_ENABLE, NULL);
 }
 
 fpga_result intel_port_umsg_disable(int fd)
 {
-	return opae_ioctl(fd, FPGA_PORT_UMSG_DISABLE, NULL);
+	return opae_internal_ioctl(fd, FPGA_PORT_UMSG_DISABLE, NULL);
 }
 
 fpga_result intel_fme_set_err_irq(int fd, uint32_t flags, int32_t evtfd)
@@ -252,7 +253,7 @@ fpga_result intel_fme_set_err_irq(int fd, uint32_t flags, int32_t evtfd)
 
 	struct fpga_fme_err_irq_set irq = {
 		.argsz = sizeof(irq), .flags = flags, .evtfd = evtfd};
-	return opae_ioctl(fd, FPGA_FME_ERR_SET_IRQ, &irq);
+	return opae_internal_ioctl(fd, FPGA_FME_ERR_SET_IRQ, &irq);
 }
 
 fpga_result intel_port_set_err_irq(int fd, uint32_t flags, int32_t evtfd)
@@ -264,7 +265,7 @@ fpga_result intel_port_set_err_irq(int fd, uint32_t flags, int32_t evtfd)
 
 	struct fpga_port_err_irq_set irq = {
 		.argsz = sizeof(irq), .flags = flags, .evtfd = evtfd};
-	return opae_ioctl(fd, FPGA_PORT_ERR_SET_IRQ, &irq);
+	return opae_internal_ioctl(fd, FPGA_PORT_ERR_SET_IRQ, &irq);
 }
 
 fpga_result intel_port_set_user_irq(int fd, uint32_t flags, uint32_t start,
@@ -299,7 +300,7 @@ fpga_result intel_port_set_user_irq(int fd, uint32_t flags, uint32_t start,
 
 	memcpy(irq->evtfd, eventfd, count * sizeof(int32_t));
 
-	res = opae_ioctl(fd, FPGA_PORT_UAFU_SET_IRQ, irq);
+	res = opae_internal_ioctl(fd, FPGA_PORT_UAFU_SET_IRQ, irq);
 
 	opae_free(irq);
 	return res;
@@ -313,7 +314,7 @@ fpga_result intel_fme_port_assign(int fd, uint32_t flags, uint32_t port_id)
 		OPAE_MSG(
 			"flags currently not supported in FPGA_FME_PORT_ASSIGN");
 	}
-	return opae_ioctl(fd, FPGA_FME_PORT_ASSIGN, &assign);
+	return opae_internal_ioctl(fd, FPGA_FME_PORT_ASSIGN, &assign);
 }
 
 fpga_result intel_fme_port_release(int fd, uint32_t flags, uint32_t port_id)
@@ -324,7 +325,7 @@ fpga_result intel_fme_port_release(int fd, uint32_t flags, uint32_t port_id)
 		OPAE_MSG(
 			"flags currently not supported in FPGA_FME_PORT_RELEASE");
 	}
-	return opae_ioctl(fd, FPGA_FME_PORT_RELEASE, &assign);
+	return opae_internal_ioctl(fd, FPGA_FME_PORT_RELEASE, &assign);
 }
 
 fpga_result intel_fme_port_pr(int fd, uint32_t flags, uint32_t port_id,
@@ -340,26 +341,26 @@ fpga_result intel_fme_port_pr(int fd, uint32_t flags, uint32_t port_id,
 		OPAE_MSG("flags currently not supported in FPGA_FME_PORT_PR");
 	}
 	ASSERT_NOT_NULL(status);
-	res = opae_ioctl(fd, FPGA_FME_PORT_PR, &port_pr);
+	res = opae_internal_ioctl(fd, FPGA_FME_PORT_PR, &port_pr);
 	*status = port_pr.status;
 	return res;
 }
 
 fpga_result intel_fme_port_reset(int fd)
 {
-	return opae_ioctl(fd, FPGA_PORT_RESET, NULL);
+	return opae_internal_ioctl(fd, FPGA_PORT_RESET, NULL);
 }
 
 fpga_result dfl_fpga_version(int fd)
 {
-	return opae_ioctl(fd, DFL_FPGA_GET_API_VERSION, NULL);
+	return opae_internal_ioctl(fd, DFL_FPGA_GET_API_VERSION, NULL);
 }
 
 fpga_result dfl_get_port_info(int fd, opae_port_info *info)
 {
 	ASSERT_NOT_NULL(info);
 	struct dfl_fpga_port_info pinfo = {.argsz = sizeof(pinfo), .flags = 0};
-	int res = opae_ioctl(fd, DFL_FPGA_PORT_GET_INFO, &pinfo);
+	int res = opae_internal_ioctl(fd, DFL_FPGA_PORT_GET_INFO, &pinfo);
 	if (!res) {
 		info->flags = pinfo.flags;
 		info->num_regions = pinfo.num_regions;
@@ -374,7 +375,7 @@ fpga_result dfl_get_port_region_info(int fd, uint32_t index,
 	ASSERT_NOT_NULL(info);
 	struct dfl_fpga_port_region_info rinfo = {
 		.argsz = sizeof(rinfo), .padding = 0, .index = index};
-	int res = opae_ioctl(fd, DFL_FPGA_PORT_GET_REGION_INFO, &rinfo);
+	int res = opae_internal_ioctl(fd, DFL_FPGA_PORT_GET_REGION_INFO, &rinfo);
 	if (!res) {
 		info->flags = rinfo.flags;
 		info->size = rinfo.size;
@@ -395,7 +396,7 @@ fpga_result dfl_port_map(int fd, void *addr, uint64_t len, uint32_t flags,
 						.iova = 0};
 	ASSERT_NOT_NULL(io_addr);
 	/* Dispatch ioctl command */
-	res = opae_ioctl(fd, DFL_FPGA_PORT_DMA_MAP, &dma_map);
+	res = opae_internal_ioctl(fd, DFL_FPGA_PORT_DMA_MAP, &dma_map);
 	if (!res) {
 		*io_addr = dma_map.iova;
 	}
@@ -409,20 +410,20 @@ fpga_result dfl_port_unmap(int fd, uint64_t io_addr)
 		.argsz = sizeof(dma_unmap), .flags = 0, .iova = io_addr};
 
 	/* Dispatch ioctl command */
-	return opae_ioctl(fd, DFL_FPGA_PORT_DMA_UNMAP, &dma_unmap);
+	return opae_internal_ioctl(fd, DFL_FPGA_PORT_DMA_UNMAP, &dma_unmap);
 }
 
 
 fpga_result dfl_fme_port_assign(int fd, uint32_t flags, uint32_t port_id)
 {
 	UNUSED_PARAM(flags);
-	return opae_ioctl(fd, DFL_FPGA_FME_PORT_ASSIGN, &port_id);
+	return opae_internal_ioctl(fd, DFL_FPGA_FME_PORT_ASSIGN, &port_id);
 }
 
 fpga_result dfl_fme_port_release(int fd, uint32_t flags, uint32_t port_id)
 {
 	UNUSED_PARAM(flags);
-	return opae_ioctl(fd, DFL_FPGA_FME_PORT_RELEASE, &port_id);
+	return opae_internal_ioctl(fd, DFL_FPGA_FME_PORT_RELEASE, &port_id);
 }
 
 fpga_result dfl_fme_port_pr(int fd, uint32_t flags, uint32_t port_id,
@@ -438,32 +439,32 @@ fpga_result dfl_fme_port_pr(int fd, uint32_t flags, uint32_t port_id,
 		OPAE_MSG("flags currently not supported in FPGA_FME_PORT_PR");
 	}
 	ASSERT_NOT_NULL(status);
-	res = opae_ioctl(fd, DFL_FPGA_FME_PORT_PR, &port_pr);
+	res = opae_internal_ioctl(fd, DFL_FPGA_FME_PORT_PR, &port_pr);
 	*status = 0;
 	return res;
 }
 
 fpga_result dfl_fme_port_reset(int fd)
 {
-	return opae_ioctl(fd, DFL_FPGA_PORT_RESET, NULL);
+	return opae_internal_ioctl(fd, DFL_FPGA_PORT_RESET, NULL);
 }
 
 fpga_result dfl_port_get_err_irq(int fd, uint32_t *num_irqs)
 {
 	ASSERT_NOT_NULL(num_irqs);
-	return opae_ioctl(fd, DFL_FPGA_PORT_ERR_GET_IRQ_NUM, num_irqs);
+	return opae_internal_ioctl(fd, DFL_FPGA_PORT_ERR_GET_IRQ_NUM, num_irqs);
 }
 
 fpga_result dfl_port_get_user_irq(int fd, uint32_t *num_irqs)
 {
 	ASSERT_NOT_NULL(num_irqs);
-	return opae_ioctl(fd, DFL_FPGA_PORT_UINT_GET_IRQ_NUM, num_irqs);;
+	return opae_internal_ioctl(fd, DFL_FPGA_PORT_UINT_GET_IRQ_NUM, num_irqs);;
 }
 
 fpga_result dfl_fme_get_err_irq(int fd, uint32_t *num_irqs)
 {
 	ASSERT_NOT_NULL(num_irqs);
-	return opae_ioctl(fd, DFL_FPGA_FME_ERR_GET_IRQ_NUM, num_irqs);
+	return opae_internal_ioctl(fd, DFL_FPGA_FME_ERR_GET_IRQ_NUM, num_irqs);
 }
 
 fpga_result dfl_set_irq(int fd, uint32_t start,
@@ -492,7 +493,7 @@ fpga_result dfl_set_irq(int fd, uint32_t start,
 	irq->count = count;
 	memcpy(irq->evtfds, eventfd, count * sizeof(int32_t));
 
-	res = opae_ioctl(fd, ioctl_id, irq);
+	res = opae_internal_ioctl(fd, ioctl_id, irq);
 	if (res) {
 		OPAE_ERR("Ioctl error=%d", res);
 	}

--- a/libraries/plugins/xfpga/open.c
+++ b/libraries/plugins/xfpga/open.c
@@ -70,7 +70,7 @@ xfpga_fpgaOpen(fpga_token token, fpga_handle *handle, int flags)
 		return FPGA_INVALID_PARAM;
 	}
 
-	_handle = malloc(sizeof(struct _fpga_handle));
+	_handle = opae_malloc(sizeof(struct _fpga_handle));
 	if (NULL == _handle) {
 		OPAE_MSG("Failed to allocate memory for handle");
 		return FPGA_NO_MEMORY;
@@ -106,7 +106,7 @@ xfpga_fpgaOpen(fpga_token token, fpga_handle *handle, int flags)
 
 	// Open resources in exclusive mode unless FPGA_OPEN_SHARED is given
 	open_flags = O_RDWR | ((flags & FPGA_OPEN_SHARED) ? 0 : O_EXCL);
-	fddev = open(_token->devpath, open_flags);
+	fddev = opae_open(_token->devpath, open_flags);
 	if (-1 == fddev) {
 		OPAE_MSG("open(%s) failed: %s", _token->devpath, strerror(errno));
 		switch (errno) {
@@ -162,10 +162,10 @@ out_free:
 out_free2:
 	wsid_tracker_cleanup(_handle->mmio_root, NULL);
 out_free1:
-	free(_handle);
+	opae_free(_handle);
 
 	if (-1 != fddev) {
-		close(fddev);
+		opae_close(fddev);
 	}
 
 	return result;

--- a/libraries/plugins/xfpga/open.c
+++ b/libraries/plugins/xfpga/open.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -32,6 +32,7 @@
 #include <opae/access.h>
 #include <opae/utils.h>
 #include "types_int.h"
+#include "mock/opae_std.h"
 
 #include <string.h>
 #include <stdio.h>

--- a/libraries/plugins/xfpga/properties.c
+++ b/libraries/plugins/xfpga/properties.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -37,6 +37,7 @@
 #include "props.h"
 #include "error_int.h"
 #include "opae_drv.h"
+#include "mock/opae_std.h"
 
 
 fpga_result __XFPGA_API__

--- a/libraries/plugins/xfpga/properties.c
+++ b/libraries/plugins/xfpga/properties.c
@@ -82,7 +82,7 @@ fpga_result __XFPGA_API__ xfpga_fpgaGetProperties(fpga_token token,
 	return result;
 
 out_free:
-	free(_prop);
+	opae_free(_prop);
 	return result;
 }
 
@@ -217,7 +217,7 @@ fpga_result __XFPGA_API__ xfpga_fpgaUpdateProperties(fpga_token token,
 		_iprop.u.accelerator.num_mmio = 0;
 		_iprop.u.accelerator.num_interrupts = 0;
 
-		res = open(_token->devpath, O_RDWR);
+		res = opae_open(_token->devpath, O_RDWR);
 		if (-1 == res) {
 			_iprop.u.accelerator.state = FPGA_ACCELERATOR_ASSIGNED;
 		} else {
@@ -235,7 +235,7 @@ fpga_result __XFPGA_API__ xfpga_fpgaUpdateProperties(fpga_token token,
 				}
 			}
 
-			close(res);
+			opae_close(res);
 			_iprop.u.accelerator.state =
 				FPGA_ACCELERATOR_UNASSIGNED;
 		}

--- a/libraries/plugins/xfpga/sysfs.c
+++ b/libraries/plugins/xfpga/sysfs.c
@@ -163,7 +163,7 @@ static sysfs_fpga_device _devices[SYSFS_MAX_DEVICES];
 #define FREE_IF(var)                                                           \
 	do {                                                                   \
 		if (var) {                                                     \
-			free(var);                                             \
+			opae_free(var);                                             \
 			var = NULL;                                            \
 		}                                                              \
 	} while (0)
@@ -210,7 +210,7 @@ int sysfs_parse_attribute64(const char *root, const char *attr_path, uint64_t *v
 	snprintf(path, sizeof(path),
 		 "%s/%s", root, attr_path);
 
-	fd = open(path, O_RDONLY);
+	fd = opae_open(path, O_RDONLY);
 	if (fd < 0) {
 		OPAE_MSG("Error opening %s: %s", path, strerror(errno));
 		return FPGA_EXCEPTION;
@@ -219,13 +219,13 @@ int sysfs_parse_attribute64(const char *root, const char *attr_path, uint64_t *v
 	if (bytes_read < 0) {
 		OPAE_ERR("Error reading from %s: %s", path,
 			 strerror(errno));
-		close(fd);
+		opae_close(fd);
 		return FPGA_EXCEPTION;
 	}
 
 	*value = strtoull(buffer, NULL, 0);
 
-	close(fd);
+	opae_close(fd);
 	return FPGA_OK;
 }
 
@@ -275,7 +275,7 @@ STATIC sysfs_fpga_region *make_region(sysfs_fpga_device *device, char *name,
 {
 	size_t len;
 
-	sysfs_fpga_region *region = malloc(sizeof(sysfs_fpga_region));
+	sysfs_fpga_region *region = opae_malloc(sizeof(sysfs_fpga_region));
 	if (region == NULL) {
 		OPAE_ERR("error creating region");
 		return NULL;
@@ -287,7 +287,7 @@ STATIC sysfs_fpga_region *make_region(sysfs_fpga_device *device, char *name,
 	// sysfs path of region is sysfs path of device + / + name
 	if (snprintf(region->sysfs_path, SYSFS_PATH_MAX,
 		     "%s/%s", device->sysfs_path, name) < 0) {
-		free(region);
+		opae_free(region);
 		OPAE_ERR("snprintf buffer overflow");
 		return NULL;
 	}
@@ -450,7 +450,7 @@ STATIC int find_regions(sysfs_fpga_device *device)
 	fpga_objtype region_type = FPGA_DEVICE;
 	sysfs_fpga_region **region_ptr = NULL;
 	struct dirent *dirent = NULL;
-	DIR *dir = opendir(device->sysfs_path);
+	DIR *dir = opae_opendir(device->sysfs_path);
 	if (!dir) {
 		OPAE_ERR("failed to open device path: %s", device->sysfs_path);
 		return FPGA_EXCEPTION;
@@ -490,7 +490,7 @@ STATIC int find_regions(sysfs_fpga_device *device)
 	}
 
 	if (dir)
-		closedir(dir);
+		opae_closedir(dir);
 	if (!device->fme && !device->port) {
 		OPAE_DBG("did not find fme/port in device: %s", device->sysfs_path);
 		return FPGA_NOT_FOUND;
@@ -518,7 +518,7 @@ STATIC int make_device(sysfs_fpga_device *device, const char *sysfs_class_fpga,
 	memcpy(device->sysfs_name, dir_name, len);
 	device->sysfs_name[len] = '\0';
 
-	sym_link_len = readlink(device->sysfs_path, buffer, SYSFS_PATH_MAX);
+	sym_link_len = opae_readlink(device->sysfs_path, buffer, SYSFS_PATH_MAX);
 	if (sym_link_len < 0) {
 		OPAE_ERR("Error reading sysfs link: %s", device->sysfs_path);
 		return FPGA_EXCEPTION;
@@ -547,11 +547,11 @@ STATIC int sysfs_device_destroy(sysfs_fpga_device *device)
 {
 	ASSERT_NOT_NULL(device);
 	if (device->fme) {
-		free(device->fme);
+		opae_free(device->fme);
 		device->fme = NULL;
 	}
 	if (device->port) {
-		free(device->port);
+		opae_free(device->port);
 		device->port = NULL;
 	}
 	return FPGA_OK;
@@ -643,7 +643,7 @@ int sysfs_initialize(void)
 
 	// open the root sysfs class directory
 	// look in the directory and get device objects
-	dir = opendir(sysfs_class_fpga);
+	dir = opae_opendir(sysfs_class_fpga);
 	if (!dir) {
 		OPAE_MSG("failed to open device path: %s", sysfs_class_fpga);
 		res = FPGA_EXCEPTION;
@@ -683,7 +683,7 @@ int sysfs_initialize(void)
 	}
 out_free:
 	if (dir)
-		closedir(dir);
+		opae_closedir(dir);
 	return res;
 }
 
@@ -1063,7 +1063,7 @@ fpga_result sysfs_read_int(const char *path, int *i)
 		return FPGA_INVALID_PARAM;
 	}
 
-	fd = open(path, O_RDONLY);
+	fd = opae_open(path, O_RDONLY);
 	if (fd < 0) {
 		OPAE_MSG("open(%s) failed", path);
 		return FPGA_NOT_FOUND;
@@ -1095,11 +1095,11 @@ fpga_result sysfs_read_int(const char *path, int *i)
 
 	*i = atoi(buf);
 
-	close(fd);
+	opae_close(fd);
 	return FPGA_OK;
 
 out_close:
-	close(fd);
+	opae_close(fd);
 	return FPGA_NOT_FOUND;
 }
 
@@ -1115,7 +1115,7 @@ fpga_result sysfs_read_u32(const char *path, uint32_t *u)
 		return FPGA_INVALID_PARAM;
 	}
 
-	fd = open(path, O_RDONLY);
+	fd = opae_open(path, O_RDONLY);
 	if (fd < 0) {
 		OPAE_MSG("open(%s) failed", path);
 		return FPGA_NOT_FOUND;
@@ -1147,11 +1147,11 @@ fpga_result sysfs_read_u32(const char *path, uint32_t *u)
 
 	*u = strtoul(buf, NULL, 0);
 
-	close(fd);
+	opae_close(fd);
 	return FPGA_OK;
 
 out_close:
-	close(fd);
+	opae_close(fd);
 	return FPGA_NOT_FOUND;
 }
 
@@ -1176,7 +1176,7 @@ fpga_result sysfs_read_u32_pair(const char *path, uint32_t *u1, uint32_t *u2,
 		return FPGA_INVALID_PARAM;
 	}
 
-	fd = open(path, O_RDONLY);
+	fd = opae_open(path, O_RDONLY);
 	if (fd < 0) {
 		OPAE_MSG("open(%s) failed", path);
 		return FPGA_NOT_FOUND;
@@ -1223,11 +1223,11 @@ fpga_result sysfs_read_u32_pair(const char *path, uint32_t *u1, uint32_t *u2,
 	*u1 = x1;
 	*u2 = x2;
 
-	close(fd);
+	opae_close(fd);
 	return FPGA_OK;
 
 out_close:
-	close(fd);
+	opae_close(fd);
 	return FPGA_NOT_FOUND;
 }
 
@@ -1243,7 +1243,7 @@ fpga_result sysfs_read_u64(const char *path, uint64_t *u)
 		return FPGA_INVALID_PARAM;
 	}
 
-	fd = open(path, O_RDONLY);
+	fd = opae_open(path, O_RDONLY);
 	if (fd < 0) {
 		OPAE_MSG("open(%s) failed", path);
 		return FPGA_NOT_FOUND;
@@ -1273,11 +1273,11 @@ fpga_result sysfs_read_u64(const char *path, uint64_t *u)
 
 	*u = strtoull(buf, NULL, 0);
 
-	close(fd);
+	opae_close(fd);
 	return FPGA_OK;
 
 out_close:
-	close(fd);
+	opae_close(fd);
 	return FPGA_NOT_FOUND;
 }
 
@@ -1294,7 +1294,7 @@ fpga_result sysfs_write_u64(const char *path, uint64_t u)
 		return FPGA_INVALID_PARAM;
 	}
 
-	fd = open(path, O_WRONLY);
+	fd = opae_open(path, O_WRONLY);
 	if (fd < 0) {
 		OPAE_MSG("open(%s) failed: %s", path, strerror(errno));
 		return FPGA_NOT_FOUND;
@@ -1323,11 +1323,11 @@ fpga_result sysfs_write_u64(const char *path, uint64_t u)
 	} while (buf[b - 1] != '\n' && buf[b - 1] != '\0'
 		 && b < len);
 
-	close(fd);
+	opae_close(fd);
 	return FPGA_OK;
 
 out_close:
-	close(fd);
+	opae_close(fd);
 	return FPGA_NOT_FOUND;
 }
 
@@ -1345,7 +1345,7 @@ fpga_result sysfs_write_u64_decimal(const char *path, uint64_t u)
 		return FPGA_INVALID_PARAM;
 	}
 
-	fd = open(path, O_WRONLY);
+	fd = opae_open(path, O_WRONLY);
 	if (fd < 0) {
 		OPAE_MSG("open(%s) failed: %s", path, strerror(errno));
 		return FPGA_NOT_FOUND;
@@ -1374,11 +1374,11 @@ fpga_result sysfs_write_u64_decimal(const char *path, uint64_t u)
 	} while (buf[b - 1] != '\n' && buf[b - 1] != '\0'
 		 && b < len);
 
-	close(fd);
+	opae_close(fd);
 	return FPGA_OK;
 
 out_close:
-	close(fd);
+	opae_close(fd);
 	return FPGA_NOT_FOUND;
 }
 
@@ -1398,7 +1398,7 @@ fpga_result sysfs_read_guid(const char *path, fpga_guid guid)
 		return FPGA_INVALID_PARAM;
 	}
 
-	fd = open(path, O_RDONLY);
+	fd = opae_open(path, O_RDONLY);
 	if (fd < 0) {
 		OPAE_MSG("open(%s) failed", path);
 		return FPGA_NOT_FOUND;
@@ -1439,11 +1439,11 @@ fpga_result sysfs_read_guid(const char *path, fpga_guid guid)
 		buf[i + 2] = tmp;
 	}
 
-	close(fd);
+	opae_close(fd);
 	return FPGA_OK;
 
 out_close:
-	close(fd);
+	opae_close(fd);
 	return FPGA_NOT_FOUND;
 }
 
@@ -1827,7 +1827,7 @@ fpga_result sysfs_sbdf_from_path(const char *sysfspath, int *s, int *b, int *d,
 	char rlpath[SYSFS_PATH_MAX];
 	char *p;
 
-	res = readlink(sysfspath, rlpath, sizeof(rlpath)-1);
+	res = opae_readlink(sysfspath, rlpath, sizeof(rlpath)-1);
 	if (-1 == res) {
 		OPAE_MSG("Can't read link %s (no driver?)", sysfspath);
 		return FPGA_NO_DRIVER;
@@ -1999,7 +1999,7 @@ STATIC char *cstr_dup(const char *str)
 	}
 
 	s = strnlen(str, PATH_MAX - 1);
-	p = malloc(s+1);
+	p = opae_malloc(s+1);
 	if (!p) {
 		OPAE_ERR("malloc failed");
 		return NULL;
@@ -2013,7 +2013,7 @@ STATIC char *cstr_dup(const char *str)
 
 struct _fpga_object *alloc_fpga_object(const char *sysfspath, const char *name)
 {
-	struct _fpga_object *obj = calloc(1, sizeof(struct _fpga_object));
+	struct _fpga_object *obj = opae_calloc(1, sizeof(struct _fpga_object));
 	if (obj) {
 		pthread_mutexattr_t mattr;
 		if (pthread_mutexattr_init(&mattr)) {
@@ -2045,7 +2045,7 @@ struct _fpga_object *alloc_fpga_object(const char *sysfspath, const char *name)
 	return obj;
 out_err:
 	if (obj) {
-		free(obj);
+		opae_free(obj);
 		obj = NULL;
 	}
 	return obj;
@@ -2075,7 +2075,7 @@ fpga_result destroy_fpga_object(struct _fpga_object *obj)
 		OPAE_ERR("Error destroying mutex");
 		res = FPGA_EXCEPTION;
 	}
-	free(obj);
+	opae_free(obj);
 	return res;
 }
 
@@ -2085,7 +2085,7 @@ fpga_result opae_glob_path(char *path, size_t len)
 	glob_t pglob;
 	pglob.gl_pathc = 0;
 	pglob.gl_pathv = NULL;
-	int globres = glob(path, 0, NULL, &pglob);
+	int globres = opae_glob(path, 0, NULL, &pglob);
 	size_t glob_len;
 	if (!globres) {
 		if (pglob.gl_pathc > 1) {
@@ -2094,7 +2094,7 @@ fpga_result opae_glob_path(char *path, size_t len)
 		glob_len = strnlen(pglob.gl_pathv[0], len-1);
 		memcpy(path, pglob.gl_pathv[0], glob_len);
 		path[glob_len] = '\0';
-		globfree(&pglob);
+		opae_globfree(&pglob);
 	} else {
 		switch (globres) {
 		case GLOB_NOSPACE:
@@ -2107,7 +2107,7 @@ fpga_result opae_glob_path(char *path, size_t len)
 			res = FPGA_EXCEPTION;
 		}
 		if (pglob.gl_pathv) {
-			globfree(&pglob);
+			opae_globfree(&pglob);
 		}
 	}
 	return res;
@@ -2121,7 +2121,7 @@ fpga_result opae_glob_paths(const char *path, size_t found_max, char *found[],
 	glob_t pglob;
 	pglob.gl_pathc = 0;
 	pglob.gl_pathv = NULL;
-	int globres = glob(path, 0, NULL, &pglob);
+	int globres = opae_glob(path, 0, NULL, &pglob);
 	size_t i = 0;
 	size_t to_copy = 0;
 
@@ -2134,7 +2134,7 @@ fpga_result opae_glob_paths(const char *path, size_t found_max, char *found[],
 				// we had an error duplicating the string
 				// undo what we've duplicated so far
 				while (i) {
-					free(found[--i]);
+					opae_free(found[--i]);
 					found[i] = NULL;
 				}
 				OPAE_ERR("Could not copy globbed path");
@@ -2158,7 +2158,7 @@ fpga_result opae_glob_paths(const char *path, size_t found_max, char *found[],
 	}
 out_free:
 	if (pglob.gl_pathv) {
-		globfree(&pglob);
+		opae_globfree(&pglob);
 	}
 	return res;
 }
@@ -2214,7 +2214,7 @@ fpga_result sync_object(fpga_object obj)
 	ssize_t bytes_read = 0;
 	ASSERT_NOT_NULL(obj);
 	_obj = (struct _fpga_object *)obj;
-	fd = open(_obj->path, _obj->perm);
+	fd = opae_open(_obj->path, _obj->perm);
 	if (fd < 0) {
 		OPAE_ERR("Error opening %s: %s", _obj->path, strerror(errno));
 		return FPGA_EXCEPTION;
@@ -2223,18 +2223,18 @@ fpga_result sync_object(fpga_object obj)
 	if (_obj->max_size <= MIN_SYSOBJECT_FILESIZE) {
 		res = sync_object_size(_obj, fd);
 		if (res != FPGA_OK) {
-			close(fd);
+			opae_close(fd);
 			return res;
 		}
 	}
 
 	bytes_read = eintr_read(fd, _obj->buffer, _obj->max_size);
 	if (bytes_read < 0) {
-		close(fd);
+		opae_close(fd);
 		return FPGA_EXCEPTION;
 	}
 	_obj->size = bytes_read;
-	close(fd);
+	opae_close(fd);
 	return FPGA_OK;
 }
 
@@ -2256,7 +2256,7 @@ fpga_result make_sysfs_group(char *sysfspath, const char *name,
 		return res;
 	}
 
-	n = scandir(sysfspath, &namelist, sysfs_filter, alphasort);
+	n = opae_scandir(sysfspath, &namelist, sysfs_filter, alphasort);
 	if (n < 0) {
 		OPAE_ERR("Error calling scandir: %s", strerror(errno));
 		switch (errno) {
@@ -2285,7 +2285,7 @@ fpga_result make_sysfs_group(char *sysfspath, const char *name,
 	    || flags & FPGA_OBJECT_RECURSE_ALL) {
 		ptr = sysfspath + pathlen;
 		*ptr++ = '/';
-		group->objects = calloc(n, sizeof(fpga_object));
+		group->objects = opae_calloc(n, sizeof(fpga_object));
 		if (!group->objects) {
 			res = FPGA_NO_MEMORY;
 			goto out_free_group;
@@ -2302,14 +2302,14 @@ fpga_result make_sysfs_group(char *sysfspath, const char *name,
 				    &subobj, flags, handle)) {
 				group->objects[group->size++] = subobj;
 			}
-			free(namelist[n]);
+			opae_free(namelist[n]);
 		}
-		free(namelist);
+		opae_free(namelist);
 	} else {
 		while (n--) {
-			free(namelist[n]);
+			opae_free(namelist[n]);
 		}
-		free(namelist);
+		opae_free(namelist);
 	}
 
 	*object = (fpga_object)group;
@@ -2322,8 +2322,8 @@ out_free_group:
 
 out_free_namelist:
 	while (n--)
-		free(namelist[n]);
-	free(namelist);
+		opae_free(namelist[n]);
+	opae_free(namelist);
 
 	return res;
 }
@@ -2342,7 +2342,7 @@ fpga_result make_sysfs_array(char *sysfspath, const char *name,
 			"Error allocating memory for container of fpga_objects");
 		return FPGA_NO_MEMORY;
 	}
-	array->objects = calloc(num_objects, sizeof(fpga_object));
+	array->objects = opae_calloc(num_objects, sizeof(fpga_object));
 	if (!array->objects) {
 		OPAE_ERR("Error allocating memory for array of fpga_objects");
 		destroy_fpga_object(array);
@@ -2422,7 +2422,7 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 		// opae_glob_paths allocates memory for each path found
 		// let's free it here since we don't need it any longer
 		while (found) {
-			free(object_paths[--found]);
+			opae_free(object_paths[--found]);
 		}
 		return res;
 	}
@@ -2457,7 +2457,7 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 	obj->max_size = objstat.st_size;
 	if (obj->max_size < MIN_SYSOBJECT_FILESIZE)
 		obj->max_size = MIN_SYSOBJECT_FILESIZE;
-	obj->buffer = calloc(obj->max_size, sizeof(uint8_t));
+	obj->buffer = opae_calloc(obj->max_size, sizeof(uint8_t));
 	if (handle && (objstat.st_mode & (S_IWUSR | S_IWGRP | S_IWOTH))) {
 		if ((objstat.st_mode & (S_IRUSR | S_IRGRP | S_IROTH))) {
 			obj->perm = O_RDWR;
@@ -2476,7 +2476,7 @@ fpga_result make_sysfs_object(char *sysfspath, const char *name,
 out_free:
 
 
-	free(obj);
+	opae_free(obj);
 	return res;
 }
 
@@ -2550,7 +2550,7 @@ fpga_result find_glob_path(const char *sysfspath, char *path)
 		} // end
 
 		while (found) {
-			free(object_paths[--found]);
+			opae_free(object_paths[--found]);
 		}
 	} else {
 		return FPGA_NOT_FOUND;

--- a/libraries/plugins/xfpga/sysfs.c
+++ b/libraries/plugins/xfpga/sysfs.c
@@ -49,6 +49,7 @@
 #include "types_int.h"
 #include "sysfs_int.h"
 #include "common_int.h"
+#include "mock/opae_std.h"
 
 // substring that identifies a sysfs directory as the FME device.
 #define FPGA_SYSFS_FME "fme"

--- a/libraries/plugins/xfpga/sysobject.c
+++ b/libraries/plugins/xfpga/sysobject.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2020, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -36,6 +36,7 @@
 #include "common_int.h"
 #include "sysfs_int.h"
 #include "types_int.h"
+#include "mock/opae_std.h"
 #include <opae/types_enum.h>
 #include <opae/sysobject.h>
 #include <opae/log.h>

--- a/libraries/plugins/xfpga/sysobject.c
+++ b/libraries/plugins/xfpga/sysobject.c
@@ -134,11 +134,11 @@ xfpga_fpgaCloneObject(fpga_object src, fpga_object *dst)
 	_dst->type = _src->type;
 	_dst->max_size = _src->max_size;
 	if (_src->type == FPGA_SYSFS_FILE) {
-		_dst->buffer = calloc(_dst->max_size, sizeof(uint8_t));
+		_dst->buffer = opae_calloc(_dst->max_size, sizeof(uint8_t));
 		memcpy(_dst->buffer, _src->buffer, _src->max_size);
 	} else {
 		_dst->buffer = NULL;
-		_dst->objects = calloc(_src->size, sizeof(fpga_object));
+		_dst->objects = opae_calloc(_src->size, sizeof(fpga_object));
 		if (!_dst->objects) {
 			res = FPGA_NO_MEMORY;
 			goto out_err;
@@ -307,7 +307,7 @@ fpga_result __XFPGA_API__ xfpga_fpgaObjectWrite64(fpga_object obj,
 			     value);
 		_obj->size = (size_t)strlen((const char *)_obj->buffer);
 	}
-	fd = open(_obj->path, _obj->perm);
+	fd = opae_open(_obj->path, _obj->perm);
 	if (fd < 0) {
 		OPAE_ERR("Error opening %s: %s", _obj->path, strerror(errno));
 		res = FPGA_EXCEPTION;
@@ -321,7 +321,7 @@ fpga_result __XFPGA_API__ xfpga_fpgaObjectWrite64(fpga_object obj,
 	}
 out_unlock:
 	if (fd >= 0)
-		close(fd);
+		opae_close(fd);
 	err = pthread_mutex_unlock(
 		&((struct _fpga_handle *)_obj->handle)->lock);
 	if (err) {

--- a/libraries/plugins/xfpga/usrclk/fpga_user_clk.c
+++ b/libraries/plugins/xfpga/usrclk/fpga_user_clk.c
@@ -37,7 +37,7 @@
 
 #include "fpga_user_clk.h"
 #include "fpga_user_clk_freq.h"
-
+#include "mock/opae_std.h"
 
 // user clock sysfs
 #define  IOPLL_CLOCK_FREQ             "dfl*/userclk/frequency"

--- a/libraries/plugins/xfpga/usrclk/fpga_user_clk.c
+++ b/libraries/plugins/xfpga/usrclk/fpga_user_clk.c
@@ -507,12 +507,12 @@ fpga_result get_usrclk_uio(const char *sysfs_path,
 		return FPGA_EXCEPTION;
 	}
 
-	gres = glob(feature_path, GLOB_NOSORT, NULL, &pglob);
+	gres = opae_glob(feature_path, GLOB_NOSORT, NULL, &pglob);
 	if (gres) {
 		OPAE_ERR("Failed pattern match %s: %s",
 			feature_path, strerror(errno));
 		if (pglob.gl_pathv)
-			globfree(&pglob);
+			opae_globfree(&pglob);
 		return FPGA_INVALID_PARAM;
 	}
 
@@ -557,7 +557,7 @@ fpga_result get_usrclk_uio(const char *sysfs_path,
 
 free:
 	if (pglob.gl_pathv)
-		globfree(&pglob);
+		opae_globfree(&pglob);
 	return res;
 }
 
@@ -681,7 +681,7 @@ fpga_result set_userclock(const char *sysfs_path,
 	ret = using_iopll(sysfs_usrpath, sysfs_path);
 	if (ret == FPGA_OK) {
 
-		fd = open(sysfs_usrpath, O_WRONLY);
+		fd = opae_open(sysfs_usrpath, O_WRONLY);
 		if (fd < 0) {
 			OPAE_MSG("open(%s) failed: %s",
 				sysfs_usrpath, strerror(errno));
@@ -692,10 +692,10 @@ fpga_result set_userclock(const char *sysfs_path,
 		bytes_written = eintr_write(fd, bufp, cnt);
 		if (bytes_written != cnt) {
 			OPAE_ERR("Failed to write: %s", strerror(errno));
-			close(fd);
+			opae_close(fd);
 			return FPGA_EXCEPTION;
 		}
-		close(fd);
+		opae_close(fd);
 
 		return FPGA_OK;
 	} else if (ret == FPGA_NO_ACCESS) {
@@ -756,10 +756,10 @@ static int using_iopll(char *sysfs_usrpath, const char *sysfs_path)
 		return FPGA_EXCEPTION;
 	}
 
-	res = glob(sysfs_usrpath, 0, NULL, &iopll_glob);
+	res = opae_glob(sysfs_usrpath, 0, NULL, &iopll_glob);
 	if (res) {
 		if (iopll_glob.gl_pathv)
-			globfree(&iopll_glob);
+			opae_globfree(&iopll_glob);
 		return FPGA_NOT_FOUND;
 	}
 
@@ -770,7 +770,7 @@ static int using_iopll(char *sysfs_usrpath, const char *sysfs_path)
 	memcpy(sysfs_usrpath, iopll_glob.gl_pathv[0], len);
 	sysfs_usrpath[len] = '\0';
 
-	globfree(&iopll_glob);
+	opae_globfree(&iopll_glob);
 
 	if (access(sysfs_usrpath, F_OK | R_OK | W_OK) != 0) {
 		OPAE_ERR("Unable to access sysfs frequency file");

--- a/libraries/plugins/xfpga/wsid_list.c
+++ b/libraries/plugins/xfpga/wsid_list.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2018, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include "wsid_list_int.h"
+#include "mock/opae_std.h"
 
 /*
  * The code here assumes the caller handles any required mutexes.

--- a/libraries/plugins/xfpga/wsid_list.c
+++ b/libraries/plugins/xfpga/wsid_list.c
@@ -49,14 +49,14 @@ struct wsid_tracker *wsid_tracker_init(uint32_t n_hash_buckets)
 	if (!n_hash_buckets || (n_hash_buckets > 16384))
 		return NULL;
 
-	struct wsid_tracker *root = malloc(sizeof(struct wsid_tracker));
+	struct wsid_tracker *root = opae_malloc(sizeof(struct wsid_tracker));
 	if (!root)
 		return NULL;
 
 	root->n_hash_buckets = n_hash_buckets;
-	root->table = calloc(n_hash_buckets, sizeof(struct wsid_map *));
+	root->table = opae_calloc(n_hash_buckets, sizeof(struct wsid_map *));
 	if (!root->table) {
-		free(root);
+		opae_free(root);
 		return NULL;
 	}
 
@@ -100,7 +100,7 @@ bool wsid_add(struct wsid_tracker *root,
 	      int flags)
 {
 	uint32_t idx = wsid_hash(root, wsid);
-	struct wsid_map *tmp = malloc(sizeof(struct wsid_map));
+	struct wsid_map *tmp = opae_malloc(sizeof(struct wsid_map));
 
 	if (!tmp)
 		return false;
@@ -136,7 +136,7 @@ bool wsid_del(struct wsid_tracker *root, uint64_t wsid)
 
 	if (tmp->wsid == wsid) { /* first entry */
 		root->table[idx] = root->table[idx]->next;
-		free(tmp);
+		opae_free(tmp);
 		return true;
 	}
 
@@ -149,7 +149,7 @@ bool wsid_del(struct wsid_tracker *root, uint64_t wsid)
 
 	struct wsid_map *tmp2 = tmp->next;
 	tmp->next = tmp->next->next;
-	free(tmp2);
+	opae_free(tmp2);
 
 	return true;
 }
@@ -175,13 +175,13 @@ void wsid_tracker_cleanup(struct wsid_tracker *root,
 			struct wsid_map *tmp2 = tmp->next;
 			if (clean)
 				clean(tmp);
-			free(tmp);
+			opae_free(tmp);
 			tmp = tmp2;
 		}
 	}
 
-	free(root->table);
-	free(root);
+	opae_free(root->table);
+	opae_free(root);
 }
 
 /**

--- a/tests/framework/mock/opae_std.c
+++ b/tests/framework/mock/opae_std.c
@@ -1,0 +1,129 @@
+// Copyright(c) 2022, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include "opae_std.h"
+
+void *opae_malloc(size_t size)
+{
+	return malloc(size);
+}
+
+void *opae_calloc(size_t nmemb, size_t size)
+{
+	return calloc(nmemb, size);
+}
+
+void opae_free(void *ptr)
+{
+	free(ptr);
+}
+
+int opae_open(const char *path, int flags)
+{
+	return open(path, flags);
+}
+
+int opae_open_create(const char *path, int flags, mode_t mode)
+{
+	return open(path, flags, mode);
+}
+
+int opae_ioctl(int fd, unsigned long request, ...)
+{
+	va_list argp;
+	int res;
+
+	va_start(argp, request);
+	res = ioctl(fd, request, va_arg(argp, char *));
+	va_end(argp);
+
+	return res;
+}
+
+int opae_close(int fd)
+{
+	return close(fd);
+}
+
+FILE *opae_fopen(const char *path, const char *mode)
+{
+	return fopen(path, mode);
+}
+
+int opae_fclose(FILE *stream)
+{
+	return fclose(stream);
+}
+
+DIR *opae_opendir(const char *name)
+{
+	return opendir(name);
+}
+
+int opae_scandir(const char *dirp,
+		 struct dirent ***namelist,
+		 int (*filter)(const struct dirent * ),
+		 int (*compar)(const struct dirent ** , const struct dirent **))
+{
+	return scandir(dirp, namelist, filter, compar);
+}
+
+int opae_closedir(DIR *dirp)
+{
+	return closedir(dirp);
+}
+
+ssize_t opae_readlink(const char *pathname, char *buf, size_t bufsiz)
+{
+	return readlink(pathname, buf, bufsiz);
+}
+
+int opae_lstat(const char *pathname, struct stat *statbuf)
+{
+	return lstat(pathname, statbuf);
+}
+
+int opae_glob(const char *pattern,
+	      int flags,
+	      int (*errfunc)(const char *epath, int eerrno),
+	      glob_t *pglob)
+{
+	return glob(pattern, flags, errfunc, pglob);
+}
+
+void opae_globfree(glob_t *pglob)
+{
+	if (pglob->gl_pathv)
+		globfree(pglob);
+}
+
+char *opae_realpath(const char *path, char *resolved_path)
+{
+	return realpath(path, resolved_path);
+}

--- a/tests/framework/mock/test_system.h
+++ b/tests/framework/mock/test_system.h
@@ -157,7 +157,10 @@ class test_system {
   void hijack_sched_setaffinity(int return_val, uint32_t after=0,
                                 const char *when_called_from=nullptr);
 
+  void *malloc(size_t size);
   void invalidate_malloc(uint32_t after=0, const char *when_called_from=nullptr);
+
+  void *calloc(size_t nmemb, size_t size);
   void invalidate_calloc(uint32_t after=0, const char *when_called_from=nullptr);
 
   bool default_ioctl_handler(int request, ioctl_handler_t);


### PR DESCRIPTION
eg, instead of calling malloc() directly, call opae_malloc().

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>