### PR TITLE
vabtool: remove PR_AUTH_CERT from SR provisioning

### DIFF
--- a/binaries/vabtool/vabtool
+++ b/binaries/vabtool/vabtool
@@ -25,7 +25,7 @@
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-declare -r VERSION='1.0.2'
+declare -r VERSION='1.0.3'
 
 oops() {
   printf "fatal: %s\n" "$*"
@@ -308,38 +308,34 @@ help() {
 [ $# -lt 1 ] && help
 
 sr_key_provision_help() {
-  printf "Usage: vabtool sr_key_provision PCIE_ADDRESS SR_RKH_FILE FPGA_IMG_FILE PR_AUTH_CERT_FILE\n"
+  printf "Usage: vabtool sr_key_provision PCIE_ADDRESS SR_RKH_FILE FPGA_IMG_FILE\n"
   printf "\n"
   printf "\tStatic Region key provisioning flow\n"
   printf "\n"
   printf "\t\tPCIE_ADDRESS      the PCIe address of the ADP in ssss:bb:dd.f form\n"
   printf "\t\tSR_RKH_FILE       the Static Region root key hash file\n"
   printf "\t\tFPGA_IMG_FILE     the Static Region update file\n"
-  printf "\t\tPR_AUTH_CERT_FILE the Programmable Region authorization certificate file\n"
   printf "\n"
   exit 1
 }
 
 sr_key_provision() {
-  [ $# -lt 4 ] && sr_key_provision_help
+  [ $# -lt 3 ] && sr_key_provision_help
 
   local -r pcie_addr="$1"
   local -r rkh_file="$2"
   local -r fpga_file="$3"
-  local -r pr_auth_file="$4"
   local -i res
   local -i i
 
   [ -e "/sys/bus/pci/devices/${pcie_addr}" ] || oops "${pcie_addr} is not a valid device."
   [ -e "${rkh_file}"  ] || oops "${rkh_file} does not exist."
   [ -e "${fpga_file}" ] || oops "${fpga_file} does not exist."
-  [ -e "${pr_auth_file}"  ] || oops "${pr_auth_file} does not exist."
 
   for (( i = 0 ; i < ${RETRIES} ; ++i )); do
     call_fpgasupdate "${rkh_file}"  "${pcie_addr}" || oops 'fpgasupdate failed'
     call_fpgasupdate "${fpga_file}" "${pcie_addr}" || oops 'fpgasupdate failed'
     call_rsu --wait 20 sdm --type=sr "${pcie_addr}"
-    call_fpgasupdate "${pr_auth_file}" "${pcie_addr}" || oops 'fpgasupdate failed'
 
     if [ ${DRY_RUN} -ne 0 ]; then
       local -r glob_pattern="${SDM_SR_PROVISION_STATUS_GLOB/ssss:bb:dd.f/${pcie_addr}}"
@@ -379,19 +375,19 @@ pr_key_provision() {
   [ $# -lt 3 ] && pr_key_provision_help
 
   local -r pcie_addr="$1"
-  local -r sr_auth_cert_file="$2"
+  local -r pr_auth_cert_file="$2"
   local -r pr_rkh_file="$3"
   local -i res
   local -i i
   local boot_page
 
   [ -e "/sys/bus/pci/devices/${pcie_addr}" ] || oops "${pcie_addr} is not a valid device."
-  [ -e "${sr_auth_cert_file}"  ] || oops "${sr_auth_cert_file} does not exist."
+  [ -e "${pr_auth_cert_file}"  ] || oops "${pr_auth_cert_file} does not exist."
   [ -e "${pr_rkh_file}" ] || oops "${pr_rkh_file} does not exist."
 
   for (( i = 0 ; i < ${RETRIES} ; ++i )); do
 
-    pr_key_provision_worker "${pcie_addr}" "${sr_auth_cert_file}" "${pr_rkh_file}"
+    pr_key_provision_worker "${pcie_addr}" "${pr_auth_cert_file}" "${pr_rkh_file}"
     res=$?
     [ ${res} -eq 0 ] && break    
 
@@ -415,11 +411,11 @@ pr_key_provision() {
 
 pr_key_provision_worker() {
   local -r pcie_addr="$1"
-  local -r sr_auth_cert_file="$2"
+  local -r pr_auth_cert_file="$2"
   local -r pr_rkh_file="$3"
   local -i res=0
 
-  call_fpgasupdate "${sr_auth_cert_file}" "${pcie_addr}" || return 1
+  call_fpgasupdate "${pr_auth_cert_file}" "${pcie_addr}" || return 1
   call_fpgasupdate "${pr_rkh_file}"       "${pcie_addr}" || return 1
   call_rsu --wait 20 sdm --type=pr "${pcie_addr}"
 


### PR DESCRIPTION
Based on feedback, it is unnecessary/undesirable to require the PR_AUTH_CERT during SR programming.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>