### PR TITLE
(cherry-pick) sim: changes to support ASE for OpenCL MMD. (#2751)

### DIFF
--- a/include/opae/types_enum.h
+++ b/include/opae/types_enum.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2021, Intel Corporation
+// Copyright(c) 2017-2022, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -126,9 +126,12 @@ typedef enum {
 	/** FPGA_IFC_VFIO indicates that the plugin interface is the
 	 * vfio-pci driver. */
 	FPGA_IFC_VFIO,
-	/** FPGA_IFC_SIM indicates that the plugin interface is the
-	 * AFU Simulation Environment. */
-	FPGA_IFC_SIM
+	/** FPGA_IFC_SIM_DFL indicates that the plugin interface is the
+	 * AFU Simulation Environment simulating DFL drivers. */
+	FPGA_IFC_SIM_DFL,
+	/** FPGA_IFC_SIM_VFIO indicates that the plugin interface is the
+	 * AFU Simulation Environment simulating vfio-pci. */
+	FPGA_IFC_SIM_VFIO
 } fpga_interface;
 
 /**

--- a/libraries/libopae-c/pluginmgr.c
+++ b/libraries/libopae-c/pluginmgr.c
@@ -297,14 +297,22 @@ STATIC int opae_plugin_mgr_detect_platforms(bool with_ase)
 
 	if (with_ase) {
 		opae_pci_device ase_pf = {
-			.name = "ase",
+			.name = "ase_pf",
 			.vendor_id = 0x8086,
 			.device_id = 0x0a5e,
 			.subsystem_vendor_id = 0x8086,
 			.subsystem_device_id = 0x0a5e
 		};
+		opae_pci_device ase_vf = {
+			.name = "ase_vf",
+			.vendor_id = 0x8086,
+			.device_id = 0x0a5e,
+			.subsystem_vendor_id = 0x8086,
+			.subsystem_device_id = 0x0a5f
+		};
 
 		opae_plugin_mgr_detect_platform(&ase_pf);
+		opae_plugin_mgr_detect_platform(&ase_vf);
 		return 0;
 	}
 

--- a/libraries/pyopae/opae.cpp
+++ b/libraries/pyopae/opae.cpp
@@ -127,7 +127,8 @@ PYBIND11_MODULE(_opae, m) {
                             "OPAE interfaces")
       .value("IFC_DFL", FPGA_IFC_DFL)
       .value("IFC_VFIO", FPGA_IFC_VFIO)
-      .value("IFC_SIM", FPGA_IFC_SIM)
+      .value("IFC_SIM_DFL", FPGA_IFC_SIM_DFL)
+      .value("IFC_SIM_VFIO", FPGA_IFC_SIM_VFIO)
       .export_values();
 
   // version method

--- a/tests/opae-c/test_props_c.cpp
+++ b/tests/opae-c/test_props_c.cpp
@@ -3374,7 +3374,7 @@ TEST_P(properties_c_p, set_interface01) {
 
   struct _fpga_properties* _prop = (struct _fpga_properties*)prop;
 
-  fpga_interface ifc = FPGA_IFC_SIM;
+  fpga_interface ifc = FPGA_IFC_SIM_DFL;
   // make sure the FPGA_PROPERTY_INTERFACE bit is zero
   EXPECT_EQ((_prop->valid_fields >> FPGA_PROPERTY_INTERFACE) & 1, 0);
   // Call the API to set the interface on the property
@@ -3386,7 +3386,7 @@ TEST_P(properties_c_p, set_interface01) {
   EXPECT_EQ((_prop->valid_fields >> FPGA_PROPERTY_INTERFACE) & 1, 1);
 
   // Assert it is set to what we set it to above
-  EXPECT_EQ(FPGA_IFC_SIM, _prop->interface);
+  EXPECT_EQ(FPGA_IFC_SIM_DFL, _prop->interface);
 
   result = fpgaDestroyProperties(&prop);
   ASSERT_EQ(NULL, prop);

--- a/tests/xfpga/test_enum_c.cpp
+++ b/tests/xfpga/test_enum_c.cpp
@@ -798,7 +798,7 @@ TEST_P(enum_c_p, interface) {
  *             the function returns zero matches
  */
 TEST_P(enum_c_p, interface_neg) {
-  ASSERT_EQ(fpgaPropertiesSetInterface(filter_, FPGA_IFC_SIM), FPGA_OK);
+  ASSERT_EQ(fpgaPropertiesSetInterface(filter_, FPGA_IFC_SIM_DFL), FPGA_OK);
   EXPECT_EQ(xfpga_fpgaEnumerate(&filter_, 1,
                                 tokens_.data(), tokens_.size(),
                                 &matches_), FPGA_OK);


### PR DESCRIPTION
* ase: add VF device when WITH_ASE present.

Michael mentioned some ASE test cases that require the DID to be 0x0a5e. We'll change the DID of the VF0 back to 0x0a5e, and we'll make the subsystem device id 0x0a5f for the VF0.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>