### PR TITLE
build: add CMAKE_INSTALL_PREFIX length check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,9 +83,11 @@ endif(OPAE_MINIMAL_BUILD)
 
 string(LENGTH ${CMAKE_INSTALL_PREFIX} INSTALL_PREFIX_LEN)
 if (${INSTALL_PREFIX_LEN} GREATER 127)
-    message(WARNING "The length of CMAKE_INSTALL_PREFIX (${INSTALL_PREFIX_LEN}) has exceeded"
-                    " a limit mandated by the Linux kernel. As a result, you may experience trouble"
-		    " with this build.")
+    message(FATAL_ERROR "The length of CMAKE_INSTALL_PREFIX (${INSTALL_PREFIX_LEN})"
+                        " has exceeded a limit mandated by the Linux kernel"
+                        " regarding the length of a script shebang. As a result,"
+                        " the build has been stopped. Please choose a more suitable"
+                        " CMAKE_INSTALL_PREFIX and try again.")
 endif ()
 
 ############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,17 @@ if (OPAE_MINIMAL_BUILD)
 endif(OPAE_MINIMAL_BUILD)
 
 ############################################################################
+## CMAKE_INSTALL_PREFIX check ##############################################
+############################################################################
+
+string(LENGTH ${CMAKE_INSTALL_PREFIX} INSTALL_PREFIX_LEN)
+if (${INSTALL_PREFIX_LEN} GREATER 127)
+    message(WARNING "The length of CMAKE_INSTALL_PREFIX (${INSTALL_PREFIX_LEN}) is approaching"
+                    " a limit mandated by the Linux kernel. As a result, you may experience trouble"
+		    " with this build.")
+endif ()
+
+############################################################################
 ## Other setup and dependencies ############################################
 ############################################################################
 find_package(Doxygen)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ endif(OPAE_MINIMAL_BUILD)
 
 string(LENGTH ${CMAKE_INSTALL_PREFIX} INSTALL_PREFIX_LEN)
 if (${INSTALL_PREFIX_LEN} GREATER 127)
-    message(WARNING "The length of CMAKE_INSTALL_PREFIX (${INSTALL_PREFIX_LEN}) is approaching"
+    message(WARNING "The length of CMAKE_INSTALL_PREFIX (${INSTALL_PREFIX_LEN}) has exceeded"
                     " a limit mandated by the Linux kernel. As a result, you may experience trouble"
 		    " with this build.")
 endif ()


### PR DESCRIPTION
Linux mandates a limit on the length of a command that may appear in
the "shebang" line of a script. In our internal environments, this
limit has been exceeded, causing ill-behaved builds.

Fail the build if the length of CMAKE_INSTALL_PREFIX exceeds the
127 character limit.