### PR TITLE
cmake: exclude .clang-format from opae headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -881,7 +881,8 @@ endif(NOT DEFINED OPAE_MINIMAL_BUILD)
 ############################################################################
 install(DIRECTORY include/opae
     DESTINATION include
-    COMPONENT libopaeheaders)
+    COMPONENT libopaeheaders
+    PATTERN .clang-format EXCLUDE)
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/config/config.h.in"
                "${CMAKE_BINARY_DIR}/include/config.h")


### PR DESCRIPTION
This resolves an rpmbuild failure when building packages from a source tarball created with git archive.

```
RPM build errors:
    Installed (but unpackaged) file(s) found:
   /usr/include/opae/cxx/.clang-format
```

Signed-off-by: Peter Colberg <peter.colberg@intel.com>
(cherry picked from commit 35ed295cef95bddef07841655b564e355b7e81f6)