### PR TITLE
Add a CSR field indicating PCIe atomics support to avoid problems on older machines

### DIFF
--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -259,8 +259,10 @@ union he_status1 {
   };
   uint64_t value;
   struct {
-    uint64_t numPendWrites : 32;
-    uint64_t numPendReads : 32;
+    uint64_t numPendWrites : 16;
+    uint64_t numPendReads : 16;
+    uint64_t numPendEmifWrites : 16;
+    uint64_t numPendEmifReads : 16;
   };
 };
 


### PR DESCRIPTION
Remains backward compatible with older systems. Unfortunately, this means
assuming that older machines do work with atomics. On future OFS systems,
"host_exerciser --testall true" will skip atomic tests if unsupported.