### PR TITLE
rsu, pci_device: fix fpga.enum returns a list (#2939)

### DIFF
--- a/python/opae.admin/opae/admin/tools/rsu.py
+++ b/python/opae.admin/opae/admin/tools/rsu.py
@@ -271,8 +271,8 @@ def main():
                     if args.which not in ['fpgadefault']:
                         filt = {'pci_node.pci_address': args.bdf.lower()}
                         dev = fpga.enum([filt])
-                        if dev:
-                            dev.clear_status_and_errors()
+                        for d in dev:
+                            d.clear_status_and_errors()
                     exit_code = os.EX_OK
                     logging.info('RSU operation complete')
                 finally:


### PR DESCRIPTION
fpga.enum returns a list, using a for loop to handle 0 or more elements.

Signed-off-by: Roger Christensen <rc@silicom.dk>
(cherry picked from commit 77d5190b811cb9228525892e394d00c5eef2686f)