### PR TITLE
pacsign: enable on CentOS 8 Stream / fix bug

### DIFF
--- a/python/pacsign/pacsign/hsm_managers/openssl/openssl.py
+++ b/python/pacsign/pacsign/hsm_managers/openssl/openssl.py
@@ -318,7 +318,7 @@ class openssl:
                 log.warn('"%s" is not a valid OpenSSL version', c_version)
                 return None
 
-            if c_version == vers:
+            if (c_version == vers or m.group('version')[:-1] == vers):
                 log.info('OpenSSL version "%s" matches "%s"', c_version, vers)
                 return dll
 
@@ -328,6 +328,7 @@ class openssl:
         common_util.assert_in_error(False, LIBCRYPTO_MSG)
 
     def __init__(self, versions=[('libcrypto.so.1.1', '1.1.1'),
+                                 ('libcrypto.so.1.1', 'OpenSSL 1.1.1k  FIPS 25 Mar 2021'),
                                  ('libcrypto.so.3', 'OpenSSL 3.0.2 15 Mar 2022')]):
         self.nanotime = None
 


### PR DESCRIPTION
Allow the version check to perform exact match or match based on
regex pattern.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>