### PR TITLE
host_exerciser: fix memory calibration check as non-root user

### DIFF
--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -571,13 +571,6 @@ public:
     return handle_->get_token();
   }
 
-  token::ptr_t get_token_device()
-  {
-    if (handle_device_)
-        return handle_device_->get_token();
-    return nullptr;
-  }
-
   bool option_passed(std::string option_str)
   {
       if (app_.count(option_str) == 0)

--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -879,9 +879,9 @@ public:
     void fpga_emif_status(test_afu* afu)
     {
         auto d_afu = dynamic_cast<host_exerciser*>(afu);
-        token_device_ = d_afu->get_token_device();
 
-        if (!token_device_)
+        const fpga::token::ptr_t token_device = d_afu->token_device();
+        if (!token_device)
             return;
 
         // Check if memory calibration has failed and error out before proceeding
@@ -908,7 +908,7 @@ public:
             mem_cal_glob << "*dfl*/**/inf" << i << "_cal_fail";
             // Ask for a sysobject with this glob string
             fpga::sysobject::ptr_t testobj = fpga::sysobject::get(
-                token_device_, mem_cal_glob.str().c_str(), FPGA_OBJECT_GLOB);
+                token_device, mem_cal_glob.str().c_str(), FPGA_OBJECT_GLOB);
 
             // if test obj !=null, the sysfs entry was found.
             // Read the calibration status from the sysfs entry.
@@ -933,7 +933,6 @@ protected:
     shared_buffer::ptr_t dsm_;
     he_interrupt0 he_interrupt_;
     token::ptr_t token_;
-    token::ptr_t token_device_;
     hostexe_req_len he_lpbk_max_reqlen_;
     uint32_t he_lpbk_bus_bytes_;
     uint32_t he_lpbk_bus_bytes_log2_;


### PR DESCRIPTION
Commit 44f9f534afa0 ("Check memory calibration status before running host_exerciser") introduced a pre-run check of the DDR calibration status for each memory channel. Whereas the sysfs entries with the calibration status are readable to non-root users, the check depends on root privileges to open the DFL FME device. Instead of obtaining a device handle, directly use the device token to obtain the sysfs path.

Link: https://github.com/OFS/opae-sdk/pull/3094
Link: https://hsdes.intel.com/appstore/article/#/14019997425
Link: https://hsdes.intel.com/appstore/article/#/16026664009