### PR TITLE
Fix fpgainfo events power on time stamp

### DIFF
--- a/libraries/libboard/board_n6000/board_event_log.c
+++ b/libraries/libboard/board_n6000/board_event_log.c
@@ -209,7 +209,7 @@ static void bel_print_value(const char *label, uint32_t value)
 	printf("    " BEL_LABEL_FMT "0x%08x\n", 48, label, value);
 }
 
-static void bel_print_timeofday(const char* label, struct bel_timeof_day *time_of_day)
+static void bel_print_timeofday(const char *label, struct bel_timeof_day *time_of_day)
 {
 	char time_str[26] = { 0 };
 	time_t time_sec = 0;
@@ -269,7 +269,7 @@ static void reserved_bit(const char *label, uint32_t value, size_t offset)
 		printf("      " BEL_LABEL_FMT "*** RESERVED BIT [%lu] IS NOT ZERO: %d\n", 46, label, offset, bit);
 }
 
-static void bel_print_power_on_status(struct bel_power_on_status *status, struct bel_timeof_day* timeof_day, bool print_bits)
+static void bel_print_power_on_status(struct bel_power_on_status *status, struct bel_timeof_day *timeof_day, bool print_bits)
 {
 	if (status->header.magic != BEL_POWER_ON_STATUS)
 		return;

--- a/libraries/libboard/board_n6000/board_event_log.c
+++ b/libraries/libboard/board_n6000/board_event_log.c
@@ -209,7 +209,7 @@ static void bel_print_value(const char *label, uint32_t value)
 	printf("    " BEL_LABEL_FMT "0x%08x\n", 48, label, value);
 }
 
-static void bel_print_timeofday(struct bel_timeof_day *time_of_day)
+static void bel_print_timeofday(const char* label, struct bel_timeof_day *time_of_day)
 {
 	char time_str[26] = { 0 };
 	time_t time_sec = 0;
@@ -231,7 +231,7 @@ static void bel_print_timeofday(struct bel_timeof_day *time_of_day)
 		OPAE_ERR("Failed to format time: %s", strerror(errno));
 		return;
 	}
-	printf("  " BEL_LABEL_FMT "%s", 50, "Time of day offset", time_str);
+	printf("  " BEL_LABEL_FMT "%s", 50, label, time_str);
 }
 
 static void bel_print_header(const char *label, struct bel_header *header)
@@ -269,12 +269,19 @@ static void reserved_bit(const char *label, uint32_t value, size_t offset)
 		printf("      " BEL_LABEL_FMT "*** RESERVED BIT [%lu] IS NOT ZERO: %d\n", 46, label, offset, bit);
 }
 
-static void bel_print_power_on_status(struct bel_power_on_status *status, bool print_bits)
+static void bel_print_power_on_status(struct bel_power_on_status *status, struct bel_timeof_day* timeof_day, bool print_bits)
 {
 	if (status->header.magic != BEL_POWER_ON_STATUS)
 		return;
 
-	bel_print_header("Power On Status Time", &status->header);
+	if (timeof_day->header.magic != BEL_TIMEOF_DAY_STATUS)
+		return;
+
+	/* Power on status is logged immediately after power on.
+	Time of the day information is written by SW into a BMC register.
+	This write will take some time after power on and hence with Power
+	on log there is no timestamp value available.*/
+	bel_print_timeofday("Power On Status Time", timeof_day);
 
 	/* Register 0x80 */
 	bel_print_value("Status (0x80)",        status->status);
@@ -685,7 +692,7 @@ static void bel_print_timeof_day(struct bel_timeof_day *timeof_day)
 		return;
 
 	bel_print_header("Time of day", &timeof_day->header);
-	bel_print_timeofday(timeof_day);
+	bel_print_timeofday("Time of day offset", timeof_day);
 
 	bel_print_value("TimeOfDay offset low", timeof_day->timeofday_offset_low);
 	bel_print_value("TimeOfDay offset high", timeof_day->timeofday_offset_high);
@@ -797,7 +804,7 @@ fpga_result bel_read(fpga_object fpga_object, uint32_t ptr, struct bel_event *ev
 
 void bel_print(struct bel_event *event, bool print_sensors, bool print_bits)
 {
-	bel_print_power_on_status(&event->power_on_status, print_bits);
+	bel_print_power_on_status(&event->power_on_status, &event->timeof_day, print_bits);
 	bel_print_timeof_day(&event->timeof_day);
 	bel_print_max10_seu(&event->max10_seu);
 	bel_print_fpga_seu(&event->fpga_seu);


### PR DESCRIPTION
SW should use the information in block with magic number '0x53696CF0' to derive power on event time stamp, and not the timestamp field of magic number '  0x53696C12'. Power on status is logged immediately after power on.  Time of the day information is written by SW into a BMC register. This write will take some time after power on and hence with Power on log there is no timestamp value available. Because of this reason, second block 'time of the day offset' (block with magic number '0x53696CF0' ) is provided from BMC. BMC internally keeps track of time lapse after the power on and first ToD write by Host and provides the correct value by reverse calculation.  Please use this information to print the power on status time

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>