### PR TITLE
cmake: fix missing include directories in opae_add_static_library()

### DIFF
--- a/cmake/modules/OPAECompiler.cmake
+++ b/cmake/modules/OPAECompiler.cmake
@@ -340,9 +340,12 @@ function(opae_add_static_library)
 
     target_include_directories(${OPAE_ADD_STATIC_LIBRARY_TARGET} PUBLIC
         $<BUILD_INTERFACE:${OPAE_INCLUDE_PATH}>
+        $<BUILD_INTERFACE:${OPAE_LIB_SOURCE}>
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
         PRIVATE ${opae-test_ROOT}/framework
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+        PUBLIC ${libjson-c_INCLUDE_DIRS}
+        PUBLIC ${libuuid_INCLUDE_DIRS})
 
     set_property(TARGET ${OPAE_ADD_STATIC_LIBRARY_TARGET} PROPERTY C_STANDARD 99)
     set_property(TARGET ${OPAE_ADD_STATIC_LIBRARY_TARGET}


### PR DESCRIPTION
This synchronizes the target include directories with those of other
targets, which resolves a build failure when libjson-c is installed
in a non-standard path and configured via CMAKE_PREFIX_PATH.

Signed-off-by: Peter Colberg <peter.colberg@intel.com>