### PR TITLE
opae-c: config file: search in $HOME for home dirs

### DIFF
--- a/libraries/libopae-c/cfg-file.c
+++ b/libraries/libopae-c/cfg-file.c
@@ -80,19 +80,19 @@ char *opae_find_cfg_file(void)
 			len = strnlen(home_dir, sizeof(home_cfg) - 1);
 			memcpy(home_cfg, home_dir, len);
 			home_cfg[len] = '\0';
-	
+
 			home_cfg_ptr = home_cfg + strlen(home_cfg);
-	
+
 			len = strnlen(_opae_home_cfg_files[i], CFG_PATH_MAX);
 			memcpy(home_cfg_ptr, _opae_home_cfg_files[i], len);
 			home_cfg_ptr[len] = '\0';
-	
+
 			file_name = opae_canonicalize_file_name(home_cfg);
 			if (file_name) {
 				OPAE_DBG("Found config file: %s", file_name);
 				return file_name;
 			}
-	
+
 			home_cfg[0] = '\0';
 		}
 	}

--- a/libraries/libopae-c/cfg-file.c
+++ b/libraries/libopae-c/cfg-file.c
@@ -73,8 +73,16 @@ char *opae_find_cfg_file(void)
 		}
 	}
 
-	// check the HOME env variable using _opae_home_cfg_files.
+	// Let the HOME env variable take precedence over the pw database.
 	home_dir = getenv("HOME");
+	if (!home_dir) {
+		// No HOME: get the user's home directory, according
+		// to the pw database.
+		user_passwd = getpwuid(getuid());
+		if (user_passwd)
+			home_dir = user_passwd->pw_dir;
+	}
+
 	if (home_dir) {
 		for (i = 0 ; i < HOME_CFG_PATHS ; ++i) {
 			len = strnlen(home_dir, sizeof(home_cfg) - 1);
@@ -95,31 +103,6 @@ char *opae_find_cfg_file(void)
 
 			home_cfg[0] = '\0';
 		}
-	}
-
-	// get the user's home directory, according to the pw database.
-	user_passwd = getpwuid(getuid());
-
-	// Look in possible paths in the user's home directory.
-	for (i = 0 ; i < HOME_CFG_PATHS ; ++i) {
-		len = strnlen(user_passwd->pw_dir,
-			      sizeof(home_cfg) - 1);
-		memcpy(home_cfg, user_passwd->pw_dir, len);
-		home_cfg[len] = '\0';
-
-		home_cfg_ptr = home_cfg + strlen(home_cfg);
-
-		len = strnlen(_opae_home_cfg_files[i], CFG_PATH_MAX);
-		memcpy(home_cfg_ptr, _opae_home_cfg_files[i], len);
-		home_cfg_ptr[len] = '\0';
-
-		file_name = opae_canonicalize_file_name(home_cfg);
-		if (file_name) {
-			OPAE_DBG("Found config file: %s", file_name);
-			return file_name;
-		}
-
-		home_cfg[0] = '\0';
 	}
 
 	// Now, look in possible system paths.


### PR DESCRIPTION
Query the value of $HOME and search in the home config file locations relative to that path before trying the password database's version of the home directory. This should more closely match the use of pathlib in the Python search code.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>