### PR TITLE
opae.io: fix two issues (#2647)

### DIFF
--- a/binaries/opae.io/main.cpp
+++ b/binaries/opae.io/main.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2020-2021, Intel Corporation
+// Copyright(c) 2020-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -46,7 +46,7 @@ struct mmio_region *the_region = nullptr;
 const char *program = "opae.io";
 const int major = 0;
 const int minor = 2;
-const int patch = 2;
+const int patch = 3;
 
 py::tuple version()
 {

--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -531,14 +531,14 @@ def find_device(pci_addr=None):
             raise OSError(os.EX_OSERR, errstr)
         return d
 
-    for pci_addr, vid, did, name, driver in lsfpga():
-        if driver == 'vfio-pci':
-            iommu_group = read_link('/sys/bus/pci/devices', pci_addr, 'iommu_group')
+    for fpga in lsfpga():
+        if fpga.driver == 'vfio-pci':
+            iommu_group = read_link('/sys/bus/pci/devices', fpga.addr, 'iommu_group')
             vfiodev = Path('/dev/vfio', iommu_group.stem)
             if vfiodev.exists():
-                device = open_pciaddr(pci_addr)
-                if device:
-                    return device
+                dev = open_pciaddr(fpga.addr)
+                if dev:
+                    return dev
 
 
 def find_region(device, region):

--- a/binaries/opae.io/vfiobindings.cpp
+++ b/binaries/opae.io/vfiobindings.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2020-2021, Intel Corporation
+// Copyright(c) 2020-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -26,9 +26,7 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <memory>
 #include <sstream>
-#include <vector>
 #include <iomanip>
 
 #include <opae/vfio.h>
@@ -44,8 +42,8 @@ PYBIND11_EMBEDDED_MODULE(libvfio, m)
 PYBIND11_MODULE(libvfio, m)
 #endif
 {
-  py::class_<vfio_device, std::unique_ptr<vfio_device>> pydevice(m, "device", "");
-  pydevice.def_static("open", &vfio_device::open)
+  py::class_<vfio_device> pydevice(m, "device", "");
+  pydevice.def_static("open", &vfio_device::open, py::return_value_policy::reference)
           .def("descriptor", &vfio_device::descriptor)
           .def("close", &vfio_device::close)
           .def("__getitem__", &vfio_device::config_read<uint32_t>)


### PR DESCRIPTION
1) When run without arguments, the code calls into
   opae/io/utils.py::find_device() with the device parameter
   equal to None. The for loop in find_device() was flawed
   and caused an exception. The utils.py change fixes that
   error.

2) The lifetime management of the global variables the_device and
   the_region were incorrect. The previous code assumed that pybind11
   had full ownership (the default) of these objects such that they
   would be tracked in a std::unique_ptr and destroyed. However, the
   main.cpp code is also able to destroy and replace these objects.
   Removing the unique_ptr designation and adding
   py::return_value_policy::reference to the definition of open()
   function tells pybind11 that it should be hands off with the
   return values of this function.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>