### PR TITLE
pci_device: add unplug and plug subcommands (#2934)

### DIFF
--- a/python/opae.admin/opae/admin/tools/pci_device.py
+++ b/python/opae.admin/opae/admin/tools/pci_device.py
@@ -245,7 +245,10 @@ class plug(object):
         if debug:
             print(f'Clearing device status for {device.pci_address}')
         cmd = f'setpci -s {device.pci_address} CAP_EXP+0x08.L'
-        output = int(call_process(cmd), 16)
+        try:
+            output = int(call_process(cmd), 16)
+        except ValueError: # Error during conversion. setpci() call failed.
+            return
         output &= ~0xFF000
         output |= 0xF5000
         call_process(f'{cmd}={output:08x}')

--- a/python/opae.admin/opae/admin/tools/rsu.py
+++ b/python/opae.admin/opae/admin/tools/rsu.py
@@ -268,6 +268,11 @@ def main():
                 except IOError as err:
                     logging.error(f'RSU operation failed: {err}')
                 else:
+                    if args.which not in ['fpgadefault']:
+                        filt = {'pci_node.pci_address': args.bdf.lower()}
+                        dev = fpga.enum([filt])
+                        if dev:
+                            dev.clear_status_and_errors()
                     exit_code = os.EX_OK
                     logging.info('RSU operation complete')
                 finally:


### PR DESCRIPTION
In support of fpga designs with an hps, add unplug and plug subcommands to pci_device. These are used to disconnect/reconnect an fpga device from the host processor perspective.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>
(cherry picked from commit c8c61aca80801b7aa0f865e3098727dc3c24f823)