### PR TITLE
opae.io: one config file integration

### DIFF
--- a/binaries/opae.io/main.cpp
+++ b/binaries/opae.io/main.cpp
@@ -46,7 +46,7 @@ struct mmio_region *the_region = nullptr;
 const char *program = "opae.io";
 const int major = 0;
 const int minor = 2;
-const int patch = 3;
+const int patch = 4;
 
 py::tuple version()
 {

--- a/binaries/opae.io/opae/io/config.py
+++ b/binaries/opae.io/opae/io/config.py
@@ -1,0 +1,383 @@
+# Copyright(c) 2022, Intel Corporation
+#
+# Redistribution  and  use  in source  and  binary  forms,  with  or  without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of  source code  must retain the  above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name  of Intel Corporation  nor the names of its contributors
+#   may be used to  endorse or promote  products derived  from this  software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+# IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+# LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+# CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+# SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+# INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+# CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import os
+
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
+
+
+OPAE_VENDOR_ANY = 0xffff
+OPAE_DEVICE_ANY = 0xffff
+
+DEFAULT_OPAE_IO_CONFIG = {
+  (0x8086, 0xbcbd, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY) : {
+    'platform': 'Intel Integrated Multi-Chip Acceleration Platform'
+  },
+  (0x8086, 0xbcc0, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY) : {
+    'platform': 'Intel Integrated Multi-Chip Acceleration Platform'
+  },
+  (0x8086, 0xbcc1, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY) : {
+    'platform': 'Intel Integrated Multi-Chip Acceleration Platform'
+  },
+  (0x8086, 0x09c4, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY) : {
+    'platform': 'Intel Programmable Acceleration Card with Intel Arria 10 GX FPGA'
+  },
+  (0x8086, 0x09c5, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY) : {
+    'platform': 'Intel Programmable Acceleration Card with Intel Arria 10 GX FPGA'
+  },
+  (0x8086, 0x0b2b, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY) : {
+    'platform': 'Intel FPGA Programmable Acceleration Card D5005'
+  },
+  (0x8086, 0x0b2c, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY) : {
+    'platform': 'Intel FPGA Programmable Acceleration Card D5005'
+  },
+  (0x8086, 0xbcce, 0x8086, 0x138d) : {
+    'platform': 'Intel FPGA Programmable Acceleration Card D5005'
+  },
+  (0x8086, 0xbccf, 0x8086, 0x138d) : {
+    'platform': 'Intel FPGA Programmable Acceleration Card D5005'
+  },
+  (0x8086, 0x0b30, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY) : {
+    'platform': 'Intel FPGA Programmable Acceleration Card N3000'
+  },
+  (0x8086, 0x0b31, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY) : {
+    'platform': 'Intel FPGA Programmable Acceleration Card N3000'
+  },
+  (0x1c2c, 0x1000, 0, 0) : {
+    'platform': 'Silicom FPGA SmartNIC N5010 Series'
+  },
+  (0x1c2c, 0x1001, 0, 0) : {
+    'platform': 'Silicom FPGA SmartNIC N5010 Series'
+  },
+  (0x8086, 0xbcce, 0x8086, 0x1770) : {
+    'platform': 'Intel Acceleration Development Platform N6000'
+  },
+  (0x8086, 0xbccf, 0x8086, 0x1770) : {
+    'platform': 'Intel Acceleration Development Platform N6000'
+  },
+  (0x8086, 0xbcce, 0x8086, 0x1771) : {
+    'platform': 'Intel Acceleration Development Platform N6001'
+  },
+  (0x8086, 0xbccf, 0x8086, 0x1771) : {
+    'platform': 'Intel Acceleration Development Platform N6001'
+  },
+  (0x8086, 0xbcce, 0x8086, 0x17d4): {
+    'platform': 'Intel Acceleration Development Platform C6100'
+  },
+  (0x8086, 0xbccf, 0x8086, 0x17d4): {
+    'platform': 'Intel Acceleration Development Platform C6100'
+  },
+  (0x8086, 0xaf00, 0x8086, 0): {
+    'platform': 'Intel Open FPGA Stack Platform'
+  },
+  (0x8086, 0xaf01, 0x8086, 0): {
+    'platform': 'Intel Open FPGA Stack Platform'
+  },
+  (0x8086, 0xbcce, 0x8086, 0): {
+    'platform': 'Intel Open FPGA Stack Platform'
+  },
+  (0x8086, 0xbccf, 0x8086, 0): {
+    'platform': 'Intel Open FPGA Stack Platform'
+  }
+}
+
+OPAE_IO_CONFIG = DEFAULT_OPAE_IO_CONFIG
+
+
+def find_config_file():
+    """ Find the one OPAE configuration file and return
+        its path as a string in Posix format.
+        First, check environment variable LIBOPAE_CFGFILE.
+        If not found there, then check a series of paths
+        relative to the user's home directory. Finally,
+        check a few system paths. Returns None if not found.
+    """
+    cfg = os.environ.get('LIBOPAE_CFGFILE')
+    if cfg:
+        try:
+            resolved = Path(cfg).resolve(strict=True)
+            if resolved.exists() and resolved.is_file():
+                return resolved.as_posix()
+        except FileNotFoundError:
+            pass
+
+    home_paths = ['~/.local/opae.cfg',
+                  '~/.local/opae/opae.cfg',
+                  '~/.config/opae/opae.cfg']
+
+    for h in home_paths:
+        try:
+            p = Path(h).expanduser()
+        except RuntimeError:
+            continue
+
+        try:
+            resolved = p.resolve(strict=True)
+            if resolved.exists() and resolved.is_file():
+                return resolved.as_posix()
+        except FileNotFoundError:
+            pass
+
+    sys_paths = ['/usr/local/etc/opae/opae.cfg',
+                 '/etc/opae/opae.cfg']
+
+    for s in sys_paths:
+        try:
+            resolved = Path(s).resolve(strict=True)
+            if resolved.exists() and resolved.is_file():
+                return resolved.as_posix()
+        except FileNotFoundError:
+            pass
+
+
+def parse_devices(devices):
+    """Parse the "devices" portion of the one config file for a given
+       config object. Returns a dictionary of the "name" keys mapped to
+       the integer VID, DID, SVID, SDID contained in a tuple.
+    """
+    devs = {}
+    for d in devices:
+        if 'name' not in d:
+            print(f'Error parsing config: "name" key not in "devices" entry.')
+            return None
+        if type(d['name']) != str:
+            print(f'Error parsing config: "name" key not a string.')
+            return None
+
+        name = d['name']
+
+        if 'id' not in d:
+            print(f'Error parsing config: "id" key not in "devices" entry.')
+            return None
+        if type(d['id']) != list or len(d['id']) != 4:
+            print(f'Error parsing config: "id" key not a list or too few items.')
+            return None
+
+        ID = d['id']
+
+        vid = int(ID[0], 0)
+        did = int(ID[1], 0)
+
+        if type(ID[2]) == str and ID[2] == '*':
+            svid = OPAE_VENDOR_ANY
+        else:
+            svid = int(ID[2], 0)
+
+        if type(ID[3]) == str and ID[3] == '*':
+            sdid = OPAE_DEVICE_ANY
+        else:
+            sdid = int(ID[3], 0)
+
+        devs[name] = (vid, did, svid, sdid)
+
+    return devs
+
+
+def load_opae_io_config(opae_io_cfg, root, config, configurations):
+    """Parse section config of the one OPAE configuration file
+       into the desired internal opae.io data structure (see
+       DEFAULT_OPAE_IO_CONFIG for the format).
+    """
+    if config not in configurations:
+        print(f'Error parsing config: {config} not found.')
+        return False
+
+    c = configurations[config]
+    key = 'enabled'
+    if key not in c or not c[key]:
+        return True # continue parsing
+
+    key = 'platform'
+    if key not in c:
+        print(f'Error parsing config: no "platform" key in "{config}".')
+        return False
+    if type(c[key]) != str:
+        print(f'Error parsing config: "platform" key not a string.')
+        return False
+    platform = c[key]
+
+    key = 'devices'
+    if key not in c:
+        print(f'Error parsing config: no "devices" key in "{config}".')
+        return False
+    if type(c[key]) != list:
+        print(f'Error parsing config: "devices" key not a list.')
+        return False
+
+    devs = parse_devices(c[key])
+    if not devs:
+        print(f'Error parsing config: "devices" is empty.')
+        return False
+
+    key = 'opae'
+    if key not in c or type(c[key]) != dict:
+        print(f'Error parsing config: "opae" key '
+              f'missing or invalid in {config}.')
+        return False
+
+    opae = c[key]
+    key = 'opae.io'
+    if key not in opae or type(opae[key]) != list:
+        print(f'Warning parsing config: "opae.io" key '
+              f'missing or invalid in {config} "opae".')
+        return True # continue parsing
+
+    value = { 'platform': platform }
+
+    opae_io = opae[key]
+    for o in opae_io:
+        key = 'enabled'
+        if key not in o or not o[key]:
+            continue
+
+        key = 'devices'
+        if key not in o or len(o[key]) == 0:
+            print(f'Warning parsing config: "devices" key '
+                  f'missing or invalid in {config} "opae.io".')
+            continue
+    
+        for d in o['devices']:
+            if d not in devs:
+                print(f'Error parsing config: {d} not found '
+                      f'in "devices" for {config}.')
+                return False
+    
+            opae_io_cfg[devs[d]] = value
+
+    return True
+
+
+def load_opae_io_configuration(cfg):
+    """Walk through each "configs" section of the given parsed
+       JSON object cfg. If cfg is None or if an error is encountered
+       during parsing, then return None. Otherwise, return the parsed
+       opae.io object.
+    """
+    if not cfg: # No parsed config from file.
+        return None
+
+    if not 'configs' in cfg:
+        print(f'Error parsing config: "configs" key not found.')
+        return None
+    if not 'configurations' in cfg:
+        print(f'Error parsing config: "configurations" key not found.')
+        return None
+
+    opae_io_cfg = {}
+    for c in cfg['configs']:
+        status = load_opae_io_config(opae_io_cfg,
+                                     cfg,
+                                     c,
+                                     cfg['configurations'])
+        if not status:
+            return None
+
+    return opae_io_cfg
+
+
+def print_opae_io_configuration(cfg):
+    """Pretty print an opae.io configuration data object.
+    """
+    for key in cfg:
+        print(f'0x{key[0]:04x}:0x{key[1]:04x} ', end='')
+        if key[2] == OPAE_VENDOR_ANY:
+            print(f'*     ', end='')
+        else:
+            print(f'0x{key[2]:04x}', end='')
+        print(':', end='')
+        if key[3] == OPAE_DEVICE_ANY:
+            print(f'*     ', end='')
+        else:
+            print(f'0x{key[3]:04x}', end='')
+
+        print(' ', end='')
+        print(cfg[key])
+
+
+def load_configs():
+    """Find the one OPAE config file and parse it,
+       constructing internal representations of the opae.io
+       configuration data. If the file cannot be found
+       or if an error is encountered during parsing,
+       then use a hard-coded default configuration.
+    """
+    cfg = None
+    cfg_file = find_config_file()
+
+    if not cfg_file: # Use defaults
+        return
+
+    with open(cfg_file, 'r') as fd:
+        cfg = json.load(fd)
+
+    global OPAE_IO_CONFIG
+    o = load_opae_io_configuration(cfg)
+    if o:
+        OPAE_IO_CONFIG = o
+
+
+def key_matches_id(key, vid, did, svid, sdid):
+    """Determine whether the given key (a 4-tuple of
+       integer PCIe ID components) is a match for the
+       given parameters.
+    """
+    if key[0] != vid:
+        return False
+    if key[1] != did:
+        return False
+    if key[2] != OPAE_VENDOR_ANY and key[2] != svid:
+        return False
+    if key[3] != OPAE_DEVICE_ANY and key[3] != sdid:
+        return False
+    return True
+
+
+class Config:
+    """The high-level user interface to the parsed opae.io
+       configuration data.
+    """
+    @staticmethod
+    def opae_io_is_supported(vid, did, svid, sdid):
+        global OPAE_IO_CONFIG
+        for key in OPAE_IO_CONFIG:
+            if key_matches_id(key, vid, did, svid, sdid):
+                return True
+        return False
+
+    @staticmethod
+    def opae_io_platform_for(vid, did, svid, sdid):
+        global OPAE_IO_CONFIG
+        ID = (vid, did, svid, sdid)
+        for key in OPAE_IO_CONFIG:
+            if key_matches_id(key, *ID):
+                return OPAE_IO_CONFIG[key]['platform']
+
+
+load_configs()

--- a/binaries/opae.io/opae/io/pci.py
+++ b/binaries/opae.io/opae/io/pci.py
@@ -72,7 +72,9 @@ def vid_did_for_address(pci_addr):
     path = Path('/sys/bus/pci/devices', pci_addr)
     vid = path.joinpath('vendor').read_text().strip()
     did = path.joinpath('device').read_text().strip()
-    return (vid, did)
+    svid = path.joinpath('subsystem_vendor').read_text().strip()
+    sdid = path.joinpath('subsystem_device').read_text().strip()
+    return (vid, did, svid, sdid)
 
 
 class sysfs_attr:

--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -41,6 +41,7 @@ import time
 from enum import Enum
 from ctypes import Union, LittleEndianStructure, c_uint64, c_uint32
 from logging import StreamHandler
+from opae.io.config import Config
 from . import pci
 
 if sys.version_info[0] == 3:
@@ -413,25 +414,6 @@ class feature(object):
                 csr.commit()
 
 
-fpga_devices = {
-    pci.make_id(0x8086, 0x09c4): "Intel PAC A10 GX",
-    pci.make_id(0x8086, 0x09c5): "Intel PAC A10 GX VF",
-    pci.make_id(0x8086, 0x0b2b): "Intel PAC D5005",
-    pci.make_id(0x8086, 0x0b2c): "Intel PAC D5005 VF",
-    pci.make_id(0x8086, 0x0b30): "Intel PAC N3000",
-    pci.make_id(0x8086, 0x0b31): "Intel PAC N3000 VF",
-    pci.make_id(0x8086, 0xbcce, 0x8086, 0x1770): "Intel N6000 ADP",
-    pci.make_id(0x8086, 0xbccf, 0x8086, 0x1770): "Intel N6000 ADP VF",
-    pci.make_id(0x8086, 0xbcce, 0x8086, 0x1771): "Intel N6001 ADP",
-    pci.make_id(0x8086, 0xbccf, 0x8086, 0x1771): "Intel N6001 ADP VF",
-    pci.make_id(0x8086, 0xbcce, 0x8086, 0x17d4): "Intel C6100 ADP",
-    pci.make_id(0x8086, 0xbccf, 0x8086, 0x17d4): "Intel C6100 ADP VF",
-    pci.make_id(0x8086, 0xbcce, 0x8086, 0x138d): "Intel D5005 ADP",
-    pci.make_id(0x8086, 0xbccf, 0x8086, 0x138d): "Intel D5005 ADP VF",
-    pci.make_id(0x1c2c, 0x1000): "Silicom SmartNIC N5010",
-    pci.make_id(0x1c2c, 0x1001): "Silicom SmartNIC N5011",
-}
-
 def read_attr(dirname, attr):
     fname = Path(dirname, attr)
     if fname.exists():
@@ -467,23 +449,12 @@ def get_conf_devices(data):
     return conf_ids
 
 
-
 def lsfpga(**kwargs):
     _all = kwargs.pop('all', False)
-    device_ids = dict(fpga_devices)
     use_class = kwargs.pop('system_class', False)
-    conf = get_conf()
-    if conf:
-        conf_ids = get_conf_devices(conf.get('fpga_devices', {}))
-        if conf.get('override', False):
-            device_ids.update(conf_ids)
-        else:
-            for k, v in conf_ids.items():
-                if k not in device_ids:
-                    device_ids[k] = v
 
-    # create a filter function that uses attributes in kwargs to match devices
-    # as well "known" devices as those listed in 'fpga_devices'
+    # Create a filter function that uses attributes in kwargs to match devices
+    # as well "known" devices as those listed in the opae.io configuration data.
     def filter_fn(d: pci.device):
         for k,v in kwargs.items():
             try:
@@ -492,21 +463,21 @@ def lsfpga(**kwargs):
                 return False
             if attr_value != v:
                 return False
-        known = (d.pci_id in device_ids or d.pci_id.short() in device_ids)
+        known = Config.opae_io_is_supported(*d.pci_id)
         if not _all and not known:
             return False
         return True
 
     def describe(d: pci.device):
-        desc = device_ids.get(d.pci_id) or device_ids.get(d.pci_id.short())
+        desc = Config.opae_io_platform_for(*d.pci_id)
         if desc:
             d._desc = desc
         return d
+
     devices = pci.ls(filter=filter_fn)
     if use_class:
         return devices
     return map(describe, devices)
-
 
 
 def ls(**kwargs):

--- a/binaries/opae.io/setup.py
+++ b/binaries/opae.io/setup.py
@@ -29,7 +29,7 @@ from distutils.core import Extension, setup
 
 setup(
     name="opae.io",
-    version="0.2.2",
+    version="0.2.4",
     packages=find_namespace_packages(include=['opae.*']),
     entry_points={
         'console_scripts': []

--- a/opae.cfg
+++ b/opae.cfg
@@ -30,7 +30,13 @@
           }
         ],
         "rsu": [],
-        "fpgareg": []
+        "fpgareg": [],
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "mcp0_pf", "mcp1_pf", "mcp1_vf" ]
+          }
+        ]
       }
     },
 
