### PR TITLE
rpm: remove reference to opae/*.py

### DIFF
--- a/opae.spec.rhel
+++ b/opae.spec.rhel
@@ -126,7 +126,6 @@ cp samples/dummy_afu/*.{cpp,h} %{buildroot}%{_usr}/src/opae/samples/dummy_afu/
 cp samples/host_exerciser/*.{cpp,h} %{buildroot}%{_usr}/src/opae/samples/host_exerciser/
 cp samples/hssi/*.{cpp,h} %{buildroot}%{_usr}/src/opae/samples/hssi/
 cp binaries/opae.io/*.{cpp,h,py} %{buildroot}%{_usr}/src/opae/samples/opae.io/
-cp binaries/opae.io/opae/*.py %{buildroot}%{_usr}/src/opae/samples/opae.io/opae
 cp binaries/opae.io/opae/io/*.py %{buildroot}%{_usr}/src/opae/samples/opae.io/opae/io
 cp binaries/opae.io/scripts/*.py %{buildroot}%{_usr}/src/opae/samples/opae.io/scripts
 


### PR DESCRIPTION
Python packages are following native namespace package scheme which
requires that the namespace (opae in this case) not contain __init__.py.
There also shouldn't be any other python files in the namespace
directory.

Signed-off-by: Rodrigo Rojo <rodrigo.rojo@intel.com>