### PR TITLE
hssi 100g: default to port 0 when no option given

### DIFF
--- a/samples/hssi/hssi_100g_cmd.h
+++ b/samples/hssi/hssi_100g_cmd.h
@@ -375,6 +375,9 @@ public:
       return test_afu::error;
     }
 
+    if (port_.empty())
+        port_.push_back(0);
+
     hssi_afu *hafu = dynamic_cast<hssi_afu *>(afu);
 
     uint64_t bin_src_addr = mac_bits_for(src_addr_);


### PR DESCRIPTION
Fixes a segfault observed when --port was missing from the command line.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>