@@ -64,7 +70,13 @@
         ],
         "fpgad": [],
         "rsu": [],
-        "fpgareg": []
+        "fpgareg": [],
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "a10gx_pf", "a10gx_vf" ]
+          }
+        ]
       }
     },
 
@@ -115,7 +127,13 @@
             "devices": [ "d5005_0_pf", "d5005_1_pf" ]
           }
         ],
-        "fpgareg": []
+        "fpgareg": [],
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "d5005_0_pf", "d5005_0_vf", "d5005_1_pf", "d5005_1_vf" ]
+          }
+        ]
       }
     },
 
@@ -178,7 +196,13 @@
             "devices": [ "n3000_pf" ]
           }
         ],
-        "fpgareg": []
+        "fpgareg": [],
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "n3000_pf", "n3000_vf" ]
+          }
+        ]
       }
     },
 
@@ -235,7 +259,13 @@
             "fpga_default_sequences": "common_rsu_sequences"
           }
         ],
-        "fpgareg": []
+        "fpgareg": [],
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "n5010_pf", "n5010_vf" ]
+          }
+        ]
       }
     },
 
@@ -299,6 +329,12 @@
           }
         ],
         "fpgareg": [
+          {
+            "enabled": true,
+            "devices": [ "n6000_pf", "n6000_vf" ]
+          }
+        ],
+        "opae.io": [
           {
             "enabled": true,
             "devices": [ "n6000_pf", "n6000_vf" ]
@@ -371,6 +407,12 @@
             "enabled": true,
             "devices": [ "n6001_pf", "n6001_vf" ]
           }
+        ],
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "n6001_pf", "n6001_vf" ]
+          }
         ]
       }
     },
