### PR TITLE
sim: fix ASE build by installing opae_std.h

### DIFF
--- a/libraries/libopae-c/CMakeLists.txt
+++ b/libraries/libopae-c/CMakeLists.txt
@@ -62,3 +62,6 @@ install(FILES adapter.h props.h opae_int.h
 install(FILES plugin.h
     DESTINATION include/opae
 )
+install(FILES ${OPAE_SDK_SOURCE}/tests/framework/mock/opae_std.h
+    DESTINATION include/mock
+)


### PR DESCRIPTION
Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>