### PR TITLE
config: use fpga_default_sequences key in rsu

### DIFF
--- a/opae.cfg
+++ b/opae.cfg
@@ -325,7 +325,7 @@
           {
             "enabled": true,
             "devices": [ "n6000_pf" ],
-            "configuration": "common_rsu_sequences"
+            "fpga_default_sequences": "common_rsu_sequences"
           }
         ],
         "fpgareg": [
@@ -399,7 +399,7 @@
           {
             "enabled": true,
             "devices": [ "n6001_pf" ],
-            "configuration": "common_rsu_sequences"
+            "fpga_default_sequences": "common_rsu_sequences"
           }
         ],
         "fpgareg": [
@@ -473,7 +473,7 @@
           {
             "enabled": true,
             "devices": [ "c6100_pf" ],
-            "configuration": "common_rsu_sequences"
+            "fpga_default_sequences": "common_rsu_sequences"
           }
         ],
         "fpgareg": [
@@ -557,7 +557,7 @@
           {
             "enabled": true,
             "devices": [ "ofs0_pf", "ofs1_pf" ],
-            "configuration": "common_rsu_sequences"
+            "fpga_default_sequences": "common_rsu_sequences"
           }
         ],
         "fpgareg": [


### PR DESCRIPTION
Some of the "rsu" entries in the config file had "configuration" instead of "fpga_default_sequences". Change them to "fpga_default_sequences" to match the parsing code.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>