### PR TITLE
rsu: (Cherry-pick) add --types to 'sdm' command (#2670)

### DIFF
--- a/doc/src/fpga_tools/rsu/rsu.md
+++ b/doc/src/fpga_tools/rsu/rsu.md
@@ -14,7 +14,7 @@ rsu [-h] [-d] {bmc,bmcimg,retimer,fpga,sdm,fpgadefault} [PCIE_ADDR]
 rsu bmc --page=(user|factory) [PCIE_ADDR]
 rsu retimer [PCIE_ADDR]
 rsu fpga --page=(user1|user2|factory) [PCIE_ADDR]
-rsu sdm [PCIE_ADDR]
+rsu sdm --type=(sr|pr|sr_cancel|pr_cancel) [PCIE_ADDR]
 ```
 
 Perform RSU (remote system update) operation on PAC device
@@ -95,10 +95,10 @@ force rsu operation
  with PCIe address 25:00.0.
 
 ```console
-# rsu sdm 25:00.0
+# rsu sdm --type=sr 25:00.0
 ```
 
- Triggers a reconfiguration of the SDM for the device with
+ Triggers Static Region key programming for the device with
  PCIE address 25:00.0.
 
 ```console

--- a/python/opae.admin/opae/admin/tools/rsu.py
+++ b/python/opae.admin/opae/admin/tools/rsu.py
@@ -179,7 +179,7 @@ def device_rsu_fpga(device, args):
 
 
 def device_rsu_sdm(device, args):
-    device_rsu(device, 'sdm', force=args.force)
+    device_rsu(device, 'sdm_' + args.type, force=args.force)
 
 
 def parse_args():
@@ -221,6 +221,9 @@ def parse_args():
     sdm.add_argument('bdf', nargs='?',
                      help=('PCIe address '
                            '(eg 04:00.0 or 0000:04:00.0)'))
+    sdm.add_argument('-t', '--type',
+                     choices=['sr', 'pr', 'sr_cancel', 'pr_cancel'],
+                     default='sr', help='select SDM type')
     sdm.set_defaults(func=device_rsu_sdm)
 
     fpgadefault = subparser.add_parser('fpgadefault',


### PR DESCRIPTION
Add types 'sr', 'pr', 'sr_cancel', 'pr_cancel' to the sdm option,
as specified by the --type option.

eg, $ rsu sdm --type=sr_cancel <PCI_ADDRESS>

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>