@@ -435,6 +477,12 @@
           }
         ],
         "fpgareg": [
+          {
+            "enabled": true,
+            "devices": [ "c6100_pf", "c6100_vf" ]
+          }
+        ],
+        "opae.io": [
           {
             "enabled": true,
             "devices": [ "c6100_pf", "c6100_vf" ]
@@ -513,6 +561,12 @@
           }
         ],
         "fpgareg": [
+          {
+            "enabled": true,
+            "devices": [ "ofs0_pf", "ofs0_vf", "ofs1_pf", "ofs1_vf" ]
+          }
+        ],
+        "opae.io": [
           {
             "enabled": true,
             "devices": [ "ofs0_pf", "ofs0_vf", "ofs1_pf", "ofs1_vf" ]

--- a/python/opae.admin/opae/admin/version.py
+++ b/python/opae.admin/opae/admin/version.py
@@ -34,7 +34,7 @@ except ImportError:
 version = {
     'major': 1,
     'minor': 4,
-    'patch': 2
+    'patch': 3
 }
 
 

--- a/tests/opae.io/test_config.py
+++ b/tests/opae.io/test_config.py
@@ -1,0 +1,416 @@
+# Copyright(c) 2022, Intel Corporation
+#
+# Redistribution  and  use  in source  and  binary  forms,  with  or  without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of  source code  must retain the  above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name  of Intel Corporation  nor the names of its contributors
+#   may be used to  endorse or promote  products derived  from this  software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+# IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+# LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+# CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+# SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+# INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+# CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import unittest
+
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
+
+from opae.io.config import find_config_file, load_configs, Config
+
+TEST_CONFIG = '''{
+  "configurations": {
+
+    "mcp" : {
+      "enabled": true,
+      "platform": "Intel Integrated Multi-Chip Acceleration Platform",
+
+      "devices": [
+        { "name": "mcp0_pf", "id": [ "0x8086", "0xbcbd", "*", "*" ] },
+        { "name": "mcp1_pf", "id": [ "0x8086", "0xbcc0", "*", "*" ] },
+        { "name": "mcp1_vf", "id": [ "0x8086", "0xbcc1", "*", "*" ] }
+      ],
+
+      "opae": {
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "mcp0_pf", "mcp1_pf", "mcp1_vf" ]
+          }
+        ]
+      }
+    },
+
+    "a10gx": {
+      "enabled": true,
+      "platform": "Intel Programmable Acceleration Card with Intel Arria 10 GX FPGA",
+
+      "devices": [
+        { "name": "a10gx_pf", "id": [ "0x8086", "0x09c4", "*", "*" ] },
+        { "name": "a10gx_vf", "id": [ "0x8086", "0x09c5", "*", "*" ] }
+      ],
+
+      "opae": {
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "a10gx_pf", "a10gx_vf" ]
+          }
+        ]
+      }
+    },
+
+    "d5005": {
+      "enabled": true,
+      "platform": "Intel FPGA Programmable Acceleration Card D5005",
+
+      "devices": [
+        { "name": "d5005_0_pf", "id": [ "0x8086", "0x0b2b", "*",      "*"      ] },
+        { "name": "d5005_0_vf", "id": [ "0x8086", "0x0b2c", "*",      "*"      ] },
+        { "name": "d5005_1_pf", "id": [ "0x8086", "0xbcce", "0x8086", "0x138d" ] },
+        { "name": "d5005_1_vf", "id": [ "0x8086", "0xbccf", "0x8086", "0x138d" ] }
+      ],
+
+      "opae": {
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "d5005_0_pf", "d5005_0_vf", "d5005_1_pf", "d5005_1_vf" ]
+          }
+        ]
+      }
+    },
+
+    "n3000": {
+      "enabled": true,
+      "platform": "Intel FPGA Programmable Acceleration Card N3000",
+
+      "devices": [
+        { "name": "n3000_pf", "id": [ "0x8086", "0x0b30", "*", "*" ] },
+        { "name": "n3000_vf", "id": [ "0x8086", "0x0b31", "*", "*" ] }
+      ],
+
+      "opae": {
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "n3000_pf", "n3000_vf" ]
+          }
+        ]
+      }
+    },
+
+    "n5010": {
+      "enabled": true,
+      "platform": "Silicom FPGA SmartNIC N5010 Series",
+
+      "devices": [
+        { "name": "n5010_pf", "id": [ "0x1c2c", "0x1000", "0", "0" ] },
+        { "name": "n5010_vf", "id": [ "0x1c2c", "0x1001", "0", "0" ] }
+      ],
+
+      "opae": {
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "n5010_pf", "n5010_vf" ]
+          }
+        ]
+      }
+    },
+
+    "n6000": {
+      "enabled": true,
+      "platform": "Intel Acceleration Development Platform N6000",
+
+      "devices": [
+        { "name": "n6000_pf", "id": [ "0x8086", "0xbcce", "0x8086", "0x1770" ] },
+        { "name": "n6000_vf", "id": [ "0x8086", "0xbccf", "0x8086", "0x1770" ] }
+      ],
+
+      "opae": {
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "n6000_pf", "n6000_vf" ]
+          }
+        ]
+      }
+    },
+
+    "n6001": {
+      "enabled": true,
+      "platform": "Intel Acceleration Development Platform N6001",
+
+      "devices": [
+        { "name": "n6001_pf", "id": [ "0x8086", "0xbcce", "0x8086", "0x1771" ] },
+        { "name": "n6001_vf", "id": [ "0x8086", "0xbccf", "0x8086", "0x1771" ] }
+      ],
+
+      "opae": {
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "n6001_pf", "n6001_vf" ]
+          }
+        ]
+      }
+    },
+
+    "c6100": {
+      "enabled": true,
+      "platform": "Intel Acceleration Development Platform C6100",
+
+      "devices": [
+        { "name": "c6100_pf", "id": [ "0x8086", "0xbcce", "0x8086", "0x17d4" ] },
+        { "name": "c6100_vf", "id": [ "0x8086", "0xbccf", "0x8086", "0x17d4" ] }
+      ],
+
+      "opae": {
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "c6100_pf", "c6100_vf" ]
+          }
+        ]
+      }
+    },
+
+    "ofs": {
+      "enabled": true,
+      "platform": "Intel Open FPGA Stack Platform",
+
+      "devices": [
+        { "name": "ofs0_pf", "id": [ "0x8086", "0xaf00", "0x8086", "0" ] },
+        { "name": "ofs0_vf", "id": [ "0x8086", "0xaf01", "0x8086", "0" ] },
+        { "name": "ofs1_pf", "id": [ "0x8086", "0xbcce", "0x8086", "0" ] },
+        { "name": "ofs1_vf", "id": [ "0x8086", "0xbccf", "0x8086", "0" ] }
+      ],
+
+      "opae": {
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "ofs0_pf", "ofs0_vf", "ofs1_pf", "ofs1_vf" ]
+          }
+        ]
+      }
+    },
+
+    "test": {
+      "enabled": true,
+      "platform": "Unit Test Platform",
+  
+      "devices": [
+        { "name": "test0_pf", "id": [ "0x8086", "0xbeef", "0", "0" ] },
+        { "name": "test0_vf", "id": [ "0x8086", "0xc01a", "0", "0" ] },
+        { "name": "test1_pf", "id": [ "0x8086", "0xbee0", "0", "0" ] },
+        { "name": "test1_vf", "id": [ "0x8086", "0xc01b", "0", "0" ] }
+      ],
+  
+      "opae": {
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "test0_pf", "test1_pf" ]
+          }
+        ]
+      }
+    }
+  },
+
+  "configs": [
+    "mcp",
+    "a10gx",
+    "d5005",
+    "n3000",
+    "n5010",
+    "n6000",
+    "n6001",
+    "c6100",
+    "ofs",
+    "test"
+  ]
+
+}'''
+
+
+class TestEnv(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+      cls.cfg = Path().cwd().joinpath('opae.cfg')
+      cls.cfg.write_text(TEST_CONFIG)
+
+      assert cls.cfg.exists()
+      assert cls.cfg.is_file()
+
+      os.environ['LIBOPAE_CFGFILE'] = cls.cfg.as_posix()
+
+      load_configs()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cfg.unlink()
+        del os.environ['LIBOPAE_CFGFILE']
+
+    def test_find(self):
+      assert find_config_file() == os.environ['LIBOPAE_CFGFILE']
+
+    def test_opae_io_is_supported(self):
+        not_supported = [
+                (0x8086, 0xc01a, 0, 0),
+                (0x8086, 0xc01b, 0, 0)
+                ]
+        supported = [
+                (0x8086, 0xbcbd, 0, 0),
+                (0x8086, 0xbcc0, 0, 0),
+                (0x8086, 0xbcc1, 0, 0),
+                (0x8086, 0x09c4, 0, 0),
+                (0x8086, 0x09c5, 0, 0),
+                (0x8086, 0x0b2b, 0, 0),
+                (0x8086, 0x0b2c, 0, 0),
+                (0x8086, 0xbcce, 0x8086, 0x138d),
+                (0x8086, 0xbccf, 0x8086, 0x138d),
+                (0x8086, 0x0b30, 0, 0),
+                (0x8086, 0x0b31, 0, 0),
+                (0x1c2c, 0x1000, 0, 0),
+                (0x1c2c, 0x1001, 0, 0),
+                (0x8086, 0xbcce, 0x8086, 0x1770),
+                (0x8086, 0xbccf, 0x8086, 0x1770),
+                (0x8086, 0xbcce, 0x8086, 0x1771),
+                (0x8086, 0xbccf, 0x8086, 0x1771),
+                (0x8086, 0xbcce, 0x8086, 0x17d4),
+                (0x8086, 0xbccf, 0x8086, 0x17d4),
+                (0x8086, 0xaf00, 0x8086, 0),
+                (0x8086, 0xaf01, 0x8086, 0),
+                (0x8086, 0xbcce, 0x8086, 0),
+                (0x8086, 0xbccf, 0x8086, 0),
+                (0x8086, 0xbeef, 0, 0),
+                (0x8086, 0xbee0, 0, 0)
+                ]
+
+        for n in not_supported:
+            assert not Config.opae_io_is_supported(*n), 'No {:04x}:{:04x} {:04x}:{:04x}'.format(*n)
+
+        for s in supported:
+            assert Config.opae_io_is_supported(*s), 'Yes {:04x}:{:04x} {:04x}:{:04x}'.format(*s)
+
+    def test_opae_io_platform_for(self):
+        not_supported = [
+                (0x8086, 0xc01a, 0, 0),
+                (0x8086, 0xc01b, 0, 0)
+                ]
+
+        for n in not_supported:
+            assert Config.opae_io_platform_for(*n) is None
+
+        assert Config.opae_io_platform_for(0x8086, 0xbcbd, 0, 0) == 'Intel Integrated Multi-Chip Acceleration Platform'
+        assert Config.opae_io_platform_for(0x8086, 0xbcc0, 0, 0) == 'Intel Integrated Multi-Chip Acceleration Platform'
+        assert Config.opae_io_platform_for(0x8086, 0xbcc1, 0, 0) == 'Intel Integrated Multi-Chip Acceleration Platform'
+        assert Config.opae_io_platform_for(0x8086, 0x09c4, 0, 0) == 'Intel Programmable Acceleration Card with Intel Arria 10 GX FPGA'
+        assert Config.opae_io_platform_for(0x8086, 0x09c5, 0, 0) == 'Intel Programmable Acceleration Card with Intel Arria 10 GX FPGA'
+        assert Config.opae_io_platform_for(0x8086, 0x0b2b, 0, 0) == 'Intel FPGA Programmable Acceleration Card D5005'
+        assert Config.opae_io_platform_for(0x8086, 0x0b2c, 0, 0) == 'Intel FPGA Programmable Acceleration Card D5005'
+        assert Config.opae_io_platform_for(0x8086, 0xbcce, 0x8086, 0x138d) == 'Intel FPGA Programmable Acceleration Card D5005'
+        assert Config.opae_io_platform_for(0x8086, 0xbccf, 0x8086, 0x138d) == 'Intel FPGA Programmable Acceleration Card D5005'
+        assert Config.opae_io_platform_for(0x8086, 0x0b30, 0, 0) == 'Intel FPGA Programmable Acceleration Card N3000'
+        assert Config.opae_io_platform_for(0x8086, 0x0b31, 0, 0) == 'Intel FPGA Programmable Acceleration Card N3000'
+        assert Config.opae_io_platform_for(0x1c2c, 0x1000, 0, 0) == 'Silicom FPGA SmartNIC N5010 Series'
+        assert Config.opae_io_platform_for(0x1c2c, 0x1001, 0, 0) == 'Silicom FPGA SmartNIC N5010 Series'
+        assert Config.opae_io_platform_for(0x8086, 0xbcce, 0x8086, 0x1770) == 'Intel Acceleration Development Platform N6000'
+        assert Config.opae_io_platform_for(0x8086, 0xbccf, 0x8086, 0x1770) == 'Intel Acceleration Development Platform N6000'
+        assert Config.opae_io_platform_for(0x8086, 0xbcce, 0x8086, 0x1771) == 'Intel Acceleration Development Platform N6001'
+        assert Config.opae_io_platform_for(0x8086, 0xbccf, 0x8086, 0x1771) == 'Intel Acceleration Development Platform N6001'
+        assert Config.opae_io_platform_for(0x8086, 0xbcce, 0x8086, 0x17d4) == 'Intel Acceleration Development Platform C6100'
+        assert Config.opae_io_platform_for(0x8086, 0xbccf, 0x8086, 0x17d4) == 'Intel Acceleration Development Platform C6100'
+        assert Config.opae_io_platform_for(0x8086, 0xaf00, 0x8086, 0) == 'Intel Open FPGA Stack Platform'
+        assert Config.opae_io_platform_for(0x8086, 0xaf01, 0x8086, 0) == 'Intel Open FPGA Stack Platform'
+        assert Config.opae_io_platform_for(0x8086, 0xbcce, 0x8086, 0) == 'Intel Open FPGA Stack Platform'
+        assert Config.opae_io_platform_for(0x8086, 0xbccf, 0x8086, 0) == 'Intel Open FPGA Stack Platform'
+        assert Config.opae_io_platform_for(0x8086, 0xbeef, 0, 0) == 'Unit Test Platform'
+        assert Config.opae_io_platform_for(0x8086, 0xbee0, 0, 0) == 'Unit Test Platform'
+
+
+class TestFindHome0(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+      cls.cfg = Path('~/.local').expanduser()
+      if not cls.cfg.exists():
+          cls.cfg.mkdir(parents=True)
+      cls.cfg = cls.cfg.joinpath('opae.cfg')
+
+      assert not cls.cfg.exists()
+
+      cls.cfg.write_text(TEST_CONFIG)
+
+      assert cls.cfg.exists()
+      assert cls.cfg.is_file()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cfg.unlink()
+
+    def test_find(self):
+      assert find_config_file() == self.cfg.as_posix()
+
+
+class TestFindHome1(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+      cls.cfg = Path('~/.local/opae').expanduser()
+      if not cls.cfg.exists():
+          cls.cfg.mkdir(parents=True)
+      cls.cfg = cls.cfg.joinpath('opae.cfg')
+
+      assert not cls.cfg.exists()
+
+      cls.cfg.write_text(TEST_CONFIG)
+
+      assert cls.cfg.exists()
+      assert cls.cfg.is_file()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cfg.unlink()
+
+    def test_find(self):
+      assert find_config_file() == self.cfg.as_posix()
+
+
+class TestFindHome2(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+      cls.cfg = Path('~/.config/opae').expanduser()
+      if not cls.cfg.exists():
+          cls.cfg.mkdir(parents=True)
+      cls.cfg = cls.cfg.joinpath('opae.cfg')
+
+      assert not cls.cfg.exists()
+
+      cls.cfg.write_text(TEST_CONFIG)
+
+      assert cls.cfg.exists()
+      assert cls.cfg.is_file()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cfg.unlink()
+
+    def test_find(self):
+      assert find_config_file() == self.cfg.as_posix()


### PR DESCRIPTION
Implement new module opae.io.config to parse and create internal
config data for opae.io. Integrate that new module with opae.io's
ls command.