### PR TITLE
fpgasupdate: (Cherry-pick) changes related to new SDM driver

### DIFF
--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -453,7 +453,8 @@ class fpga_base(sysfs_device):
         spi = f.spi_bus
         if spi:
             patterns = ['*-sec*.auto/*fpga_sec_mgr*/*fpga_sec*',
-                        '*-sec*.auto/fpga_image_load/fpga_image*']
+                        '*-sec*.auto/fpga_image_load/fpga_image*',
+                        '*-sec*.auto/firmware/secure-update*' ]
             for pattern in patterns:
                 fpga_sec = spi.find_one(pattern)
                 if fpga_sec:
@@ -461,7 +462,8 @@ class fpga_base(sysfs_device):
         else:
             pmci = f.pmci_bus
             patterns = ['*fpga_sec_mgr*/*fpga_sec*',
-                        'fpga_image_load/fpga_image*']
+                        'fpga_image_load/fpga_image*',
+                        'firmware/secure-update*' ]
             for pattern in patterns:
                 fpga_sec = pmci.find_one(pattern)
                 if fpga_sec:

--- a/python/opae.admin/opae/admin/sysfs.py
+++ b/python/opae.admin/opae/admin/sysfs.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019, Intel Corporation
+# Copyright(c) 2019-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -177,6 +177,23 @@ class sysfs_node(loggable):
         else:
             with self._open('w') as fd:
                 fd.write(str(val))
+
+    @property
+    def bin_value(self):
+        try:
+            with self._open('rb') as fd:
+                return fd.read()
+        except IOError as err:
+            self.log.exception('error (bin)opening: %s - %s', self.sysfs_path, err)
+            raise
+
+    @bin_value.setter
+    def bin_value(self, val):
+        if DRY_RUN:
+            print('echo {} > {}'.format('(bin)', self._sysfs_path))
+        else:
+            with self._open('w+b') as fd:
+                fd.write(val)
 
     @property
     def sysfs_path(self):

--- a/python/opae.admin/opae/admin/version.py
+++ b/python/opae.admin/opae/admin/version.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2020, Intel Corporation
+# Copyright(c) 2020-2022, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -34,7 +34,7 @@ except ImportError:
 version = {
     'major': 1,
     'minor': 4,
-    'patch': 1
+    'patch': 2
 }
 
 


### PR DESCRIPTION
The secure device manager changed back to a sysfs-driven mechanism;
but instead of writing the firmware file name to a sysfs node, the
mechanism is to write '1' to "loading", followed by writing the binary
file to "data", followed by writing '0' to "loading". Implement this
new method alongside the existing sysfs method to preserve backwards
compatibility.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>