### PR TITLE
opae-sdk: (cherry-pick) fix  hssismac documentation (remove mtu command) (#2696)

### DIFF
--- a/doc/src/fpga_tools/hssi_ethernet/hssimac.md
+++ b/doc/src/fpga_tools/hssi_ethernet/hssimac.md
@@ -2,7 +2,7 @@
 
 ## SYNOPSIS ##
 ```console
-hssimac [-h] [--pcie-address PCIE_ADDRESS] [--mtu [MTU]]
+hssimac [-h] --pcie-address PCIE_ADDRESS [--port PORT]
 ```
 
 ## DESCRIPTION ##
@@ -17,18 +17,18 @@ The ```hssimac```  tool provides Maximum TX and RX frame size.
 
 `--pcie-address PCIE_ADDRESS, -P PCIE_ADDRESS`
 
-  The PCIe address of the desired fpga  in ssss:bb:dd.f format. sbdf of device to program (e.g. 04:00.0 or 0000:04:00.0). Optional when one device in system.
+  The PCIe address of the desired fpga  in ssss:bb:dd.f format. sbdf of device to program (e.g. 04:00.0 or 0000:04:00.0).
 
 
-`--mtu [MTU]`
+`--port PORT`
 
-  Maximum allowable ethernet frame length.
+  hssi port number.
 
 ## EXAMPLES ##
 
-`hssimac --pcie-address  0000:04:00.0 --mtu`
+`hssimac --pcie-address  0000:04:00.0 --port 1`
 
-  prints Maximum TX and RX frame size.
+  prints Maximum TX and RX frame size for port 1.
 
 
 
@@ -37,5 +37,3 @@ The ```hssimac```  tool provides Maximum TX and RX frame size.
 | Date | Intel Acceleration Stack Version | Changes Made |
 |:------|----------------------------|:--------------|
 |2018.05.21| DCP 1.1 Beta (works with Quartus Prime Pro 17.1.1) | Made the following changes: <br>Expanded descriptions of `nlb_mode_3` and`dma_afu` tests. <br> Added a second example command. |
-
-


### PR DESCRIPTION
- remove mtu command from hssismac documentation