### PR TITLE
cfg search: log error when "configs" not detected

### DIFF
--- a/libraries/libopae-c/cfg-file.c
+++ b/libraries/libopae-c/cfg-file.c
@@ -297,15 +297,15 @@ STATIC libopae_config_data default_libopae_config_table[] = {
 };
 
 libopae_config_data *
-opae_parse_libopae_json(const char *json_input);
+opae_parse_libopae_json(const char *cfgfile, const char *json_input);
 
 libopae_config_data *
-opae_parse_libopae_config(const char *json_input)
+opae_parse_libopae_config(const char *cfgfile, const char *json_input)
 {
 	libopae_config_data *c = NULL;
 
 	if (json_input)
-		c = opae_parse_libopae_json(json_input);
+		c = opae_parse_libopae_json(cfgfile, json_input);
 
 	return c ? c : default_libopae_config_table;
 }

--- a/libraries/libopae-c/cfg-file.c
+++ b/libraries/libopae-c/cfg-file.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2022, Intel Corporation
+// Copyright(c) 2022-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:

--- a/libraries/libopae-c/cfg-file.h
+++ b/libraries/libopae-c/cfg-file.h
@@ -80,7 +80,8 @@ typedef struct _libopae_config_data {
 } libopae_config_data;
 
 libopae_config_data *
-opae_parse_libopae_config(const char *json_input);
+opae_parse_libopae_config(const char *cfgfile,
+			  const char *json_input);
 
 void opae_print_libopae_config(libopae_config_data *cfg);
 

--- a/libraries/libopae-c/cfg-file.h
+++ b/libraries/libopae-c/cfg-file.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2022, Intel Corporation
+// Copyright(c) 2022-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:

--- a/libraries/libopae-c/init.c
+++ b/libraries/libopae-c/init.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2022, Intel Corporation
+// Copyright(c) 2017-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -60,10 +60,12 @@ STATIC const char _ase_home_cfg_files[HOME_CFG_PATHS][CFG_PATH_MAX] = {
 	{ "/.local/opae/opae_ase.cfg" },
 	{ "/.config/opae/opae_ase.cfg" },
 };
-#define SYS_CFG_PATHS 2
+#define SYS_CFG_PATHS 4
 STATIC const char _ase_sys_cfg_files[SYS_CFG_PATHS][CFG_PATH_MAX] = {
-	{ "/usr/local/etc/opae/opae_ase.cfg" },
-	{ "/etc/opae/opae_ase.cfg" },
+	{ "/usr/share/opae/ase/opae_ase.cfg"       },
+	{ "/usr/local/share/opae/ase/opae_ase.cfg" },
+	{ "/usr/local/etc/opae/opae_ase.cfg"       },
+	{ "/etc/opae/opae_ase.cfg"                 },
 };
 
 void opae_print(int loglevel, const char *fmt, ...)
@@ -112,13 +114,17 @@ STATIC char *find_ase_cfg(void)
 
 	// first look in the OPAE source directory
 	file_name = opae_canonicalize_file_name(OPAE_ASE_CFG_SRC_PATH);
-	if (file_name)
+	if (file_name) {
+		OPAE_DBG("Found ASE config file: %s", file_name);
 		return file_name;
+	}
 
 	// second look in OPAE installation directory
 	file_name = opae_canonicalize_file_name(OPAE_ASE_CFG_INST_PATH);
-	if (file_name)
+	if (file_name) {
+		OPAE_DBG("Found ASE config file: %s", file_name);
 		return file_name;
+	}
 
 	// third look in the release directory
 	opae_path = getenv("OPAE_PLATFORM_ROOT");
@@ -129,8 +135,10 @@ STATIC char *find_ase_cfg(void)
 			OPAE_ERR("snprintf buffer overflow");
 		} else {
 			file_name = opae_canonicalize_file_name(cfg_path);
-			if (file_name)
+			if (file_name) {
+				OPAE_DBG("Found ASE config file: %s", file_name);
 				return file_name;
+			}
 		}
 	}
 
