### PR TITLE
ci: update to action/upload-artifact@v3

### DIFF
--- a/.github/workflows/build-debs.yml
+++ b/.github/workflows/build-debs.yml
@@ -29,7 +29,7 @@ jobs:
           docker run --rm -v ${{ github.workspace }}:/opae-${{ matrix.distro }}/opae-sdk --workdir /opae-${{ matrix.distro }}/opae-sdk --entrypoint /bin/bash opae-${{ matrix.distro }} -c "/scripts/test-debs.sh"
       - name: Upload Artifact
         if: ${{ github.event_name != 'pull_request'}}
-        uses: actions/upload-artifact@v2.1.4
+        uses: actions/upload-artifact@v3
         with:
           name: OPAE-${{ matrix.distro }}
           path:

--- a/.github/workflows/build-rpms.yml
+++ b/.github/workflows/build-rpms.yml
@@ -30,7 +30,7 @@ jobs:
           docker run --rm -v ${{ github.workspace }}:/opae-${{ matrix.distro }}/opae-sdk --workdir /opae-${{ matrix.distro }}/opae-sdk --entrypoint /bin/bash opae-${{ matrix.distro }} -c "/scripts/test-rpms.sh"
       - name: Upload Artifact
         if: ${{ github.event_name != 'pull_request'}}
-        uses: actions/upload-artifact@v2.1.4
+        uses: actions/upload-artifact@v3
         with:
           name: OPAE-${{ matrix.distro }}
           path:

--- a/.github/workflows/ccpp-tests.yml
+++ b/.github/workflows/ccpp-tests.yml
@@ -108,7 +108,7 @@ jobs:
       working-directory: ${{ github.workspace }}/mybuild_docs
       run: ${{ github.workspace }}/scripts/push-documentation.sh "${GITHUB_TAG##*/}"
     - name: Archive html docs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: docs
         path: mybuild_docs/sphinx/html
@@ -117,7 +117,7 @@ jobs:
       with:
         args: -v -r mybuild_docs/sphinx/html
     - name: Archive link-checker result
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: link-checker
         path: link-checker

--- a/.github/workflows/python-static-analysis.yml
+++ b/.github/workflows/python-static-analysis.yml
@@ -49,7 +49,7 @@ jobs:
           --format csv \
           | tee ${{ github.workspace }}/bandit.log.csv
     - name: Archive results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: static-analysis
         path: |

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -30,7 +30,7 @@ jobs:
         OPAE_EXPLICIT_INITIALIZE: 1
         LD_LIBRARY_PATH: ${{ github.workspace }}/.build/lib
     - name: Archive Results
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: valgrind
         path: ${{ github.workspace }}/.build/valgrind


### PR DESCRIPTION
Updating to the node16 version of this, per the following deprecation notice:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>