### PR TITLE
Don't use the deprecated and removed os.errno

### DIFF
--- a/platforms/scripts/afu_synth_setup
+++ b/platforms/scripts/afu_synth_setup
@@ -131,7 +131,7 @@ def commands_list(cmd, cwd=None, stdout=None):
     try:
         subprocess.check_call(cmd, cwd=cwd, stdout=stdout, env=getCmdEnv())
     except OSError as e:
-        if e.errno == os.errno.ENOENT:
+        if e.errno == errno.ENOENT:
             msg = cmd[0] + " not found on PATH!"
             errorExit(msg)
         else:
@@ -151,7 +151,7 @@ def commands_list_getoutput(cmd, cwd=None):
         byte_out = subprocess.check_output(cmd, cwd=cwd, env=getCmdEnv())
         str_out = byte_out.decode()
     except OSError as e:
-        if e.errno == os.errno.ENOENT:
+        if e.errno == errno.ENOENT:
             msg = cmd[0] + " not found on PATH!"
             errorExit(msg)
         else:


### PR DESCRIPTION
This API was apparently undocumented, and it was removed altogether in
the 3.7 timeframe: https://bugs.python.org/issue33666