### PR TITLE
build: bump minimum Linux kernel headers version to 5.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ if (OPAE_BUILD_LIBOPAEVFIO)
         set(PLATFORM_SUPPORTS_VFIO FALSE CACHE BOOL "Platform supports vfio driver" FORCE)
         message(WARNING
             "Could not compile VFIO.
-            This most likely means that kernel( version >= 4.6) headers aren't installed.
+            This most likely means that kernel( version >= 5.4) headers aren't installed.
             See errors in platform_vfio_errors.txt")
         file(WRITE ${CMAKE_BINARY_DIR}/platform_vfio_errors.txt ${TRY_COMPILE_OUTPUT})
     endif(VFIO_CHECK)


### PR DESCRIPTION
opae-sdk requires [[1]](https://github.com/OPAE/opae-sdk/commit/1a8079e293bc4731d2e2eca11c3c9c57f1563fa5
) IOVA range capability support [[2]](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a717072007e8aedd3f951726d8cf55454860b30d) added in Linux 5.4.