### PR TITLE
fpgainfo: one config file integration

### DIFF
--- a/binaries/fpgainfo/CMakeLists.txt
+++ b/binaries/fpgainfo/CMakeLists.txt
@@ -49,4 +49,5 @@ opae_add_executable(TARGET fpgainfo
 target_include_directories(fpgainfo
     PRIVATE
         ${OPAE_LIB_SOURCE}/argsfilter
+        ${OPAE_LIB_SOURCE}/libopae-c
 )

--- a/binaries/fpgainfo/board.c
+++ b/binaries/fpgainfo/board.c
@@ -56,7 +56,7 @@
 static pthread_mutex_t board_plugin_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
 // Board plug-in table
-fpgainfo_config_data *platform_data_table = NULL;
+fpgainfo_config_data *platform_data_table;
 
 void *find_plugin(const char *libpath)
 {

--- a/binaries/fpgainfo/board.c
+++ b/binaries/fpgainfo/board.c
@@ -79,7 +79,7 @@ void *find_plugin(const char *libpath)
 	return NULL;
 }
 
-STATIC bool device_is_supported(fpgainfo_config_data *d,
+STATIC bool device_is_supported(const fpgainfo_config_data *d,
 				uint16_t vid,
 				uint16_t did,
 				uint16_t svid,

--- a/binaries/fpgainfo/board.h
+++ b/binaries/fpgainfo/board.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2019, Intel Corporation
+// Copyright(c) 2019-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -33,21 +33,13 @@
 #define _FPGA_BOARD_H
 
 #include <opae/fpga.h>
+#include "cfg-file.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef struct _platform_data {
-	uint16_t vendor_id;
-	uint16_t device_id;
-	uint16_t subvendor_id;
-	uint16_t subdevice_id;
-	int32_t feature_id;
-	char *board_plugin;
-	void *dl_handle;
-	char product_name[256];
-} platform_data;
+extern fpgainfo_config_data *platform_data_table;
 
 fpga_result load_board_plugin(fpga_token token, void **dl_handle);
 int unload_board_plugin(void);

--- a/binaries/fpgainfo/main.c
+++ b/binaries/fpgainfo/main.c
@@ -221,6 +221,8 @@ int main(int argc, char *argv[])
 	uint32_t i = 0;
 	fpga_properties filter = NULL;
 	fpga_token *tokens = NULL;
+	char *cfg_file = NULL;
+	char *raw_cfg = NULL;
 
 	if (NULL == setlocale(LC_ALL, "")) {
 		OPAE_ERR("Could not set locale\n");
@@ -272,7 +274,20 @@ int main(int argc, char *argv[])
 		goto out_destroy_tokens;
 	}
 
+	cfg_file = opae_find_cfg_file();
+	if (cfg_file) {
+		raw_cfg = opae_read_cfg_file(cfg_file);
+		opae_free(cfg_file);
+	}
+
+	platform_data_table = opae_parse_fpgainfo_config(raw_cfg);
+
+	opae_print_fpgainfo_config(platform_data_table);
+
 	res = handler->run(tokens, matches, argc, argv);
+
+	opae_free_fpgainfo_config(platform_data_table);
+	platform_data_table = NULL;
 
 out_destroy_tokens:
 	for (i = 0; i < num_tokens; i++) {

--- a/tests/fpgainfo/test_board_c.cpp
+++ b/tests/fpgainfo/test_board_c.cpp
@@ -29,8 +29,10 @@
 
 #define NO_OPAE_C
 #include "mock/opae_fixtures.h"
+#include "cfg-file.h"
 
 extern "C" {
+extern fpgainfo_config_data *platform_data_table;
 fpga_result load_board_plugin(fpga_token token, void** dl_handle);
 int unload_board_plugin(void);
 int parse_mac_args(int argc, char *argv[]);
@@ -52,7 +54,17 @@ class fpgainfo_board_c_p : public opae_base_p<> {
   virtual void SetUp() override 
   {
     opae_base_p<>::SetUp();
+
+    platform_data_table = opae_parse_fpgainfo_config(NULL);
     optind = 0;
+  }
+
+  virtual void TearDown() override
+  {
+    opae_free_fpgainfo_config(platform_data_table);
+    platform_data_table = NULL;
+
+    opae_base_p<>::TearDown();
   }
 };
 

--- a/tests/fpgainfo/test_fpgainfo_c.cpp
+++ b/tests/fpgainfo/test_fpgainfo_c.cpp
@@ -31,10 +31,13 @@
 
 #define NO_OPAE_C
 #include "mock/opae_fixtures.h"
+#include "cfg-file.h"
 
 #define ARRAY_SIZE(a) (sizeof(a)/sizeof(*a))
 
 extern "C" {
+
+extern fpgainfo_config_data *platform_data_table;
 
 typedef fpga_result (*filter_fn)(fpga_properties *, int, char **);
 typedef fpga_result (*command_fn)(fpga_token *, int, int, char **);
@@ -128,7 +131,17 @@ class fpgainfo_c_p : public opae_base_p<> {
   virtual void SetUp() override
   {
     opae_base_p<>::SetUp();
+
+    platform_data_table = opae_parse_fpgainfo_config(NULL);
     optind = 0;
+  }
+
+  virtual void TearDown() override
+  {
+    opae_free_fpgainfo_config(platform_data_table);
+    platform_data_table = NULL;
+
+    opae_base_p<>::TearDown();
   }
 };
 


### PR DESCRIPTION
Refactor fpgainfo so that it acquires its platform_data_table
via the common config file parsing code.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>