### PR TITLE
Add HBM support to mem_tg sample

### DIFF
--- a/samples/mem_tg/mem_tg.h
+++ b/samples/mem_tg/mem_tg.h
@@ -78,6 +78,7 @@ enum {
   SCRATCHPAD      = 0x0028,
   MEM_TG_CTRL     = 0x0030,
   MEM_TG_STAT     = 0x0038,
+  MEM_TG_FEAT     = 0x0048,
   MEM_TG_CLOCKS   = 0x0050  
 };
 const int MEM_TG_CFG_OFFSET = 0x1000;


### PR DESCRIPTION
Add High Bandwidth Memory (HBM) support to the memory traffic generator (mem_tg) sample used to exercise and test available memory channels, which currently supports DDR memory only. For DDR, each memory channel accesses an independent memory bank, each starting from offset 0.

For HBM, each memory channel has access to the entire memory space and must therefore access memory from different locations when reading or writing on multiple channels simultaneously to avoid collisions.

For details on the HBM memory architecture, refer to the Intel Agilex® 7 M-Series FPGA Network-on-Chip (NoC) User Guide.

Link: https://cdrdv2-public.intel.com/780779/ug-768844-780779.pdf
Cc: @nanditha-intel @nahidhassan-intel @mdeckar1