### PR TITLE
opae-sdk: fix pybind build error on Fedora 37

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -31,7 +31,7 @@ if(OPAE_WITH_PYBIND11)
         set(PYBIND11_TAG "v2.4.3")
     else()
     # Otherwise, pull recent pybind11 tag to enable Python 3.9 support.
-        set(PYBIND11_TAG "v2.8.1")
+        set(PYBIND11_TAG "v2.9.2")
     endif()
     message(STATUS "Using pybind11 ${PYBIND11_TAG}")
     opae_external_project_add(PROJECT_NAME pybind11


### PR DESCRIPTION
Fedora 37 python version 3.11 and compatible pybind 11 version 2.9.2

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>