### PR TITLE
.github: workflows: restrict top-level workflow permissions

### DIFF
--- a/.github/workflows/build-debs.yml
+++ b/.github/workflows/build-debs.yml
@@ -1,5 +1,9 @@
 name: Build DEBs
 
+# https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/build-rpms.yml
+++ b/.github/workflows/build-rpms.yml
@@ -1,5 +1,9 @@
 name: Build RPMs
 
+# https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/ccpp-tests.yml
+++ b/.github/workflows/ccpp-tests.yml
@@ -1,5 +1,9 @@
 name: C/C++ CI Build and Test
 
+# https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/docker-rpm.yml
+++ b/.github/workflows/docker-rpm.yml
@@ -1,5 +1,9 @@
 name: Docker Build and Review RPM
 
+# https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions
+permissions:
+  contents: read
+
 on:
   push:
     branches-ignore:

--- a/.github/workflows/no-ccpp-tests.yml
+++ b/.github/workflows/no-ccpp-tests.yml
@@ -1,5 +1,9 @@
 name: C/C++ CI Build and Test (dummy)
 
+# https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/no-python-analysis.yml
+++ b/.github/workflows/no-python-analysis.yml
@@ -1,5 +1,9 @@
 name: python static analysis (dummy)
 
+# https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/pacsign.yml
+++ b/.github/workflows/pacsign.yml
@@ -1,5 +1,9 @@
 name: Python pacsign tests
 
+# https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths: 

--- a/.github/workflows/python-static-analysis.yml
+++ b/.github/workflows/python-static-analysis.yml
@@ -1,5 +1,9 @@
 name: python static analysis
 
+# https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,5 +1,8 @@
 name: valgrind OPAE tests
 
+# https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Only permit reading the repository contents by default, and set further privileges at the job level to satisfy OpenSSF Scorecard criteria.

Link: https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions
Link: https://securityscorecards.dev/viewer/?uri=github.com/OFS/opae-sdk