### PR TITLE
Host Exerciser:  (Cherry-pick) Add support support max 4k vectors and remove hardco…

### DIFF
--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -362,7 +362,7 @@ public:
   : test_afu("host_exerciser", nullptr, "warning")
   , count_(1)
   , he_interleave_(0)
-  , he_interrupt_(99)
+  , he_interrupt_(0xffff)
   {
     // Mode
     app_.add_option("-m,--mode", he_modes_, "host exerciser mode {lpbk,read, write, trput}")
@@ -392,7 +392,7 @@ public:
     // The Interrupt Vector Number for the device
     app_.add_option("--interrupt", he_interrupt_,
         "The Interrupt Vector Number for the device")
-        ->transform(CLI::Range(0, 3));
+        ->transform(CLI::Range(0, 4095));
 
      // Continuous mode time
     app_.add_option("--contmodetime", he_contmodetime_,
@@ -556,6 +556,12 @@ public:
     return handle_->get_token();
   }
 
+  bool option_passed(std::string option_str)
+  {
+      if (app_.count(option_str) == 0)
+            return false;
+      return true;
+  }
 };
 } // end of namespace host_exerciser
 

--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -33,6 +33,7 @@
 using test_afu = opae::afu_test::afu;
 using opae::fpga::types::shared_buffer;
 using opae::fpga::types::token;
+namespace fpga = opae::fpga::types;
 
 // HE exit global flag
 volatile bool g_he_exit = false;
@@ -396,8 +397,15 @@ public:
         }
 
         // Set Interrupt test mode
-        if (host_exe_->he_interrupt_ <= 3) {
-            he_lpbk_cfg_.IntrTestMode = 1;
+        auto afu_props = fpga::properties::get(token_);
+        if (host_exe_->option_passed("--interrupt")) {
+            if (host_exe_->he_interrupt_ < afu_props->num_interrupts) {
+                he_lpbk_cfg_.IntrTestMode = 1;
+            } else {
+                std::cerr << "Invalid Input interrupts vector number:" << host_exe_->he_interrupt_ << std::endl;
+                std::cout << "Please enter Interrupts vector range 0 to " << afu_props->num_interrupts -1 << std::endl;
+                return -1;
+            }
         }
 
         // Atomic functions


### PR DESCRIPTION
…… (#2726)

* Host Exerciser:  Add support support max 4k vectors and remove hardcode vector number

Read the  VFIO Number of interrupts are supported  on that function instead of having it hardcoded as currently

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>

* Host Exerciser: fix typo

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>