### PR TITLE
python: fix python namespace packages

### DIFF
--- a/binaries/fpgadiag/opae/__init__.py
+++ b/binaries/fpgadiag/opae/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)

--- a/binaries/fpgadiag/opae/diag/__init__.py
+++ b/binaries/fpgadiag/opae/diag/__init__.py
@@ -1,1 +1,26 @@
-__import__("pkg_resources").declare_namespace(__name__)
+
+# Copyright(c) 2020-2022, Intel Corporation
+#
+# Redistribution  and  use  in source  and  binary  forms,  with  or  without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of  source code  must retain the  above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name  of Intel Corporation  nor the names of its contributors
+#   may be used to  endorse or promote  products derived  from this  software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+# IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+# LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+# CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+# SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+# INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+# CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.

--- a/binaries/fpgadiag/opae/diag/__init__.py
+++ b/binaries/fpgadiag/opae/diag/__init__.py
@@ -1,4 +1,3 @@
-
 # Copyright(c) 2020-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without

--- a/binaries/fpgadiag/setup.py
+++ b/binaries/fpgadiag/setup.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2020, Intel Corporation
+# Copyright(c) 2020-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -23,7 +23,7 @@
 # CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 from setuptools.command.build_ext import build_ext
 from distutils.ccompiler import new_compiler
 from distutils.extension import Extension
@@ -64,7 +64,7 @@ def extensions():
                       language="c++",
                       extra_compile_args=["-std=c++11"],
                       extra_link_args=["-std=c++11"],
-                      libraries = ['opaeuio'],
+                      libraries=['opaeuio'],
                       )
         )
     return ext
