### PR TITLE
ci: update to actions/checkout@v3

### DIFF
--- a/.github/workflows/build-debs.yml
+++ b/.github/workflows/build-debs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build ${{ matrix.distro }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build Docker Image
         run: docker build . -f docker/${{ matrix.distro }}/Dockerfile -t opae-${{ matrix.distro }}
       - name: Build DEBs

--- a/.github/workflows/build-rpms.yml
+++ b/.github/workflows/build-rpms.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build ${{ matrix.distro }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build Docker Image
         run: docker build . -f docker/${{ matrix.distro }}/Dockerfile -t opae-${{ matrix.distro }}
       - name: Build RPMs

--- a/.github/workflows/ccpp-tests.yml
+++ b/.github/workflows/ccpp-tests.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         lang-type: [c, cpp]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: update
       run: sudo apt-get update -y
     - name: Get Packages
@@ -57,7 +57,7 @@ jobs:
       matrix:
         build-type: [Debug, Release, RelWithDebInfo]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: update
       run: sudo apt-get update -y
     - name: Get Packages
@@ -73,7 +73,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: update
       run: sudo apt-get update -y
     - name: Get Packages
@@ -92,7 +92,7 @@ jobs:
   build-doc:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: update
       run: sudo apt-get update -y
     - name: Build Docker image

--- a/.github/workflows/pacsign.yml
+++ b/.github/workflows/pacsign.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/python-static-analysis.yml
+++ b/.github/workflows/python-static-analysis.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Update
       run: sudo apt-get update -y
     - name: Setup python${{ matrix.python-version }}

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: update
       run: sudo apt-get update -y
     - name: Get Packages


### PR DESCRIPTION
github will be deprecating node12-based actions by summer of 2023. checkout@v3 is developed for node16.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>