### PR TITLE
hssi: suggest hssi{loopback,stats} when eth interface is absent

### DIFF
--- a/samples/hssi/hssi_100g_cmd.h
+++ b/samples/hssi/hssi_100g_cmd.h
@@ -416,7 +416,9 @@ public:
 
     if (eth_ifc == "") {
       std::cout << "No eth interface, so not "
-                   "honoring --eth-loopback." << std::endl;
+                   "honoring --eth-loopback. "
+                   "Try using the hssiloopback command instead."
+                << std::endl;
     } else {
       if (eth_loopback_ == "on")
         enable_eth_loopback(eth_ifc, true);
@@ -506,7 +508,9 @@ public:
 
     if (eth_ifc == "") {
       std::cout << "No eth interface, so not "
-                   "showing stats." << std::endl;
+                   "showing stats. "
+                   "Try using the hssistats command instead."
+                << std::endl;
     } else {
       show_eth_stats(eth_ifc);
 

--- a/samples/hssi/hssi_10g_cmd.h
+++ b/samples/hssi/hssi_10g_cmd.h
@@ -197,8 +197,10 @@ public:
               << std::endl;
 
     if (eth_ifc == "") {
-        std::cout << "No eth interface, so not "
-		     "honoring --eth-loopback." << std::endl;
+      std::cout << "No eth interface, so not "
+                   "honoring --eth-loopback. "
+                   "Try using the hssiloopback command instead."
+                << std::endl;
     } else {
         if (eth_loopback_ == "on")
             enable_eth_loopback(eth_ifc, true);
@@ -306,8 +308,10 @@ public:
     }
 
     if (eth_ifc == "") {
-        std::cout << "No eth interface, so not "
-		     "showing stats." << std::endl;
+      std::cout << "No eth interface, so not "
+                   "showing stats. "
+                   "Try using the hssistats command instead."
+                << std::endl;
     } else {
         show_eth_stats(eth_ifc);
 


### PR DESCRIPTION
While the D5005 FPGA card employs a separate kernel driver (s10hssi) to configure loopback and provide statistics via a network device, newer FPGA cards expose a UIO device used with hssiloopback and hssistats.

Closes: https://hsdes.intel.com/appstore/article/#/22019839240

Cc: @badanur