### PR TITLE
deb packaging: add support for Ubuntu 20.04

### DIFF
--- a/packaging/opae/deb/control
+++ b/packaging/opae/deb/control
@@ -20,8 +20,7 @@ Package: opae
 Section: libs
 Priority: optional
 Architecture: any
-Depends: libuuid1, libjson-c5,
-         ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}
+Depends: ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}
 Description: OPAE runtime
 
 Package: opae-devel
@@ -40,6 +39,5 @@ Priority: optional
 Architecture: any
 Multi-Arch: same
 Depends: opae (= ${binary:Version}), opae-devel (= ${binary:Version}),
-         libhwloc15, libtbb12, libedit2,
          ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends},
 Description: OPAE extra tool binaries

--- a/packaging/opae/deb/create
+++ b/packaging/opae/deb/create
@@ -41,7 +41,6 @@ for pkg in 'devscripts' \
            'pkg-config' \
            'uuid-dev' \
            'libjson-c-dev' \
-           'libtbb2' \
            'libtbb-dev' \
            'libhwloc-dev' \
            'python3-dev' \


### PR DESCRIPTION
Remove explicit mentions of .so deps from the control file
and let ${shlibs:Depends} do its thing.

Verified using Ubuntu 22.04 LTS and Ubuntu 20.04 LTS.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>
Co-authored-by: Peter Colberg <Peter.Colberg@intel.com>