@@ -143,8 +151,11 @@ STATIC char *find_ase_cfg(void)
 				OPAE_ERR("snprintf buffer overflow");
 			} else {
 				file_name = opae_canonicalize_file_name(home_cfg);
-				if (file_name)
+				if (file_name) {
+					OPAE_DBG("Found ASE config file: %s",
+						 file_name);
 					return file_name;
+				}
 			}
 		}
 	}
@@ -155,8 +166,10 @@ STATIC char *find_ase_cfg(void)
 		memcpy(home_cfg, _ase_sys_cfg_files[i], len);
 		home_cfg[len] = '\0';
 		file_name = opae_canonicalize_file_name(home_cfg);
-		if (file_name)
+		if (file_name) {
+			OPAE_DBG("Found ASE config file: %s", file_name);
 			return file_name;
+		}
 	}
 
 	return NULL;

--- a/libraries/libopae-c/init.c
+++ b/libraries/libopae-c/init.c
@@ -62,8 +62,8 @@ STATIC const char _ase_home_cfg_files[HOME_CFG_PATHS][CFG_PATH_MAX] = {
 };
 #define SYS_CFG_PATHS 4
 STATIC const char _ase_sys_cfg_files[SYS_CFG_PATHS][CFG_PATH_MAX] = {
-	{ "/usr/share/opae/ase/opae_ase.cfg"       },
 	{ "/usr/local/share/opae/ase/opae_ase.cfg" },
+	{ "/usr/share/opae/ase/opae_ase.cfg"       },
 	{ "/usr/local/etc/opae/opae_ase.cfg"       },
 	{ "/etc/opae/opae_ase.cfg"                 },
 };

--- a/libraries/libopae-c/opae-cfg.c
+++ b/libraries/libopae-c/opae-cfg.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2022, Intel Corporation
+// Copyright(c) 2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -358,8 +358,12 @@ opae_parse_libopae_json(const char *json_input)
 	}
 
 	j_configs = parse_json_array(root, "configs", &num_configs);
-	if (!j_configs)
+	if (!j_configs) {
+		OPAE_ERR("Failed to find \"configs\" in configuration JSON.");
+		OPAE_ERR("You may have encountered an old config file.");
+		OPAE_ERR("Enable debug logging to see which file is found.");
 		goto out_free;
+	}
 
 	for (i = 0 ; i < num_configs ; ++i) {
 		json_object *j_config_i =

--- a/libraries/libopae-c/opae-cfg.c
+++ b/libraries/libopae-c/opae-cfg.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2023, Intel Corporation
+// Copyright(c) 2022-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:

--- a/libraries/libopae-c/opae-cfg.c
+++ b/libraries/libopae-c/opae-cfg.c
@@ -339,7 +339,7 @@ out_free:
 }
 
 libopae_config_data *
