### PR TITLE
fpgadiag, libopaecxx: link the libraries whose symbols are used

### DIFF
--- a/binaries/fpgadiag/CMakeLists.txt
+++ b/binaries/fpgadiag/CMakeLists.txt
@@ -42,6 +42,7 @@ opae_add_shared_library(TARGET opae-c++-nlb
         src/diag_utils.cpp
     LIBS
         opae-c
+        opae-c++-utils
         opae-cxx-core
     VERSION ${OPAE_VERSION}
     SOVERSION ${OPAE_VERSION_MAJOR}

--- a/libraries/libopaecxx/CMakeLists.txt
+++ b/libraries/libopaecxx/CMakeLists.txt
@@ -42,6 +42,7 @@ opae_add_shared_library(TARGET opae-cxx-core
     EXPORT opae-targets
     SOURCE ${OPAECXXCORE_SRC}
     LIBS
+        opae-c
         ${uuid_LIBRARIES}
     VERSION ${OPAE_VERSION}
     SOVERSION ${OPAE_VERSION_MAJOR}


### PR DESCRIPTION
While building the OPAE libraries as proper shared objects with `-Wl,-z,defs` / `--no-undefined` (the default for shared libraries on openSUSE, and a good correctness check generally), two libraries fail to link:

- `opae-cxx-core` (libraries/libopaecxx) uses the `fpga*` C API from **opae-c** (e.g. `fpgaErrStr`, `fpgaDestroyProperties`, `fpgaUnregisterEvent`) but does not link it.
- `opae-c++-nlb` (binaries/fpgadiag) uses **opae-c++-utils** (`intel::utils::wrapped_stream`, …) but does not link it.

```
undefined reference to 'fpgaErrStr'
undefined reference to 'intel::utils::wrapped_stream::~wrapped_stream()'
```

This is invisible with the default linker behaviour on Fedora/RHEL/Ubuntu (the symbols resolve transitively at load time), so the underlinking goes unnoticed there. This PR adds the missing entries to each `opae_add_shared_library(... LIBS ...)` so the libraries are self-contained.

No functional change.