### PR TITLE
(cherry-pick) config: change 1c2c:1001 to N5011 PF (#2742)

### DIFF
--- a/libraries/libopae-c/cfg-file.c
+++ b/libraries/libopae-c/cfg-file.c
@@ -255,7 +255,7 @@ int opae_parse_device_id(json_object *j_id,
 
 STATIC libopae_config_data default_libopae_config_table[] = {
 	{ 0x1c2c, 0x1000, 0x0000,          0x0000,          "libxfpga.so",  "{}", 0 }, // N5010
-	{ 0x1c2c, 0x1001, 0x0000,          0x0000,          "libxfpga.so",  "{}", 0 }, // N5010
+	{ 0x1c2c, 0x1001, 0x0000,          0x0000,          "libxfpga.so",  "{}", 0 }, // N5011
 	{ 0x8086, 0xbcbd, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // MCP
 	{ 0x8086, 0xbcc0, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // MCP
 	{ 0x8086, 0xbcc1, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // MCP
@@ -488,6 +488,8 @@ STATIC fpgad_config_data default_fpgad_config_table[] = {
 	{ 0x8086, 0x0b30, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libfpgad-vc.so", 0, NULL, "{ \"cool-down\": 30, \"get-aer\": [ \"setpci -s %s ECAP_AER+0x08.L\", \"setpci -s %s ECAP_AER+0x14.L\" ], \"disable-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0xffffffff\", \"setpci -s %s ECAP_AER+0x14.L=0xffffffff\" ], \"set-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0x%08x\", \"setpci -s %s ECAP_AER+0x14.L=0x%08x\" ], \"sensor-overrides\": [ { \"enabled\": true, \"name\": \"12V AUX Voltage\", \"low-warn\": 11.40, \"low-fatal\": 10.56 } ] }" },
 
 	{ 0x1c2c, 0x1000,          0x0000,          0x0000, "libfpgad-vc.so", 0, NULL, "{ \"cool-down\": 30, \"get-aer\": [ \"setpci -s %s ECAP_AER+0x08.L\", \"setpci -s %s ECAP_AER+0x14.L\" ], \"disable-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0xffffffff\", \"setpci -s %s ECAP_AER+0x14.L=0xffffffff\" ], \"set-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0x%08x\", \"setpci -s %s ECAP_AER+0x14.L=0x%08x\" ], \"sensor-overrides\": [] }" },
+
+	{ 0x1c2c, 0x1001,          0x0000,          0x0000, "libfpgad-vc.so", 0, NULL, "{ \"cool-down\": 30, \"get-aer\": [ \"setpci -s %s ECAP_AER+0x08.L\", \"setpci -s %s ECAP_AER+0x14.L\" ], \"disable-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0xffffffff\", \"setpci -s %s ECAP_AER+0x14.L=0xffffffff\" ], \"set-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0x%08x\", \"setpci -s %s ECAP_AER+0x14.L=0x%08x\" ], \"sensor-overrides\": [] }" },
 
 	{ 0x8086, 0xbcce,          0x8086,          0x1770, "libfpgad-vc.so", 0, NULL, "{ \"cool-down\": 30, \"get-aer\": [ \"setpci -s %s ECAP_AER+0x08.L\", \"setpci -s %s ECAP_AER+0x14.L\" ], \"disable-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0xffffffff\", \"setpci -s %s ECAP_AER+0x14.L=0xffffffff\" ], \"set-aer\": [ \"setpci -s %s ECAP_AER+0x08.L=0x%08x\", \"setpci -s %s ECAP_AER+0x14.L=0x%08x\" ], \"sensor-overrides\": [] }" },
 

--- a/opae.cfg
+++ b/opae.cfg
@@ -212,7 +212,7 @@
 
       "devices": [
         { "name": "n5010_pf", "id": [ "0x1c2c", "0x1000", "0", "0" ] },
-        { "name": "n5010_vf", "id": [ "0x1c2c", "0x1001", "0", "0" ] }
+        { "name": "n5011_pf", "id": [ "0x1c2c", "0x1001", "0", "0" ] }
       ],
 
       "opae": {
@@ -220,7 +220,7 @@
           {
             "enabled": true,
             "module": "libxfpga.so",
-            "devices": [ "n5010_pf", "n5010_vf" ],
+            "devices": [ "n5010_pf", "n5011_pf" ],
             "configuration": {}
           }
         ],
@@ -230,7 +230,7 @@
             "module": "libboard_n5010.so",
             "devices": [
               { "device": "n5010_pf", "feature_id": "0xe" },
-              { "device": "n5010_vf", "feature_id": "0xe" }
+              { "device": "n5011_pf", "feature_id": "0xe" }
             ]
           }
         ],
@@ -238,7 +238,7 @@
           {
             "enabled": true,
             "module": "libfpgad-vc.so",
-            "devices": [ "n5010_pf" ],
+            "devices": [ "n5010_pf", "n5011_pf" ],
             "configuration": {
               "cool-down": 30,
               "get-aer":     [ "setpci -s %s ECAP_AER+0x08.L",
@@ -255,15 +255,14 @@
         "rsu": [
           {
             "enabled": true,
-            "devices": [ "n5010_pf" ],
-            "fpga_default_sequences": "common_rsu_sequences"
+            "devices": [ "n5010_pf", "n5011_pf" ]
           }
         ],
         "fpgareg": [],
         "opae.io": [
           {
             "enabled": true,
-            "devices": [ "n5010_pf", "n5010_vf" ]
+            "devices": [ "n5010_pf", "n5011_pf" ]
           }
         ]
       }

--- a/python/opae.admin/opae/admin/config.py
+++ b/python/opae.admin/opae/admin/config.py
@@ -40,21 +40,8 @@ DEFAULT_RSU_CONFIG = {
   (0x8086, 0x0b2b, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY): None, # D5005
   (0x8086, 0xbcce,          0x8086,          0x138d): None, # D5005
   (0x8086, 0x0b30, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY): None, # N3000
-  (0x1c2c, 0x1000,               0,               0): {     # N5010
-    'fpga_default_sequences': [
-      "fpga_user1",
-      "fpga_user2",
-      "fpga_user1 fpga_user2",
-      "fpga_user2 fpga_user1",
-      "fpga_factory",
-      "fpga_factory fpga_user1",
-      "fpga_factory fpga_user2",
-      "fpga_factory fpga_user1 fpga_user2",
-      "fpga_factory fpga_user2 fpga_user1",
-      "fpga_user1 fpga_user2 fpga_factory",
-      "fpga_user2 fpga_user1 fpga_factory"
-    ]
-  },
+  (0x1c2c, 0x1000,               0,               0): None, # N5010
+  (0x1c2c, 0x1001,               0,               0): None, # N5011
   (0x8086, 0xbcce, 0x8086, 0x1770): {                       # N6000
     'fpga_default_sequences': [
       "fpga_user1",


### PR DESCRIPTION
The previous implementation erroneously treated 1001 as the n5010 VF. Also, removes default fpga boot sequence treatment from n5010 (and 5011), based on feedback from Silicom.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>