### PR TITLE
(cherry-pick) pluginmgr: remove invalid test case (#2749)

### DIFF
--- a/tests/opae-c/test_pluginmgr_c.cpp
+++ b/tests/opae-c/test_pluginmgr_c.cpp
@@ -106,21 +106,6 @@ TEST(pluginmgr, multi_finalize) {
   finalizing = 0;
 }
 
-/**
- * @test       free_adapter_err0
- * @brief      Test: opae_plugin_mgr_free_adapter
- * @details    When opae_plugin_mgr_free_adapter is called with an<br>
- *             adapter that has a closed dl_handle,<br>
- *             then the fn returns a non-zero value.<br>
- */
-TEST(pluginmgr, free_adapter_err0) {
-  opae_api_adapter_table *adapter =
-	  (opae_api_adapter_table *)opae_calloc(1, sizeof(opae_api_adapter_table));
-  adapter->plugin.dl_handle = opae_plugin_mgr_find_plugin("libxfpga.so");
-  dlclose(adapter->plugin.dl_handle);
-  EXPECT_NE(0, opae_plugin_mgr_free_adapter(adapter));
-}
-
 extern "C" {
 
 static int test_plugin_initialize_called;


### PR DESCRIPTION
Remove invalid test free_adapter_err0. The test case was dependent on dlclose() behaving nicely when a dl handle was double-freed. This depedency proved false during nightly regression, where it caused a seg fault.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>