### PR TITLE
vabtool: Fix the format of the usage message

### DIFF
--- a/binaries/vabtool/vabtool
+++ b/binaries/vabtool/vabtool
@@ -292,7 +292,7 @@ help() {
   printf "Usage: vabtool {sr_key_provision, sr_status,\n"
   printf "		  pr_key_provision, pr_status,\n"
   printf "		  sr_key_cancel, sr_cancel_status,\n"
-  printf "		  pr_key_cancel, pr_cancel_status,\n"
+  printf "		  pr_key_cancel, pr_cancel_status} ...\n"
   printf "\n"
   printf "\tPerform Vendor Authorized Boot flows for Intel Acceleration Development Platform\n"
   printf "\n"


### PR DESCRIPTION
Recent additions to the vabtool and the usage message left the usage
message in a bad state (a missing end-brace at the end of the parameter
list).  This change replaces the final comma with "} ..."

Signed-off-by: Russ Weight <russell.h.weight@intel.com>