### PR TITLE
cmake: exclude .clang-format from opae headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -881,7 +881,8 @@ endif(NOT DEFINED OPAE_MINIMAL_BUILD)
 ############################################################################
 install(DIRECTORY include/opae
     DESTINATION include
-    COMPONENT libopaeheaders)
+    COMPONENT libopaeheaders
+    PATTERN .clang-format EXCLUDE)
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/config/config.h.in"
                "${CMAKE_BINARY_DIR}/include/config.h")


### PR DESCRIPTION
This resolves an rpmbuild failure when building packages from a source tarball created with git archive.

```
RPM build errors:
    Installed (but unpackaged) file(s) found:
   /usr/include/opae/cxx/.clang-format
```