### PR TITLE
opae.io: (Cherry-pick) add --safe option to walk command (#2667)

### DIFF
--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -327,11 +327,20 @@ def dfh_walk(region, offset=0, header=None, guid=None):
         offset += h.bits.next
 
 
+def w_aligned(offset: int):
+    mask = 0b11 if ACCESS_MODE == 32 else 0b111
+    return (offset & mask) == 0
+
+
 def walk(region,
-         offset=0, show_uuid=False, count=None, delay=None, dump=False):
+         offset=0, show_uuid=False, count=None, delay=None, dump=False,
+         safe_walk=True):
     for i, (offset_, hdr) in enumerate(dfh_walk(region, offset=offset)):
         if count and i >= count:
             break
+        if safe_walk and not w_aligned(offset_):
+            raise ValueError(
+                f'offset 0x{offset_:04x} not {ACCESS_MODE}-bit aligned')
         print(f'offset: 0x{offset_:04x}, value: 0x{hdr.value:04x}')
         print(f'    dfh: {hdr}')
         if delay:

--- a/binaries/opae.io/pymain.h
+++ b/binaries/opae.io/pymain.h
@@ -171,6 +171,7 @@ class walk_action(base_action):
         self.parser.add_argument('-D', '--dump', action='store_true', default=False)
         self.parser.add_argument('-c', '--count', type=int, default=None)
         self.parser.add_argument('-y', '--delay', type=int, default=None)
+        self.parser.add_argument('-s', '--safe', action='store_true', default=False)
 
     def execute(self, args):
         if not self.device:
@@ -179,7 +180,8 @@ class walk_action(base_action):
             raise SystemExit('walk requires region.')
 
         offset = 0 if args.offset is None else args.offset
-        utils.walk(self.region, offset, args.show_uuid, args.count, args.delay, args.dump)
+        utils.walk(self.region, offset, args.show_uuid, args.count,
+            args.delay, args.dump, args.safe)
 
 
 class dump_action(base_action):


### PR DESCRIPTION
Verifies that the next offset field when walking the DFL is aligned
per the active ACCESS_MODE. If it is not properly aligned, raise
an exception without dereferencing the offset.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>