-opae_parse_libopae_json(const char *json_input)
+opae_parse_libopae_json(const char *cfgfile, const char *json_input)
 {
 	enum json_tokener_error j_err = json_tokener_success;
 	json_object *root = NULL;
@@ -359,9 +359,9 @@ opae_parse_libopae_json(const char *json_input)
 
 	j_configs = parse_json_array(root, "configs", &num_configs);
 	if (!j_configs) {
-		OPAE_ERR("Failed to find \"configs\" in configuration JSON.");
+		OPAE_ERR("Failed to find \"configs\" in \"%s\".",
+			 cfgfile ? cfgfile : "<unknown>");
 		OPAE_ERR("You may have encountered an old config file.");
-		OPAE_ERR("Enable debug logging to see which file is found.");
 		goto out_free;
 	}
 

--- a/libraries/libopae-c/pluginmgr.c
+++ b/libraries/libopae-c/pluginmgr.c
@@ -562,7 +562,7 @@ int opae_plugin_mgr_initialize(const char *cfg_file)
 	// Parse the config file content, allocating and initializing
 	// our configuration table. If raw_config is non-NULL, then
 	// this function will delete it.
-	platform_data_table = opae_parse_libopae_config(raw_config);
+	platform_data_table = opae_parse_libopae_config(cfg_file, raw_config);
 
 	// Print the config table for debug builds.
 	opae_print_libopae_config(platform_data_table);

--- a/libraries/libopae-c/pluginmgr.c
+++ b/libraries/libopae-c/pluginmgr.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2022, Intel Corporation
+// Copyright(c) 2018-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:

--- a/libraries/plugins/vfio/plugin.c
+++ b/libraries/plugins/vfio/plugin.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2020-2021, Intel Corporation
+// Copyright(c) 2020-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:

--- a/libraries/plugins/vfio/plugin.c
+++ b/libraries/plugins/vfio/plugin.c
@@ -50,13 +50,15 @@ int __VFIO_API__ vfio_plugin_initialize(void)
 	char *cfg_file;
 
 	cfg_file = opae_find_cfg_file();
-	if (cfg_file) {
+	if (cfg_file)
 		raw_cfg = opae_read_cfg_file(cfg_file);
+
+	opae_v_supported_devices = opae_parse_libopae_config(cfg_file, raw_cfg);
+
+	if (cfg_file) {
 		opae_free(cfg_file);
 		cfg_file = NULL;
 	}
-
-	opae_v_supported_devices = opae_parse_libopae_config(raw_cfg);
 
 	res = pci_discover();
 	if (res) {

--- a/tests/opae-c/test_opae_cfg_c.cpp
+++ b/tests/opae-c/test_opae_cfg_c.cpp
@@ -43,7 +43,7 @@ int parse_plugin_config(json_object *root,
                         const char *cfg_name,
                         libopae_parse_context *ctx);
 libopae_config_data *
-opae_parse_libopae_json(const char *json_input);
+opae_parse_libopae_json(const char *cfgfile, const char *json_input);
 
 }
 
@@ -1029,7 +1029,7 @@ TEST(opae_cfg, parse_config_err12) {
  */
 TEST(opae_cfg, parse_libopae_err0) {
   char *json = opae_strdup("This is not JSON");
-  EXPECT_EQ((libopae_config_data *)NULL, opae_parse_libopae_json(json));
+  EXPECT_EQ((libopae_config_data *)NULL, opae_parse_libopae_json(NULL, json));
 }
 
 /**
@@ -1071,7 +1071,7 @@ TEST(opae_cfg, parse_libopae_err1) {
 )json";
 
   char *json_dup = opae_strdup(json);
-  EXPECT_EQ((libopae_config_data *)NULL, opae_parse_libopae_json(json_dup));
+  EXPECT_EQ((libopae_config_data *)NULL, opae_parse_libopae_json(NULL, json_dup));
 }
 
 /**
@@ -1124,7 +1124,7 @@ TEST(opae_cfg, parse_libopae_0) {
   char *json_dup = opae_strdup(json);
   libopae_config_data *cfg, *c;
 
-  cfg = c = opae_parse_libopae_json(json_dup);
+  cfg = c = opae_parse_libopae_json(NULL, json_dup);
   ASSERT_NE((libopae_config_data *)NULL, cfg);
 
   // ofs0_pf / libxfpga.so

--- a/tests/opae-c/test_opae_cfg_c.cpp
+++ b/tests/opae-c/test_opae_cfg_c.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2022, Intel Corporation
+// Copyright(c) 2022-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
* Search for ASE config in both /usr/share/opae and /usr/local/share/opae to avoid conflicts caused by mismatched CMAKE_INSTALL_PREFIX.
* OPAE_ERR() when parsing the config JSON fails to find the "configs" array in order to help detect the case when an old configuration is encountered.
* OPAE_DBG() when the ASE configuration file is found. This was already being done for the non-ASE case.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>