### PR TITLE
rsu: (Cherry-pick) remove sr_cancel, pr_cancel from sdm command (#2677)

### DIFF
--- a/doc/src/fpga_tools/rsu/rsu.md
+++ b/doc/src/fpga_tools/rsu/rsu.md
@@ -14,7 +14,7 @@ rsu [-h] [-d] {bmc,bmcimg,retimer,fpga,sdm,fpgadefault} [PCIE_ADDR]
 rsu bmc --page=(user|factory) [PCIE_ADDR]
 rsu retimer [PCIE_ADDR]
 rsu fpga --page=(user1|user2|factory) [PCIE_ADDR]
-rsu sdm --type=(sr|pr|sr_cancel|pr_cancel) [PCIE_ADDR]
+rsu sdm --type=(sr|pr) [PCIE_ADDR]
 ```
 
 Perform RSU (remote system update) operation on PAC device

--- a/python/opae.admin/opae/admin/tools/rsu.py
+++ b/python/opae.admin/opae/admin/tools/rsu.py
@@ -222,7 +222,7 @@ def parse_args():
                      help=('PCIe address '
                            '(eg 04:00.0 or 0000:04:00.0)'))
     sdm.add_argument('-t', '--type',
-                     choices=['sr', 'pr', 'sr_cancel', 'pr_cancel'],
+                     choices=['sr', 'pr'],
                      default='sr', help='select SDM type')
     sdm.set_defaults(func=device_rsu_sdm)
 


### PR DESCRIPTION
It was determined that these are no longer needed.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>