### PR TITLE
Use 40 bit counters for reads and writes

### DIFF
--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -297,9 +297,11 @@ struct he_dsm_status {
 	uint64_t res1 : 16;
 	uint64_t err_vector : 32;
 	uint64_t num_ticks : 40;
-	uint64_t res2 : 24;
-	uint64_t num_reads : 32;
-	uint64_t num_writes : 32;
+	uint64_t res2 : 8;
+	uint64_t num_reads_h : 8;
+	uint64_t num_writes_h : 8;
+	uint64_t num_reads_l : 32;
+	uint64_t num_writes_l : 32;
 	uint64_t penalty_start : 16;
 	uint64_t res3 : 16;
 	uint64_t penalty_end : 8;

--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -125,9 +125,26 @@ public:
         return (double)(num_lines * 64) / ((1000.0 / host_exe_->he_clock_mhz_ * num_ticks));
     }
 
+    inline uint64_t dsm_num_ticks(const volatile he_dsm_status *dsm_status)
+    {
+        return dsm_status->num_ticks;
+    }
+
+    // Read count has two parts -- the size was increased after the first release
+    inline uint64_t dsm_num_reads(const volatile he_dsm_status *dsm_status)
+    {
+        return (uint64_t(dsm_status->num_reads_h) << 32) | dsm_status->num_reads_l;
+    }
+
+    // Write count has two parts -- the size was increased after the first release
+    inline uint64_t dsm_num_writes(const volatile he_dsm_status *dsm_status)
+    {
+        return (uint64_t(dsm_status->num_writes_h) << 32) | dsm_status->num_writes_l;
+    }
+
     void he_perf_counters()
     {
-        struct he_dsm_status *dsm_status = NULL;
+        volatile he_dsm_status *dsm_status = NULL;
         volatile uint8_t* status_ptr = dsm_->c_type();
         uint64_t num_cache_lines = 0;
         if (!status_ptr)
@@ -141,13 +158,13 @@ public:
         // calculate number of cache lines in continuous mode
         if (host_exe_->he_continuousmode_) {
             if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_LPBK1)
-                num_cache_lines = dsm_status->num_writes * 2;
+                num_cache_lines = dsm_num_writes(dsm_status) * 2;
             if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_READ)
-                num_cache_lines = dsm_status->num_reads;
+                num_cache_lines = dsm_num_reads(dsm_status);
             if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_WRITE)
-                num_cache_lines = (dsm_status->num_writes);
+                num_cache_lines = (dsm_num_writes(dsm_status));
             if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_TRPUT)
-                num_cache_lines = dsm_status->num_writes * 2;
+                num_cache_lines = dsm_num_writes(dsm_status) * 2;
         } else {
             num_cache_lines = (LPBK1_BUFFER_SIZE / (1 * CL));
         }
@@ -156,16 +173,16 @@ public:
 
         uint64_t tmp;
 
-        tmp = dsm_status->num_ticks;
+        tmp = dsm_num_ticks(dsm_status);
         host_exe_->logger_->info("Number of clocks: {0}", tmp);
-        tmp = dsm_status->num_reads;
+        tmp = dsm_num_reads(dsm_status);
         host_exe_->logger_->info("Total number of Reads sent: {0}", tmp);
-        tmp = dsm_status->num_writes;
+        tmp = dsm_num_writes(dsm_status);
         host_exe_->logger_->info("Total number of Writes sent: {0}", tmp);
 
         // print bandwidth
-        if (dsm_status->num_ticks > 0) {
-            double perf_data = he_num_xfers_to_bw(num_cache_lines, dsm_status->num_ticks);
+        if (dsm_num_ticks(dsm_status) > 0) {
+            double perf_data = he_num_xfers_to_bw(num_cache_lines, dsm_num_ticks(dsm_status));
             host_exe_->logger_->info("Bandwidth: {0:0.3f} GB/s", perf_data);
         }
     }
@@ -649,7 +666,7 @@ public:
             if (test_status)
                 std::cout << "FAIL" << std::endl;
             else {
-                std::cout << he_num_xfers_to_bw(dsm_status->num_reads, dsm_status->num_ticks)
+                std::cout << he_num_xfers_to_bw(dsm_num_reads(dsm_status), dsm_num_ticks(dsm_status))
                           << std::endl;
             }
 
@@ -660,7 +677,7 @@ public:
             if (test_status)
                 std::cout << "FAIL" << std::endl;
             else {
-                std::cout << he_num_xfers_to_bw(dsm_status->num_writes, dsm_status->num_ticks)
+                std::cout << he_num_xfers_to_bw(dsm_num_writes(dsm_status), dsm_num_ticks(dsm_status))
                           << std::endl;
             }
 
@@ -671,8 +688,8 @@ public:
             if (test_status)
                 std::cout << "FAIL" << std::endl;
             else {
-                std::cout << he_num_xfers_to_bw(dsm_status->num_reads + dsm_status->num_writes,
-                                                dsm_status->num_ticks)
+                std::cout << he_num_xfers_to_bw(dsm_num_reads(dsm_status) + dsm_num_writes(dsm_status),
+                                                dsm_num_ticks(dsm_status))
                           << std::endl;
             }
 


### PR DESCRIPTION
The hardware had already extended the status line (DSM), adding 8 bits to read and write counters. Host exerciser software was using only the low 32 bits. Update host_exerciser to use all 40 bits.

(cherry picked from commit f5f42f081afe9d200a93f6d74d4201f1af82a973)