### PR TITLE
packaging: Fedora: update for RHEL8.2

### DIFF
--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -95,6 +95,7 @@ Additional OPAE tools
        -DOPAE_BUILD_FPGABIST=ON 
 
 %if 0%{?rhel}
+  %{?!__cmake_builddir: %global __cmake_builddir %{?__builddir}%{!?__builddir:.}}
   %make_build
 %else
   %cmake_build


### PR DESCRIPTION
Set __cmake_builddir conditionally to enable full builds on RHEL8.2.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>