### PR TITLE
opaevfio, opae.io: bind vfio-pci driver to single PF instead of all PFs

### DIFF
--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -131,14 +131,28 @@ def vfio_init(pci_addr, new_owner='', force=False):
     load_driver('vfio-pci')
 
     print('Binding {} to vfio-pci'.format(msg))
-    new_id = '/sys/bus/pci/drivers/vfio-pci/new_id'
-    try:
-        with open(new_id, 'w') as outf:
-            outf.write('{} {}'.format(vid_did[0], vid_did[1]))
-    except OSError as exc:
-        if exc.errno != errno.EEXIST:
-            LOG.error(f'Cannot write new_id to vfio-pci for: {msg}')
-            return
+    # On Linux kernel >= 3.15, use driver_override to bind the
+    # vfio-pci driver, which ensures the driver binds only to the
+    # given physical function (PF). On older kernels, the driver
+    # will instead bind to all PFs of the corresponding device.
+    driver_override = '/sys/bus/pci/devices/{}/driver_override'.format(pci_addr)
+    if os.path.exists(driver_override):
+        try:
+            with open(driver_override, 'w') as outf:
+                outf.write('vfio-pci')
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                LOG.error(f'Cannot write driver_override to vfio-pci for: {msg}')
+                return
+    else:
+        new_id = '/sys/bus/pci/drivers/vfio-pci/new_id'
+        try:
+            with open(new_id, 'w') as outf:
+                outf.write('{} {}'.format(vid_did[0], vid_did[1]))
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                LOG.error(f'Cannot write new_id to vfio-pci for: {msg}')
+                return
 
     time.sleep(0.50)
 


### PR DESCRIPTION
On Linux kernel >= 3.15, use driver_override to bind the
vfio-pci driver, which ensures the driver binds only to the
given physical function (PF). On older kernels, the driver
will instead bind to all PFs of the corresponding device.

See also https://github.com/DPDK/dpdk/commit/2fc3502935700243d9a6d903166e6fd11e429843