### PR TITLE
changing packages in create

### DIFF
--- a/packaging/opae/rpm/create
+++ b/packaging/opae/rpm/create
@@ -58,7 +58,9 @@ declare -a PKG_DEPS=(\
 'gcc-c++' \
 'json-c-devel' \
 'libuuid-devel' \
-'python3*-devel' \
+'libedit-devel' \
+'python3-devel' \
+'systemd-devel' \
 'python3-jsonschema' \
 'python3-pip' \
 'rpm-build' \


### PR DESCRIPTION
replaced catchall python package on line 61 with 3 individual packages. Original breaks Fedora Rawhide, proposed change