@@ -73,7 +73,7 @@ def extensions():
 setup(
     name='opae.diag',
     version="2.0",
-    packages=find_packages(include=['opae.*']),
+    packages=find_namespace_packages(include=['opae.*']),
     include_dirs=[pybind_include_dirs()],
     entry_points={
         'console_scripts': [

--- a/binaries/opae.io/opae/__init__.py
+++ b/binaries/opae.io/opae/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)

--- a/binaries/opae.io/opae/io/__init__.py
+++ b/binaries/opae.io/opae/io/__init__.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2020, Intel Corporation
+# Copyright(c) 2020-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -23,4 +23,3 @@
 # CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/binaries/opae.io/setup.py
+++ b/binaries/opae.io/setup.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2020-2021, Intel Corporation
+# Copyright(c) 2020-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -24,13 +24,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from setuptools import find_packages
+from setuptools import find_namespace_packages
 from distutils.core import Extension, setup
 
 setup(
     name="opae.io",
     version="0.2.2",
-    packages=find_packages(include=['opae.*']),
+    packages=find_namespace_packages(include=['opae.*']),
     entry_points={
         'console_scripts': []
     },
@@ -46,5 +46,4 @@ setup(
     license="BSD3",
     keywords="OPAE accelerator vfio bindings",
     url="https://01.org/OPAE",
-    namespace_packages=['opae']
 )

--- a/docker/centos7.6/Dockerfile
+++ b/docker/centos7.6/Dockerfile
@@ -31,7 +31,7 @@ RUN yum install -y \
         openssl11-devel
 
 RUN /usr/bin/python3 -m pip install setuptools --upgrade --prefix /usr
-RUN /usr/bin/python3 -m pip install python-pkcs11 -pyyaml jsonschema --prefix=/usr
+RUN /usr/bin/python3 -m pip install python-pkcs11 pyyaml jsonschema --prefix=/usr
 
 WORKDIR /root
 COPY scripts/build-rpms.sh /scripts/build-rpms.sh

--- a/docker/centos7.6/Dockerfile
+++ b/docker/centos7.6/Dockerfile
@@ -3,12 +3,12 @@ FROM centos:7.6.1810
 RUN yum install -y https://www.elrepo.org/elrepo-release-7.0-4.el7.elrepo.noarch.rpm
 RUN rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
 RUN yum --enablerepo=elrepo-kernel install -y kernel-ml-headers
-
+RUN yum update -y
 RUN yum install -y \
-        python-devel \
         python3 \
         python3-pip \
         python3-devel \
+        python3-wheel \
         python3-pybind11 \
         make \
         libuuid-devel \
@@ -30,9 +30,8 @@ RUN yum install -y \
         cmake3 \
         openssl11-devel
 
-RUN python3 -m pip install setuptools --upgrade
-RUN python3 -m pip install wheel
-RUN python3 -m pip install python-pkcs11 pyyaml jsonschema
+RUN /usr/bin/python3 -m pip install setuptools --upgrade --prefix /usr
+RUN /usr/bin/python3 -m pip install python-pkcs11 -pyyaml jsonschema --prefix=/usr
 
 WORKDIR /root
 COPY scripts/build-rpms.sh /scripts/build-rpms.sh

--- a/libraries/pyopae/CMakeLists.txt
+++ b/libraries/pyopae/CMakeLists.txt
@@ -72,9 +72,6 @@ opae_target_depends_external(_opae pybind11)
 add_custom_command(TARGET _opae
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
-    ${CMAKE_CURRENT_SOURCE_DIR}/opae/__init__.py
-    ${LIBRARY_OUTPUT_PATH}/python${OPAE_PYTHON_VERSION}/opae
-    COMMAND ${CMAKE_COMMAND} -E copy
     ${CMAKE_CURRENT_SOURCE_DIR}/opae/fpga/__init__.py
     ${LIBRARY_OUTPUT_PATH}/python${OPAE_PYTHON_VERSION}/opae/fpga
     COMMENT "Copying namespace package files")
@@ -91,7 +88,6 @@ if (OPAE_BUILD_PYTHON_DIST)
 
     set(PYFILES
         setup.py
-        opae/__init__.py
         opae/fpga/__init__.py
         test_pyopae.py
         )
@@ -110,10 +106,15 @@ if (OPAE_BUILD_PYTHON_DIST)
     add_custom_target(pyopae-dist
         COMMAND ${PYTHON_EXECUTABLE} setup.py sdist
         COMMAND ${PYTHON_EXECUTABLE} setup.py build_ext
-	--include-dirs=${OPAE_INCLUDE_PATH}
-        --library-dirs=${LIBRARY_OUTPUT_PATH}
+            --include-dirs=${OPAE_INCLUDE_PATH}
+            --library-dirs=${LIBRARY_OUTPUT_PATH}
         COMMAND ${PYTHON_EXECUTABLE} setup.py bdist_wheel
         DEPENDS ${PYFILES} ${PYOPAE_SRC}
         WORKING_DIRECTORY ${PYDIST_STAGE_DIR}
         COMMENT "Building Python distrubutions")
+    opae_python_install(
+        COMPONONENT opae.fpga
+        RECORD_FILE opae.fpga-install.txt
+        SOURCE_DIR ${PYDIST_STAGE_DIR}
+    )
 endif (OPAE_BUILD_PYTHON_DIST)

--- a/libraries/pyopae/opae/__init__.py
+++ b/libraries/pyopae/opae/__init__.py
@@ -1,1 +1,0 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/libraries/pyopae/opae/fpga/__init__.py
+++ b/libraries/pyopae/opae/fpga/__init__.py
@@ -1,3 +1,28 @@
+# Copyright(c) 2020-2022, Intel Corporation
+#
+# Redistribution  and  use  in source  and  binary  forms,  with  or  without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of  source code  must retain the  above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name  of Intel Corporation  nor the names of its contributors
+#   may be used to  endorse or promote  products derived  from this  software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+# IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+# LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+# CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+# SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+# INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+# CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 from ._opae import (
     properties,
     token,
@@ -15,9 +40,9 @@ from ._opae import (
     build,
     memory_barrier)
 from ._opae import (DEVICE, ACCELERATOR, OPEN_SHARED, EVENT_ERROR,
-                   EVENT_INTERRUPT, EVENT_POWER_THERMAL, ACCELERATOR_ASSIGNED,
-                   ACCELERATOR_UNASSIGNED, RECONF_FORCE, SYSOBJECT_GLOB,
-                   IFC_DFL, IFC_VFIO, IFC_SIM)
+                    EVENT_INTERRUPT, EVENT_POWER_THERMAL, ACCELERATOR_ASSIGNED,
+                    ACCELERATOR_UNASSIGNED, RECONF_FORCE, SYSOBJECT_GLOB,
+                    IFC_DFL, IFC_VFIO, IFC_SIM)
 __all__ = ['properties',
            'token',
            'handle',

--- a/libraries/pyopae/setup.py
+++ b/libraries/pyopae/setup.py
@@ -23,8 +23,7 @@
 # CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-import os
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 from setuptools.command.build_ext import build_ext
 from distutils.extension import Extension
 
@@ -83,7 +82,7 @@ extensions = [
 setup(
     name="opae.fpga",
     version="@OPAE_VERSION@",
-    packages=find_packages(),
+    packages=find_namespace_packages(),
     entry_points={
         'console_scripts': [
         ]

--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -244,7 +244,6 @@ done
 
 %{python3_sitelib}/opae.admin*
 %{python3_sitelib}/opae/admin*
-%{python3_sitearch}/opae/__init__.py
 %{python3_sitearch}/opae/__pycache__*
 
 %config(noreplace) %{_sysconfdir}/opae/fpgad.cfg*

--- a/opae.spec.rhel
+++ b/opae.spec.rhel
@@ -253,7 +253,6 @@ done
 %{_usr}/src/opae/samples/opae.io/pymain.h
 %{_usr}/src/opae/samples/opae.io/setup.py
 %{_usr}/src/opae/samples/opae.io/vfiobindings.cpp
-%{_usr}/src/opae/samples/opae.io/opae/__init__.py
 %{_usr}/src/opae/samples/opae.io/opae/io/__init__.py
 %{_usr}/src/opae/samples/opae.io/opae/io/utils.py
 %{_usr}/src/opae/samples/opae.io/opae/io/pci.py

--- a/packaging/opae/deb/opae.install
+++ b/packaging/opae/deb/opae.install
@@ -32,7 +32,6 @@ usr/bin/rsu
 usr/bin/pci_device
 usr/lib/python3/dist-packages/opae.admin*
 usr/lib/python3/dist-packages/opae/admin*
-usr/lib/python3/dist-packages/opae/__init__.py
 usr/lib/python3/dist-packages/opae/__pycache__*
 etc/opae/fpgad.cfg
 etc/sysconfig/fpgad.conf

--- a/python/opae.admin/opae/__init__.py
+++ b/python/opae.admin/opae/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)

--- a/python/opae.admin/opae/admin/__init__.py
+++ b/python/opae.admin/opae/admin/__init__.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019, Intel Corporation
+# Copyright(c) 2019-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -23,4 +23,3 @@
 # CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/opae.admin/opae/admin/tools/__init__.py
+++ b/python/opae.admin/opae/admin/tools/__init__.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019, Intel Corporation
+# Copyright(c) 2019-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -23,4 +23,3 @@
 # CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/opae.admin/opae/admin/utils/__init__.py
+++ b/python/opae.admin/opae/admin/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019, Intel Corporation
+# Copyright(c) 2019-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:

--- a/python/opae.admin/setup.py
+++ b/python/opae.admin/setup.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019-2020, Intel Corporation
+# Copyright(c) 2019-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -23,13 +23,13 @@
 # CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 from opae.admin.version import pretty_version
 
 setup(
     name="opae.admin",
     version=pretty_version(),
-    packages=find_packages(include=['opae.*']),
+    packages=find_namespace_packages(include=['opae.*']),
     entry_points={
         'console_scripts': [
             'fpgasupdate = opae.admin.tools.fpgasupdate:main',
@@ -53,5 +53,4 @@ setup(
     data_files=[('share/doc/opae.admin',
                  ['LICENSE'])],
     url="https://01.org/OPAE",
-    namespace_packages=['opae']
 )


### PR DESCRIPTION
Since we no longer need to support Python 2, this change makes it so
that all Python namespace packages follow PEP 420 for native namespace
packages per the packaging user guide:
https://packaging.python.org/en/latest/guides/packaging-namespace-packages

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>