### PR TITLE
Add support for Alibaba F5 cards

### DIFF
--- a/libraries/libopae-c/cfg-file.c
+++ b/libraries/libopae-c/cfg-file.c
@@ -258,6 +258,7 @@ STATIC libopae_config_data default_libopae_config_table[] = {
 	{ 0x1c2c, 0x1001, 0x0000,          0x0000,          "libxfpga.so",  "{}", 0 }, // N5011
 	{ 0x1c2c, 0x1002, 0x0000,          0x0000,          "libxfpga.so",  "{}", 0 }, // N5013
 	{ 0x1c2c, 0x1003, 0x0000,          0x0000,          "libxfpga.so",  "{}", 0 }, // N5014
+	{ 0x1ded, 0x8103, 0x1ded,          0x4342,          "libxfpga.so",  "{}", 0 }, // F5
 	{ 0x8086, 0xbcbd, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // MCP
 	{ 0x8086, 0xbcc0, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // MCP
 	{ 0x8086, 0xbcc1, OPAE_VENDOR_ANY, OPAE_DEVICE_ANY, "libxfpga.so",  "{}", 0 }, // MCP

--- a/opae.cfg
+++ b/opae.cfg
@@ -692,6 +692,36 @@
           }
         ]
       }
+    },
+
+    "f5": {
+      "enabled": true,
+      "platform": "Alibaba F5 Card with Intel Agilex FPGA",
+
+      "devices": [
+        { "name": "f5", "id": [ "0x1ded", "0x8103", "0x1ded", "0x4342" ] }
+      ],
+
+      "opae": {
+        "plugin": [
+          {
+            "enabled": true,
+            "module": "libxfpga.so",
+            "devices": [ "f5"],
+            "configuration": {}
+          }
+        ],
+        "fpgainfo": [],
+        "fpgad": [],
+        "rsu": [],
+        "fpgareg": [],
+        "opae.io": [
+          {
+            "enabled": true,
+            "devices": [ "f5" ]
+          }
+        ]
+      }
     }
   },
 
@@ -706,6 +736,7 @@
     "n6000",
     "n6001",
     "c6100",
+    "f5",
     "ofs"
   ],
 


### PR DESCRIPTION
do not support fpgainfo this time, and will support it in the future.