### PR TITLE
mmio: ensure x86 arch for AVX512 mmio

### DIFF
--- a/libraries/plugins/vfio/opae_vfio.c
+++ b/libraries/plugins/vfio/opae_vfio.c
@@ -677,12 +677,14 @@ fpga_result vfio_fpgaOpen(fpga_token token, fpga_handle *handle, int flags)
 	_handle->mmio_size = size;
 
 	_handle->flags = 0;
+#if defined(__i386__) || defined(__x86_64__) || defined(__ia64__)
 #if GCC_VERSION >= 40900
 	__builtin_cpu_init();
 	if (__builtin_cpu_supports("avx512f")) {
 		_handle->flags |= OPAE_FLAG_HAS_AVX512;
 	}
-#endif
+#endif // GCC_VERSION
+#endif // x86
 
 	*handle = _handle;
 	res = FPGA_OK;

--- a/libraries/plugins/xfpga/open.c
+++ b/libraries/plugins/xfpga/open.c
@@ -143,12 +143,14 @@ xfpga_fpgaOpen(fpga_token token, fpga_handle *handle, int flags)
 	pthread_mutexattr_destroy(&mattr);
 
 	_handle->flags = 0;
+#if defined(__i386__) || defined(__x86_64__) || defined(__ia64__)
 #if GCC_VERSION >= 40900
 	__builtin_cpu_init();
 	if (__builtin_cpu_supports("avx512f")) {
 		_handle->flags |= OPAE_FLAG_HAS_MMX512;
 	}
-#endif
+#endif // GCC_VERSION
+#endif // x86
 
 	// set handle return value
 	*handle = (void *)_handle;


### PR DESCRIPTION
Enables building on ARM/other platforms that don't support these
instructions.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>