### PR TITLE
python: migrate from deprecated distutils to setuptools

### DIFF
--- a/binaries/fpgadiag/setup.py
+++ b/binaries/fpgadiag/setup.py
@@ -24,9 +24,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from setuptools import setup, find_namespace_packages
+from setuptools import Extension, setup, find_namespace_packages
 from setuptools.command.build_ext import build_ext
-from distutils.extension import Extension
 
 # get the original build_extensions method
 original_build_extensions = build_ext.build_extensions

--- a/binaries/opae.io/setup.py
+++ b/binaries/opae.io/setup.py
@@ -24,8 +24,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from setuptools import find_namespace_packages
-from distutils.core import Extension, setup
+from setuptools import Extension, setup, find_namespace_packages
 
 setup(
     name='opae.io',

--- a/libraries/pyopae/setup.py
+++ b/libraries/pyopae/setup.py
@@ -24,10 +24,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from setuptools import setup, find_namespace_packages
+from setuptools import Extension, setup, find_namespace_packages
 from setuptools.command.build_ext import build_ext
-from distutils.extension import Extension
-
 
 # get the original build_extensions method
 original_build_extensions = build_ext.build_extensions

--- a/libraries/pyopaeuio/setup.py
+++ b/libraries/pyopaeuio/setup.py
@@ -24,9 +24,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from setuptools import setup, find_packages
+from setuptools import Extension, setup, find_packages
 from setuptools.command.build_ext import build_ext
-from distutils.extension import Extension
 
 # get the original build_extensions method
 original_build_extensions = build_ext.build_extensions


### PR DESCRIPTION
Closes: https://github.com/OFS/opae-sdk/issues/3141
Link: https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html
Reported-by: Fuga Kato (IBEX Technology Co., Ltd.)