### PR TITLE
opae.cfg: add config file parsing to libopae-c

### DIFF
--- a/libraries/libopae-c/CMakeLists.txt
+++ b/libraries/libopae-c/CMakeLists.txt
@@ -29,6 +29,10 @@ set(SRC
     api-shell.c
     init.c
     props.c
+    cfg-file.c
+    fpgad-cfg.c
+    fpgainfo-cfg.c
+    opae-cfg.c
     ${opae-test_ROOT}/framework/mock/opae_std.c
 )
 

--- a/libraries/libopae-c/cfg-file.c
+++ b/libraries/libopae-c/cfg-file.c
@@ -1,0 +1,539 @@
+// Copyright(c) 2022, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <stdio.h>
+#include <string.h>
+#include <pwd.h>
+#include <linux/limits.h>
+#include <opae/log.h>
+#include "cfg-file.h"
+#include "mock/opae_std.h"
+
+
+#define CFG_PATH_MAX 64
+#define HOME_CFG_PATHS 3
+STATIC const char _opae_home_cfg_files[HOME_CFG_PATHS][CFG_PATH_MAX] = {
+	{ "/.local/opae.cfg" },
+	{ "/.local/opae/opae.cfg" },
+	{ "/.config/opae/opae.cfg" },
+};
+#define SYS_CFG_PATHS 2
+STATIC const char _opae_sys_cfg_files[SYS_CFG_PATHS][CFG_PATH_MAX] = {
+	{ "/usr/local/etc/opae/opae.cfg" },
+	{ "/etc/opae/opae.cfg" },
+};
+
+// Find the canonicalized configuration file. If null, the file was not found.
+// Otherwise, it's the first configuration file found from a list of possible
+// paths. Note: The char * returned is allocated here, caller must free.
+char *opae_find_cfg_file(void)
+{
+	int i = 0;
+	char *file_name = NULL;
+	char home_cfg[PATH_MAX] = { 0, };
+	char *home_cfg_ptr = NULL;
+	size_t len;
+
+	// get the user's home directory
+	struct passwd *user_passwd = getpwuid(getuid());
+
+	// first, look in possible paths in the user's home directory
+	for (i = 0 ; i < HOME_CFG_PATHS ; ++i) {
+		len = strnlen(user_passwd->pw_dir,
+			      sizeof(home_cfg) - 1);
+		memcpy(home_cfg, user_passwd->pw_dir, len);
+		home_cfg[len] = '\0';
+
+		home_cfg_ptr = home_cfg + strlen(home_cfg);
+
+		len = strnlen(_opae_home_cfg_files[i], CFG_PATH_MAX);
+		memcpy(home_cfg_ptr, _opae_home_cfg_files[i], len);
+		home_cfg_ptr[len] = '\0';
+
+		file_name = opae_canonicalize_file_name(home_cfg);
+		if (file_name) {
+			OPAE_DBG("Found config file: %s", file_name);
+			return file_name;
+		}
+
+		home_cfg[0] = '\0';
+	}
+
+	// now, look in possible system paths
+	for (i = 0 ; i < SYS_CFG_PATHS ; ++i) {
+		len = strnlen(_opae_sys_cfg_files[i], CFG_PATH_MAX);
+		memcpy(home_cfg, _opae_sys_cfg_files[i], len);
+		home_cfg[len] = '\0';
+
+		file_name = opae_canonicalize_file_name(home_cfg);
+		if (file_name) {
+			OPAE_DBG("Found config file: %s", file_name);
+			return file_name;
+		}
+	}
+
+	return NULL;
+}
+
+#define MAX_CFG_SIZE (8 * 4096)
+char *opae_read_cfg_file(char *config_file_path)
+{
+	char *ptr = NULL;
+	size_t file_size = 0;
+	size_t bytes_read = 0;
+	size_t total_read = 0;
+	FILE *fp = NULL;
+
+	if (!config_file_path) {
+		OPAE_DBG("config file is NULL");
+		return NULL;
+	}
+
+	fp = opae_fopen(config_file_path, "r");
+	if (!fp) {
+		OPAE_ERR("Error opening config file: %s",
+			 config_file_path);
+		goto out;
+	}
+
+	fseek(fp, 0, SEEK_END);
+	file_size = (size_t)ftell(fp);
+	fseek(fp, 0, SEEK_SET);
+
+	if (file_size > MAX_CFG_SIZE) {
+		OPAE_ERR("config file %s is too large. Max size: %ld",
+			 config_file_path, MAX_CFG_SIZE);
+		goto out_close;
+	}
+
+	ptr = opae_malloc(file_size + 1);
+	if (!ptr) {
+		OPAE_ERR("malloc failed for config buffer");
+		goto out_close;
+	}
+
+	do
+	{
+		bytes_read = fread(ptr + total_read,
+				   1,
+				   file_size - total_read,
+				   fp);
+		total_read += bytes_read;
+	
+	} while((total_read < file_size) && !ferror(fp));
+
+	if (ferror(fp)) {
+		OPAE_ERR("Error reading config file: %s - %s",
+			 config_file_path, strerror(errno));
+		goto out_free;
+	}
+
+	ptr[total_read] = '\0';
+	goto out_close;
+
+out_free:
+	opae_free(ptr);
+	ptr = NULL;
+out_close:
+	opae_fclose(fp);
+out:
+	opae_free(config_file_path);
+	return ptr;
+}
+
+int opae_parse_device_id(json_object *j_id,
+			 opae_pci_device *dev)
+{
+	int len;
+	int i;
+	//                            VID,  DID,  SVID, SDID
+	char *id_strings[ID_SIZE] = { NULL, NULL, NULL, NULL };
+	unsigned long u;
+	const char *json = json_object_get_string(j_id);
+
+	if (!json_object_is_type(j_id, json_type_array)) {
+		OPAE_ERR("\"id\" value is not an array: %s",
+			 json);
+		return 1;
+	}
+
+	len = json_object_array_length(j_id);
+	if (len < ID_SIZE) {
+		OPAE_ERR("\"id\" has fewer than 4 entries: %s",
+			 json);
+		return 2;
+	}
+
+	for (i = 0 ; i < ID_SIZE ; ++i) {
+		json_object *j_id_i =
+			json_object_array_get_idx(j_id, i);
+
+		if (!json_object_is_type(j_id_i, json_type_string)) {
+			OPAE_ERR("\"id\" array member %d not a string: %s",
+				 i, json);
+			return 3;
+		}
+
+		id_strings[i] = (char *)json_object_get_string(j_id_i);
+	}
+
+	u = 0;
+	if (string_to_unsigned_wildcard(id_strings[0], &u, OPAE_VENDOR_ANY)) {
+		OPAE_ERR("Vendor ID not an integer in %s", json);
+		return 4;
+	}
+	dev->vendor_id = u;
+
+	u = 0;
+	if (string_to_unsigned_wildcard(id_strings[1], &u, OPAE_DEVICE_ANY)) {
+		OPAE_ERR("Device ID not an integer in %s", json);
+		return 5;
+	}
+	dev->device_id = u;
+
+	u = 0;
+	if (string_to_unsigned_wildcard(id_strings[2], &u, OPAE_VENDOR_ANY)) {
+		OPAE_ERR("Subsystem Vendor ID not an integer in %s", json);
+		return 6;
+	}
+	dev->subsystem_vendor_id = u;
+
+	u = 0;
+	if (string_to_unsigned_wildcard(id_strings[3], &u, OPAE_DEVICE_ANY)) {
+		OPAE_ERR("Subsystem Device ID not an integer in %s", json);
+		return 7;
+	}
+	dev->subsystem_device_id = u;
+
+	return 0;
+}
+
+
+STATIC libopae_config_data default_libopae_config_table[] = {
+        { 0x1c2c, 0x1000, 0x0000,          0x0000,          "libxfpga.so",  "{}", 0 }, // N5010
+        { 0x1c2c, 0x1001, 0x0000,          0x0000,          "libxfpga.so",  "{}", 0 }, // N5010
+        { 0x8086, 0xbcbd, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // MCP
+        { 0x8086, 0xbcc0, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // MCP
+        { 0x8086, 0xbcc1, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // MCP
+        { 0x8086, 0x09c4, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // A10GX
+        { 0x8086, 0x09c5, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // A10GX
+
+        { 0x8086, 0x0b2b, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // D5005
+        { 0x8086, 0x0b2c, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // D5005
+        { 0x8086, 0xbcce, 0x8086,          0x138d,          "libxfpga.so",  "{}", 0 }, // D5005
+        { 0x8086, 0xbcce, 0x8086,          0x138d,          "libopae-v.so", "{}", 0 }, // D5005
+        { 0x8086, 0xbccf, 0x8086,          0x138d,          "libopae-v.so", "{}", 0 }, // D5005
+
+        { 0x8086, 0x0b30, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // N3000
+        { 0x8086, 0x0b31, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // N3000
+        { 0x8086, 0xaf00, 0x8086,          0x0000,          "libxfpga.so",  "{}", 0 }, // OFS EA
+        { 0x8086, 0xaf00, 0x8086,          0x0000,          "libopae-v.so", "{}", 0 }, // OFS EA
+        { 0x8086, 0xaf01, 0x8086,          0x0000,          "libopae-v.so", "{}", 0 }, // OFS EA
+
+        { 0x8086, 0xbcce, 0x8086,          0x0000,          "libxfpga.so",  "{}", 0 }, // OFS
+        { 0x8086, 0xbcce, 0x8086,          0x0000,          "libopae-v.so", "{}", 0 }, // OFS
+        { 0x8086, 0xbccf, 0x8086,          0x0000,          "libopae-v.so", "{}", 0 }, // OFS
+
+        { 0x8086, 0xbcce, 0x8086,          0x1770,          "libxfpga.so",  "{}", 0 }, // N6000
+        { 0x8086, 0xbcce, 0x8086,          0x1770,          "libopae-v.so", "{}", 0 }, // N6000
+        { 0x8086, 0xbccf, 0x8086,          0x1770,          "libopae-v.so", "{}", 0 }, // N6000
+
+        { 0x8086, 0xbcce, 0x8086,          0x1771,          "libxfpga.so",  "{}", 0 }, // N6001
+        { 0x8086, 0xbcce, 0x8086,          0x1771,          "libopae-v.so", "{}", 0 }, // N6001
+        { 0x8086, 0xbccf, 0x8086,          0x1771,          "libopae-v.so", "{}", 0 }, // N6001
+
+        { 0x8086, 0xbcce, 0x8086,          0x17d4,          "libxfpga.so",  "{}", 0 }, // C6100
+        { 0x8086, 0xbcce, 0x8086,          0x17d4,          "libopae-v.so", "{}", 0 }, // C6100
+        { 0x8086, 0xbccf, 0x8086,          0x17d4,          "libopae-v.so", "{}", 0 }, // C6100
+
+        {      0,      0,      0,               0,          NULL,           NULL, 0 },
+};
+
+libopae_config_data *
+opae_parse_libopae_json(const char *json_input);
+
+libopae_config_data *
+opae_parse_libopae_config(const char *json_input)
+{
+	libopae_config_data *c = NULL;
+
+	if (json_input)
+		c = opae_parse_libopae_json(json_input);
+
+	return c ? c : default_libopae_config_table;
+}
+
+void opae_print_libopae_config(libopae_config_data *cfg)
+{
+	const int l = OPAE_LOG_DEBUG;
+
+	opae_print(l, "libopae config:\n");
+
+	while (cfg->module_library) {
+		opae_print(l,
+			   "0x%04x 0x%04x ",
+			   cfg->vendor_id, cfg->device_id);
+
+		if (cfg->subsystem_vendor_id == OPAE_VENDOR_ANY)
+			opae_print(l, "*      ");
+		else
+			opae_print(l, "0x%04x ", cfg->subsystem_vendor_id);
+
+		if (cfg->subsystem_device_id == OPAE_DEVICE_ANY)
+			opae_print(l, "*      ");
+		else
+			opae_print(l, "0x%04x ", cfg->subsystem_device_id);
+
+		opae_print(l, "%-12s %s 0x%08x\n",
+			   cfg->module_library,
+			   cfg->config_json,
+			   cfg->flags);
+
+		++cfg;
+	}
+}
+
+void opae_free_libopae_config(libopae_config_data *cfg)
+{
+	libopae_config_data *base;
+
+	if (cfg == default_libopae_config_table || !cfg)
+		return;
+
+	base = cfg;
+	while (cfg->module_library) {
+		if (cfg->module_library)
+			opae_free((char *)cfg->module_library);
+		if (cfg->config_json)
+			opae_free((char *)cfg->config_json);
+		++cfg;
+	}
+
+	opae_free(base);
+}
+
+
+STATIC fpgainfo_config_data default_fpgainfo_config_table[] = {
+        { 0x8086, 0x09c4, 0x8086, 0x0, OPAE_FEATURE_ID_ANY, "libboard_a10gx.so", NULL,
+        "Intel Programmable Acceleration Card with Intel Arria 10 GX FPGA" },
+
+        { 0x8086, 0x09c5, 0x8086, 0x0, OPAE_FEATURE_ID_ANY, "libboard_a10gx.so", NULL,
+        "Intel Programmable Acceleration Card with Intel Arria 10 GX FPGA" },
+
+        { 0x8086, 0x0b30, 0x8086, 0x0, OPAE_FEATURE_ID_ANY, "libboard_n3000.so", NULL,
+        "Intel FPGA Programmable Acceleration Card N3000" },
+
+        { 0x8086, 0x0b31, 0x8086, 0x0, OPAE_FEATURE_ID_ANY, "libboard_n3000.so", NULL,
+        "Intel FPGA Programmable Acceleration Card N3000" },
+
+        { 0x8086, 0x0b2b, 0x8086, 0x0, OPAE_FEATURE_ID_ANY, "libboard_d5005.so", NULL,
+        "Intel FPGA Programmable Acceleration Card D5005" },
+
+        { 0x8086, 0x0b2c, 0x8086, 0x0, OPAE_FEATURE_ID_ANY, "libboard_d5005.so", NULL,
+        "Intel FPGA Programmable Acceleration Card D5005" },
+
+        // Max10 SPI feature id 0xe
+        { 0x1c2c, 0x1000, 0x0, 0x0, 0xe, "libboard_n5010.so", NULL,
+        "Silicom FPGA SmartNIC N5010 Series" },
+
+        { 0x1c2c, 0x1001, 0x0, 0x0, 0xe, "libboard_n5010.so", NULL,
+        "Silicom FPGA SmartNIC N5010 Series" },
+
+        { 0x8086, 0xaf00, 0x8086, 0x0, 0xe, "libboard_d5005.so", NULL,
+        "Intel Open FPGA Stack Platform" },
+
+        { 0x8086, 0xbcce, 0x8086, 0x0, 0xe, "libboard_d5005.so", NULL,
+        "Intel Open FPGA Stack Platform" },
+
+        { 0x8086, 0xbcce, 0x8086, 0x138d, 0xe, "libboard_d5005.so", NULL,
+        "Intel Open FPGA Stack Platform" },
+
+        // Max10 PMCI feature id 0x12
+        { 0x8086, 0xaf00, 0x8086, 0x0, 0x12, "libboard_n6000.so", NULL,
+        "Intel Open FPGA Stack Platform" },
+
+        { 0x8086, 0xbcce, 0x8086, 0x1770, 0x12, "libboard_n6000.so", NULL,
+        "Intel Acceleration Development Platform N6000" },
+
+        { 0x8086, 0xbcce, 0x8086, 0x1771, 0x12, "libboard_n6000.so", NULL,
+        "Intel Acceleration Development Platform N6001" },
+
+        { 0x8086, 0xbcce, 0x8086, 0x17d4, 0x12, "libboard_c6100.so", NULL,
+        "Intel Acceleration Development Platform C6100" },
+
+        { 0,      0, 0, 0, -1,         NULL, NULL, "" }
+};
+
+fpgainfo_config_data *
+opae_parse_fpgainfo_json(const char *json_input);
+
+fpgainfo_config_data *
+opae_parse_fpgainfo_config(const char *json_input)
+{
+	fpgainfo_config_data *c = NULL;
+
+	if (json_input)
+		c = opae_parse_fpgainfo_json(json_input);
+
+	return c ? c : default_fpgainfo_config_table;
+}
+
+void opae_print_fpgainfo_config(fpgainfo_config_data *cfg)
+{
+	const int l = OPAE_LOG_DEBUG;
+
+	opae_print(l, "fpgainfo config:\n");
+
+	while (cfg->board_plugin) {
+		opae_print(l,
+			   "0x%04x 0x%04x ",
+			   cfg->vendor_id, cfg->device_id);
+
+		if (cfg->subvendor_id == OPAE_VENDOR_ANY)
+			opae_print(l, "*      ");
+		else
+			opae_print(l, "0x%04x ", cfg->subvendor_id);
+
+		if (cfg->subdevice_id == OPAE_DEVICE_ANY)
+			opae_print(l, "*      ");
+		else
+			opae_print(l, "0x%04x ", cfg->subdevice_id);
+
+		if (cfg->feature_id == OPAE_FEATURE_ID_ANY)
+			opae_print(l, "*      ");
+		else
+			opae_print(l, "0x%04x ", cfg->feature_id);
+
+		opae_print(l, "%-12s 0x%08x %s\n",
+			   cfg->board_plugin,
+			   cfg->dl_handle,
+			   cfg->product_name);
+
+		++cfg;
+	}
+}
+
+void opae_free_fpgainfo_config(fpgainfo_config_data *cfg)
+{
+	fpgainfo_config_data *base;
+
+	if (cfg == default_fpgainfo_config_table || !cfg)
+		return;
+
+	base = cfg;
+	while (cfg->board_plugin) {
+		opae_free((char *)cfg->board_plugin);
+		++cfg;
+	}
+
+	opae_free(base);
+}
+
+
+STATIC fpgad_config_data default_fpgad_config_table[] = {
+	{ 0x8086, 0x0b30, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libfpgad-vc.so", 0, NULL, "{ \"cool-down\": 30, \"get-aer\": [ \"setpci -s %s ECAP_AER+0x08.L\", \"setpci -s %s ECAP_AER+0x14.L\" ], \"disable-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0xffffffff\", \"setpci -s %s ECAP_AER+0x14.L=0xffffffff\" ], \"set-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0x%08x\", \"setpci -s %s ECAP_AER+0x14.L=0x%08x\" ], \"sensor-overrides\": [ { \"enabled\": true, \"name\": \"12V AUX Voltage\", \"low-warn\": 11.40, \"low-fatal\": 10.56 } ] }" },
+
+	{ 0x1c2c, 0x1000,          0x0000,          0x0000, "libfpgad-vc.so", 0, NULL, "{ \"cool-down\": 30, \"get-aer\": [ \"setpci -s %s ECAP_AER+0x08.L\", \"setpci -s %s ECAP_AER+0x14.L\" ], \"disable-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0xffffffff\", \"setpci -s %s ECAP_AER+0x14.L=0xffffffff\" ], \"set-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0x%08x\", \"setpci -s %s ECAP_AER+0x14.L=0x%08x\" ], \"sensor-overrides\": [] }" },
+
+	{ 0x8086, 0xbcce,          0x8086,          0x1770, "libfpgad-vc.so", 0, NULL, "{ \"cool-down\": 30, \"get-aer\": [ \"setpci -s %s ECAP_AER+0x08.L\", \"setpci -s %s ECAP_AER+0x14.L\" ], \"disable-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0xffffffff\", \"setpci -s %s ECAP_AER+0x14.L=0xffffffff\" ], \"set-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0x%08x\", \"setpci -s %s ECAP_AER+0x14.L=0x%08x\" ], \"sensor-overrides\": [] }" },
+
+	{ 0x8086, 0xbcce,          0x8086,          0x1771, "libfpgad-vc.so", 0, NULL, "{ \"cool-down\": 30, \"get-aer\": [ \"setpci -s %s ECAP_AER+0x08.L\", \"setpci -s %s ECAP_AER+0x14.L\" ], \"disable-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0xffffffff\", \"setpci -s %s ECAP_AER+0x14.L=0xffffffff\" ], \"set-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0x%08x\", \"setpci -s %s ECAP_AER+0x14.L=0x%08x\" ], \"sensor-overrides\": [] }" },
+
+	{ 0x8086, 0xbcce,          0x8086,          0x17d4, "libfpgad-vc.so", 0, NULL, "{ \"cool-down\": 30, \"get-aer\": [ \"setpci -s %s ECAP_AER+0x08.L\", \"setpci -s %s ECAP_AER+0x14.L\" ], \"disable-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0xffffffff\", \"setpci -s %s ECAP_AER+0x14.L=0xffffffff\" ], \"set-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0x%08x\", \"setpci -s %s ECAP_AER+0x14.L=0x%08x\" ], \"sensor-overrides\": [] }" },
+
+	{ 0x8086, 0xaf00,          0x8086,          0x0000, "libfpgad-vc.so", 0, NULL, "{ \"cool-down\": 30, \"get-aer\": [ \"setpci -s %s ECAP_AER+0x08.L\", \"setpci -s %s ECAP_AER+0x14.L\" ], \"disable-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0xffffffff\", \"setpci -s %s ECAP_AER+0x14.L=0xffffffff\" ], \"set-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0x%08x\", \"setpci -s %s ECAP_AER+0x14.L=0x%08x\" ], \"sensor-overrides\": [] }" },
+
+	{ 0x8086, 0xbcce,          0x8086,          0x0000, "libfpgad-vc.so", 0, NULL, "{ \"cool-down\": 30, \"get-aer\": [ \"setpci -s %s ECAP_AER+0x08.L\", \"setpci -s %s ECAP_AER+0x14.L\" ], \"disable-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0xffffffff\", \"setpci -s %s ECAP_AER+0x14.L=0xffffffff\" ], \"set-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0x%08x\", \"setpci -s %s ECAP_AER+0x14.L=0x%08x\" ], \"sensor-overrides\": [] }" },
+
+	{      0,      0,               0,               0, NULL,             0, NULL, ""   },
+};
+
+fpgad_config_data *
+opae_parse_fpgad_json(const char *json_input);
+
+fpgad_config_data *
+opae_parse_fpgad_config(const char *json_input)
+{
+	fpgad_config_data *c = NULL;
+
+	if (json_input)
+		c = opae_parse_fpgad_json(json_input);
+
+	return c ? c : default_fpgad_config_table;
+}
+
+void opae_print_fpgad_config(fpgad_config_data *cfg)
+{
+	const int l = OPAE_LOG_DEBUG;
+
+	opae_print(l, "fpgad config:\n");
+
+	while (cfg->module_library) {
+		opae_print(l,
+			   "0x%04x 0x%04x ",
+			   cfg->vendor_id, cfg->device_id);
+
+		if (cfg->subsystem_vendor_id == OPAE_VENDOR_ANY)
+			opae_print(l, "*      ");
+		else
+			opae_print(l, "0x%04x ", cfg->subsystem_vendor_id);
+
+		if (cfg->subsystem_device_id == OPAE_DEVICE_ANY)
+			opae_print(l, "*      ");
+		else
+			opae_print(l, "0x%04x ", cfg->subsystem_device_id);
+
+		opae_print(l, "%-12s 0x%08x 0x%08x %s\n",
+			   cfg->module_library,
+			   cfg->flags,
+			   cfg->dl_handle,
+			   cfg->config_json);
+
+		++cfg;
+	}
+}
+
+void opae_free_fpgad_config(fpgad_config_data *cfg)
+{
+	fpgad_config_data *base;
+
+	if (cfg == default_fpgad_config_table || !cfg)
+		return;
+
+	base = cfg;
+	while (cfg->module_library) {
+		if (cfg->module_library)
+			opae_free((char *)cfg->module_library);
+		if (cfg->config_json)
+			opae_free((char *)cfg->config_json);
+		++cfg;
+	}
+
+	opae_free(base);
+}

--- a/libraries/libopae-c/cfg-file.h
+++ b/libraries/libopae-c/cfg-file.h
@@ -1,0 +1,242 @@
+// Copyright(c) 2022, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifndef __OPAE_CFG_FILE_H__
+#define __OPAE_CFG_FILE_H__
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <opae/log.h>
+#include <json-c/json.h>
+
+// Returns the canonicalized path to the first config
+// file found, or NULL if not found. When the return
+// value is non-NULL, it was allocated by the function.
+// Caller must free it.
+char *opae_find_cfg_file(void);
+
+// Returns an allocated buffer containing the contents
+// of the config file found at config_file_path. The
+// config_file_path parameter is assumed to have been
+// allocated by opae_find_cfg_file(), and is freed by
+// this function.
+// return: NULL on error or an allocated buffer on success.
+// Caller must free any allocated buffer.
+char *opae_read_cfg_file(char *config_file_path);
+
+// VID, DID, SVID, SDID
+#define ID_SIZE              4
+
+#define MAX_DEV_NAME       256
+
+#define OPAE_VENDOR_ANY 0xffff
+#define OPAE_DEVICE_ANY 0xffff
+
+typedef struct _opae_pci_device {
+	const char *name;
+	uint16_t vendor_id;
+	uint16_t device_id;
+	uint16_t subsystem_vendor_id;
+	uint16_t subsystem_device_id;
+} opae_pci_device;
+
+int opae_parse_device_id(json_object *j_id,
+			 opae_pci_device *dev);
+
+
+typedef struct _libopae_config_data {
+	uint16_t vendor_id;
+	uint16_t device_id;
+	uint16_t subsystem_vendor_id;
+	uint16_t subsystem_device_id;
+	const char *module_library;
+	const char *config_json;
+	uint32_t flags;
+#define OPAE_PLATFORM_DATA_DETECTED 0x00000001
+#define OPAE_PLATFORM_DATA_LOADED   0x00000002
+} libopae_config_data;
+
+libopae_config_data *
+opae_parse_libopae_config(const char *json_input);
+
+void opae_print_libopae_config(libopae_config_data *cfg);
+
+void opae_free_libopae_config(libopae_config_data *cfg);
+
+
+#define OPAE_FEATURE_ID_ANY -1
+typedef struct _fpgainfo_config_data {
+        uint16_t vendor_id;
+        uint16_t device_id;
+        uint16_t subvendor_id;
+        uint16_t subdevice_id;
+        int32_t feature_id;
+        char *board_plugin;
+        void *dl_handle;
+        char product_name[256];
+} fpgainfo_config_data;
+
+fpgainfo_config_data *
+opae_parse_fpgainfo_config(const char *json_input);
+
+void opae_print_fpgainfo_config(fpgainfo_config_data *cfg);
+
+void opae_free_fpgainfo_config(fpgainfo_config_data *cfg);
+
+
+typedef struct _fpgad_config_data {
+	uint16_t vendor_id;
+	uint16_t device_id;
+	uint16_t subsystem_vendor_id;
+	uint16_t subsystem_device_id;
+	const char *module_library;
+#define FPGAD_DEV_DETECTED 0x00000001
+#define FPGAD_DEV_LOADED   0x00000002
+	uint32_t flags;
+	void *dl_handle;
+	const char *config_json;
+} fpgad_config_data;
+
+fpgad_config_data *
+opae_parse_fpgad_config(const char *json_input);
+
+void opae_print_fpgad_config(fpgad_config_data *cfg);
+
+void opae_free_fpgad_config(fpgad_config_data *cfg);
+
+
+
+static inline json_object *
+parse_json_array(json_object *parent, const char *name, int *len)
+{
+	json_object *jname = NULL;
+
+	if (!json_object_object_get_ex(parent, name, &jname)) {
+                OPAE_DBG("Error parsing JSON: missing '%s'", name);
+		return NULL;
+        }
+
+	if (!json_object_is_type(jname, json_type_array)) {
+                OPAE_DBG("'%s' JSON object not array type", name);
+                return NULL;
+        }
+
+	if (len)
+		*len = json_object_array_length(jname);
+
+	return jname;
+}
+
+static inline json_object *
+parse_json_boolean(json_object *parent, const char *name, bool *value)
+{
+	json_object *jname = NULL;
+
+	if (!json_object_object_get_ex(parent, name, &jname)) {
+                OPAE_DBG("Error parsing JSON: missing '%s'", name);
+		return NULL;
+        }
+
+	if (!json_object_is_type(jname, json_type_boolean)) {
+                OPAE_DBG("'%s' JSON object not boolean", name);
+                return NULL;
+        }
+
+	if (value)
+		*value = json_object_get_boolean(jname);
+
+	return jname;
+}
+
+static inline json_object *
+parse_json_string(json_object *parent, const char *name, char **value)
+{
+	json_object *jname = NULL;
+
+	if (!json_object_object_get_ex(parent, name, &jname)) {
+                OPAE_DBG("Error parsing JSON: missing '%s'", name);
+		return NULL;
+        }
+
+	if (!json_object_is_type(jname, json_type_string)) {
+                OPAE_DBG("'%s' JSON object not string", name);
+                return NULL;
+        }
+
+	if (value)
+		*value = (char *)json_object_get_string(jname);
+
+	return jname;
+}
+
+static inline int
+string_to_unsigned_wildcard(const char *s,
+			    unsigned long *u,
+			    unsigned long w)
+{
+	char *endptr = NULL;
+	unsigned long res;
+
+	if (*s == '*') {
+		if (u)
+			*u = w;
+		return 0;
+	}
+
+	res = strtoul(s, &endptr, 0);
+	if (endptr == s + strlen(s)) {
+		if (u)
+			*u = res;
+		return 0;
+	}
+
+	return 1;
+}
+
+static inline int
+string_to_signed_wildcard(const char *s,
+			  long *l,
+			  long w)
+{
+	char *endptr = NULL;
+	long res;
+
+	if (*s == '*') {
+		if (l)
+			*l = w;
+		return 0;
+	}
+
+	res = strtol(s, &endptr, 0);
+	if (endptr == s + strlen(s)) {
+		if (l)
+			*l = res;
+		return 0;
+	}
+
+	return 1;
+}
+
+#endif // __OPAE_CFG_FILE_H__

--- a/libraries/libopae-c/fpgad-cfg.c
+++ b/libraries/libopae-c/fpgad-cfg.c
@@ -1,0 +1,378 @@
+// Copyright(c) 2022, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <stdlib.h>
+#include <string.h>
+#include <opae/log.h>
+#include "mock/opae_std.h"
+#include "cfg-file.h"
+
+typedef struct _fpgad_parse_context {
+	fpgad_config_data *cfg;
+	fpgad_config_data *current;
+	int table_entries;
+} fpgad_parse_context;
+
+STATIC int resize_fpgad_context(fpgad_parse_context *ctx,
+				int num_new_entries)
+{
+	fpgad_config_data *save;
+	int save_entries;
+	int i;
+
+	if (!ctx->table_entries) {
+		// No table yet - allocate one.
+		// +1 for NULL terminator row.
+		ctx->cfg = opae_calloc(num_new_entries + 1,
+				       sizeof(fpgad_config_data));
+		if (!ctx->cfg) {
+			OPAE_ERR("calloc() failed");
+			return 1;
+		}
+		ctx->current = ctx->cfg;
+		ctx->table_entries = num_new_entries + 1;
+
+		return 0;
+	}
+
+	// We've already allocated ctx->cfg, so we need
+	// to resize it.
+	save = ctx->cfg;
+	save_entries = ctx->table_entries;
+
+	ctx->table_entries += num_new_entries;
+	ctx->cfg = opae_calloc(ctx->table_entries,
+			       sizeof(fpgad_config_data));
+	if (!ctx->cfg) {
+		OPAE_ERR("calloc() failed");
+		ctx->cfg = save;
+		ctx->table_entries = save_entries;
+		return 2;
+	}
+
+	for (i = 0 ; i < save_entries - 1 ; ++i)
+		ctx->cfg[i] = save[i];
+
+	ctx->current = &ctx->cfg[i];
+	opae_free(save);
+
+	return 0;
+}
+
+STATIC int parse_fpgad_plugin_config(json_object *root,
+				     const char *cfg_name,
+				     fpgad_parse_context *ctx)
+{
+	int res = 0;
+	json_object *j_configurations = NULL;
+	json_object *j_config = NULL;
+	json_object *j_config_enabled = NULL;
+	bool config_enabled = false;
+	json_object *j_config_devices = NULL;
+	int num_devices = 0;
+	opae_pci_device *pci_devices = NULL;
+	int d;
+	int i;
+	int j;
+	json_object *j_opae = NULL;
+	json_object *j_fpgad = NULL;
+	int num_fpgads = 0;
+	int table_entries = 0;
+
+	// Get the main "configurations" key.
+	if (!json_object_object_get_ex(root,
+				       "configurations",
+				       &j_configurations)) {
+		OPAE_ERR("Error parsing JSON: missing 'configurations'");
+		return 1;
+	}
+
+	// Get the config object corresponding to cfg_name.
+	if (!json_object_object_get_ex(j_configurations,
+				       cfg_name,
+				       &j_config)) {
+		OPAE_ERR("Error parsing JSON: missing '%s' config", cfg_name);
+		return 2;
+	}
+
+	// Determine whether the config is enabled.
+	j_config_enabled = parse_json_boolean(j_config,
+					      "enabled",
+					      &config_enabled);
+	if (!j_config_enabled || !config_enabled) {
+		// "enabled" key not found or is false.
+		OPAE_DBG("config %s is disabled", cfg_name);
+		return 0; // not fatal
+	}
+
+	// Get the "devices" array from the current config.
+	j_config_devices = parse_json_array(j_config,
+					    "devices",
+					    &num_devices);
+	if (!j_config_devices || !num_devices) {
+		OPAE_ERR("\"devices\" not found or empty");
+		return 3;
+	}
+
+	// Allocate a chunk of memory to hold the parsed "devices" data.
+	pci_devices = opae_calloc(num_devices, sizeof(opae_pci_device));
+	if (!pci_devices) {
+		OPAE_ERR("calloc() failed");
+		return 4;
+	}
+
+	// Parse each "devices" array entry.
+	for (d = 0 ; d < num_devices ; ++d) {
+		json_object *j_config_devices_i =
+			json_object_array_get_idx(j_config_devices, d);
+		char *name = NULL;
+		json_object *j_id = NULL;
+		int id_len = 0;
+
+		if (!parse_json_string(j_config_devices_i,
+				       "name",
+				       &name)) {
+			OPAE_ERR("config's devices[%d] "
+				 "has no \"name\" key", d);
+			res = 5;
+			goto out_free;
+		}
+		pci_devices[d].name = name;
+
+		j_id = parse_json_array(j_config_devices_i,
+					"id",
+					&id_len);
+		if (!j_id || id_len != ID_SIZE) {
+			OPAE_ERR("devices[%d] \"id\" field not present "
+				 " or wrong size", d);
+			res = 6;
+			goto out_free;
+		}
+
+		if (opae_parse_device_id(j_id, &pci_devices[d])) {
+			res = 7;
+			goto out_free;
+		}
+	}
+
+	// Get the "opae" object from the config.
+	if (!json_object_object_get_ex(j_config, "opae", &j_opae)) {
+		OPAE_ERR("Error parsing JSON: missing \"opae\" in config");
+		res = 8;
+		goto out_free;
+	}
+
+	// Get the "fpgad" object from "opae".
+	j_fpgad = parse_json_array(j_opae, "fpgad", &num_fpgads);
+	if (!j_fpgad || !num_fpgads) {
+		OPAE_DBG("Skipping \"fpgad\" section in %s", cfg_name);
+		goto out_free; // not fatal (res == 0)
+	}
+
+	// First scan of "fpgad" counts the required number of
+	// configuration table entries.
+	for (i = 0 ; i < num_fpgads ; ++i) {
+		json_object *j_fpgad_i =
+			json_object_array_get_idx(j_fpgad, i);
+		int num_devices_i = 0;
+		json_object *j_devices = NULL;
+		json_object *j_enabled = NULL;
+		bool enabled = false;
+
+		j_enabled =
+			parse_json_boolean(j_fpgad_i, "enabled", &enabled);
+		if (!j_enabled || !enabled) {
+			OPAE_DBG("fpgad[%d] in %s not enabled. skipping",
+				 i, cfg_name);
+			continue;
+		}
+
+		j_devices =
+			parse_json_array(j_fpgad_i, "devices", &num_devices_i);
+		if (!j_devices || !num_devices) {
+			OPAE_DBG("fpgad[%d] \"devices\" in %s missing "
+				 "or empty. skipping", i, cfg_name);
+			continue;
+		}
+
+		table_entries += num_devices_i;
+	}
+
+	// Resize our configuration data table.
+	if (resize_fpgad_context(ctx, table_entries)) {
+		res = 9;
+		goto out_free;
+	}
+
+	// Second scan of "fpgad" populates the context's
+	// configuration table entries.
+	for (i = 0 ; i < num_fpgads ; ++i) {
+		json_object *j_fpgad_i =
+			json_object_array_get_idx(j_fpgad, i);
+		int num_devices_i = 0;
+		json_object *j_devices = NULL;
+		json_object *j_enabled = NULL;
+		bool enabled = false;
+		json_object *j_module = NULL;
+		char *module = NULL;
+		json_object *j_configuration = NULL;
+		char *configuration = NULL;
+
+		j_enabled =
+			parse_json_boolean(j_fpgad_i, "enabled", &enabled);
+		if (!j_enabled || !enabled) {
+			OPAE_DBG("fpgad[%d] in %s not enabled. skipping",
+				 i, cfg_name);
+			continue;
+		}
+
+		j_devices =
+			parse_json_array(j_fpgad_i, "devices", &num_devices_i);
+		if (!j_devices || !num_devices) {
+			OPAE_DBG("fpgad[%d] \"devices\" in %s missing "
+				 "or empty. skipping", i, cfg_name);
+			continue;
+		}
+
+		j_module =
+			parse_json_string(j_fpgad_i, "module", &module);
+		if (!j_module || !strlen(module)) {
+			OPAE_ERR("fpgad[%d] \"module\" in %s missing "
+				 "or empty.", i, cfg_name);
+			res = 10;
+			goto out_free;
+		}
+
+		if (!json_object_object_get_ex(j_fpgad_i,
+					       "configuration",
+					       &j_configuration)) {
+			OPAE_ERR("fpgad[%d] \"configuration\" in %s missing "
+				 "or invalid.", i, cfg_name);
+			res = 11;
+			goto out_free;
+		}
+
+		configuration = (char *)
+			json_object_to_json_string_ext(j_configuration,
+						       JSON_C_TO_STRING_PLAIN);
+
+		for (j = 0 ; j < num_devices_i ; ++j) {
+			json_object *j_device_j =
+				json_object_array_get_idx(j_devices, j);
+			const char *dev_name = NULL;
+			fpgad_config_data *pcfg;
+			opae_pci_device *dev;
+
+			if (!json_object_is_type(j_device_j,
+						 json_type_string)) {
+				OPAE_ERR("Non-string JSON item "
+					 "found in 'devices[%d]'", j);
+				res = 11;
+				goto out_free;
+			}
+
+			dev_name = json_object_get_string(j_device_j);
+
+			// Find the device named dev_name in pci_devices.
+			for (d = 0 ; d < num_devices ; ++d) {
+				if (!strncmp(dev_name,
+					     pci_devices[d].name,
+					     MAX_DEV_NAME))
+					break;
+			}
+
+			if (d == num_devices) {
+				OPAE_ERR("device %s not found\n", dev_name);
+				res = 12;
+				goto out_free;
+			}
+
+			pcfg = ctx->current;
+			++(ctx->current);
+			dev = &pci_devices[d];
+
+			pcfg->vendor_id = dev->vendor_id;
+			pcfg->device_id = dev->device_id;
+			pcfg->subsystem_vendor_id = dev->subsystem_vendor_id;
+			pcfg->subsystem_device_id = dev->subsystem_device_id;
+
+			pcfg->module_library = opae_strdup(module);
+			pcfg->config_json = opae_strdup(configuration);
+		}
+	}
+
+out_free:
+	opae_free(pci_devices);
+	return res;
+}
+
+fpgad_config_data *
+opae_parse_fpgad_json(const char *json_input)
+{
+	enum json_tokener_error j_err = json_tokener_success;
+	json_object *root = NULL;
+	json_object *j_configs = NULL;
+
+	int i;
+	int num_configs = 0;
+
+	fpgad_parse_context ctx = { NULL, NULL, 0 };
+
+	root = json_tokener_parse_verbose(json_input, &j_err);
+	if (!root) {
+		OPAE_ERR("Config JSON parse failed: %s",
+			 json_tokener_error_desc(j_err));
+		goto out_free;
+	}
+
+	j_configs = parse_json_array(root, "configs", &num_configs);
+	if (!j_configs)
+		goto out_free;
+
+	for (i = 0 ; i < num_configs ; ++i) {
+		json_object *j_config_i =
+			json_object_array_get_idx(j_configs, i);
+		const char *config_i =
+			json_object_get_string(j_config_i);
+
+		if (parse_fpgad_plugin_config(root, config_i, &ctx))
+			goto out_parse_failed;
+	}
+
+	goto out_free;
+
+out_parse_failed:
+	opae_free_fpgad_config(ctx.cfg);
+	ctx.cfg = NULL;
+out_free:
+	if (root)
+		json_object_put(root);
+	opae_free((char *)json_input);
+	return ctx.cfg;
+}

--- a/libraries/libopae-c/fpgainfo-cfg.c
+++ b/libraries/libopae-c/fpgainfo-cfg.c
@@ -1,0 +1,405 @@
+// Copyright(c) 2022, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <stdlib.h>
+#include <string.h>
+#include <opae/log.h>
+#include "mock/opae_std.h"
+#include "cfg-file.h"
+
+typedef struct _fpgainfo_parse_context {
+	fpgainfo_config_data *cfg;
+	fpgainfo_config_data *current;
+	int table_entries;
+} fpgainfo_parse_context;
+
+STATIC int resize_fpgainfo_context(fpgainfo_parse_context *ctx,
+				   int num_new_entries)
+{
+	fpgainfo_config_data *save;
+	int save_entries;
+	int i;
+
+	if (!ctx->table_entries) {
+		// No table yet - allocate one.
+		// +1 for NULL terminator row.
+		ctx->cfg = opae_calloc(num_new_entries + 1,
+				       sizeof(fpgainfo_config_data));
+		if (!ctx->cfg) {
+			OPAE_ERR("calloc() failed");
+			return 1;
+		}
+		ctx->current = ctx->cfg;
+		ctx->table_entries = num_new_entries + 1;
+
+		return 0;
+	}
+
+	// We've already allocated ctx->cfg, so we need
+	// to resize it.
+	save = ctx->cfg;
+	save_entries = ctx->table_entries;
+
+	ctx->table_entries += num_new_entries;
+	ctx->cfg = opae_calloc(ctx->table_entries,
+			       sizeof(fpgainfo_config_data));
+	if (!ctx->cfg) {
+		OPAE_ERR("calloc() failed");
+		ctx->cfg = save;
+		ctx->table_entries = save_entries;
+		return 2;
+	}
+
+	for (i = 0 ; i < save_entries - 1 ; ++i)
+		ctx->cfg[i] = save[i];
+
+	ctx->current = &ctx->cfg[i];
+	opae_free(save);
+
+	return 0;
+}
+
+STATIC int parse_fpgainfo_plugin_config(json_object *root,
+					const char *cfg_name,
+					fpgainfo_parse_context *ctx)
+{
+	int res = 0;
+	json_object *j_configurations = NULL;
+	json_object *j_config = NULL;
+	json_object *j_config_enabled = NULL;
+	bool config_enabled = false;
+	json_object *j_config_devices = NULL;
+	char *platform = NULL;
+	json_object *j_config_platform = NULL;
+	int num_devices = 0;
+	opae_pci_device *pci_devices = NULL;
+	int d;
+	int i;
+	int j;
+	json_object *j_opae = NULL;
+	json_object *j_fpgainfo = NULL;
+	int num_fpgainfos = 0;
+	int table_entries = 0;
+
+	// Get the main "configurations" key.
+	if (!json_object_object_get_ex(root,
+				       "configurations",
+				       &j_configurations)) {
+		OPAE_ERR("Error parsing JSON: missing 'configurations'");
+		return 1;
+	}
+
+	// Get the config object corresponding to cfg_name.
+	if (!json_object_object_get_ex(j_configurations,
+				       cfg_name,
+				       &j_config)) {
+		OPAE_ERR("Error parsing JSON: missing '%s' config", cfg_name);
+		return 2;
+	}
+
+	// Determine whether the config is enabled.
+	j_config_enabled = parse_json_boolean(j_config,
+					      "enabled",
+					      &config_enabled);
+	if (!j_config_enabled || !config_enabled) {
+		// "enabled" key not found or is false.
+		OPAE_DBG("config %s is disabled", cfg_name);
+		return 0; // not fatal
+	}
+
+	j_config_platform = parse_json_string(j_config,
+					      "platform",
+					      &platform);
+	if (!j_config_platform || !platform || !strlen(platform)) {
+		// "platform string not found or is empty.
+		OPAE_ERR("\"platform\" key missing from config %s",
+			 cfg_name);
+		return 3;
+	}
+
+	// Get the "devices" array from the current config.
+	j_config_devices = parse_json_array(j_config,
+					    "devices",
+					    &num_devices);
+	if (!j_config_devices || !num_devices) {
+		OPAE_ERR("\"devices\" not found or empty");
+		return 4;
+	}
+
+	// Allocate a chunk of memory to hold the parsed "devices" data.
+	pci_devices = opae_calloc(num_devices, sizeof(opae_pci_device));
+	if (!pci_devices) {
+		OPAE_ERR("calloc() failed");
+		return 5;
+	}
+
+	// Parse each "devices" array entry.
+	for (d = 0 ; d < num_devices ; ++d) {
+		json_object *j_config_devices_i =
+			json_object_array_get_idx(j_config_devices, d);
+		char *name = NULL;
+		json_object *j_id = NULL;
+		int id_len = 0;
+
+		if (!parse_json_string(j_config_devices_i,
+				       "name",
+				       &name)) {
+			OPAE_ERR("config's devices[%d] "
+				 "has no \"name\" key", d);
+			res = 6;
+			goto out_free;
+		}
+		pci_devices[d].name = name;
+
+		j_id = parse_json_array(j_config_devices_i,
+					"id",
+					&id_len);
+		if (!j_id || id_len != ID_SIZE) {
+			OPAE_ERR("devices[%d] \"id\" field not present "
+				 " or wrong size", d);
+			res = 7;
+			goto out_free;
+		}
+
+		if (opae_parse_device_id(j_id, &pci_devices[d])) {
+			res = 8;
+			goto out_free;
+		}
+	}
+
+	// Get the "opae" object from the config.
+	if (!json_object_object_get_ex(j_config, "opae", &j_opae)) {
+		OPAE_ERR("Error parsing JSON: missing \"opae\" in config");
+		res = 9;
+		goto out_free;
+	}
+
+	// Get the "fpgainfo" object from "opae".
+	j_fpgainfo = parse_json_array(j_opae, "fpgainfo", &num_fpgainfos);
+	if (!j_fpgainfo || !num_fpgainfos) {
+		OPAE_DBG("Skipping \"fpgainfo\" section in %s", cfg_name);
+		goto out_free; // not fatal (res == 0)
+	}
+
+	// First scan of "fpgainfos" counts the required number of
+	// configuration table entries.
+	for (i = 0 ; i < num_fpgainfos ; ++i) {
+		json_object *j_fpgainfo_i =
+			json_object_array_get_idx(j_fpgainfo, i);
+		int num_devices_i = 0;
+		json_object *j_devices = NULL;
+		json_object *j_enabled = NULL;
+		bool enabled = false;
+
+		j_enabled =
+			parse_json_boolean(j_fpgainfo_i, "enabled", &enabled);
+		if (!j_enabled || !enabled) {
+			OPAE_DBG("fpgainfo[%d] in %s not enabled. skipping",
+				 i, cfg_name);
+			continue;
+		}
+
+		j_devices =
+			parse_json_array(j_fpgainfo_i, "devices", &num_devices_i);
+		if (!j_devices || !num_devices) {
+			OPAE_DBG("fpgainfo[%d] \"devices\" in %s missing "
+				 "or empty. skipping", i, cfg_name);
+			continue;
+		}
+
+		table_entries += num_devices_i;
+	}
+
+	// Resize our configuration data table.
+	if (resize_fpgainfo_context(ctx, table_entries)) {
+		res = 10;
+		goto out_free;
+	}
+
+	// Second scan of "fpgainfo" populates the context's
+	// configuration table entries.
+	for (i = 0 ; i < num_fpgainfos ; ++i) {
+		json_object *j_fpgainfo_i =
+			json_object_array_get_idx(j_fpgainfo, i);
+		int num_devices_i = 0;
+		json_object *j_devices = NULL;
+		json_object *j_enabled = NULL;
+		bool enabled = false;
+		json_object *j_module = NULL;
+		char *module = NULL;
+
+		j_enabled =
+			parse_json_boolean(j_fpgainfo_i, "enabled", &enabled);
+		if (!j_enabled || !enabled) {
+			OPAE_DBG("fpgainfo[%d] in %s not enabled. skipping",
+				 i, cfg_name);
+			continue;
+		}
+
+		j_devices =
+			parse_json_array(j_fpgainfo_i, "devices", &num_devices_i);
+		if (!j_devices || !num_devices) {
+			OPAE_DBG("fpgainfo[%d] \"devices\" in %s missing "
+				 "or empty. skipping", i, cfg_name);
+			continue;
+		}
+
+		j_module =
+			parse_json_string(j_fpgainfo_i, "module", &module);
+		if (!j_module || !strlen(module)) {
+			OPAE_ERR("fpgainfo[%d] \"module\" in %s missing "
+				 "or empty.", i, cfg_name);
+			res = 11;
+			goto out_free;
+		}
+
+		for (j = 0 ; j < num_devices_i ; ++j) {
+			json_object *j_device_j =
+				json_object_array_get_idx(j_devices, j);
+			char *dev_name = NULL;
+			json_object *j_device_name = NULL;
+			char *feature_id = NULL;
+			json_object *j_device_feature_id = NULL;
+			fpgainfo_config_data *pcfg;
+			opae_pci_device *dev;
+			long l = 0;
+
+			j_device_name =
+				parse_json_string(j_device_j,
+						  "device",
+						  &dev_name);
+			if (!j_device_name) {
+				OPAE_ERR("Failed to read device[%d] "
+					 "name from config %s", j, cfg_name);
+				res = 12;
+				goto out_free;
+			}
+
+			j_device_feature_id =
+				parse_json_string(j_device_j,
+						  "feature_id",
+						  &feature_id);
+			if (!j_device_feature_id) {
+				OPAE_ERR("Failed to read device[%d] "
+					 "feature_id from config %s",
+					 j, cfg_name);
+				res = 13;
+				goto out_free;
+			}
+
+			if (string_to_signed_wildcard(feature_id,
+						      &l,
+						      OPAE_FEATURE_ID_ANY)) {
+				OPAE_ERR("device[%d] "
+					 "feature_id is invalid %s",
+					 j, cfg_name);
+				res = 14;
+				goto out_free;
+			}
+
+			// Find the device named dev_name in pci_devices.
+			for (d = 0 ; d < num_devices ; ++d) {
+				if (!strncmp(dev_name,
+					     pci_devices[d].name,
+					     MAX_DEV_NAME))
+					break;
+			}
+
+			if (d == num_devices) {
+				OPAE_ERR("device %s not found\n", dev_name);
+				res = 15;
+				goto out_free;
+			}
+
+			pcfg = ctx->current;
+			++(ctx->current);
+			dev = &pci_devices[d];
+
+			pcfg->vendor_id = dev->vendor_id;
+			pcfg->device_id = dev->device_id;
+			pcfg->subvendor_id = dev->subsystem_vendor_id;
+			pcfg->subdevice_id = dev->subsystem_device_id;
+			pcfg->feature_id = l;
+
+			pcfg->board_plugin = opae_strdup(module);
+			memcpy(pcfg->product_name,
+			       platform,
+			       strlen(platform) + 1);
+		}
+	}
+
+out_free:
+	opae_free(pci_devices);
+	return res;
+}
+
+fpgainfo_config_data *
+opae_parse_fpgainfo_json(const char *json_input)
+{
+	enum json_tokener_error j_err = json_tokener_success;
+	json_object *root = NULL;
+	json_object *j_configs = NULL;
+
+	int i;
+	int num_configs = 0;
+
+	fpgainfo_parse_context ctx = { NULL, NULL, 0 };
+
+	root = json_tokener_parse_verbose(json_input, &j_err);
+	if (!root) {
+		OPAE_ERR("Config JSON parse failed: %s",
+			 json_tokener_error_desc(j_err));
+		goto out_free;
+	}
+
+	j_configs = parse_json_array(root, "configs", &num_configs);
+	if (!j_configs)
+		goto out_free;
+
+	for (i = 0 ; i < num_configs ; ++i) {
+		json_object *j_config_i =
+			json_object_array_get_idx(j_configs, i);
+		const char *config_i =
+			json_object_get_string(j_config_i);
+
+		if (parse_fpgainfo_plugin_config(root, config_i, &ctx))
+			goto out_parse_failed;
+	}
+
+	goto out_free;
+
+out_parse_failed:
+	opae_free_fpgainfo_config(ctx.cfg);
+	ctx.cfg = NULL;
+out_free:
+	if (root)
+		json_object_put(root);
+	opae_free((char *)json_input);
+	return ctx.cfg;
+}

--- a/libraries/libopae-c/opae-cfg.c
+++ b/libraries/libopae-c/opae-cfg.c
@@ -1,0 +1,378 @@
+// Copyright(c) 2022, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <stdlib.h>
+#include <string.h>
+#include <opae/log.h>
+#include "mock/opae_std.h"
+#include "cfg-file.h"
+
+typedef struct _libopae_parse_context {
+	libopae_config_data *cfg;
+	libopae_config_data *current;
+	int table_entries;
+} libopae_parse_context;
+
+STATIC int resize_context(libopae_parse_context *ctx,
+			  int num_new_entries)
+{
+	libopae_config_data *save;
+	int save_entries;
+	int i;
+
+	if (!ctx->table_entries) {
+		// No table yet - allocate one.
+		// +1 for NULL terminator row.
+		ctx->cfg = opae_calloc(num_new_entries + 1,
+				       sizeof(libopae_config_data));
+		if (!ctx->cfg) {
+			OPAE_ERR("calloc() failed");
+			return 1;
+		}
+		ctx->current = ctx->cfg;
+		ctx->table_entries = num_new_entries + 1;
+
+		return 0;
+	}
+
+	// We've already allocated ctx->cfg, so we need
+	// to resize it.
+	save = ctx->cfg;
+	save_entries = ctx->table_entries;
+
+	ctx->table_entries += num_new_entries;
+	ctx->cfg = opae_calloc(ctx->table_entries,
+			       sizeof(libopae_config_data));
+	if (!ctx->cfg) {
+		OPAE_ERR("calloc() failed");
+		ctx->cfg = save;
+		ctx->table_entries = save_entries;
+		return 2;
+	}
+
+	for (i = 0 ; i < save_entries - 1 ; ++i)
+		ctx->cfg[i] = save[i];
+
+	ctx->current = &ctx->cfg[i];
+	opae_free(save);
+
+	return 0;
+}
+
+STATIC int parse_plugin_config(json_object *root,
+			       const char *cfg_name,
+			       libopae_parse_context *ctx)
+{
+	int res = 0;
+	json_object *j_configurations = NULL;
+	json_object *j_config = NULL;
+	json_object *j_config_enabled = NULL;
+	bool config_enabled = false;
+	json_object *j_config_devices = NULL;
+	int num_devices = 0;
+	opae_pci_device *pci_devices = NULL;
+	int d;
+	int i;
+	int j;
+	json_object *j_opae = NULL;
+	json_object *j_plugin = NULL;
+	int num_plugins = 0;
+	int table_entries = 0;
+
+	// Get the main "configurations" key.
+	if (!json_object_object_get_ex(root,
+				       "configurations",
+				       &j_configurations)) {
+		OPAE_ERR("Error parsing JSON: missing 'configurations'");
+		return 1;
+	}
+
+	// Get the config object corresponding to cfg_name.
+	if (!json_object_object_get_ex(j_configurations,
+				       cfg_name,
+				       &j_config)) {
+		OPAE_ERR("Error parsing JSON: missing '%s' config", cfg_name);
+		return 2;
+	}
+
+	// Determine whether the config is enabled.
+	j_config_enabled = parse_json_boolean(j_config,
+					      "enabled",
+					      &config_enabled);
+	if (!j_config_enabled || !config_enabled) {
+		// "enabled" key not found or is false.
+		OPAE_DBG("config %s is disabled", cfg_name);
+		return 0; // not fatal
+	}
+
+	// Get the "devices" array from the current config.
+	j_config_devices = parse_json_array(j_config,
+					    "devices",
+					    &num_devices);
+	if (!j_config_devices || !num_devices) {
+		OPAE_ERR("\"devices\" not found or empty");
+		return 3;
+	}
+
+	// Allocate a chunk of memory to hold the parsed "devices" data.
+	pci_devices = opae_calloc(num_devices, sizeof(opae_pci_device));
+	if (!pci_devices) {
+		OPAE_ERR("calloc() failed");
+		return 4;
+	}
+
+	// Parse each "devices" array entry.
+	for (d = 0 ; d < num_devices ; ++d) {
+		json_object *j_config_devices_i =
+			json_object_array_get_idx(j_config_devices, d);
+		char *name = NULL;
+		json_object *j_id = NULL;
+		int id_len = 0;
+
+		if (!parse_json_string(j_config_devices_i,
+				       "name",
+				       &name)) {
+			OPAE_ERR("config's devices[%d] "
+				 "has no \"name\" key", d);
+			res = 5;
+			goto out_free;
+		}
+		pci_devices[d].name = name;
+
+		j_id = parse_json_array(j_config_devices_i,
+					"id",
+					&id_len);
+		if (!j_id || id_len != ID_SIZE) {
+			OPAE_ERR("devices[%d] \"id\" field not present "
+				 " or wrong size", d);
+			res = 6;
+			goto out_free;
+		}
+
+		if (opae_parse_device_id(j_id, &pci_devices[d])) {
+			res = 7;
+			goto out_free;
+		}
+	}
+
+	// Get the "opae" object from the config.
+	if (!json_object_object_get_ex(j_config, "opae", &j_opae)) {
+		OPAE_ERR("Error parsing JSON: missing \"opae\" in config");
+		res = 8;
+		goto out_free;
+	}
+
+	// Get the "plugin" object from "opae".
+	j_plugin = parse_json_array(j_opae, "plugin", &num_plugins);
+	if (!j_plugin || !num_plugins) {
+		OPAE_DBG("Skipping \"plugin\" section in %s", cfg_name);
+		goto out_free; // not fatal (res == 0)
+	}
+
+	// First scan of "plugin" counts the required number of
+	// configuration table entries.
+	for (i = 0 ; i < num_plugins ; ++i) {
+		json_object *j_plugin_i =
+			json_object_array_get_idx(j_plugin, i);
+		int num_devices_i = 0;
+		json_object *j_devices = NULL;
+		json_object *j_enabled = NULL;
+		bool enabled = false;
+
+		j_enabled =
+			parse_json_boolean(j_plugin_i, "enabled", &enabled);
+		if (!j_enabled || !enabled) {
+			OPAE_DBG("plugin[%d] in %s not enabled. skipping",
+				 i, cfg_name);
+			continue;
+		}
+
+		j_devices =
+			parse_json_array(j_plugin_i, "devices", &num_devices_i);
+		if (!j_devices || !num_devices) {
+			OPAE_DBG("plugin[%d] \"devices\" in %s missing "
+				 "or empty. skipping", i, cfg_name);
+			continue;
+		}
+
+		table_entries += num_devices_i;
+	}
+
+	// Resize our configuration data table.
+	if (resize_context(ctx, table_entries)) {
+		res = 9;
+		goto out_free;
+	}
+
+	// Second scan of "plugin" populates the context's
+	// configuration table entries.
+	for (i = 0 ; i < num_plugins ; ++i) {
+		json_object *j_plugin_i =
+			json_object_array_get_idx(j_plugin, i);
+		int num_devices_i = 0;
+		json_object *j_devices = NULL;
+		json_object *j_enabled = NULL;
+		bool enabled = false;
+		json_object *j_module = NULL;
+		char *module = NULL;
+		json_object *j_configuration = NULL;
+		char *configuration = NULL;
+
+		j_enabled =
+			parse_json_boolean(j_plugin_i, "enabled", &enabled);
+		if (!j_enabled || !enabled) {
+			OPAE_DBG("plugin[%d] in %s not enabled. skipping",
+				 i, cfg_name);
+			continue;
+		}
+
+		j_devices =
+			parse_json_array(j_plugin_i, "devices", &num_devices_i);
+		if (!j_devices || !num_devices) {
+			OPAE_DBG("plugin[%d] \"devices\" in %s missing "
+				 "or empty. skipping", i, cfg_name);
+			continue;
+		}
+
+		j_module =
+			parse_json_string(j_plugin_i, "module", &module);
+		if (!j_module || !strlen(module)) {
+			OPAE_ERR("plugin[%d] \"module\" in %s missing "
+				 "or empty.", i, cfg_name);
+			res = 10;
+			goto out_free;
+		}
+
+		if (!json_object_object_get_ex(j_plugin_i,
+					       "configuration",
+					       &j_configuration)) {
+			OPAE_ERR("plugin[%d] \"configuration\" in %s missing "
+				 "or invalid.", i, cfg_name);
+			res = 11;
+			goto out_free;
+		}
+
+		configuration = (char *)
+			json_object_to_json_string_ext(j_configuration,
+						       JSON_C_TO_STRING_PLAIN);
+
+		for (j = 0 ; j < num_devices_i ; ++j) {
+			json_object *j_device_j =
+				json_object_array_get_idx(j_devices, j);
+			const char *dev_name = NULL;
+			libopae_config_data *pcfg;
+			opae_pci_device *dev;
+
+			if (!json_object_is_type(j_device_j,
+						 json_type_string)) {
+				OPAE_ERR("Non-string JSON item "
+					 "found in 'devices[%d]'", j);
+				res = 11;
+				goto out_free;
+			}
+
+			dev_name = json_object_get_string(j_device_j);
+
+			// Find the device named dev_name in pci_devices.
+			for (d = 0 ; d < num_devices ; ++d) {
+				if (!strncmp(dev_name,
+					     pci_devices[d].name,
+					     MAX_DEV_NAME))
+					break;
+			}
+
+			if (d == num_devices) {
+				OPAE_ERR("device %s not found\n", dev_name);
+				res = 12;
+				goto out_free;
+			}
+
+			pcfg = ctx->current;
+			++(ctx->current);
+			dev = &pci_devices[d];
+
+			pcfg->vendor_id = dev->vendor_id;
+			pcfg->device_id = dev->device_id;
+			pcfg->subsystem_vendor_id = dev->subsystem_vendor_id;
+			pcfg->subsystem_device_id = dev->subsystem_device_id;
+
+			pcfg->module_library = opae_strdup(module);
+			pcfg->config_json = opae_strdup(configuration);
+		}
+	}
+
+out_free:
+	opae_free(pci_devices);
+	return res;
+}
+
+libopae_config_data *
+opae_parse_libopae_json(const char *json_input)
+{
+	enum json_tokener_error j_err = json_tokener_success;
+	json_object *root = NULL;
+	json_object *j_configs = NULL;
+
+	int i;
+	int num_configs = 0;
+
+	libopae_parse_context ctx = { NULL, NULL, 0 };
+
+	root = json_tokener_parse_verbose(json_input, &j_err);
+	if (!root) {
+		OPAE_ERR("Config JSON parse failed: %s",
+			 json_tokener_error_desc(j_err));
+		goto out_free;
+	}
+
+	j_configs = parse_json_array(root, "configs", &num_configs);
+	if (!j_configs)
+		goto out_free;
+
+	for (i = 0 ; i < num_configs ; ++i) {
+		json_object *j_config_i =
+			json_object_array_get_idx(j_configs, i);
+		const char *config_i =
+			json_object_get_string(j_config_i);
+
+		if (parse_plugin_config(root, config_i, &ctx))
+			goto out_parse_failed;
+	}
+
+	goto out_free;
+
+out_parse_failed:
+	opae_free_libopae_config(ctx.cfg);
+	ctx.cfg = NULL;
+out_free:
+	if (root)
+		json_object_put(root);
+	opae_free((char *)json_input);
+	return ctx.cfg;
+}

--- a/opae.cfg
+++ b/opae.cfg
@@ -1,6 +1,31 @@
 {
   "configurations": {
 
+    "mcp" : {
+      "enabled": true,
+      "platform": "Intel Integrated Multi-Chip Acceleration Platform",
+
+      "devices": [
+        { "name": "mcp0_pf", "id": [ "0x8086", "0xbcbd", "*", "*" ] },
+        { "name": "mcp1_pf", "id": [ "0x8086", "0xbcc0", "*", "*" ] },
+        { "name": "mcp1_vf", "id": [ "0x8086", "0xbcc1", "*", "*" ] }
+      ],
+
+      "opae": {
+        "plugin": [
+          {
+            "enabled": true,
+            "module": "libxfpga.so",
+            "devices": [ "mcp0_pf", "mcp1_pf", "mcp1_vf" ],
+            "configuration": {}
+          }
+        ],
+        "fpgainfo": [],
+        "fpgad": [],
+        "rsu": [] 
+      }
+    },
+
     "a10gx": {
       "enabled": true,
       "platform": "Intel Programmable Acceleration Card with Intel Arria 10 GX FPGA",
@@ -440,6 +465,7 @@
   },
 
   "configs": [
+    "mcp",
     "a10gx",
     "d5005",
     "n3000",

--- a/tests/opae-c/CMakeLists.txt
+++ b/tests/opae-c/CMakeLists.txt
@@ -27,12 +27,16 @@
 opae_test_add_static_lib(TARGET opae-c-static
     SOURCE
         ${OPAE_LIB_SOURCE}/libopae-c/api-shell.c
-	${OPAE_LIB_SOURCE}/libopae-c/init.c
-	${OPAE_LIB_SOURCE}/libopae-c/pluginmgr.c
-	${OPAE_LIB_SOURCE}/libopae-c/props.c
+        ${OPAE_LIB_SOURCE}/libopae-c/init.c
+        ${OPAE_LIB_SOURCE}/libopae-c/pluginmgr.c
+        ${OPAE_LIB_SOURCE}/libopae-c/props.c
+        ${OPAE_LIB_SOURCE}/libopae-c/cfg-file.c
+        ${OPAE_LIB_SOURCE}/libopae-c/fpgad-cfg.c
+        ${OPAE_LIB_SOURCE}/libopae-c/fpgainfo-cfg.c
+        ${OPAE_LIB_SOURCE}/libopae-c/opae-cfg.c
     LIBS
         ${CMAKE_THREAD_LIBS_INIT}
-	${libjson-c_LIBRARIES}
+        ${libjson-c_LIBRARIES}
 )
 
 opae_test_add(TARGET self_test


### PR DESCRIPTION
Adds the config file parsing code for libopae-c, fpgainfo, and
fpgad to the libopae-c build.
Add "mcp" configuration to opae.cfg, as it still persists in
libopae-c's default device table.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>