### PR TITLE
n6000: handle a 0 subdevice

### DIFF
--- a/binaries/fpgainfo/board.c
+++ b/binaries/fpgainfo/board.c
@@ -95,6 +95,9 @@ static platform_data platform_data_table[] = {
 	{ 0x8086, 0xaf00, 0x8086, 0x0, 0x12, "libboard_n6000.so", NULL,
 	"Intel Open FPGA Stack Platform" },
 
+	{ 0x8086, 0xbcce, 0x8086, 0x0, 0x12, "libboard_n6000.so", NULL,
+	"Intel Acceleration Development Platform N6000" },
+
 	{ 0x8086, 0xbcce, 0x8086, 0x1770, 0x12, "libboard_n6000.so", NULL,
 	"Intel Acceleration Development Platform N6000" },
 


### PR DESCRIPTION
There are some old n6000 cards with a 0 subdevice id.
To be handled by libboard_n6000.so, this entry is needed.

fpgainfo fme

before:

//****** FME ******//
Object Id                        : 0xEB00000
PCIe s:b:d.f                     : 0000:0D:00.0
Vendor Id                        : 0x8086
Device Id                        : 0xBCCE
SubVendor Id                     : 0x8086
SubDevice Id                     : 0x0000
Socket Id                        : 0x00
Ports Num                        : 01
Bitstream Id                     : 0x5010602FE05BDA1
Bitstream Version                : 5.0.1
Pr Interface Id                  : d43642b4-c298-5631-823a-6735bb92b21f

after:

Intel Open FPGA Stack Platform
Board Management Controller NIOS FW version: 65.5.0
Board Management Controller Build version: 65.5.0
//****** FME ******//
Object Id                        : 0xEB00000
PCIe s:b:d.f                     : 0000:0D:00.0
Vendor Id                        : 0x8086
Device Id                        : 0xBCCE
SubVendor Id                     : 0x8086
SubDevice Id                     : 0x0000
Socket Id                        : 0x00
Ports Num                        : 01
Bitstream Id                     : 0x5010602FE05BDA1
Bitstream Version                : 5.0.1
Pr Interface Id                  : d43642b4-c298-5631-823a-6735bb92b21f
Boot Page                        : user1
Factory Image Info               : None
User1 Image Info                 : Empty
User2 Image Info                 : None

Signed-off-by: Tom Rix <trix@redhat.com>