### PR TITLE
opae-c: avoid stack-based strings / add tests

### DIFF
--- a/libraries/libopae-c/pluginmgr.c
+++ b/libraries/libopae-c/pluginmgr.c
@@ -101,7 +101,14 @@ STATIC opae_api_adapter_table *opae_plugin_mgr_alloc_adapter(const char *lib_pat
 		return NULL;
 	}
 
-	adapter->plugin.path = (char *)lib_path;
+	adapter->plugin.path = opae_strdup(lib_path);
+	if (!adapter->plugin.path) {
+		dlclose(dl_handle);
+		opae_free(adapter);
+		OPAE_ERR("out of memory");
+		return NULL;
+	}
+
 	adapter->plugin.dl_handle = dl_handle;
 
 	return adapter;
@@ -119,6 +126,7 @@ STATIC int opae_plugin_mgr_free_adapter(opae_api_adapter_table *adapter)
 		OPAE_ERR("dlclose failed with %d %s", res, err ? err : "");
 	}
 
+	opae_free(adapter->plugin.path);
 	opae_free(adapter);
 
 	return res;
@@ -226,9 +234,17 @@ STATIC int opae_plugin_mgr_register_adapter(opae_api_adapter_table *adapter)
 		return 0;
 	}
 
-	// new entries go to the end of the list.
-	for (aptr = adapter_list; aptr->next; aptr = aptr->next)
-		/* find the last entry */;
+	/*
+	 * Adapter entries are unique.
+	 * New entries go to the end of the list.
+	 */
+	for (aptr = adapter_list; aptr->next; aptr = aptr->next) {
+		if (!strcmp(aptr->plugin.path, adapter->plugin.path))
+			return 1; // Prevent duplicate entries.
+	}
+
+	if (!strcmp(aptr->plugin.path, adapter->plugin.path))
+		return 1; // Prevent duplicate entries.
 
 	aptr->next = adapter;
 
@@ -494,9 +510,8 @@ STATIC int opae_plugin_mgr_load_plugins(int *platforms_detected)
 
 		res = opae_plugin_mgr_register_adapter(adapter);
 		if (res) {
+			// Duplicate adapter detected. Free it and continue.
 			opae_plugin_mgr_free_adapter(adapter);
-			OPAE_ERR("Failed to register \"%s\"", plugin);
-			++errors;
 			continue; // Keep going.
 		}
 
@@ -626,9 +641,9 @@ int opae_plugin_mgr_register_plugin(const char *name, const char *cfg)
 	opae_mutex_unlock(lock_res, &adapter_list_lock);
 
 	if (res) {
+		// Duplicate adapter detected.
+		// Free the adapter and continue.
 		opae_plugin_mgr_free_adapter(adapter);
-		OPAE_ERR("Failed to register \"%s\"", name);
-		return res;
 	}
 
 	return 0;


### PR DESCRIPTION
opae_plugin_mgr_alloc_adapter() was saving the value of its lib_path parameter directly in the adapter. This could lead to problems if, for example opae_plugin_mgr_register_plugin() were to pass through a stack-based path. The fix involves using strdup() and free() in the alloc and free adapter calls.

With the string fix in place, we add a check to
opae_plugin_mgr_register_adapter() to prevent duplicate entries in the list. This could happen when, eg ASE loads via
opae_plugin_mgr_register_plugin() but is also present in the configuration file passed to fpgaInitialize(). Duplicate adapter entries would mean duplicate tokens during enumeration. The uniqueness check guarantees that we won't duplicate any tokens.

Add unit tests for opae_plugin_mgr_register_plugin().

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>