### PR TITLE
Use 40 bit counters for reads and writes

### DIFF
--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -299,9 +299,11 @@ struct he_dsm_status {
 	uint64_t res1 : 16;
 	uint64_t err_vector : 32;
 	uint64_t num_ticks : 40;
-	uint64_t res2 : 24;
-	uint64_t num_reads : 32;
-	uint64_t num_writes : 32;
+	uint64_t res2 : 8;
+	uint64_t num_reads_h : 8;
+	uint64_t num_writes_h : 8;
+	uint64_t num_reads_l : 32;
+	uint64_t num_writes_l : 32;
 	uint64_t penalty_start : 16;
 	uint64_t res3 : 16;
 	uint64_t penalty_end : 8;


### PR DESCRIPTION
The hardware had already extended the status line (DSM), adding 8 bits to read and write counters. Host exerciser software was using only the low 32 bits. Update host_exerciser to use all 40 bits.